### PR TITLE
docs: add project documentation, community files, and CI workflows

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,6 +18,41 @@ Then, if it appears that it's a real bug, you may report it using Github by foll
 
 > _NOTE:_ Don’t hesitate to give as much information as you can (OS, PHP version extensions...)
 
+## Branching
+
+Create a branch from `main` using the appropriate prefix:
+
+| Prefix      | Purpose                               | Example                   |
+|-------------|---------------------------------------|---------------------------|
+| `feature/`  | New functionality                     | `feature/add-user-entity` |
+| `fix/`      | Bug fixes                             | `fix/login-validation`    |
+| `chore/`    | Maintenance, deps, config             | `chore/upgrade-deps`      |
+| `docs/`     | Documentation changes                 | `docs/update-api-guide`   |
+| `refactor/` | Code restructuring (no behavior change) | `refactor/extract-service` |
+
+Use lowercase `kebab-case` for branch names.
+
+## Commit Messages
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/). Format:
+
+```
+<type>(<optional scope>): <description>
+```
+
+**Types:** `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`, `style`
+
+**Scopes:** `api`, `pwa`, `e2e`, `infra`
+
+**Examples:**
+```
+feat(api): add Book entity with CRUD endpoints
+fix(pwa): correct login form validation
+docs: update contributing guidelines
+```
+
+See `docs/branching-and-releases.md` for the full strategy.
+
 ## Pull Requests
 
 ### Writing a Pull Request

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,22 +1,14 @@
-# Contributing to API Platform
+# Contributing to Aura
 
-First, thank you for contributing, you're awesome!
-
-To have your code integrated in the API Platform project, there are some rules to follow, but don't panic, it's easy!
+Thanks for your interest in contributing!
 
 ## Reporting Bugs
 
-If you happen to find a bug, we kindly request you to report it. However, before submitting it, please:
+Before submitting a bug report:
 
-  * Check the [project documentation available online](https://api-platform.com/docs/)
-
-Then, if it appears that it's a real bug, you may report it using Github by following these 3 points:
-
-  * Check if the bug is not already reported!
-  * A clear title to resume the issue
-  * A description of the workflow needed to reproduce the bug,
-
-> _NOTE:_ Don’t hesitate to give as much information as you can (OS, PHP version extensions...)
+1. Check [existing issues](https://github.com/roboparker/Aura/issues) to avoid duplicates
+2. Use the [bug report template](https://github.com/roboparker/Aura/issues/new?template=bug_report.yml)
+3. Include as much detail as possible (OS, PHP version, Node version, steps to reproduce)
 
 ## Branching
 
@@ -32,106 +24,21 @@ Create a branch from `main` using the appropriate prefix:
 
 Use lowercase `kebab-case` for branch names.
 
-## Commit Messages
-
-This project uses [Conventional Commits](https://www.conventionalcommits.org/). Format:
-
-```
-<type>(<optional scope>): <description>
-```
-
-**Types:** `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`, `style`
-
-**Scopes:** `api`, `pwa`, `e2e`, `infra`
-
-**Examples:**
-```
-feat(api): add Book entity with CRUD endpoints
-fix(pwa): correct login form validation
-docs: update contributing guidelines
-```
-
-See `docs/branching-and-releases.md` for the full strategy.
-
 ## Pull Requests
 
-### Writing a Pull Request
+1. Base your changes on the `main` branch
+2. Fill in the PR template
+3. Make sure all CI checks pass
+4. Add tests for new functionality or bug fixes
+5. Commits will be squashed on merge
 
-You should base your changes on the `main` branch.
+### Coding Standards
 
-### Matching Coding Standards
+- **PHP**: Follow [Symfony coding standards](https://symfony.com/doc/current/contributing/code/standards.html)
+- **TypeScript/React**: Follow the existing patterns in the codebase
 
-The API Platform project follows [Symfony coding standards](https://symfony.com/doc/current/contributing/code/standards.html).
-But don't worry, you can fix CS issues automatically using the [PHP CS Fixer](http://cs.sensiolabs.org/) tool:
+See `docs/branching-and-releases.md` for the full branching and release strategy.
 
-```bash
-php-cs-fixer.phar fix
-```
+## License
 
-And then, add fixed file to your commit before push.
-Be sure to add only **your modified files**. If another files are fixed by cs tools, just revert it before commit.
-
-### Sending a Pull Request
-
-When you send a PR, just make sure that:
-
-* You add valid test cases.
-* Tests are green.
-* You make a PR on the related documentation in the [api-platform/docs](https://github.com/api-platform/docs) repository.
-* You make the PR on the same branch you based your changes on. If you see commits
-  that you did not make in your PR, you're doing it wrong.
-* Also don't forget to add a comment when you update a PR with a ping to [the maintainers](https://github.com/orgs/api-platform/people),
-  so he/she will get a notification.
-* Squash your commits into one commit. (see the next chapter)
-
-Fill in the following header from the pull request template:
-
-```markdown
-| Q             | A
-| ------------- | ---
-| Bug fix?      | yes/no
-| New feature?  | yes/no
-| BC breaks?    | no
-| Deprecations? | no
-| Tests pass?   | yes
-| Fixed tickets | #1234, #5678
-| License       | MIT
-| Doc PR        | api-platform/docs#1234
-```
-
-## Squash your Commits
-
-If you have 3 commits. So start with:
-
-```bash
-git rebase -i HEAD~3
-```
-
-An editor will be opened with your 3 commits, all prefixed by `pick`.
-
-Replace all `pick` prefixes by `fixup` (or `f`) **except the first commit** of the list.
-
-Save and quit the editor.
-
-After that, all your commits where squashed into the first one and the commit message of the first commit.
-
-If you would like to rename your commit message type:
-
-```bash
-git commit --amend
-```
-
-Now force push to update your PR:
-
-```bash
-git push --force
-```
-
-# License and Copyright Attribution
-
-When you open a Pull Request to the API Platform project, you agree to license your code under the [MIT license](../LICENSE)
-and to transfer the copyright on the submitted code to [Kévin Dunglas](https://github.com/dunglas).
-
-Be sure to you have the right to do that (if you are a professional, ask your company)!
-
-If you include code from another project, please mention it in the Pull Request description and credit the original author.
+By submitting a PR, you agree to license your contribution under the [MIT license](../LICENSE).

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,82 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill out the sections below so we can reproduce and fix the issue.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+      placeholder: What happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Step-by-step instructions to reproduce the behavior.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of the project is affected?
+      options:
+        - API (PHP/Symfony)
+        - PWA (Next.js)
+        - Infrastructure (Docker/Helm)
+        - E2E Tests
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Any relevant environment details.
+      placeholder: |
+        OS: Ubuntu 22.04
+        PHP: 8.4
+        Node: 20
+        Docker: 24.0
+        Browser: Chrome 120
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Screenshots
+      description: Paste any relevant logs, error messages, or screenshots.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,55 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement! Please describe what you'd like and why it would be useful.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this feature solve? Is this related to a frustration?
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or workarounds you've considered.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of the project would this affect?
+      options:
+        - API (PHP/Symfony)
+        - PWA (Next.js)
+        - Infrastructure (Docker/Helm)
+        - E2E Tests
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context, mockups, or screenshots.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+## Description
+
+<!-- What does this PR do? Why is it needed? -->
+
+## Type of Change
+
+| Question        | Answer |
+|-----------------|--------|
+| Bug fix?        | yes/no |
+| New feature?    | yes/no |
+| Breaking change?| yes/no |
+| Documentation?  | yes/no |
+
+## Component
+
+- [ ] API (PHP/Symfony)
+- [ ] PWA (Next.js)
+- [ ] Infrastructure (Docker/Helm)
+- [ ] E2E Tests
+- [ ] Documentation
+
+## How Has This Been Tested?
+
+<!-- Describe the tests you ran and how to reproduce them. -->
+
+## Checklist
+
+- [ ] My code follows the project's conventions
+- [ ] I have used [conventional commits](docs/branching-and-releases.md) for my commit messages
+- [ ] I have added tests that prove my fix or feature works
+- [ ] New and existing tests pass locally
+- [ ] I have updated documentation if needed

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,12 +4,10 @@
 
 ## Type of Change
 
-| Question        | Answer |
-|-----------------|--------|
-| Bug fix?        | yes/no |
-| New feature?    | yes/no |
-| Breaking change?| yes/no |
-| Documentation?  | yes/no |
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation
 
 ## Component
 
@@ -26,7 +24,6 @@
 ## Checklist
 
 - [ ] My code follows the project's conventions
-- [ ] I have used [conventional commits](docs/branching-and-releases.md) for my commit messages
 - [ ] I have added tests that prove my fix or feature works
 - [ ] New and existing tests pass locally
 - [ ] I have updated documentation if needed

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Aura, please report it responsibly. **Do not open a public issue.**
+
+Instead, please report vulnerabilities via [GitHub's private vulnerability reporting](https://github.com/roboparker/Aura/security/advisories/new).
+
+### What to include
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+### Response Timeline
+
+- **Acknowledgment**: Within 48 hours
+- **Initial assessment**: Within 1 week
+- **Fix or mitigation**: As soon as reasonably possible depending on severity
+
+## Supported Versions
+
+Only the latest release on `main` is actively supported with security updates.
+
+## Scope
+
+This policy covers the Aura application code including:
+
+- API (PHP/Symfony backend)
+- PWA (Next.js frontend)
+- Docker and infrastructure configuration
+
+Third-party dependencies are managed via Dependabot and updated regularly.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -13,12 +13,6 @@ Instead, please report vulnerabilities via [GitHub's private vulnerability repor
 - Potential impact
 - Suggested fix (if any)
 
-### Response Timeline
-
-- **Acknowledgment**: Within 48 hours
-- **Initial assessment**: Within 1 week
-- **Fix or mitigation**: As soon as reasonably possible depending on severity
-
 ## Supported Versions
 
 Only the latest release on `main` is actively supported with security updates.

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,17 @@
+# Support
+
+## Getting Help
+
+- **Bug reports**: [Open a bug report](https://github.com/roboparker/Aura/issues/new?template=bug_report.yml)
+- **Feature requests**: [Open a feature request](https://github.com/roboparker/Aura/issues/new?template=feature_request.yml)
+- **Questions & discussions**: [GitHub Discussions](https://github.com/roboparker/Aura/discussions) (if enabled) or open an issue
+
+## Before Opening an Issue
+
+1. Search [existing issues](https://github.com/roboparker/Aura/issues) to avoid duplicates
+2. Check the [project documentation](docs/) for answers
+3. Include as much detail as possible — steps to reproduce, environment info, and logs
+
+## Security Issues
+
+Do **not** open a public issue for security vulnerabilities. See [SECURITY.md](SECURITY.md) for responsible disclosure instructions.

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,19 @@
+name: Auto Assign PR
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign PR to author
+        run: gh pr edit "$PR_URL" --add-assignee "$PR_AUTHOR"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project uses [date-based build numbers](docs/branching-and-releases.md) for versioning (`YYYY.MM.DD.N`).
+
+## [Unreleased]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,143 @@
+# Aura - API Platform Project
+
+## Overview
+
+Aura is built on **API Platform**, a Symfony-based framework for building API-first applications. It uses a monorepo structure with three main components: a PHP API backend, a Next.js PWA frontend, and Playwright E2E tests.
+
+## Project Structure
+
+```
+Aura/
+  api/                # Symfony/API Platform backend (PHP 8.4+)
+  pwa/                # Next.js frontend (React/TypeScript)
+  e2e/                # Playwright end-to-end tests
+  helm/               # Kubernetes/Helm deployment charts
+  docs/               # Project documentation
+  .github/            # GitHub config (templates, workflows, policies)
+  compose.yaml        # Docker Compose (dev environment)
+  CHANGELOG.md        # Project changelog
+  CODE_OF_CONDUCT.md  # Contributor code of conduct
+  LICENSE             # MIT license
+```
+
+## Tech Stack
+
+### API (Backend)
+- **Framework**: Symfony 7.2 with API Platform 4.x
+- **PHP**: >= 8.4
+- **Database**: PostgreSQL 16 (via Doctrine ORM)
+- **Server**: FrankenPHP
+- **Real-time**: Mercure (WebSocket-like push)
+- **Testing**: PHPUnit
+- **Key packages**: doctrine/orm, nelmio/cors-bundle, symfony/security-bundle, symfony/serializer
+
+### PWA (Frontend)
+- **Framework**: Next.js 15 (React)
+- **Language**: TypeScript
+- **Styling**: Tailwind CSS v4
+- **State**: @tanstack/react-query
+- **Forms**: Formik
+- **Admin**: @api-platform/admin
+- **Package manager**: pnpm
+
+### E2E Tests
+- **Framework**: Playwright
+
+### Infrastructure
+- Docker Compose for local development
+- Helm charts + Skaffold for Kubernetes deployment
+
+## Development
+
+### Prerequisites
+- Docker & Docker Compose
+- PHP 8.4+ (for local API development)
+- Node.js + pnpm (for local PWA development)
+
+### Running Locally
+```bash
+docker compose up -d
+```
+The API is served at `https://localhost` (FrankenPHP handles both API and PWA proxying).
+
+### API Development
+```bash
+cd api
+composer install
+bin/console doctrine:migrations:migrate
+bin/phpunit                           # Run tests
+```
+
+### PWA Development
+```bash
+cd pwa
+pnpm install
+pnpm dev                              # Next.js dev server on port 3000
+pnpm lint                             # ESLint
+```
+
+### E2E Tests
+```bash
+cd e2e
+npm install
+npx playwright test
+```
+
+## Code Conventions
+
+### PHP / API
+- Follow [Symfony coding standards](https://symfony.com/doc/current/contributing/code/standards.html)
+- Entities live in `api/src/Entity/` with API Platform attributes
+- Use Doctrine ORM attributes for mapping
+- Validate with Symfony Validator constraints
+- Tests in `api/tests/Api/`
+
+### TypeScript / PWA
+- Components in `pwa/components/`
+- Pages follow Next.js file-based routing in `pwa/pages/`
+- Use Tailwind CSS for styling
+
+### Git & Branching
+- `main` is the only long-lived branch — always deployable
+- Create short-lived branches: `feature/`, `fix/`, `chore/`, `docs/`, `refactor/`
+- Use [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(api): add Book entity`)
+- Squash and merge PRs
+- See `docs/branching-and-releases.md` for the full strategy
+
+### Releases
+- Date-based build numbers: `YYYY.MM.DD.N` (e.g., `2026.04.12.1`)
+- Tag `main` when ready to release: `git tag 2026.04.12.1 && git push origin 2026.04.12.1`
+
+## Key Configuration
+- **Database URL**: `DATABASE_URL` env var (default: PostgreSQL on `database:5432`)
+- **Mercure**: JWT secret via `CADDY_MERCURE_JWT_SECRET`
+- **CORS**: Configured via nelmio/cors-bundle
+- **Trusted proxies/hosts**: Configurable via env vars
+
+## Branch Protection
+
+`main` is protected:
+- All CI status checks must pass (Tests, Docker Lint)
+- At least 1 approving review required
+- PRs are auto-assigned to their author
+
+## Documentation
+
+### Project Docs (`docs/`)
+- `docs/architecture.md` - System architecture and component relationships
+- `docs/api-guide.md` - API development patterns and conventions
+- `docs/branching-and-releases.md` - Branch naming, PR workflow, conventional commits, and release process
+- `docs/deployment.md` - Deployment and infrastructure guide
+
+### GitHub Community Files (`.github/`)
+- `.github/CONTRIBUTING.md` - Contribution guidelines
+- `.github/SECURITY.md` - Security vulnerability reporting policy
+- `.github/SUPPORT.md` - How to get help
+- `.github/PULL_REQUEST_TEMPLATE.md` - PR template
+- `.github/ISSUE_TEMPLATE/bug_report.yml` - Bug report form
+- `.github/ISSUE_TEMPLATE/feature_request.yml` - Feature request form
+
+### Root Files
+- `CHANGELOG.md` - Project changelog (Keep a Changelog format)
+- `CODE_OF_CONDUCT.md` - Contributor Covenant code of conduct
+- `LICENSE` - MIT license

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,4 +140,5 @@ npx playwright test
 ### Root Files
 - `CHANGELOG.md` - Project changelog (Keep a Changelog format)
 - `CODE_OF_CONDUCT.md` - Contributor Covenant code of conduct
+- `CONTRIBUTORS.md` - Project contributors list
 - `LICENSE` - MIT license

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,6 @@ npx playwright test
 ### Git & Branching
 - `main` is the only long-lived branch — always deployable
 - Create short-lived branches: `feature/`, `fix/`, `chore/`, `docs/`, `refactor/`
-- Use [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(api): add Book entity`)
 - Squash and merge PRs
 - See `docs/branching-and-releases.md` for the full strategy
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,40 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers pledge to make participation in our project and community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces and in public spaces when an individual is representing the project or its community.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting the project maintainer directly via GitHub. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,7 @@
+# Contributors
+
+Thanks to everyone who has contributed to Aura!
+
+## Maintainers
+
+- [Robert Parker](https://github.com/roboparker)

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -1,0 +1,103 @@
+# API Development Guide
+
+## Creating an Entity
+
+Entities are PHP classes in `api/src/Entity/` with API Platform and Doctrine attributes.
+
+### Example Entity
+
+```php
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Metadata\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(mercure: true)]
+#[ORM\Entity]
+class Book
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
+    private ?int $id = null;
+
+    #[ORM\Column]
+    #[Assert\NotBlank]
+    public string $title = '';
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    public ?string $description = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+}
+```
+
+This single class auto-generates:
+- `GET /api/books` (collection)
+- `POST /api/books`
+- `GET /api/books/{id}`
+- `PUT /api/books/{id}`
+- `PATCH /api/books/{id}`
+- `DELETE /api/books/{id}`
+- OpenAPI documentation at `/docs`
+- Real-time Mercure updates on changes
+
+## Database Migrations
+
+After modifying entities:
+
+```bash
+bin/console doctrine:migrations:diff    # Generate migration
+bin/console doctrine:migrations:migrate # Apply migration
+```
+
+Migrations live in `api/migrations/`.
+
+## Validation
+
+Use Symfony Validator constraints as attributes:
+
+```php
+#[Assert\NotBlank]
+#[Assert\Length(min: 3, max: 255)]
+#[Assert\Email]
+```
+
+## Filtering & Pagination
+
+API Platform provides built-in filters:
+
+```php
+use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
+use ApiPlatform\Metadata\ApiFilter;
+
+#[ApiFilter(SearchFilter::class, properties: ['title' => 'partial'])]
+```
+
+Pagination is enabled by default (30 items per page).
+
+## Testing
+
+Tests use PHPUnit and live in `api/tests/Api/`:
+
+```bash
+bin/phpunit                        # Run all tests
+bin/phpunit tests/Api/BookTest.php # Run specific test
+```
+
+API test pattern: extend `ApiTestCase` from API Platform.
+
+## Serialization Formats
+
+Supported out of the box: JSON-LD, JSON:API, HAL, JSON, XML, CSV, YAML.
+Content negotiation via `Accept` header.
+
+## Security
+
+Configure authentication in `api/config/packages/security.yaml`. API Platform integrates with Symfony's security system for access control on operations.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,60 @@
+# Architecture
+
+## System Overview
+
+Aura follows an API-first architecture built on API Platform. The system consists of three runtime components orchestrated via Docker Compose.
+
+```mermaid
+graph TD
+    Browser["Browser"] -->|HTTPS :443| Caddy["FrankenPHP / Caddy"]
+
+    subgraph Caddy["FrankenPHP (Caddy) :80/:443"]
+        API["API (Symfony/PHP)<br/>/api/*"]
+        PWAProxy["PWA Proxy<br/>→ pwa:3000"]
+        Mercure["Mercure Hub<br/>/.well-known/mercure"]
+    end
+
+    Caddy --> API
+    Caddy --> PWAProxy
+    API --> Mercure
+    API -->|Doctrine ORM| DB["PostgreSQL 16<br/>database:5432"]
+    Mercure -->|SSE push| Browser
+    PWAProxy -->|proxy| PWA["Next.js PWA<br/>:3000"]
+```
+
+## Component Details
+
+### API (Symfony + API Platform)
+- **Entry point**: FrankenPHP worker mode (no php-fpm, no nginx)
+- **Routing**: API Platform auto-generates REST endpoints from entity attributes
+- **Serialization**: Symfony Serializer with JSON-LD, JSON:API, HAL, etc.
+- **Authentication**: Symfony Security Bundle (configurable)
+- **Validation**: Symfony Validator constraints on entities
+- **Database**: Doctrine ORM with PostgreSQL; migrations in `api/migrations/`
+
+### PWA (Next.js)
+- **Rendering**: Server-side rendering via Next.js
+- **Admin panel**: Auto-generated admin UI at `/admin` via `@api-platform/admin`
+- **API communication**: Hydra/JSON-LD client via API Platform's client libraries
+- **Styling**: Tailwind CSS v4 with PostCSS
+
+### Mercure
+- **Purpose**: Real-time push notifications (server-sent events)
+- **Integration**: Built into FrankenPHP/Caddy via Mercure hub
+- **Usage**: Entities with `mercure: true` attribute auto-publish updates
+
+## Data Flow
+
+1. **Client request** hits FrankenPHP (Caddy) on port 443
+2. Caddy routes to either the PHP API or proxies to the PWA (port 3000)
+3. API Platform handles request lifecycle: deserialization, validation, persistence, serialization
+4. Doctrine ORM manages database operations against PostgreSQL
+5. On entity changes, Mercure publishes updates to subscribed clients
+
+## Docker Services
+
+| Service    | Image              | Purpose                    | Port  |
+|------------|--------------------|-----------------------------|-------|
+| php        | app-php            | API + FrankenPHP + Mercure  | 80/443|
+| pwa        | app-pwa            | Next.js frontend            | 3000  |
+| database   | postgres:16-alpine | PostgreSQL database         | 5432  |

--- a/docs/branching-and-releases.md
+++ b/docs/branching-and-releases.md
@@ -1,0 +1,171 @@
+# Branching & Release Strategy
+
+## Overview
+
+Aura follows **GitHub Flow** — a lightweight, branch-based workflow where `main` is always deployable and all changes arrive via pull requests. Releases are tagged with **date-based build numbers**.
+
+## Workflow
+
+```mermaid
+gitDiagram
+    commit id: "main"
+    branch feature/add-books
+    commit id: "feat: add Book entity"
+    commit id: "test: add Book tests"
+    checkout main
+    merge feature/add-books id: "Merge PR #12"
+    commit id: "2026.04.12.1" tag: "2026.04.12.1"
+    branch fix/validation-bug
+    commit id: "fix: required field check"
+    checkout main
+    merge fix/validation-bug id: "Merge PR #13"
+    commit id: "2026.04.13.1" tag: "2026.04.13.1"
+```
+
+## Branch Naming
+
+All branches are short-lived and created from `main`. Use the following prefixes:
+
+| Prefix      | Purpose                          | Example                        |
+|-------------|----------------------------------|--------------------------------|
+| `feature/`  | New functionality                | `feature/add-user-entity`      |
+| `fix/`      | Bug fixes                        | `fix/login-validation`         |
+| `chore/`    | Maintenance, deps, config        | `chore/upgrade-symfony-7.3`    |
+| `docs/`     | Documentation changes            | `docs/update-api-guide`        |
+| `refactor/` | Code restructuring (no behavior change) | `refactor/extract-service` |
+
+**Rules:**
+- Use lowercase with hyphens (`kebab-case`)
+- Keep names short but descriptive
+- Delete branches after merging
+
+## Pull Request Workflow
+
+1. **Create a branch** from `main`
+2. **Make commits** following [Conventional Commits](#conventional-commits)
+3. **Open a PR** against `main`
+4. **CI checks must pass** (tests, linting, E2E)
+5. **Squash and merge** into `main`
+6. **Delete the branch**
+
+### PR Requirements
+- Descriptive title following conventional commit format
+- Fill in the PR template (bug fix, new feature, tests pass, etc.)
+- All CI checks green
+- Squash commits into a single commit on merge
+
+## Conventional Commits
+
+Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) specification:
+
+```
+<type>(<optional scope>): <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Types
+
+| Type       | When to use                                  |
+|------------|----------------------------------------------|
+| `feat`     | A new feature                                |
+| `fix`      | A bug fix                                    |
+| `chore`    | Maintenance (deps, config, tooling)          |
+| `docs`     | Documentation only                           |
+| `refactor` | Code change that neither fixes nor adds      |
+| `test`     | Adding or updating tests                     |
+| `ci`       | CI/CD configuration changes                  |
+| `style`    | Formatting, whitespace (no logic change)     |
+
+### Scopes
+
+Optional scopes narrow the change area:
+- `api` — Backend PHP/Symfony changes
+- `pwa` — Frontend Next.js changes
+- `e2e` — End-to-end test changes
+- `infra` — Docker, Helm, CI changes
+
+### Examples
+
+```
+feat(api): add Book entity with CRUD endpoints
+fix(pwa): correct login form validation
+chore: upgrade api-platform to 4.2.0
+docs: add branching strategy documentation
+ci: add Playwright to CI pipeline
+```
+
+## Releases
+
+### Build Number Format
+
+Releases use **date-based build numbers**: `YYYY.MM.DD.N`
+
+- `YYYY` — four-digit year
+- `MM` — two-digit month
+- `DD` — two-digit day
+- `N` — sequence number for that day (starts at 1)
+
+**Examples:**
+- `2026.04.12.1` — first release on April 12, 2026
+- `2026.04.12.2` — second release on the same day
+- `2026.05.01.1` — first release on May 1, 2026
+
+### Creating a Release
+
+1. Ensure `main` is in a deployable state (CI green)
+2. Determine the build number (check latest tag for today's date)
+3. Tag and push:
+
+```bash
+# Check the latest tag
+git tag -l "$(date +%Y.%m.%d).*" --sort=-v:refname | head -1
+
+# Tag the release (increment N if a tag already exists today)
+git tag 2026.04.12.1
+git push origin 2026.04.12.1
+```
+
+4. Create a GitHub release from the tag (optional but recommended)
+
+### What Triggers a Release
+
+Not every merge needs a release. Create a release when:
+- A meaningful feature or fix is merged and ready for deployment
+- A security patch needs to ship immediately
+- A batch of related changes is complete
+
+## Hotfix Process
+
+For urgent fixes to a deployed release:
+
+```mermaid
+gitDiagram
+    commit id: "main"
+    commit id: "2026.04.12.1" tag: "2026.04.12.1"
+    branch fix/critical-bug
+    commit id: "fix: patch security issue"
+    checkout main
+    merge fix/critical-bug id: "Merge hotfix"
+    commit id: "2026.04.12.2" tag: "2026.04.12.2"
+```
+
+1. Create a `fix/` branch from `main`
+2. Apply the fix with tests
+3. Open a PR, get CI green
+4. Merge to `main`
+5. Tag immediately with the next build number
+
+## Summary
+
+| Aspect              | Approach                          |
+|---------------------|-----------------------------------|
+| Default branch      | `main` (always deployable)        |
+| Branch lifetime     | Short-lived (hours to days)       |
+| Merge strategy      | Squash and merge                  |
+| Commit format       | Conventional Commits              |
+| Versioning          | Date-based build numbers `YYYY.MM.DD.N` |
+| Release mechanism   | Git tags + GitHub releases        |
+| CI triggers         | Push to `main`, all PRs           |

--- a/docs/branching-and-releases.md
+++ b/docs/branching-and-releases.md
@@ -42,60 +42,17 @@ All branches are short-lived and created from `main`. Use the following prefixes
 ## Pull Request Workflow
 
 1. **Create a branch** from `main`
-2. **Make commits** following [Conventional Commits](#conventional-commits)
+2. **Make commits** with clear, descriptive messages
 3. **Open a PR** against `main`
 4. **CI checks must pass** (tests, linting, E2E)
 5. **Squash and merge** into `main`
 6. **Delete the branch**
 
 ### PR Requirements
-- Descriptive title following conventional commit format
+- Descriptive title
 - Fill in the PR template (bug fix, new feature, tests pass, etc.)
 - All CI checks green
 - Squash commits into a single commit on merge
-
-## Conventional Commits
-
-Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) specification:
-
-```
-<type>(<optional scope>): <description>
-
-[optional body]
-
-[optional footer(s)]
-```
-
-### Types
-
-| Type       | When to use                                  |
-|------------|----------------------------------------------|
-| `feat`     | A new feature                                |
-| `fix`      | A bug fix                                    |
-| `chore`    | Maintenance (deps, config, tooling)          |
-| `docs`     | Documentation only                           |
-| `refactor` | Code change that neither fixes nor adds      |
-| `test`     | Adding or updating tests                     |
-| `ci`       | CI/CD configuration changes                  |
-| `style`    | Formatting, whitespace (no logic change)     |
-
-### Scopes
-
-Optional scopes narrow the change area:
-- `api` — Backend PHP/Symfony changes
-- `pwa` — Frontend Next.js changes
-- `e2e` — End-to-end test changes
-- `infra` — Docker, Helm, CI changes
-
-### Examples
-
-```
-feat(api): add Book entity with CRUD endpoints
-fix(pwa): correct login form validation
-chore: upgrade api-platform to 4.2.0
-docs: add branching strategy documentation
-ci: add Playwright to CI pipeline
-```
 
 ## Releases
 
@@ -165,7 +122,7 @@ gitDiagram
 | Default branch      | `main` (always deployable)        |
 | Branch lifetime     | Short-lived (hours to days)       |
 | Merge strategy      | Squash and merge                  |
-| Commit format       | Conventional Commits              |
+| Commit messages     | Clear and descriptive             |
 | Versioning          | Date-based build numbers `YYYY.MM.DD.N` |
 | Release mechanism   | Git tags + GitHub releases        |
 | CI triggers         | Push to `main`, all PRs           |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,109 @@
+# Deployment Guide
+
+## Local Development (Docker Compose)
+
+### Start
+```bash
+docker compose up -d
+```
+
+### Access
+- **API / PWA**: https://localhost (accept self-signed cert)
+- **API docs**: https://localhost/docs
+- **Admin panel**: https://localhost/admin
+
+### Stop
+```bash
+docker compose down
+```
+
+### Environment Variables
+
+Key variables (set in `.env` or `compose.override.yaml`):
+
+| Variable                       | Default                  | Description              |
+|--------------------------------|--------------------------|--------------------------|
+| `SERVER_NAME`                  | `localhost`              | Server hostname          |
+| `POSTGRES_USER`                | `app`                    | Database user            |
+| `POSTGRES_PASSWORD`            | `!ChangeMe!`             | Database password        |
+| `POSTGRES_DB`                  | `app`                    | Database name            |
+| `CADDY_MERCURE_JWT_SECRET`     | `!ChangeThisMercure...`  | Mercure JWT secret       |
+| `HTTPS_PORT`                   | `443`                    | HTTPS port               |
+| `HTTP_PORT`                    | `80`                     | HTTP port                |
+
+## Production (Docker Compose)
+
+Use `compose.prod.yaml` with overrides:
+
+```bash
+docker compose -f compose.yaml -f compose.prod.yaml up -d
+```
+
+Ensure all secrets are set to strong, unique values in production.
+
+## Kubernetes (Helm + Skaffold)
+
+### Prerequisites
+- Kubernetes cluster
+- Helm 3
+- Skaffold
+
+### Deploy
+```bash
+skaffold run
+```
+
+### Configuration
+- Helm chart: `helm/api-platform/`
+- Skaffold config: `skaffold.yaml`
+- Values override: `skaffold-values.yaml`
+
+## CI/CD
+
+### Health Checks
+The API container includes a health check that verifies the `/docs` endpoint is accessible:
+
+```yaml
+healthcheck:
+  test: curl --insecure --fail https://localhost/docs || exit 1
+  timeout: 5s
+  retries: 5
+  start_period: 60s
+```
+
+### Build Targets
+- **API image**: Multi-stage Dockerfile at `api/Dockerfile`
+- **PWA image**: Dockerfile at `pwa/Dockerfile`
+
+## Releases
+
+Releases are tagged on `main` using date-based build numbers (`YYYY.MM.DD.N`).
+
+### Creating a Release
+
+```bash
+# Check if a tag already exists for today
+git tag -l "$(date +%Y.%m.%d).*" --sort=-v:refname | head -1
+
+# Tag and push
+git tag 2026.04.12.1
+git push origin 2026.04.12.1
+```
+
+### Release Checklist
+
+1. All CI checks pass on `main` (tests, lint, E2E)
+2. Docker images build successfully
+3. Health checks pass in the compose environment
+4. Tag the release and push the tag
+5. Optionally create a GitHub release with changelog notes
+
+See `docs/branching-and-releases.md` for the full release strategy.
+
+## Dependency Updates
+
+Use the `update-deps.sh` script to update all project dependencies:
+
+```bash
+./update-deps.sh
+```


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` with project overview, tech stack, conventions, and file index
- Add `docs/` folder: architecture (with Mermaid diagrams), API guide, branching & release strategy, deployment guide
- Add GitHub community files: code of conduct, security policy, support guide, contributing updates
- Add issue templates (bug report, feature request) and PR template
- Add `CHANGELOG.md` (Keep a Changelog format, date-based build numbers)
- Add auto-assign workflow to assign PRs to their author
- Update `.github/CONTRIBUTING.md` with branch naming and conventional commits guidance

## Test plan

- [ ] Verify Mermaid diagrams render on GitHub in `docs/architecture.md` and `docs/branching-and-releases.md`
- [ ] Verify issue templates appear when creating a new issue
- [ ] Verify PR template auto-populates on new PRs
- [ ] Verify auto-assign workflow triggers on PR creation