### PR TITLE
chore: enable Dependabot version update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,11 +12,11 @@ updates:
       interval: daily
     labels:
       - dependencies
-    open-pull-requests-limit: 0 # open Pull Requests for security updates only
+    open-pull-requests-limit: 5
   - package-ecosystem: npm
     directory: /pwa
     schedule:
       interval: daily
     labels:
       - dependencies
-    open-pull-requests-limit: 0 # open Pull Requests for security updates only
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

- Raise `open-pull-requests-limit` from 0 to 5 for both Composer and npm ecosystems
- Dependabot will now open version update PRs in addition to security patches

## Type of Change

- [x] Documentation

## Test plan

- [ ] Verify Dependabot opens version update PRs after merge