### PR TITLE
Add user registration and authentication

### DIFF
--- a/api/composer.json
+++ b/api/composer.json
@@ -33,6 +33,7 @@
     },
     "require-dev": {
         "api-platform/schema-generator": "^5.0",
+        "doctrine/doctrine-fixtures-bundle": "^4.3",
         "symfony/browser-kit": "7.2.*",
         "symfony/css-selector": "7.2.*",
         "symfony/debug-bundle": "7.2.*",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d684ab51fa052cc4c571d243e1f54def",
+    "content-hash": "ffed57acb84358601cfa78d066a552bd",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -8043,6 +8043,177 @@
             "time": "2025-01-16T11:12:34+00:00"
         },
         {
+            "name": "doctrine/data-fixtures",
+            "version": "2.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/data-fixtures.git",
+                "reference": "bf7ac3a050b54b261cedfb3d0a44733819062275"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/data-fixtures/zipball/bf7ac3a050b54b261cedfb3d0a44733819062275",
+                "reference": "bf7ac3a050b54b261cedfb3d0a44733819062275",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/persistence": "^3.1 || ^4.0",
+                "php": "^8.1",
+                "psr/log": "^1.1 || ^2 || ^3"
+            },
+            "conflict": {
+                "doctrine/dbal": "<3.5 || >=5",
+                "doctrine/orm": "<2.14 || >=4",
+                "doctrine/phpcr-odm": "<1.3.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14",
+                "doctrine/dbal": "^3.5 || ^4",
+                "doctrine/mongodb-odm": "^1.3.0 || ^2.0.0",
+                "doctrine/orm": "^2.14 || ^3",
+                "doctrine/phpcr-odm": "^1.8 || ^2.0",
+                "ext-sqlite3": "*",
+                "fig/log-test": "^1",
+                "jackalope/jackalope-fs": "*",
+                "phpstan/phpstan": "2.1.46",
+                "phpunit/phpunit": "10.5.63 || 12.5.12",
+                "symfony/cache": "^6.4 || ^7 || ^8",
+                "symfony/var-exporter": "^6.4 || ^7 || ^8"
+            },
+            "suggest": {
+                "alcaeus/mongo-php-adapter": "For using MongoDB ODM 1.3 with PHP 7 (deprecated)",
+                "doctrine/mongodb-odm": "For loading MongoDB ODM fixtures",
+                "doctrine/orm": "For loading ORM fixtures",
+                "doctrine/phpcr-odm": "For loading PHPCR ODM fixtures"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\DataFixtures\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Data Fixtures for all Doctrine Object Managers",
+            "homepage": "https://www.doctrine-project.org",
+            "keywords": [
+                "database"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/data-fixtures/issues",
+                "source": "https://github.com/doctrine/data-fixtures/tree/2.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdata-fixtures",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-01T13:56:01+00:00"
+        },
+        {
+            "name": "doctrine/doctrine-fixtures-bundle",
+            "version": "4.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/DoctrineFixturesBundle.git",
+                "reference": "9e013ed10d49bf7746b07204d336384a7d9b5a4d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/DoctrineFixturesBundle/zipball/9e013ed10d49bf7746b07204d336384a7d9b5a4d",
+                "reference": "9e013ed10d49bf7746b07204d336384a7d9b5a4d",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/data-fixtures": "^2.2",
+                "doctrine/doctrine-bundle": "^2.2 || ^3.0",
+                "doctrine/orm": "^2.14.0 || ^3.0",
+                "doctrine/persistence": "^2.4 || ^3.0 || ^4.0",
+                "php": "^8.1",
+                "psr/log": "^2 || ^3",
+                "symfony/config": "^6.4 || ^7.0 || ^8.0",
+                "symfony/console": "^6.4 || ^7.0 || ^8.0",
+                "symfony/dependency-injection": "^6.4 || ^7.0 || ^8.0",
+                "symfony/deprecation-contracts": "^2.1 || ^3",
+                "symfony/doctrine-bridge": "^6.4.16 || ^7.1.9 || ^8.0",
+                "symfony/http-kernel": "^6.4 || ^7.0 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/dbal": "< 3"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "14.0.0",
+                "phpstan/phpstan": "2.1.11",
+                "phpunit/phpunit": "^10.5.38 || 11.4.14"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Bundle\\FixturesBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Doctrine Project",
+                    "homepage": "https://www.doctrine-project.org"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony DoctrineFixturesBundle",
+            "homepage": "https://www.doctrine-project.org",
+            "keywords": [
+                "Fixture",
+                "persistence"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/DoctrineFixturesBundle/issues",
+                "source": "https://github.com/doctrine/DoctrineFixturesBundle/tree/4.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdoctrine-fixtures-bundle",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-12-03T16:05:42+00:00"
+        },
+        {
             "name": "evenement/evenement",
             "version": "v3.0.2",
             "source": {
@@ -10332,5 +10503,5 @@
         "ext-iconv": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/api/config/bundles.php
+++ b/api/config/bundles.php
@@ -13,4 +13,5 @@ return [
     Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],
     Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],
     Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true, 'test' => true],
+    Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle::class => ['dev' => true, 'test' => true],
 ];

--- a/api/config/packages/api_platform.yaml
+++ b/api/config/packages/api_platform.yaml
@@ -6,6 +6,6 @@ api_platform:
         include_type: true
     # Good defaults for REST APIs
     defaults:
-        stateless: true
+        stateless: false
         cache_headers:
             vary: ['Content-Type', 'Authorization', 'Origin']

--- a/api/config/packages/framework.yaml
+++ b/api/config/packages/framework.yaml
@@ -7,8 +7,8 @@ framework:
     # See https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#headers
     trusted_headers: [ 'x-forwarded-for', 'x-forwarded-proto' ]
 
-    # Note that the session will be started ONLY if you read or write from it.
-    #session: true
+    # Session is needed for json_login authentication
+    session: true
 
     #esi: true
     #fragments: true
@@ -16,5 +16,5 @@ framework:
 when@test:
     framework:
         test: true
-        #session:
-        #    storage_factory_id: session.storage.factory.mock_file
+        session:
+            storage_factory_id: session.storage.factory.mock_file

--- a/api/config/packages/security.yaml
+++ b/api/config/packages/security.yaml
@@ -1,39 +1,40 @@
 security:
-    # https://symfony.com/doc/current/security.html#registering-the-user-hashing-passwords
     password_hashers:
         Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
-    # https://symfony.com/doc/current/security.html#loading-the-user-the-user-provider
+
     providers:
-        users_in_memory: { memory: null }
+        app_user_provider:
+            entity:
+                class: App\Entity\User
+                property: email
+
     firewalls:
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
         main:
             lazy: true
-            provider: users_in_memory
+            stateless: false
+            provider: app_user_provider
+            json_login:
+                check_path: auth_login
+                username_path: email
+                password_path: password
+            logout:
+                path: /auth/logout
 
-            # activate different ways to authenticate
-            # https://symfony.com/doc/current/security.html#the-firewall
-
-            # https://symfony.com/doc/current/security/impersonating_user.html
-            # switch_user: true
-
-    # Easy way to control access for large sections of your site
-    # Note: Only the *first* access control that matches will be used
     access_control:
-        # - { path: ^/admin, roles: ROLE_ADMIN }
-        # - { path: ^/profile, roles: ROLE_USER }
+        - { path: ^/users$, methods: [POST], roles: PUBLIC_ACCESS }
+        - { path: ^/auth/login$, roles: PUBLIC_ACCESS }
+        - { path: ^/api/me$, roles: ROLE_USER }
+        - { path: ^/docs, roles: PUBLIC_ACCESS }
+        - { path: ^/, roles: PUBLIC_ACCESS }
 
 when@test:
     security:
         password_hashers:
-            # By default, password hashers are resource intensive and take time. This is
-            # important to generate secure password hashes. In tests however, secure hashes
-            # are not important, waste resources and increase test times. The following
-            # reduces the work factor to the lowest possible values.
             Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface:
                 algorithm: auto
-                cost: 4 # Lowest possible value for bcrypt
-                time_cost: 3 # Lowest possible value for argon
-                memory_cost: 10 # Lowest possible value for argon
+                cost: 4
+                time_cost: 3
+                memory_cost: 10

--- a/api/migrations/Version20260414091220.php
+++ b/api/migrations/Version20260414091220.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260414091220 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE SEQUENCE "user_id_seq" INCREMENT BY 1 MINVALUE 1 START 1');
+        $this->addSql('CREATE TABLE "user" (id INT NOT NULL, email VARCHAR(180) NOT NULL, password VARCHAR(255) NOT NULL, roles JSON NOT NULL, PRIMARY KEY (id))');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_8D93D649E7927C74 ON "user" (email)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP SEQUENCE "user_id_seq" CASCADE');
+        $this->addSql('DROP TABLE "user"');
+    }
+}

--- a/api/src/Controller/AuthController.php
+++ b/api/src/Controller/AuthController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use App\Entity\User;
+
+class AuthController extends AbstractController
+{
+    #[Route('/auth/login', name: 'auth_login', methods: ['POST'])]
+    public function login(#[CurrentUser] ?User $user): JsonResponse
+    {
+        if (null === $user) {
+            return $this->json([
+                'error' => 'Invalid credentials.',
+            ], 401);
+        }
+
+        return $this->json([
+            'id' => $user->getId(),
+            'email' => $user->getEmail(),
+            'roles' => $user->getRoles(),
+        ]);
+    }
+
+    #[Route('/api/me', name: 'api_me', methods: ['GET'])]
+    public function me(#[CurrentUser] ?User $user): JsonResponse
+    {
+        if (null === $user) {
+            return $this->json(['error' => 'Not authenticated.'], 401);
+        }
+
+        return $this->json([
+            'id' => $user->getId(),
+            'email' => $user->getEmail(),
+            'roles' => $user->getRoles(),
+        ]);
+    }
+}

--- a/api/src/DataFixtures/AppFixtures.php
+++ b/api/src/DataFixtures/AppFixtures.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\DataFixtures;
+
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+
+class AppFixtures extends Fixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        // $product = new Product();
+        // $manager->persist($product);
+
+        $manager->flush();
+    }
+}

--- a/api/src/DataFixtures/UserFixtures.php
+++ b/api/src/DataFixtures/UserFixtures.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\DataFixtures;
+
+use App\Entity\User;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+class UserFixtures extends Fixture
+{
+    public function __construct(
+        private UserPasswordHasherInterface $passwordHasher,
+    ) {
+    }
+
+    public function load(ObjectManager $manager): void
+    {
+        $admin = new User();
+        $admin->setEmail('admin@aura.test');
+        $admin->setRoles(['ROLE_ADMIN']);
+        $admin->setPassword($this->passwordHasher->hashPassword($admin, 'admin123'));
+        $manager->persist($admin);
+
+        $user = new User();
+        $user->setEmail('user@aura.test');
+        $user->setRoles(['ROLE_USER']);
+        $user->setPassword($this->passwordHasher->hashPassword($user, 'user123'));
+        $manager->persist($user);
+
+        $manager->flush();
+    }
+}

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Post;
+use App\State\UserPasswordHasherProcessor;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new GetCollection(security: "is_granted('ROLE_ADMIN')"),
+        new Post(processor: UserPasswordHasherProcessor::class),
+        new Get(security: "is_granted('ROLE_ADMIN') or object == user"),
+    ],
+    normalizationContext: ['groups' => ['user:read']],
+    denormalizationContext: ['groups' => ['user:write']],
+)]
+#[ORM\Entity]
+#[ORM\Table(name: '`user`')]
+#[UniqueEntity('email', message: 'This email is already registered.')]
+class User implements UserInterface, PasswordAuthenticatedUserInterface
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
+    #[Groups(['user:read'])]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 180, unique: true)]
+    #[Assert\NotBlank]
+    #[Assert\Email]
+    #[Groups(['user:read', 'user:write'])]
+    private string $email = '';
+
+    #[ORM\Column]
+    private string $password = '';
+
+    #[Assert\NotBlank(groups: ['user:write'])]
+    #[Assert\Length(min: 6, minMessage: 'Password must be at least {{ limit }} characters.')]
+    #[Groups(['user:write'])]
+    private ?string $plainPassword = null;
+
+    /** @var string[] */
+    #[ORM\Column(type: 'json')]
+    #[Groups(['user:read'])]
+    private array $roles = [];
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(string $email): static
+    {
+        $this->email = $email;
+        return $this;
+    }
+
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+
+    public function setPassword(string $password): static
+    {
+        $this->password = $password;
+        return $this;
+    }
+
+    public function getPlainPassword(): ?string
+    {
+        return $this->plainPassword;
+    }
+
+    public function setPlainPassword(?string $plainPassword): static
+    {
+        $this->plainPassword = $plainPassword;
+        return $this;
+    }
+
+    /** @return string[] */
+    public function getRoles(): array
+    {
+        $roles = $this->roles;
+        $roles[] = 'ROLE_USER';
+        return array_unique($roles);
+    }
+
+    /** @param string[] $roles */
+    public function setRoles(array $roles): static
+    {
+        $this->roles = $roles;
+        return $this;
+    }
+
+    public function getUserIdentifier(): string
+    {
+        return $this->email;
+    }
+
+    public function eraseCredentials(): void
+    {
+        $this->plainPassword = null;
+    }
+}

--- a/api/src/State/UserPasswordHasherProcessor.php
+++ b/api/src/State/UserPasswordHasherProcessor.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\Entity\User;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * @implements ProcessorInterface<User, User>
+ */
+final class UserPasswordHasherProcessor implements ProcessorInterface
+{
+    /**
+     * @param ProcessorInterface<User, User> $persistProcessor
+     */
+    public function __construct(
+        #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
+        private ProcessorInterface $persistProcessor,
+        private UserPasswordHasherInterface $passwordHasher,
+    ) {
+    }
+
+    /**
+     * @param User $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): User
+    {
+        if ($data->getPlainPassword()) {
+            $data->setPassword(
+                $this->passwordHasher->hashPassword($data, $data->getPlainPassword())
+            );
+            $data->eraseCredentials();
+        }
+
+        return $this->persistProcessor->process($data, $operation, $uriVariables, $context);
+    }
+}

--- a/api/symfony.lock
+++ b/api/symfony.lock
@@ -13,6 +13,15 @@
             "src/ApiResource/.gitignore"
         ]
     },
+    "doctrine/deprecations": {
+        "version": "1.1",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "1.0",
+            "ref": "fdd756167454623e21f1d769c5b814b243782a67"
+        }
+    },
     "doctrine/doctrine-bundle": {
         "version": "2.13",
         "recipe": {
@@ -25,6 +34,18 @@
             "config/packages/doctrine.yaml",
             "src/Entity/.gitignore",
             "src/Repository/.gitignore"
+        ]
+    },
+    "doctrine/doctrine-fixtures-bundle": {
+        "version": "4.3",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "3.0",
+            "ref": "1f5514cfa15b947298df4d771e694e578d4c204d"
+        },
+        "files": [
+            "src/DataFixtures/AppFixtures.php"
         ]
     },
     "doctrine/doctrine-migrations-bundle": {

--- a/api/tests/Api/UserTest.php
+++ b/api/tests/Api/UserTest.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+class UserTest extends ApiTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $this->entityManager = $kernel->getContainer()
+            ->get('doctrine')
+            ->getManager();
+
+        // Clean user table before each test
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testRegisterUser(): void
+    {
+        $client = static::createClient();
+        $client->request('POST', '/users', [
+            'json' => [
+                'email' => 'newuser@example.com',
+                'plainPassword' => 'password123',
+            ],
+            'headers' => [
+                'Content-Type' => 'application/ld+json',
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertJsonContains([
+            '@type' => 'User',
+            'email' => 'newuser@example.com',
+        ]);
+
+        // Password should not be in response
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertArrayNotHasKey('password', $response);
+        $this->assertArrayNotHasKey('plainPassword', $response);
+    }
+
+    public function testRegisterDuplicateEmail(): void
+    {
+        $this->createTestUser('existing@example.com', 'password123');
+
+        static::createClient()->request('POST', '/users', [
+            'json' => [
+                'email' => 'existing@example.com',
+                'plainPassword' => 'password123',
+            ],
+            'headers' => [
+                'Content-Type' => 'application/ld+json',
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testRegisterInvalidEmail(): void
+    {
+        static::createClient()->request('POST', '/users', [
+            'json' => [
+                'email' => 'not-an-email',
+                'plainPassword' => 'password123',
+            ],
+            'headers' => [
+                'Content-Type' => 'application/ld+json',
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testRegisterBlankPassword(): void
+    {
+        static::createClient()->request('POST', '/users', [
+            'json' => [
+                'email' => 'test@example.com',
+                'plainPassword' => '',
+            ],
+            'headers' => [
+                'Content-Type' => 'application/ld+json',
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testRegisterShortPassword(): void
+    {
+        static::createClient()->request('POST', '/users', [
+            'json' => [
+                'email' => 'test@example.com',
+                'plainPassword' => 'ab',
+            ],
+            'headers' => [
+                'Content-Type' => 'application/ld+json',
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testLoginSuccess(): void
+    {
+        $this->createTestUser('login@example.com', 'password123');
+
+        $client = static::createClient();
+        $client->request('POST', '/auth/login', [
+            'json' => [
+                'email' => 'login@example.com',
+                'password' => 'password123',
+            ],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains([
+            'email' => 'login@example.com',
+        ]);
+    }
+
+    public function testLoginWrongPassword(): void
+    {
+        $this->createTestUser('login@example.com', 'password123');
+
+        $client = static::createClient();
+        $client->request('POST', '/auth/login', [
+            'json' => [
+                'email' => 'login@example.com',
+                'password' => 'wrongpassword',
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(401);
+    }
+
+    public function testGetMeAuthenticated(): void
+    {
+        $user = $this->createTestUser('me@example.com', 'password123');
+
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        $client->request('GET', '/api/me');
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains([
+            'email' => 'me@example.com',
+        ]);
+    }
+
+    public function testGetMeUnauthenticated(): void
+    {
+        static::createClient()->request('GET', '/api/me');
+        $this->assertResponseStatusCodeSame(401);
+    }
+
+    private function createTestUser(string $email, string $plainPassword, array $roles = ['ROLE_USER']): User
+    {
+        $container = static::getContainer();
+        /** @var UserPasswordHasherInterface $hasher */
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles($roles);
+        $user->setPassword($hasher->hashPassword($user, $plainPassword));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/e2e/tests/auth.spec.js
+++ b/e2e/tests/auth.spec.js
@@ -1,0 +1,109 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+
+const BASE_URL = "https://localhost";
+
+// Generate unique email per test run to avoid conflicts
+const uniqueEmail = () => `test-${Date.now()}@example.com`;
+
+test.describe("Authentication", () => {
+  test("sign up with valid credentials", async ({ page }) => {
+    const email = uniqueEmail();
+
+    await page.goto(`${BASE_URL}/signup`);
+    await expect(page).toHaveTitle("Sign Up - Aura");
+
+    await page.fill("#email", email);
+    await page.fill("#password", "password123");
+    await page.fill("#confirmPassword", "password123");
+    await page.click('button[type="submit"]');
+
+    // Should redirect to sign-in with success message
+    await expect(page).toHaveURL(/\/signin\?registered=true/);
+    await expect(page.locator("text=Account created successfully")).toBeVisible();
+  });
+
+  test("sign up shows validation errors", async ({ page }) => {
+    await page.goto(`${BASE_URL}/signup`);
+
+    // Submit empty form
+    await page.click('button[type="submit"]');
+    await expect(page.locator("text=Email is required")).toBeVisible();
+    await expect(page.locator("text=Password is required")).toBeVisible();
+  });
+
+  test("sign up shows password mismatch error", async ({ page }) => {
+    await page.goto(`${BASE_URL}/signup`);
+
+    await page.fill("#email", uniqueEmail());
+    await page.fill("#password", "password123");
+    await page.fill("#confirmPassword", "different");
+    await page.click('button[type="submit"]');
+
+    await expect(page.locator("text=Passwords do not match")).toBeVisible();
+  });
+
+  test("sign in with valid credentials", async ({ page }) => {
+    // Register first via API
+    const email = uniqueEmail();
+    const res = await page.request.post(`${BASE_URL}/users`, {
+      headers: { "Content-Type": "application/ld+json" },
+      data: { email, plainPassword: "password123" },
+    });
+    expect(res.ok()).toBeTruthy();
+
+    // Sign in via UI
+    await page.goto(`${BASE_URL}/signin`);
+    await expect(page).toHaveTitle("Sign In - Aura");
+
+    await page.fill("#email", email);
+    await page.fill("#password", "password123");
+    await page.click('button[type="submit"]');
+
+    // Should redirect to account page
+    await expect(page).toHaveURL(/\/account/);
+    await expect(page.locator(`text=${email}`)).toBeVisible();
+  });
+
+  test("sign in with invalid credentials shows error", async ({ page }) => {
+    await page.goto(`${BASE_URL}/signin`);
+
+    await page.fill("#email", "nonexistent@example.com");
+    await page.fill("#password", "wrongpassword");
+    await page.click('button[type="submit"]');
+
+    await expect(page.locator("text=Invalid credentials")).toBeVisible();
+  });
+
+  test("sign in with fixture admin user accesses admin page", async ({ page }) => {
+    await page.goto(`${BASE_URL}/signin`);
+    await page.fill("#email", "admin@aura.test");
+    await page.fill("#password", "admin123");
+    await page.click('button[type="submit"]');
+
+    await expect(page).toHaveURL(/\/account/);
+
+    // Navigate to admin
+    await page.goto(`${BASE_URL}/admin`);
+    // Admin page should load (not show access denied)
+    await expect(page.locator("text=Access Denied")).not.toBeVisible();
+  });
+
+  test("sign in with fixture standard user denied admin access", async ({ page }) => {
+    await page.goto(`${BASE_URL}/signin`);
+    await page.fill("#email", "user@aura.test");
+    await page.fill("#password", "user123");
+    await page.click('button[type="submit"]');
+
+    await expect(page).toHaveURL(/\/account/);
+
+    // Navigate to admin — should show access denied
+    await page.goto(`${BASE_URL}/admin`);
+    await expect(page.locator("text=Access Denied")).toBeVisible();
+  });
+
+  test("account page redirects unauthenticated users to sign in", async ({ page }) => {
+    await page.goto(`${BASE_URL}/account`);
+    await expect(page).toHaveURL(/\/signin/);
+  });
+});

--- a/pwa/components/admin/App.tsx
+++ b/pwa/components/admin/App.tsx
@@ -1,10 +1,10 @@
-import { HydraAdmin } from "@api-platform/admin";
+import { HydraAdmin, ResourceGuesser } from "@api-platform/admin";
 
 const App = () => (
-  <HydraAdmin
-    entrypoint={window.origin}
-    title="API Platform admin"
-  ></HydraAdmin>
+  <HydraAdmin entrypoint={window.origin} title="Aura Admin">
+    <ResourceGuesser name="users" />
+    <ResourceGuesser name="greetings" />
+  </HydraAdmin>
 );
 
 export default App;

--- a/pwa/components/common/Layout.tsx
+++ b/pwa/components/common/Layout.tsx
@@ -5,6 +5,8 @@ import {
   QueryClient,
   QueryClientProvider,
 } from "@tanstack/react-query";
+import { AuthProvider } from "../../contexts/AuthContext";
+import Navbar from "./Navbar";
 
 const Layout = ({
   children,
@@ -17,7 +19,12 @@ const Layout = ({
 
   return (
     <QueryClientProvider client={queryClient}>
-      <HydrationBoundary state={dehydratedState}>{children}</HydrationBoundary>
+      <HydrationBoundary state={dehydratedState}>
+        <AuthProvider>
+          <Navbar />
+          {children}
+        </AuthProvider>
+      </HydrationBoundary>
     </QueryClientProvider>
   );
 };

--- a/pwa/components/common/Navbar.tsx
+++ b/pwa/components/common/Navbar.tsx
@@ -1,0 +1,52 @@
+import Link from "next/link";
+import { useAuth } from "../../contexts/AuthContext";
+
+const Navbar = () => {
+  const { user, isAuthenticated, logout } = useAuth();
+  const isAdmin = user?.roles?.includes("ROLE_ADMIN");
+
+  return (
+    <nav className="bg-cyan-700 text-white">
+      <div className="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
+        <Link href="/" className="text-white font-bold text-lg no-underline">
+          Aura
+        </Link>
+
+        <div className="flex items-center gap-4">
+          {isAuthenticated ? (
+            <>
+              {isAdmin && (
+                <Link href="/admin" className="text-cyan-200 hover:text-white no-underline text-sm">
+                  Admin
+                </Link>
+              )}
+              <Link href="/account" className="text-cyan-200 hover:text-white no-underline text-sm">
+                My Account
+              </Link>
+              <button
+                onClick={logout}
+                className="text-cyan-200 hover:text-white text-sm bg-transparent border-0 cursor-pointer"
+              >
+                Sign Out
+              </button>
+            </>
+          ) : (
+            <>
+              <Link href="/signin" className="text-cyan-200 hover:text-white no-underline text-sm">
+                Sign In
+              </Link>
+              <Link
+                href="/signup"
+                className="bg-white text-cyan-700 px-3 py-1 rounded text-sm font-semibold no-underline hover:bg-cyan-100"
+              >
+                Sign Up
+              </Link>
+            </>
+          )}
+        </div>
+      </div>
+    </nav>
+  );
+};
+
+export default Navbar;

--- a/pwa/contexts/AuthContext.tsx
+++ b/pwa/contexts/AuthContext.tsx
@@ -1,0 +1,117 @@
+import React, { createContext, useContext, useState, useEffect, useCallback, ReactNode } from "react";
+import { ENTRYPOINT } from "../config/entrypoint";
+
+interface User {
+  id: number;
+  email: string;
+  roles: string[];
+}
+
+interface AuthContextType {
+  user: User | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  register: (email: string, password: string) => Promise<void>;
+  logout: () => void;
+  error: string | null;
+  clearError: () => void;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const clearError = useCallback(() => setError(null), []);
+
+  const fetchMe = useCallback(async () => {
+    try {
+      const res = await fetch(`${ENTRYPOINT}/api/me`, { credentials: "include" });
+      if (res.ok) {
+        const data = await res.json();
+        setUser(data);
+      } else {
+        setUser(null);
+      }
+    } catch {
+      setUser(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchMe();
+  }, [fetchMe]);
+
+  const login = useCallback(async (email: string, password: string) => {
+    setError(null);
+    const res = await fetch(`${ENTRYPOINT}/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({ email, password }),
+    });
+
+    if (!res.ok) {
+      const data = await res.json();
+      throw new Error(data.error || "Invalid credentials.");
+    }
+
+    const data = await res.json();
+    setUser(data);
+  }, []);
+
+  const register = useCallback(async (email: string, password: string) => {
+    setError(null);
+    const res = await fetch(`${ENTRYPOINT}/users`, {
+      method: "POST",
+      headers: { "Content-Type": "application/ld+json" },
+      credentials: "include",
+      body: JSON.stringify({ email, plainPassword: password }),
+    });
+
+    if (!res.ok) {
+      const data = await res.json();
+      const message =
+        data["hydra:description"] || data.detail || "Registration failed.";
+      throw new Error(message);
+    }
+  }, []);
+
+  const logout = useCallback(() => {
+    setUser(null);
+    fetch(`${ENTRYPOINT}/auth/logout`, {
+      method: "POST",
+      credentials: "include",
+    }).catch(() => {});
+  }, []);
+
+  return (
+    <AuthContext.Provider
+      value={{
+        user,
+        isAuthenticated: !!user,
+        isLoading,
+        login,
+        register,
+        logout,
+        error,
+        clearError,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthContextType {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+  return context;
+}

--- a/pwa/pages/account.tsx
+++ b/pwa/pages/account.tsx
@@ -1,0 +1,73 @@
+import Head from "next/head";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+import { useAuth } from "../contexts/AuthContext";
+
+const Account = () => {
+  const { user, isAuthenticated, isLoading, logout } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated) {
+      router.push("/signin");
+    }
+  }, [isLoading, isAuthenticated, router]);
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <p className="text-gray-500">Loading...</p>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return null;
+  }
+
+  return (
+    <>
+      <Head>
+        <title>My Account - Aura</title>
+      </Head>
+      <div className="min-h-screen bg-gray-50 px-4 py-12">
+        <div className="max-w-md mx-auto bg-white rounded-lg shadow-card p-8">
+          <h1 className="text-2xl font-bold text-black mb-6">My Account</h1>
+
+          <div className="space-y-4">
+            <div>
+              <p className="text-sm font-medium text-gray-500">Email</p>
+              <p className="text-black">{user.email}</p>
+            </div>
+
+            <div>
+              <p className="text-sm font-medium text-gray-500">Roles</p>
+              <div className="flex gap-2 mt-1">
+                {user.roles.map((role) => (
+                  <span
+                    key={role}
+                    className="inline-block bg-cyan-100 text-cyan-700 text-xs font-medium px-2 py-1 rounded"
+                  >
+                    {role}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <button
+            onClick={() => {
+              logout();
+              router.push("/");
+            }}
+            className="mt-8 w-full bg-red-500 text-white py-2 px-4 rounded-md font-semibold hover:bg-red-600"
+          >
+            Sign Out
+          </button>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default Account;

--- a/pwa/pages/admin/index.tsx
+++ b/pwa/pages/admin/index.tsx
@@ -1,5 +1,9 @@
 import type { NextPage } from "next";
 import dynamic from "next/dynamic";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+import Head from "next/head";
+import { useAuth } from "../../contexts/AuthContext";
 
 // load the admin client-side
 const App = dynamic(() => import("../../components/admin/App"), {
@@ -7,6 +11,46 @@ const App = dynamic(() => import("../../components/admin/App"), {
   loading: () => <p>Loading...</p>,
 });
 
-const Admin: NextPage = () => <App />;
+const Admin: NextPage = () => {
+  const { user, isAuthenticated, isLoading } = useAuth();
+  const router = useRouter();
+  const isAdmin = user?.roles?.includes("ROLE_ADMIN");
+
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated) {
+      router.push("/signin");
+    }
+  }, [isLoading, isAuthenticated, router]);
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <p className="text-gray-500">Loading...</p>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return null;
+  }
+
+  if (!isAdmin) {
+    return (
+      <>
+        <Head>
+          <title>Access Denied - Aura</title>
+        </Head>
+        <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+          <div className="text-center">
+            <h1 className="text-2xl font-bold text-black mb-2">Access Denied</h1>
+            <p className="text-gray-600">You need administrator privileges to view this page.</p>
+          </div>
+        </div>
+      </>
+    );
+  }
+
+  return <App />;
+};
 
 export default Admin;

--- a/pwa/pages/signin.tsx
+++ b/pwa/pages/signin.tsx
@@ -1,0 +1,123 @@
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { Formik, Form, Field, ErrorMessage } from "formik";
+import { useAuth } from "../contexts/AuthContext";
+
+interface SignInValues {
+  email: string;
+  password: string;
+}
+
+const validate = (values: SignInValues) => {
+  const errors: Partial<SignInValues> = {};
+
+  if (!values.email) {
+    errors.email = "Email is required.";
+  }
+
+  if (!values.password) {
+    errors.password = "Password is required.";
+  }
+
+  return errors;
+};
+
+const SignIn = () => {
+  const { login } = useAuth();
+  const router = useRouter();
+  const registered = router.query.registered === "true";
+
+  return (
+    <>
+      <Head>
+        <title>Sign In - Aura</title>
+      </Head>
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+        <div className="w-full max-w-md bg-white rounded-lg shadow-card p-8">
+          <h1 className="text-2xl font-bold text-center text-black mb-6">
+            Sign In
+          </h1>
+
+          {registered && (
+            <div className="bg-green-50 text-green-700 p-3 rounded text-sm mb-4">
+              Account created successfully. Please sign in.
+            </div>
+          )}
+
+          <Formik<SignInValues>
+            initialValues={{ email: "", password: "" }}
+            validate={validate}
+            onSubmit={async (values, { setSubmitting, setStatus }) => {
+              try {
+                await login(values.email, values.password);
+                router.push("/account");
+              } catch (err) {
+                setStatus(
+                  err instanceof Error ? err.message : "Sign in failed."
+                );
+              } finally {
+                setSubmitting(false);
+              }
+            }}
+          >
+            {({ isSubmitting, status }) => (
+              <Form className="space-y-4" noValidate>
+                {status && (
+                  <div className="bg-red-50 text-red-500 p-3 rounded text-sm">
+                    {status}
+                  </div>
+                )}
+
+                <div>
+                  <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
+                    Email
+                  </label>
+                  <Field
+                    id="email"
+                    name="email"
+                    type="email"
+                    className="w-full rounded-md border-gray-300 shadow-sm focus:border-cyan-500 focus:ring-cyan-500"
+                    placeholder="you@example.com"
+                  />
+                  <ErrorMessage name="email" component="p" className="mt-1 text-sm text-red-500" />
+                </div>
+
+                <div>
+                  <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
+                    Password
+                  </label>
+                  <Field
+                    id="password"
+                    name="password"
+                    type="password"
+                    className="w-full rounded-md border-gray-300 shadow-sm focus:border-cyan-500 focus:ring-cyan-500"
+                    placeholder="Your password"
+                  />
+                  <ErrorMessage name="password" component="p" className="mt-1 text-sm text-red-500" />
+                </div>
+
+                <button
+                  type="submit"
+                  disabled={isSubmitting}
+                  className="w-full bg-cyan-700 text-white py-2 px-4 rounded-md font-semibold hover:bg-cyan-800 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {isSubmitting ? "Signing In..." : "Sign In"}
+                </button>
+
+                <p className="text-center text-sm text-gray-600">
+                  Don&apos;t have an account?{" "}
+                  <Link href="/signup" className="text-cyan-700 font-medium">
+                    Sign Up
+                  </Link>
+                </p>
+              </Form>
+            )}
+          </Formik>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default SignIn;

--- a/pwa/pages/signup.tsx
+++ b/pwa/pages/signup.tsx
@@ -1,0 +1,141 @@
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { Formik, Form, Field, ErrorMessage } from "formik";
+import { useAuth } from "../contexts/AuthContext";
+
+interface SignUpValues {
+  email: string;
+  password: string;
+  confirmPassword: string;
+}
+
+const validate = (values: SignUpValues) => {
+  const errors: Partial<SignUpValues> = {};
+
+  if (!values.email) {
+    errors.email = "Email is required.";
+  } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(values.email)) {
+    errors.email = "Invalid email address.";
+  }
+
+  if (!values.password) {
+    errors.password = "Password is required.";
+  } else if (values.password.length < 6) {
+    errors.password = "Password must be at least 6 characters.";
+  }
+
+  if (!values.confirmPassword) {
+    errors.confirmPassword = "Please confirm your password.";
+  } else if (values.password !== values.confirmPassword) {
+    errors.confirmPassword = "Passwords do not match.";
+  }
+
+  return errors;
+};
+
+const SignUp = () => {
+  const { register } = useAuth();
+  const router = useRouter();
+
+  return (
+    <>
+      <Head>
+        <title>Sign Up - Aura</title>
+      </Head>
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+        <div className="w-full max-w-md bg-white rounded-lg shadow-card p-8">
+          <h1 className="text-2xl font-bold text-center text-black mb-6">
+            Create an Account
+          </h1>
+
+          <Formik<SignUpValues>
+            initialValues={{ email: "", password: "", confirmPassword: "" }}
+            validate={validate}
+            onSubmit={async (values, { setSubmitting, setStatus }) => {
+              try {
+                await register(values.email, values.password);
+                router.push("/signin?registered=true");
+              } catch (err) {
+                setStatus(
+                  err instanceof Error ? err.message : "Registration failed."
+                );
+              } finally {
+                setSubmitting(false);
+              }
+            }}
+          >
+            {({ isSubmitting, status }) => (
+              <Form className="space-y-4" noValidate>
+                {status && (
+                  <div className="bg-red-50 text-red-500 p-3 rounded text-sm">
+                    {status}
+                  </div>
+                )}
+
+                <div>
+                  <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
+                    Email
+                  </label>
+                  <Field
+                    id="email"
+                    name="email"
+                    type="email"
+                    className="w-full rounded-md border-gray-300 shadow-sm focus:border-cyan-500 focus:ring-cyan-500"
+                    placeholder="you@example.com"
+                  />
+                  <ErrorMessage name="email" component="p" className="mt-1 text-sm text-red-500" />
+                </div>
+
+                <div>
+                  <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
+                    Password
+                  </label>
+                  <Field
+                    id="password"
+                    name="password"
+                    type="password"
+                    className="w-full rounded-md border-gray-300 shadow-sm focus:border-cyan-500 focus:ring-cyan-500"
+                    placeholder="At least 6 characters"
+                  />
+                  <ErrorMessage name="password" component="p" className="mt-1 text-sm text-red-500" />
+                </div>
+
+                <div>
+                  <label htmlFor="confirmPassword" className="block text-sm font-medium text-gray-700 mb-1">
+                    Confirm Password
+                  </label>
+                  <Field
+                    id="confirmPassword"
+                    name="confirmPassword"
+                    type="password"
+                    className="w-full rounded-md border-gray-300 shadow-sm focus:border-cyan-500 focus:ring-cyan-500"
+                    placeholder="Re-enter your password"
+                  />
+                  <ErrorMessage name="confirmPassword" component="p" className="mt-1 text-sm text-red-500" />
+                </div>
+
+                <button
+                  type="submit"
+                  disabled={isSubmitting}
+                  className="w-full bg-cyan-700 text-white py-2 px-4 rounded-md font-semibold hover:bg-cyan-800 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {isSubmitting ? "Creating Account..." : "Sign Up"}
+                </button>
+
+                <p className="text-center text-sm text-gray-600">
+                  Already have an account?{" "}
+                  <Link href="/signin" className="text-cyan-700 font-medium">
+                    Sign In
+                  </Link>
+                </p>
+              </Form>
+            )}
+          </Formik>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default SignUp;


### PR DESCRIPTION
## Summary
- Full-stack email/password registration and login with session-based authentication
- User entity with validation (unique email, min 6 char password), role-based access control, and password hashing via API Platform state processor
- Frontend auth pages (Sign Up, Sign In, My Account, Admin) with Formik validation, AuthContext provider, and Navbar with auth-aware navigation
- Test fixtures for admin and standard user accounts
- 9 PHPUnit API tests and 8 Playwright E2E tests covering registration, login, validation errors, role-based page access, and unauthenticated redirects

## Test plan
- [ ] All PHPUnit tests pass (9/9 in UserTest)
- [ ] E2E tests cover sign up, sign in, validation, role-based access
- [ ] Sign up form validates email, password length, password match
- [ ] Sign in redirects to account page on success
- [ ] Account page is protected (redirects unauthenticated users)
- [ ] Admin page restricted to ROLE_ADMIN users
- [ ] Fixture users (admin@aura.test, user@aura.test) work correctly

Fixes #20