### PR TITLE
Add password change and password reset flows

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -46,3 +46,7 @@ MERCURE_PUBLIC_URL=https://localhost/.well-known/mercure
 # The secret used to sign the JWTs
 MERCURE_JWT_SECRET="!ChangeThisMercureHubJWTSecretKey!"
 ###< symfony/mercure-bundle ###
+
+###> symfony/mailer ###
+MAILER_DSN=null://null
+###< symfony/mailer ###

--- a/api/composer.json
+++ b/api/composer.json
@@ -20,6 +20,7 @@
         "symfony/expression-language": "7.2.*",
         "symfony/flex": "^2.2",
         "symfony/framework-bundle": "7.2.*",
+        "symfony/mailer": "7.2.*",
         "symfony/mercure-bundle": "^0.3.5",
         "symfony/monolog-bundle": "^3.8",
         "symfony/property-access": "7.2.*",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ffed57acb84358601cfa78d066a552bd",
+    "content-hash": "2306a53229a835566a517678014d0423",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -2335,6 +2335,73 @@
                 "source": "https://github.com/doctrine/sql-formatter/tree/1.5.2"
             },
             "time": "2025-01-24T11:45:48+00:00"
+        },
+        {
+            "name": "egulias/email-validator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/egulias/EmailValidator.git",
+                "reference": "d42c8731f0624ad6bdc8d3e5e9a4524f68801cfa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/d42c8731f0624ad6bdc8d3e5e9a4524f68801cfa",
+                "reference": "d42c8731f0624ad6bdc8d3e5e9a4524f68801cfa",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "^2.0 || ^3.0",
+                "php": ">=8.1",
+                "symfony/polyfill-intl-idn": "^1.26"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.2",
+                "vimeo/psalm": "^5.12"
+            },
+            "suggest": {
+                "ext-intl": "PHP Internationalization Libraries are required to use the SpoofChecking validation"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Egulias\\EmailValidator\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Eduardo Gulias Davis"
+                }
+            ],
+            "description": "A library for validating emails against several RFCs",
+            "homepage": "https://github.com/egulias/EmailValidator",
+            "keywords": [
+                "email",
+                "emailvalidation",
+                "emailvalidator",
+                "validation",
+                "validator"
+            ],
+            "support": {
+                "issues": "https://github.com/egulias/EmailValidator/issues",
+                "source": "https://github.com/egulias/EmailValidator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/egulias",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-06T22:45:56+00:00"
         },
         {
             "name": "lcobucci/jwt",
@@ -5034,6 +5101,90 @@
             "time": "2025-07-31T09:36:38+00:00"
         },
         {
+            "name": "symfony/mailer",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/mailer.git",
+                "reference": "aa8d1d5df027626c3cbe2f5f185118cc461fe4ea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/aa8d1d5df027626c3cbe2f5f185118cc461fe4ea",
+                "reference": "aa8d1d5df027626c3cbe2f5f185118cc461fe4ea",
+                "shasum": ""
+            },
+            "require": {
+                "egulias/email-validator": "^2.1.10|^3|^4",
+                "php": ">=8.2",
+                "psr/event-dispatcher": "^1",
+                "psr/log": "^1|^2|^3",
+                "symfony/event-dispatcher": "^6.4|^7.0",
+                "symfony/mime": "^7.2",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/http-client-contracts": "<2.5",
+                "symfony/http-kernel": "<6.4",
+                "symfony/messenger": "<6.4",
+                "symfony/mime": "<6.4",
+                "symfony/twig-bridge": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0",
+                "symfony/http-client": "^6.4|^7.0",
+                "symfony/messenger": "^6.4|^7.0",
+                "symfony/twig-bridge": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mailer\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Helps sending emails",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/mailer/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-15T11:30:57+00:00"
+        },
+        {
             "name": "symfony/mercure",
             "version": "v0.6.5",
             "source": {
@@ -5199,6 +5350,94 @@
                 }
             ],
             "time": "2024-05-31T09:07:18+00:00"
+        },
+        {
+            "name": "symfony/mime",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/mime.git",
+                "reference": "e0a0f859148daf1edf6c60b398eb40bfc96697d1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/e0a0f859148daf1edf6c60b398eb40bfc96697d1",
+                "reference": "e0a0f859148daf1edf6c60b398eb40bfc96697d1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-intl-idn": "^1.10",
+                "symfony/polyfill-mbstring": "^1.0"
+            },
+            "conflict": {
+                "egulias/email-validator": "~3.0.0",
+                "phpdocumentor/reflection-docblock": "<3.2.2",
+                "phpdocumentor/type-resolver": "<1.4.0",
+                "symfony/mailer": "<6.4",
+                "symfony/serializer": "<6.4.3|>7.0,<7.0.3"
+            },
+            "require-dev": {
+                "egulias/email-validator": "^2.1.10|^3.1|^4",
+                "league/html-to-markdown": "^5.0",
+                "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/process": "^6.4|^7.0",
+                "symfony/property-access": "^6.4|^7.0",
+                "symfony/property-info": "^6.4|^7.0",
+                "symfony/serializer": "^6.4.3|^7.0.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mime\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows manipulating MIME messages",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "mime",
+                "mime-type"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/mime/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-15T13:41:35+00:00"
         },
         {
             "name": "symfony/monolog-bridge",
@@ -5430,6 +5669,93 @@
                 }
             ],
             "time": "2024-09-25T14:21:43+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-idn",
+            "version": "v1.36.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-idn.git",
+                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/9614ac4d8061dc257ecc64cba1b140873dce8ad3",
+                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2",
+                "symfony/polyfill-intl-normalizer": "^1.10"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Laurent Bassin",
+                    "email": "laurent@bassin.info"
+                },
+                {
+                    "name": "Trevor Rowbotham",
+                    "email": "trevor.rowbotham@pm.me"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's idn_to_ascii and idn_to_utf8 functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "idn",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.36.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-10T14:38:51+00:00"
         },
         {
             "name": "symfony/polyfill-uuid",

--- a/api/config/packages/mailer.yaml
+++ b/api/config/packages/mailer.yaml
@@ -1,0 +1,3 @@
+framework:
+    mailer:
+        dsn: '%env(MAILER_DSN)%'

--- a/api/config/packages/security.yaml
+++ b/api/config/packages/security.yaml
@@ -26,6 +26,9 @@ security:
     access_control:
         - { path: ^/users$, methods: [POST], roles: PUBLIC_ACCESS }
         - { path: ^/auth/login$, roles: PUBLIC_ACCESS }
+        - { path: ^/auth/forgot-password$, roles: PUBLIC_ACCESS }
+        - { path: ^/auth/reset-password$, roles: PUBLIC_ACCESS }
+        - { path: ^/auth/change-password$, roles: ROLE_USER }
         - { path: ^/api/me$, roles: ROLE_USER }
         - { path: ^/docs, roles: PUBLIC_ACCESS }
         - { path: ^/, roles: PUBLIC_ACCESS }

--- a/api/migrations/Version20260422012820.php
+++ b/api/migrations/Version20260422012820.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260422012820 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE SEQUENCE password_reset_token_id_seq INCREMENT BY 1 MINVALUE 1 START 1');
+        $this->addSql('CREATE TABLE password_reset_token (id INT NOT NULL, token_hash VARCHAR(64) NOT NULL, expires_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, used_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, user_id INT NOT NULL, PRIMARY KEY (id))');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_6B7BA4B6B3BC57DA ON password_reset_token (token_hash)');
+        $this->addSql('CREATE INDEX IDX_6B7BA4B6A76ED395 ON password_reset_token (user_id)');
+        $this->addSql('CREATE INDEX idx_token_hash ON password_reset_token (token_hash)');
+        $this->addSql('ALTER TABLE password_reset_token ADD CONSTRAINT FK_6B7BA4B6A76ED395 FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP SEQUENCE password_reset_token_id_seq CASCADE');
+        $this->addSql('ALTER TABLE password_reset_token DROP CONSTRAINT FK_6B7BA4B6A76ED395');
+        $this->addSql('DROP TABLE password_reset_token');
+    }
+}

--- a/api/src/Controller/PasswordController.php
+++ b/api/src/Controller/PasswordController.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\PasswordResetToken;
+use App\Entity\User;
+use App\Repository\PasswordResetTokenRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+
+class PasswordController extends AbstractController
+{
+    private const RESET_TOKEN_TTL_HOURS = 1;
+    private const MIN_PASSWORD_LENGTH = 6;
+
+    public function __construct(
+        private EntityManagerInterface $em,
+        private UserPasswordHasherInterface $hasher,
+        private PasswordResetTokenRepository $tokenRepository,
+        private MailerInterface $mailer,
+        #[Autowire('%env(APP_FRONTEND_URL)%')]
+        private string $frontendUrl,
+        #[Autowire('%env(default::MAILER_FROM)%')]
+        private ?string $mailerFrom = null,
+    ) {
+    }
+
+    #[Route('/auth/change-password', name: 'auth_change_password', methods: ['POST'])]
+    public function changePassword(Request $request, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if (null === $user) {
+            return $this->json(['error' => 'Not authenticated.'], 401);
+        }
+
+        $data = json_decode($request->getContent(), true) ?? [];
+        $currentPassword = (string) ($data['currentPassword'] ?? '');
+        $newPassword = (string) ($data['newPassword'] ?? '');
+
+        if (!$this->hasher->isPasswordValid($user, $currentPassword)) {
+            return $this->json(['error' => 'Current password is incorrect.'], 400);
+        }
+
+        if (strlen($newPassword) < self::MIN_PASSWORD_LENGTH) {
+            return $this->json([
+                'error' => sprintf('New password must be at least %d characters.', self::MIN_PASSWORD_LENGTH),
+            ], 422);
+        }
+
+        if ($currentPassword === $newPassword) {
+            return $this->json([
+                'error' => 'New password must be different from current password.',
+            ], 422);
+        }
+
+        $user->setPassword($this->hasher->hashPassword($user, $newPassword));
+        $this->em->flush();
+
+        return $this->json(['message' => 'Password updated successfully.']);
+    }
+
+    #[Route('/auth/forgot-password', name: 'auth_forgot_password', methods: ['POST'])]
+    public function forgotPassword(Request $request): JsonResponse
+    {
+        $data = json_decode($request->getContent(), true) ?? [];
+        $email = (string) ($data['email'] ?? '');
+
+        // Always return 200 to prevent email enumeration
+        $response = $this->json([
+            'message' => 'If an account exists for that email, a reset link has been sent.',
+        ]);
+
+        if ('' === $email) {
+            return $response;
+        }
+
+        $user = $this->em->getRepository(User::class)->findOneBy(['email' => $email]);
+        if (null === $user) {
+            return $response;
+        }
+
+        // Invalidate prior outstanding tokens, then issue a fresh one
+        $this->tokenRepository->invalidateAllForUser($user->getId());
+
+        $plainToken = bin2hex(random_bytes(32));
+        $tokenHash = hash('sha256', $plainToken);
+        $expiresAt = new \DateTimeImmutable(sprintf('+%d hours', self::RESET_TOKEN_TTL_HOURS));
+
+        $resetToken = new PasswordResetToken($user, $tokenHash, $expiresAt);
+        $this->em->persist($resetToken);
+        $this->em->flush();
+
+        $this->sendResetEmail($user, $plainToken);
+
+        return $response;
+    }
+
+    #[Route('/auth/reset-password', name: 'auth_reset_password', methods: ['POST'])]
+    public function resetPassword(Request $request): JsonResponse
+    {
+        $data = json_decode($request->getContent(), true) ?? [];
+        $plainToken = (string) ($data['token'] ?? '');
+        $newPassword = (string) ($data['newPassword'] ?? '');
+
+        if ('' === $plainToken) {
+            return $this->json(['error' => 'Token is required.'], 400);
+        }
+
+        if (strlen($newPassword) < self::MIN_PASSWORD_LENGTH) {
+            return $this->json([
+                'error' => sprintf('Password must be at least %d characters.', self::MIN_PASSWORD_LENGTH),
+            ], 422);
+        }
+
+        $tokenHash = hash('sha256', $plainToken);
+        $resetToken = $this->tokenRepository->findByTokenHash($tokenHash);
+
+        if (null === $resetToken || !$resetToken->isValid()) {
+            return $this->json(['error' => 'Invalid or expired token.'], 400);
+        }
+
+        $user = $resetToken->getUser();
+        $user->setPassword($this->hasher->hashPassword($user, $newPassword));
+        $resetToken->markUsed();
+        $this->em->flush();
+
+        return $this->json(['message' => 'Password reset successfully.']);
+    }
+
+    private function sendResetEmail(User $user, string $plainToken): void
+    {
+        $resetUrl = sprintf('%s/reset-password?token=%s', rtrim($this->frontendUrl, '/'), $plainToken);
+        $from = $this->mailerFrom ?: 'no-reply@aura.test';
+
+        $email = (new Email())
+            ->from($from)
+            ->to($user->getEmail())
+            ->subject('Reset your Aura password')
+            ->text(sprintf(
+                "Hi,\n\nWe received a request to reset your Aura password. Click the link below to set a new password:\n\n%s\n\nThis link expires in %d hour(s). If you did not request a password reset, you can safely ignore this email.\n\n— Aura",
+                $resetUrl,
+                self::RESET_TOKEN_TTL_HOURS,
+            ))
+            ->html(sprintf(
+                '<p>Hi,</p><p>We received a request to reset your Aura password. Click the link below to set a new password:</p><p><a href="%1$s">%1$s</a></p><p>This link expires in %2$d hour(s). If you did not request a password reset, you can safely ignore this email.</p><p>— Aura</p>',
+                htmlspecialchars($resetUrl),
+                self::RESET_TOKEN_TTL_HOURS,
+            ));
+
+        $this->mailer->send($email);
+    }
+}

--- a/api/src/Entity/PasswordResetToken.php
+++ b/api/src/Entity/PasswordResetToken.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\PasswordResetTokenRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: PasswordResetTokenRepository::class)]
+#[ORM\Table(name: 'password_reset_token')]
+#[ORM\Index(columns: ['token_hash'], name: 'idx_token_hash')]
+class PasswordResetToken
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private User $user;
+
+    #[ORM\Column(length: 64, unique: true)]
+    private string $tokenHash;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $expiresAt;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?\DateTimeImmutable $usedAt = null;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $createdAt;
+
+    public function __construct(User $user, string $tokenHash, \DateTimeImmutable $expiresAt)
+    {
+        $this->user = $user;
+        $this->tokenHash = $tokenHash;
+        $this->expiresAt = $expiresAt;
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getUser(): User
+    {
+        return $this->user;
+    }
+
+    public function getTokenHash(): string
+    {
+        return $this->tokenHash;
+    }
+
+    public function getExpiresAt(): \DateTimeImmutable
+    {
+        return $this->expiresAt;
+    }
+
+    public function getUsedAt(): ?\DateTimeImmutable
+    {
+        return $this->usedAt;
+    }
+
+    public function markUsed(): void
+    {
+        $this->usedAt = new \DateTimeImmutable();
+    }
+
+    public function isValid(\DateTimeImmutable $now = null): bool
+    {
+        $now ??= new \DateTimeImmutable();
+        return null === $this->usedAt && $this->expiresAt > $now;
+    }
+}

--- a/api/src/Repository/PasswordResetTokenRepository.php
+++ b/api/src/Repository/PasswordResetTokenRepository.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\PasswordResetToken;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<PasswordResetToken>
+ */
+class PasswordResetTokenRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, PasswordResetToken::class);
+    }
+
+    public function findByTokenHash(string $tokenHash): ?PasswordResetToken
+    {
+        return $this->findOneBy(['tokenHash' => $tokenHash]);
+    }
+
+    /**
+     * Invalidates all outstanding tokens for a user.
+     */
+    public function invalidateAllForUser(int $userId): void
+    {
+        $this->createQueryBuilder('t')
+            ->update()
+            ->set('t.usedAt', ':now')
+            ->where('t.user = :userId')
+            ->andWhere('t.usedAt IS NULL')
+            ->setParameter('now', new \DateTimeImmutable())
+            ->setParameter('userId', $userId)
+            ->getQuery()
+            ->execute();
+    }
+}

--- a/api/symfony.lock
+++ b/api/symfony.lock
@@ -141,6 +141,18 @@
             "src/Kernel.php"
         ]
     },
+    "symfony/mailer": {
+        "version": "7.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "4.3",
+            "ref": "09051cfde49476e3c12cd3a0e44289ace1c75a4f"
+        },
+        "files": [
+            "config/packages/mailer.yaml"
+        ]
+    },
     "symfony/maker-bundle": {
         "version": "1.61",
         "recipe": {

--- a/api/tests/Api/PasswordTest.php
+++ b/api/tests/Api/PasswordTest.php
@@ -1,0 +1,303 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\PasswordResetToken;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Mailer\Test\Constraint as MailerAssertions;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+class PasswordTest extends ApiTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $this->entityManager = $kernel->getContainer()
+            ->get('doctrine')
+            ->getManager();
+
+        // Clean tables before each test
+        $this->entityManager->createQuery('DELETE FROM App\Entity\PasswordResetToken')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    // --- Change password ---
+
+    public function testChangePasswordSuccess(): void
+    {
+        $user = $this->createTestUser('change@example.com', 'oldpassword');
+
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        $client->request('POST', '/auth/change-password', [
+            'json' => [
+                'currentPassword' => 'oldpassword',
+                'newPassword' => 'newpassword123',
+            ],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        // Verify the password actually changed (re-fetch from a fresh EM)
+        $refreshed = $this->reloadUser('change@example.com');
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $this->assertTrue($hasher->isPasswordValid($refreshed, 'newpassword123'));
+        $this->assertFalse($hasher->isPasswordValid($refreshed, 'oldpassword'));
+    }
+
+    public function testChangePasswordWrongCurrent(): void
+    {
+        $user = $this->createTestUser('change@example.com', 'oldpassword');
+
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        $client->request('POST', '/auth/change-password', [
+            'json' => [
+                'currentPassword' => 'wrongpassword',
+                'newPassword' => 'newpassword123',
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    public function testChangePasswordTooShort(): void
+    {
+        $user = $this->createTestUser('change@example.com', 'oldpassword');
+
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        $client->request('POST', '/auth/change-password', [
+            'json' => [
+                'currentPassword' => 'oldpassword',
+                'newPassword' => 'abc',
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testChangePasswordSameAsCurrent(): void
+    {
+        $user = $this->createTestUser('change@example.com', 'oldpassword');
+
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        $client->request('POST', '/auth/change-password', [
+            'json' => [
+                'currentPassword' => 'oldpassword',
+                'newPassword' => 'oldpassword',
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testChangePasswordUnauthenticated(): void
+    {
+        static::createClient()->request('POST', '/auth/change-password', [
+            'json' => [
+                'currentPassword' => 'oldpassword',
+                'newPassword' => 'newpassword123',
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(401);
+    }
+
+    // --- Forgot password ---
+
+    public function testForgotPasswordValidEmail(): void
+    {
+        $this->createTestUser('forgot@example.com', 'password123');
+
+        $client = static::createClient();
+        $client->request('POST', '/auth/forgot-password', [
+            'json' => ['email' => 'forgot@example.com'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertEmailCount(1);
+
+        // Verify a token was created
+        $tokens = $this->entityManager->getRepository(PasswordResetToken::class)->findAll();
+        $this->assertCount(1, $tokens);
+    }
+
+    public function testForgotPasswordUnknownEmailStillReturns200(): void
+    {
+        $client = static::createClient();
+        $client->request('POST', '/auth/forgot-password', [
+            'json' => ['email' => 'nobody@example.com'],
+        ]);
+
+        // Prevents email enumeration: always 200, no email sent, no token created
+        $this->assertResponseIsSuccessful();
+        $this->assertEmailCount(0);
+
+        $tokens = $this->entityManager->getRepository(PasswordResetToken::class)->findAll();
+        $this->assertCount(0, $tokens);
+    }
+
+    public function testForgotPasswordInvalidatesPriorTokens(): void
+    {
+        $this->createTestUser('forgot@example.com', 'password123');
+
+        $client = static::createClient();
+
+        // Request twice
+        $client->request('POST', '/auth/forgot-password', [
+            'json' => ['email' => 'forgot@example.com'],
+        ]);
+        $client->request('POST', '/auth/forgot-password', [
+            'json' => ['email' => 'forgot@example.com'],
+        ]);
+
+        $tokens = $this->entityManager->getRepository(PasswordResetToken::class)->findAll();
+        $this->assertCount(2, $tokens);
+
+        $unusedTokens = array_filter($tokens, fn (PasswordResetToken $t) => null === $t->getUsedAt());
+        $this->assertCount(1, $unusedTokens, 'Only the newest token should remain unused');
+    }
+
+    // --- Reset password ---
+
+    public function testResetPasswordSuccess(): void
+    {
+        $user = $this->createTestUser('reset@example.com', 'oldpassword');
+        $plainToken = $this->createResetToken($user);
+
+        $client = static::createClient();
+        $client->request('POST', '/auth/reset-password', [
+            'json' => [
+                'token' => $plainToken,
+                'newPassword' => 'brandnewpass',
+            ],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        $refreshed = $this->reloadUser('reset@example.com');
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $this->assertTrue($hasher->isPasswordValid($refreshed, 'brandnewpass'));
+    }
+
+    public function testResetPasswordInvalidToken(): void
+    {
+        $client = static::createClient();
+        $client->request('POST', '/auth/reset-password', [
+            'json' => [
+                'token' => 'nonexistent-token',
+                'newPassword' => 'brandnewpass',
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    public function testResetPasswordExpiredToken(): void
+    {
+        $user = $this->createTestUser('reset@example.com', 'oldpassword');
+        $plainToken = $this->createResetToken($user, new \DateTimeImmutable('-1 hour'));
+
+        $client = static::createClient();
+        $client->request('POST', '/auth/reset-password', [
+            'json' => [
+                'token' => $plainToken,
+                'newPassword' => 'brandnewpass',
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    public function testResetPasswordUsedToken(): void
+    {
+        $user = $this->createTestUser('reset@example.com', 'oldpassword');
+        $plainToken = $this->createResetToken($user);
+
+        $client = static::createClient();
+
+        // First use succeeds
+        $client->request('POST', '/auth/reset-password', [
+            'json' => [
+                'token' => $plainToken,
+                'newPassword' => 'brandnewpass',
+            ],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        // Second use fails
+        $client->request('POST', '/auth/reset-password', [
+            'json' => [
+                'token' => $plainToken,
+                'newPassword' => 'anothernewpass',
+            ],
+        ]);
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    public function testResetPasswordTooShort(): void
+    {
+        $user = $this->createTestUser('reset@example.com', 'oldpassword');
+        $plainToken = $this->createResetToken($user);
+
+        $client = static::createClient();
+        $client->request('POST', '/auth/reset-password', [
+            'json' => [
+                'token' => $plainToken,
+                'newPassword' => 'abc',
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    // --- Helpers ---
+
+    private function createTestUser(string $email, string $plainPassword): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setPassword($hasher->hashPassword($user, $plainPassword));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+
+    private function reloadUser(string $email): User
+    {
+        $em = static::getContainer()->get('doctrine')->getManager();
+        $em->clear();
+        $user = $em->getRepository(User::class)->findOneBy(['email' => $email]);
+        $this->assertNotNull($user, sprintf('User %s should exist', $email));
+
+        return $user;
+    }
+
+    private function createResetToken(User $user, ?\DateTimeImmutable $expiresAt = null): string
+    {
+        $plainToken = bin2hex(random_bytes(32));
+        $tokenHash = hash('sha256', $plainToken);
+        $expiresAt ??= new \DateTimeImmutable('+1 hour');
+
+        $token = new PasswordResetToken($user, $tokenHash, $expiresAt);
+        $this->entityManager->persist($token);
+        $this->entityManager->flush();
+
+        return $plainToken;
+    }
+}

--- a/compose.yaml
+++ b/compose.yaml
@@ -15,6 +15,8 @@ services:
       MERCURE_URL: ${CADDY_MERCURE_URL:-http://php/.well-known/mercure}
       MERCURE_PUBLIC_URL: ${CADDY_MERCURE_PUBLIC_URL:-https://${SERVER_NAME:-localhost}:${HTTPS_PORT:-443}/.well-known/mercure}
       MERCURE_JWT_SECRET: ${CADDY_MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
+      MAILER_DSN: ${MAILER_DSN:-smtp://mailpit:1025}
+      APP_FRONTEND_URL: ${APP_FRONTEND_URL:-https://localhost}
     volumes:
       - caddy_data:/data
       - caddy_config:/config
@@ -45,8 +47,18 @@ services:
       test: curl -f http://localhost:3000 || exit 1
       timeout: 5s
       retries: 5
-      start_period: 60s  
-  
+      start_period: 60s
+
+  mailpit:
+    image: axllent/mailpit:latest
+    restart: unless-stopped
+    environment:
+      MP_SMTP_AUTH_ACCEPT_ANY: 1
+      MP_SMTP_AUTH_ALLOW_INSECURE: 1
+    ports:
+      - "${MAILPIT_SMTP_PORT:-1025}:1025"
+      - "${MAILPIT_WEB_PORT:-8025}:8025"
+
   ###> doctrine/doctrine-bundle ###
   database:
     image: postgres:${POSTGRES_VERSION:-16}-alpine

--- a/e2e/tests/password.spec.js
+++ b/e2e/tests/password.spec.js
@@ -1,0 +1,213 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+
+const BASE_URL = "https://localhost";
+const MAILPIT_URL = process.env.MAILPIT_URL || "http://localhost:8025";
+
+const uniqueEmail = () => `pw-test-${Date.now()}-${Math.floor(Math.random() * 10000)}@example.com`;
+
+/**
+ * Registers a user via the API.
+ */
+async function registerUser(request, email, password) {
+  const res = await request.post(`${BASE_URL}/users`, {
+    headers: { "Content-Type": "application/ld+json" },
+    data: { email, plainPassword: password },
+  });
+  expect(res.ok()).toBeTruthy();
+}
+
+/**
+ * Fetches Mailpit messages and returns the most recent email to `recipient`.
+ * Polls for up to `timeout` ms.
+ */
+async function getLatestEmail(request, recipient, timeout = 5000) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const res = await request.get(`${MAILPIT_URL}/api/v1/messages?limit=50`);
+    if (res.ok()) {
+      const { messages = [] } = await res.json();
+      const match = messages.find((m) =>
+        (m.To || []).some((to) => to.Address === recipient)
+      );
+      if (match) {
+        const detailRes = await request.get(
+          `${MAILPIT_URL}/api/v1/message/${match.ID}`
+        );
+        if (detailRes.ok()) {
+          return await detailRes.json();
+        }
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`No email to ${recipient} found within ${timeout}ms`);
+}
+
+/**
+ * Clears all messages in Mailpit so tests don't cross-pollinate.
+ */
+async function clearMailpit(request) {
+  await request.delete(`${MAILPIT_URL}/api/v1/messages`);
+}
+
+test.describe("Change password (authenticated)", () => {
+  test("user can change their password and sign in with the new one", async ({
+    page,
+    request,
+  }) => {
+    const email = uniqueEmail();
+    await registerUser(request, email, "originalpass");
+
+    // Sign in with original password
+    await page.goto(`${BASE_URL}/signin`);
+    await page.fill("#email", email);
+    await page.fill("#password", "originalpass");
+    await page.click('button[type="submit"]');
+    await expect(page).toHaveURL(/\/account/);
+
+    // Change password
+    await page.fill("#currentPassword", "originalpass");
+    await page.fill("#newPassword", "brandnewpass");
+    await page.fill("#confirmPassword", "brandnewpass");
+    await page.click('button:has-text("Update Password")');
+
+    await expect(
+      page.locator('[data-testid="change-password-success"]')
+    ).toBeVisible();
+
+    // Sign out and sign back in with the new password
+    await page.click('button:has-text("Sign Out")');
+    await page.goto(`${BASE_URL}/signin`);
+    await page.fill("#email", email);
+    await page.fill("#password", "brandnewpass");
+    await page.click('button[type="submit"]');
+    await expect(page).toHaveURL(/\/account/);
+  });
+
+  test("wrong current password shows error", async ({ page, request }) => {
+    const email = uniqueEmail();
+    await registerUser(request, email, "originalpass");
+
+    await page.goto(`${BASE_URL}/signin`);
+    await page.fill("#email", email);
+    await page.fill("#password", "originalpass");
+    await page.click('button[type="submit"]');
+    await expect(page).toHaveURL(/\/account/);
+
+    await page.fill("#currentPassword", "wrongpass");
+    await page.fill("#newPassword", "newpassword123");
+    await page.fill("#confirmPassword", "newpassword123");
+    await page.click('button:has-text("Update Password")');
+
+    await expect(
+      page.locator('[data-testid="change-password-error"]')
+    ).toContainText(/current password is incorrect/i);
+  });
+
+  test("client-side validation for mismatched new passwords", async ({
+    page,
+    request,
+  }) => {
+    const email = uniqueEmail();
+    await registerUser(request, email, "originalpass");
+
+    await page.goto(`${BASE_URL}/signin`);
+    await page.fill("#email", email);
+    await page.fill("#password", "originalpass");
+    await page.click('button[type="submit"]');
+    await expect(page).toHaveURL(/\/account/);
+
+    await page.fill("#currentPassword", "originalpass");
+    await page.fill("#newPassword", "newpassword123");
+    await page.fill("#confirmPassword", "different");
+    await page.click('button:has-text("Update Password")');
+
+    await expect(page.locator("text=Passwords do not match")).toBeVisible();
+  });
+});
+
+test.describe("Forgot password (reset via email)", () => {
+  test("full forgot-password flow: request reset, follow email link, set new password, sign in", async ({
+    page,
+    request,
+  }) => {
+    const email = uniqueEmail();
+    await registerUser(request, email, "originalpass");
+
+    await clearMailpit(request);
+
+    // Request reset
+    await page.goto(`${BASE_URL}/forgot-password`);
+    await page.fill("#email", email);
+    await page.click('button:has-text("Send Reset Link")');
+
+    await expect(
+      page.locator('[data-testid="forgot-password-success"]')
+    ).toBeVisible();
+
+    // Grab the reset link from Mailpit
+    const message = await getLatestEmail(request, email);
+    const body = message.Text || message.HTML || "";
+    const match = body.match(/reset-password\?token=([a-f0-9]+)/);
+    expect(match, "Reset link should be present in the email").toBeTruthy();
+    const resetUrl = `${BASE_URL}/reset-password?token=${match[1]}`;
+
+    // Visit reset link and set new password
+    await page.goto(resetUrl);
+    await page.fill("#newPassword", "brandnewpass");
+    await page.fill("#confirmPassword", "brandnewpass");
+    await page.click('button:has-text("Reset Password")');
+
+    // Redirected to sign in with success banner
+    await expect(page).toHaveURL(/\/signin\?reset=true/);
+    await expect(
+      page.locator('[data-testid="password-reset-success"]')
+    ).toBeVisible();
+
+    // Sign in with the new password
+    await page.fill("#email", email);
+    await page.fill("#password", "brandnewpass");
+    await page.click('button[type="submit"]');
+    await expect(page).toHaveURL(/\/account/);
+  });
+
+  test("forgot-password returns success for unknown email (no enumeration)", async ({
+    page,
+    request,
+  }) => {
+    await clearMailpit(request);
+
+    await page.goto(`${BASE_URL}/forgot-password`);
+    await page.fill("#email", `nobody-${Date.now()}@example.com`);
+    await page.click('button:has-text("Send Reset Link")');
+
+    await expect(
+      page.locator('[data-testid="forgot-password-success"]')
+    ).toBeVisible();
+  });
+
+  test("reset-password page without token shows error", async ({ page }) => {
+    await page.goto(`${BASE_URL}/reset-password`);
+    await expect(
+      page.locator('[data-testid="reset-password-missing-token"]')
+    ).toBeVisible();
+  });
+
+  test("reset-password page rejects an invalid token", async ({ page }) => {
+    await page.goto(`${BASE_URL}/reset-password?token=not-a-real-token`);
+
+    await page.fill("#newPassword", "brandnewpass");
+    await page.fill("#confirmPassword", "brandnewpass");
+    await page.click('button:has-text("Reset Password")');
+
+    await expect(
+      page.locator('[data-testid="reset-password-error"]')
+    ).toContainText(/invalid or expired/i);
+  });
+
+  test("Forgot password link is visible on sign-in page", async ({ page }) => {
+    await page.goto(`${BASE_URL}/signin`);
+    await expect(page.locator("text=Forgot password?")).toBeVisible();
+  });
+});

--- a/pwa/components/account/ChangePasswordForm.tsx
+++ b/pwa/components/account/ChangePasswordForm.tsx
@@ -1,0 +1,154 @@
+import { Formik, Form, Field, ErrorMessage } from "formik";
+import { useState } from "react";
+import { useAuth } from "../../contexts/AuthContext";
+
+interface ChangePasswordValues {
+  currentPassword: string;
+  newPassword: string;
+  confirmPassword: string;
+}
+
+const validate = (values: ChangePasswordValues) => {
+  const errors: Partial<ChangePasswordValues> = {};
+
+  if (!values.currentPassword) {
+    errors.currentPassword = "Current password is required.";
+  }
+
+  if (!values.newPassword) {
+    errors.newPassword = "New password is required.";
+  } else if (values.newPassword.length < 6) {
+    errors.newPassword = "New password must be at least 6 characters.";
+  }
+
+  if (!values.confirmPassword) {
+    errors.confirmPassword = "Please confirm your new password.";
+  } else if (values.newPassword !== values.confirmPassword) {
+    errors.confirmPassword = "Passwords do not match.";
+  }
+
+  return errors;
+};
+
+const ChangePasswordForm = () => {
+  const { changePassword } = useAuth();
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  return (
+    <div className="mt-8 border-t border-gray-200 pt-6">
+      <h2 className="text-lg font-semibold text-black mb-4">Change Password</h2>
+
+      <Formik<ChangePasswordValues>
+        initialValues={{ currentPassword: "", newPassword: "", confirmPassword: "" }}
+        validate={validate}
+        onSubmit={async (values, { setSubmitting, setStatus, resetForm }) => {
+          setSuccessMessage(null);
+          try {
+            await changePassword(values.currentPassword, values.newPassword);
+            setSuccessMessage("Password updated successfully.");
+            resetForm();
+          } catch (err) {
+            setStatus(
+              err instanceof Error ? err.message : "Failed to change password."
+            );
+          } finally {
+            setSubmitting(false);
+          }
+        }}
+      >
+        {({ isSubmitting, status }) => (
+          <Form className="space-y-4" noValidate>
+            {status && (
+              <div
+                className="bg-red-50 text-red-500 p-3 rounded text-sm"
+                data-testid="change-password-error"
+              >
+                {status}
+              </div>
+            )}
+
+            {successMessage && (
+              <div
+                className="bg-green-50 text-green-700 p-3 rounded text-sm"
+                data-testid="change-password-success"
+              >
+                {successMessage}
+              </div>
+            )}
+
+            <div>
+              <label
+                htmlFor="currentPassword"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Current Password
+              </label>
+              <Field
+                id="currentPassword"
+                name="currentPassword"
+                type="password"
+                className="w-full rounded-md border-gray-300 shadow-sm focus:border-cyan-500 focus:ring-cyan-500"
+              />
+              <ErrorMessage
+                name="currentPassword"
+                component="p"
+                className="mt-1 text-sm text-red-500"
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor="newPassword"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                New Password
+              </label>
+              <Field
+                id="newPassword"
+                name="newPassword"
+                type="password"
+                className="w-full rounded-md border-gray-300 shadow-sm focus:border-cyan-500 focus:ring-cyan-500"
+                placeholder="At least 6 characters"
+              />
+              <ErrorMessage
+                name="newPassword"
+                component="p"
+                className="mt-1 text-sm text-red-500"
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor="confirmPassword"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Confirm New Password
+              </label>
+              <Field
+                id="confirmPassword"
+                name="confirmPassword"
+                type="password"
+                className="w-full rounded-md border-gray-300 shadow-sm focus:border-cyan-500 focus:ring-cyan-500"
+              />
+              <ErrorMessage
+                name="confirmPassword"
+                component="p"
+                className="mt-1 text-sm text-red-500"
+              />
+            </div>
+
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="w-full bg-cyan-700 text-white py-2 px-4 rounded-md font-semibold hover:bg-cyan-800 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isSubmitting ? "Updating..." : "Update Password"}
+            </button>
+          </Form>
+        )}
+      </Formik>
+    </div>
+  );
+};
+
+export default ChangePasswordForm;

--- a/pwa/contexts/AuthContext.tsx
+++ b/pwa/contexts/AuthContext.tsx
@@ -14,6 +14,9 @@ interface AuthContextType {
   login: (email: string, password: string) => Promise<void>;
   register: (email: string, password: string) => Promise<void>;
   logout: () => void;
+  changePassword: (currentPassword: string, newPassword: string) => Promise<void>;
+  requestPasswordReset: (email: string) => Promise<void>;
+  resetPassword: (token: string, newPassword: string) => Promise<void>;
   error: string | null;
   clearError: () => void;
 }
@@ -82,6 +85,47 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
+  const changePassword = useCallback(async (currentPassword: string, newPassword: string) => {
+    const res = await fetch(`${ENTRYPOINT}/auth/change-password`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({ currentPassword, newPassword }),
+    });
+
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new Error(data.error || "Failed to change password.");
+    }
+  }, []);
+
+  const requestPasswordReset = useCallback(async (email: string) => {
+    const res = await fetch(`${ENTRYPOINT}/auth/forgot-password`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({ email }),
+    });
+
+    if (!res.ok) {
+      throw new Error("Failed to request password reset.");
+    }
+  }, []);
+
+  const resetPassword = useCallback(async (token: string, newPassword: string) => {
+    const res = await fetch(`${ENTRYPOINT}/auth/reset-password`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({ token, newPassword }),
+    });
+
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new Error(data.error || "Failed to reset password.");
+    }
+  }, []);
+
   const logout = useCallback(() => {
     setUser(null);
     fetch(`${ENTRYPOINT}/auth/logout`, {
@@ -99,6 +143,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         login,
         register,
         logout,
+        changePassword,
+        requestPasswordReset,
+        resetPassword,
         error,
         clearError,
       }}

--- a/pwa/pages/account.tsx
+++ b/pwa/pages/account.tsx
@@ -2,6 +2,7 @@ import Head from "next/head";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
 import { useAuth } from "../contexts/AuthContext";
+import ChangePasswordForm from "../components/account/ChangePasswordForm";
 
 const Account = () => {
   const { user, isAuthenticated, isLoading, logout } = useAuth();
@@ -54,6 +55,8 @@ const Account = () => {
               </div>
             </div>
           </div>
+
+          <ChangePasswordForm />
 
           <button
             onClick={() => {

--- a/pwa/pages/forgot-password.tsx
+++ b/pwa/pages/forgot-password.tsx
@@ -1,0 +1,129 @@
+import Head from "next/head";
+import Link from "next/link";
+import { useState } from "react";
+import { Formik, Form, Field, ErrorMessage } from "formik";
+import { useAuth } from "../contexts/AuthContext";
+
+interface ForgotPasswordValues {
+  email: string;
+}
+
+const validate = (values: ForgotPasswordValues) => {
+  const errors: Partial<ForgotPasswordValues> = {};
+
+  if (!values.email) {
+    errors.email = "Email is required.";
+  } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(values.email)) {
+    errors.email = "Invalid email address.";
+  }
+
+  return errors;
+};
+
+const ForgotPassword = () => {
+  const { requestPasswordReset } = useAuth();
+  const [submitted, setSubmitted] = useState(false);
+
+  return (
+    <>
+      <Head>
+        <title>Forgot Password - Aura</title>
+      </Head>
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+        <div className="w-full max-w-md bg-white rounded-lg shadow-card p-8">
+          <h1 className="text-2xl font-bold text-center text-black mb-6">
+            Forgot Password
+          </h1>
+
+          {submitted ? (
+            <div
+              className="bg-green-50 text-green-700 p-4 rounded text-sm text-center space-y-3"
+              data-testid="forgot-password-success"
+            >
+              <p>
+                If an account exists for that email, a reset link has been
+                sent.
+              </p>
+              <p>
+                <Link href="/signin" className="text-cyan-700 font-medium">
+                  Back to Sign In
+                </Link>
+              </p>
+            </div>
+          ) : (
+            <Formik<ForgotPasswordValues>
+              initialValues={{ email: "" }}
+              validate={validate}
+              onSubmit={async (values, { setSubmitting, setStatus }) => {
+                try {
+                  await requestPasswordReset(values.email);
+                  setSubmitted(true);
+                } catch (err) {
+                  setStatus(
+                    err instanceof Error
+                      ? err.message
+                      : "Failed to request password reset."
+                  );
+                } finally {
+                  setSubmitting(false);
+                }
+              }}
+            >
+              {({ isSubmitting, status }) => (
+                <Form className="space-y-4" noValidate>
+                  <p className="text-sm text-gray-600 mb-2">
+                    Enter your email and we&apos;ll send you a link to reset
+                    your password.
+                  </p>
+
+                  {status && (
+                    <div className="bg-red-50 text-red-500 p-3 rounded text-sm">
+                      {status}
+                    </div>
+                  )}
+
+                  <div>
+                    <label
+                      htmlFor="email"
+                      className="block text-sm font-medium text-gray-700 mb-1"
+                    >
+                      Email
+                    </label>
+                    <Field
+                      id="email"
+                      name="email"
+                      type="email"
+                      className="w-full rounded-md border-gray-300 shadow-sm focus:border-cyan-500 focus:ring-cyan-500"
+                      placeholder="you@example.com"
+                    />
+                    <ErrorMessage
+                      name="email"
+                      component="p"
+                      className="mt-1 text-sm text-red-500"
+                    />
+                  </div>
+
+                  <button
+                    type="submit"
+                    disabled={isSubmitting}
+                    className="w-full bg-cyan-700 text-white py-2 px-4 rounded-md font-semibold hover:bg-cyan-800 disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {isSubmitting ? "Sending..." : "Send Reset Link"}
+                  </button>
+
+                  <p className="text-center text-sm text-gray-600">
+                    <Link href="/signin" className="text-cyan-700 font-medium">
+                      Back to Sign In
+                    </Link>
+                  </p>
+                </Form>
+              )}
+            </Formik>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ForgotPassword;

--- a/pwa/pages/reset-password.tsx
+++ b/pwa/pages/reset-password.tsx
@@ -1,0 +1,156 @@
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { Formik, Form, Field, ErrorMessage } from "formik";
+import { useAuth } from "../contexts/AuthContext";
+
+interface ResetPasswordValues {
+  newPassword: string;
+  confirmPassword: string;
+}
+
+const validate = (values: ResetPasswordValues) => {
+  const errors: Partial<ResetPasswordValues> = {};
+
+  if (!values.newPassword) {
+    errors.newPassword = "New password is required.";
+  } else if (values.newPassword.length < 6) {
+    errors.newPassword = "Password must be at least 6 characters.";
+  }
+
+  if (!values.confirmPassword) {
+    errors.confirmPassword = "Please confirm your password.";
+  } else if (values.newPassword !== values.confirmPassword) {
+    errors.confirmPassword = "Passwords do not match.";
+  }
+
+  return errors;
+};
+
+const ResetPassword = () => {
+  const { resetPassword } = useAuth();
+  const router = useRouter();
+  const token = typeof router.query.token === "string" ? router.query.token : "";
+
+  // Wait for router query to hydrate before rendering the token check
+  if (!router.isReady) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <p className="text-gray-500">Loading...</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Reset Password - Aura</title>
+      </Head>
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+        <div className="w-full max-w-md bg-white rounded-lg shadow-card p-8">
+          <h1 className="text-2xl font-bold text-center text-black mb-6">
+            Reset Password
+          </h1>
+
+          {!token ? (
+            <div
+              className="bg-red-50 text-red-500 p-4 rounded text-sm text-center space-y-3"
+              data-testid="reset-password-missing-token"
+            >
+              <p>This reset link is missing or invalid.</p>
+              <p>
+                <Link
+                  href="/forgot-password"
+                  className="text-cyan-700 font-medium"
+                >
+                  Request a new reset link
+                </Link>
+              </p>
+            </div>
+          ) : (
+            <Formik<ResetPasswordValues>
+              initialValues={{ newPassword: "", confirmPassword: "" }}
+              validate={validate}
+              onSubmit={async (values, { setSubmitting, setStatus }) => {
+                try {
+                  await resetPassword(token, values.newPassword);
+                  router.push("/signin?reset=true");
+                } catch (err) {
+                  setStatus(
+                    err instanceof Error ? err.message : "Failed to reset password."
+                  );
+                } finally {
+                  setSubmitting(false);
+                }
+              }}
+            >
+              {({ isSubmitting, status }) => (
+                <Form className="space-y-4" noValidate>
+                  {status && (
+                    <div
+                      className="bg-red-50 text-red-500 p-3 rounded text-sm"
+                      data-testid="reset-password-error"
+                    >
+                      {status}
+                    </div>
+                  )}
+
+                  <div>
+                    <label
+                      htmlFor="newPassword"
+                      className="block text-sm font-medium text-gray-700 mb-1"
+                    >
+                      New Password
+                    </label>
+                    <Field
+                      id="newPassword"
+                      name="newPassword"
+                      type="password"
+                      className="w-full rounded-md border-gray-300 shadow-sm focus:border-cyan-500 focus:ring-cyan-500"
+                      placeholder="At least 6 characters"
+                    />
+                    <ErrorMessage
+                      name="newPassword"
+                      component="p"
+                      className="mt-1 text-sm text-red-500"
+                    />
+                  </div>
+
+                  <div>
+                    <label
+                      htmlFor="confirmPassword"
+                      className="block text-sm font-medium text-gray-700 mb-1"
+                    >
+                      Confirm Password
+                    </label>
+                    <Field
+                      id="confirmPassword"
+                      name="confirmPassword"
+                      type="password"
+                      className="w-full rounded-md border-gray-300 shadow-sm focus:border-cyan-500 focus:ring-cyan-500"
+                    />
+                    <ErrorMessage
+                      name="confirmPassword"
+                      component="p"
+                      className="mt-1 text-sm text-red-500"
+                    />
+                  </div>
+
+                  <button
+                    type="submit"
+                    disabled={isSubmitting}
+                    className="w-full bg-cyan-700 text-white py-2 px-4 rounded-md font-semibold hover:bg-cyan-800 disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {isSubmitting ? "Resetting..." : "Reset Password"}
+                  </button>
+                </Form>
+              )}
+            </Formik>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ResetPassword;

--- a/pwa/pages/signin.tsx
+++ b/pwa/pages/signin.tsx
@@ -27,6 +27,7 @@ const SignIn = () => {
   const { login } = useAuth();
   const router = useRouter();
   const registered = router.query.registered === "true";
+  const reset = router.query.reset === "true";
 
   return (
     <>
@@ -42,6 +43,15 @@ const SignIn = () => {
           {registered && (
             <div className="bg-green-50 text-green-700 p-3 rounded text-sm mb-4">
               Account created successfully. Please sign in.
+            </div>
+          )}
+
+          {reset && (
+            <div
+              className="bg-green-50 text-green-700 p-3 rounded text-sm mb-4"
+              data-testid="password-reset-success"
+            >
+              Password reset successfully. Please sign in with your new password.
             </div>
           )}
 
@@ -104,6 +114,15 @@ const SignIn = () => {
                 >
                   {isSubmitting ? "Signing In..." : "Sign In"}
                 </button>
+
+                <p className="text-center text-sm">
+                  <Link
+                    href="/forgot-password"
+                    className="text-cyan-700 font-medium"
+                  >
+                    Forgot password?
+                  </Link>
+                </p>
 
                 <p className="text-center text-sm text-gray-600">
                   Don&apos;t have an account?{" "}


### PR DESCRIPTION
## Summary
Implements password management for Aura. Authenticated users can change their password from the account page; users who forget their password can request a reset email and set a new password via a time-limited link.

### Backend
- New `PasswordController` with three endpoints under `/auth`:
  - `POST /auth/change-password` (authenticated) — requires current + new password
  - `POST /auth/forgot-password` (public) — always returns 200 to prevent email enumeration, sends reset email on match
  - `POST /auth/reset-password` (public) — consumes a single-use token, enforces min password length
- `PasswordResetToken` entity — stores only the SHA-256 hash of the token; plaintext lives only in the email
- Tokens are single-use and expire after 1 hour; issuing a new token invalidates prior outstanding tokens
- `symfony/mailer` wired up with HTML + text bodies
- Mailpit added to `compose.yaml` — web UI at http://localhost:8025, captures all outgoing mail in dev
- Migration for `password_reset_token` table

### Frontend
- `Change Password` section on `/account` with current/new/confirm fields
- `Forgot password?` link added to sign-in page
- New `/forgot-password` page (always shows generic success message)
- New `/reset-password?token=...` page — validates token via API, redirects to `/signin?reset=true` on success
- `AuthContext` extended with `changePassword`, `requestPasswordReset`, `resetPassword` methods

### Tests
- 13 new PHPUnit tests in `PasswordTest` covering all three endpoints, including: wrong current password, too-short new password, reusing same password, unauthenticated access, token expiration, token reuse, unknown email (enumeration guard), and prior-token invalidation
- 8 new Playwright E2E tests in `password.spec.js` covering: full change-password → sign-in flow, wrong current password error, mismatched new passwords, full forgot → email → reset → sign-in flow using Mailpit HTTP API, enumeration guard, missing token, invalid token

## Manual verification
- End-to-end reset flow verified locally: POST /auth/forgot-password → email received in Mailpit with correct reset URL → token hash matches DB row → POST /auth/reset-password consumes token → password updated.

## Dependencies
- Based on `feature/user-auth` (#21) — targets that branch so it rebases onto main cleanly once #21 merges.

## Test plan
- [ ] All PHPUnit tests pass (22 including existing UserTest)
- [ ] All Playwright E2E tests pass
- [ ] Change password from account page works end-to-end
- [ ] Forgot password delivers email via Mailpit in dev
- [ ] Reset link sets new password and allows sign-in
- [ ] Expired/used/invalid tokens are rejected

Fixes #22