### PR TITLE
Ignore Symfony major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,12 @@ updates:
     labels:
       - dependencies
     open-pull-requests-limit: 5
+    ignore:
+      # Symfony components are pinned to 7.2.* in composer.json — bumping a
+      # single component to a new major (e.g. dotenv 8.0) desyncs the stack.
+      # Major Symfony upgrades must be done together as a coordinated PR.
+      - dependency-name: "symfony/*"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: npm
     directory: /pwa
     schedule:


### PR DESCRIPTION
## Summary
Symfony components are pinned to `7.2.*` in `api/composer.json`. Dependabot was overriding that constraint to propose single-component major bumps (e.g. `symfony/dotenv` 8.0 in #14), which would desync the Symfony stack.

This adds an `ignore` rule so Dependabot no longer opens major-version PRs for `symfony/*`. Minor and patch bumps are still proposed as normal. Major Symfony upgrades should be done as a coordinated PR across all components.

## Test plan
- [ ] Merged
- [ ] #14 closed
- [ ] No new `symfony/*` major PRs from Dependabot
