### PR TITLE
Add shared Projects with full-access membership

### DIFF
--- a/api/migrations/Version20260422130000.php
+++ b/api/migrations/Version20260422130000.php
@@ -28,10 +28,10 @@ final class Version20260422130000 extends AbstractMigration
         $this->addSql('ALTER TABLE project ADD CONSTRAINT FK_2FB3D0EE7E3C61F9 FOREIGN KEY (owner_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE');
 
         $this->addSql('CREATE TABLE project_member (project_id UUID NOT NULL, user_id UUID NOT NULL, PRIMARY KEY (project_id, user_id))');
-        $this->addSql('CREATE INDEX IDX_FDCFBC3B166D1F9C ON project_member (project_id)');
-        $this->addSql('CREATE INDEX IDX_FDCFBC3BA76ED395 ON project_member (user_id)');
-        $this->addSql('ALTER TABLE project_member ADD CONSTRAINT FK_FDCFBC3B166D1F9C FOREIGN KEY (project_id) REFERENCES project (id) ON DELETE CASCADE NOT DEFERRABLE');
-        $this->addSql('ALTER TABLE project_member ADD CONSTRAINT FK_FDCFBC3BA76ED395 FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('CREATE INDEX IDX_67401132166D1F9C ON project_member (project_id)');
+        $this->addSql('CREATE INDEX IDX_67401132A76ED395 ON project_member (user_id)');
+        $this->addSql('ALTER TABLE project_member ADD CONSTRAINT FK_67401132166D1F9C FOREIGN KEY (project_id) REFERENCES project (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE project_member ADD CONSTRAINT FK_67401132A76ED395 FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE');
 
         $this->addSql('ALTER TABLE task ADD project_id UUID DEFAULT NULL');
         $this->addSql('ALTER TABLE task ADD CONSTRAINT FK_527EDB25166D1F9C FOREIGN KEY (project_id) REFERENCES project (id) ON DELETE SET NULL NOT DEFERRABLE');
@@ -44,8 +44,8 @@ final class Version20260422130000 extends AbstractMigration
         $this->addSql('DROP INDEX idx_task_project');
         $this->addSql('ALTER TABLE task DROP project_id');
 
-        $this->addSql('ALTER TABLE project_member DROP CONSTRAINT FK_FDCFBC3BA76ED395');
-        $this->addSql('ALTER TABLE project_member DROP CONSTRAINT FK_FDCFBC3B166D1F9C');
+        $this->addSql('ALTER TABLE project_member DROP CONSTRAINT FK_67401132A76ED395');
+        $this->addSql('ALTER TABLE project_member DROP CONSTRAINT FK_67401132166D1F9C');
         $this->addSql('DROP TABLE project_member');
 
         $this->addSql('ALTER TABLE project DROP CONSTRAINT FK_2FB3D0EE7E3C61F9');

--- a/api/migrations/Version20260422130000.php
+++ b/api/migrations/Version20260422130000.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds the Projects feature: a `project` table, a `project_member` join
+ * table linking users to projects (all members share full access), and an
+ * optional `project_id` foreign key on `task`. A null `project_id` keeps
+ * today's personal tasks scoped strictly to their owner; a set value opens
+ * the task to every project member.
+ */
+final class Version20260422130000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add project and project_member tables; attach task.project_id for shared access.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE project (id UUID NOT NULL, owner_id UUID NOT NULL, title VARCHAR(255) NOT NULL, description TEXT DEFAULT NULL, created_on TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY (id))');
+        $this->addSql('CREATE INDEX idx_project_owner ON project (owner_id)');
+        $this->addSql('ALTER TABLE project ADD CONSTRAINT FK_2FB3D0EE7E3C61F9 FOREIGN KEY (owner_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE');
+
+        $this->addSql('CREATE TABLE project_member (project_id UUID NOT NULL, user_id UUID NOT NULL, PRIMARY KEY (project_id, user_id))');
+        $this->addSql('CREATE INDEX IDX_FDCFBC3B166D1F9C ON project_member (project_id)');
+        $this->addSql('CREATE INDEX IDX_FDCFBC3BA76ED395 ON project_member (user_id)');
+        $this->addSql('ALTER TABLE project_member ADD CONSTRAINT FK_FDCFBC3B166D1F9C FOREIGN KEY (project_id) REFERENCES project (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE project_member ADD CONSTRAINT FK_FDCFBC3BA76ED395 FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE');
+
+        $this->addSql('ALTER TABLE task ADD project_id UUID DEFAULT NULL');
+        $this->addSql('ALTER TABLE task ADD CONSTRAINT FK_527EDB25166D1F9C FOREIGN KEY (project_id) REFERENCES project (id) ON DELETE SET NULL NOT DEFERRABLE');
+        $this->addSql('CREATE INDEX idx_task_project ON task (project_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE task DROP CONSTRAINT FK_527EDB25166D1F9C');
+        $this->addSql('DROP INDEX idx_task_project');
+        $this->addSql('ALTER TABLE task DROP project_id');
+
+        $this->addSql('ALTER TABLE project_member DROP CONSTRAINT FK_FDCFBC3BA76ED395');
+        $this->addSql('ALTER TABLE project_member DROP CONSTRAINT FK_FDCFBC3B166D1F9C');
+        $this->addSql('DROP TABLE project_member');
+
+        $this->addSql('ALTER TABLE project DROP CONSTRAINT FK_2FB3D0EE7E3C61F9');
+        $this->addSql('DROP TABLE project');
+    }
+}

--- a/api/src/Doctrine/ProjectAccessExtension.php
+++ b/api/src/Doctrine/ProjectAccessExtension.php
@@ -6,18 +6,17 @@ use ApiPlatform\Doctrine\Orm\Extension\QueryCollectionExtensionInterface;
 use ApiPlatform\Doctrine\Orm\Extension\QueryItemExtensionInterface;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use ApiPlatform\Metadata\Operation;
-use App\Entity\Task;
+use App\Entity\Project;
 use App\Entity\User;
 use Doctrine\ORM\QueryBuilder;
 use Symfony\Bundle\SecurityBundle\Security;
 
 /**
- * Filters Task queries so non-admin users only see tasks they can act on:
- * tasks they own directly, plus any task attached to a project they belong
- * to. Applies to both collection and item queries as defense-in-depth
- * against leaks; operation-level `security` already covers item access.
+ * Filters Project queries so non-admin users only see projects they belong
+ * to. Item lookups for non-member projects return 404 rather than 403, which
+ * mirrors the existence-hiding behavior of TaskOwnerExtension.
  */
-final class TaskOwnerExtension implements QueryCollectionExtensionInterface, QueryItemExtensionInterface
+final class ProjectAccessExtension implements QueryCollectionExtensionInterface, QueryItemExtensionInterface
 {
     public function __construct(private Security $security)
     {
@@ -46,7 +45,7 @@ final class TaskOwnerExtension implements QueryCollectionExtensionInterface, Que
 
     private function applyFilter(QueryBuilder $queryBuilder, string $resourceClass): void
     {
-        if (Task::class !== $resourceClass) {
+        if (Project::class !== $resourceClass) {
             return;
         }
 
@@ -60,13 +59,19 @@ final class TaskOwnerExtension implements QueryCollectionExtensionInterface, Que
         }
 
         $rootAlias = $queryBuilder->getRootAliases()[0];
-        // A LEFT JOIN on project.members keeps owner-only (project=null) rows
-        // visible while also surfacing tasks from projects the user belongs
-        // to. The task is visible when either side matches.
+        // Use an EXISTS subquery rather than a join on the root query. Adding
+        // a join on `members` here — even without addSelect — ends up
+        // partially hydrating the Project's members collection (the join is
+        // reused during result hydration), so a later writer sees a pruned
+        // collection and Doctrine mis-diffs inserts on flush. The subquery
+        // keeps the root query's join graph clean.
+        $subQuery = sprintf(
+            'SELECT 1 FROM %s project_access_probe JOIN project_access_probe.members project_access_member WHERE project_access_probe = %s AND project_access_member = :currentUser',
+            Project::class,
+            $rootAlias,
+        );
         $queryBuilder
-            ->leftJoin(sprintf('%s.project', $rootAlias), 'tp_access')
-            ->leftJoin('tp_access.members', 'tp_member', 'WITH', 'tp_member = :currentUser')
-            ->andWhere(sprintf('%s.owner = :currentUser OR tp_member IS NOT NULL', $rootAlias))
+            ->andWhere(sprintf('EXISTS(%s)', $subQuery))
             ->setParameter('currentUser', $user);
     }
 }

--- a/api/src/Entity/Project.php
+++ b/api/src/Entity/Project.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use App\Repository\ProjectRepository;
+use App\State\ProjectOwnerProcessor;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Shared container for tasks. Access is all-or-nothing: every member (the
+ * owner included) can read, edit, add members to, and delete the project,
+ * and can see/edit every task attached to it regardless of task ownership.
+ * The `owner` field records who created the project for display/audit —
+ * it does not grant extra privileges beyond what members already have.
+ */
+#[ApiResource(
+    operations: [
+        new GetCollection(
+            security: "is_granted('ROLE_USER')",
+        ),
+        new Post(
+            security: "is_granted('ROLE_USER')",
+            processor: ProjectOwnerProcessor::class,
+        ),
+        new Get(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getMembers().contains(user))",
+        ),
+        new Patch(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getMembers().contains(user))",
+        ),
+        new Delete(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getMembers().contains(user))",
+        ),
+    ],
+    normalizationContext: ['groups' => ['project:read']],
+    denormalizationContext: ['groups' => ['project:write']],
+    order: ['createdOn' => 'DESC'],
+)]
+#[ORM\Entity(repositoryClass: ProjectRepository::class)]
+#[ORM\Table(name: 'project')]
+#[ORM\Index(columns: ['owner_id'], name: 'idx_project_owner')]
+class Project
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
+    #[Groups(['project:read', 'task:read'])]
+    private ?Uuid $id = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    #[Groups(['project:read'])]
+    private ?User $owner = null;
+
+    #[ORM\Column(length: 255)]
+    #[Assert\NotBlank(message: 'Title is required.')]
+    #[Assert\Length(max: 255, maxMessage: 'Title cannot be longer than {{ limit }} characters.')]
+    #[Groups(['project:read', 'project:write', 'task:read'])]
+    private string $title = '';
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    #[Groups(['project:read', 'project:write'])]
+    private ?string $description = null;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    #[Groups(['project:read'])]
+    private \DateTimeImmutable $createdOn;
+
+    /**
+     * Members with full access to the project and its tasks. The creator is
+     * added here automatically by ProjectOwnerProcessor; keeping owner inside
+     * the set means access checks only need to inspect `members`.
+     *
+     * @var Collection<int, User>
+     */
+    #[ORM\ManyToMany(targetEntity: User::class)]
+    #[ORM\JoinTable(name: 'project_member')]
+    #[ORM\JoinColumn(name: 'project_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
+    #[ORM\InverseJoinColumn(name: 'user_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
+    #[Groups(['project:read', 'project:write'])]
+    private Collection $members;
+
+    /**
+     * @var Collection<int, Task>
+     */
+    #[ORM\OneToMany(mappedBy: 'project', targetEntity: Task::class)]
+    private Collection $tasks;
+
+    public function __construct()
+    {
+        $this->createdOn = new \DateTimeImmutable();
+        $this->members = new ArrayCollection();
+        $this->tasks = new ArrayCollection();
+    }
+
+    public function getId(): ?Uuid
+    {
+        return $this->id;
+    }
+
+    public function getOwner(): ?User
+    {
+        return $this->owner;
+    }
+
+    public function setOwner(?User $owner): static
+    {
+        $this->owner = $owner;
+        return $this;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): static
+    {
+        $this->title = $title;
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(?string $description): static
+    {
+        $this->description = $description;
+        return $this;
+    }
+
+    public function getCreatedOn(): \DateTimeImmutable
+    {
+        return $this->createdOn;
+    }
+
+    /**
+     * @return Collection<int, User>
+     */
+    public function getMembers(): Collection
+    {
+        return $this->members;
+    }
+
+    public function addMember(User $member): static
+    {
+        if (!$this->members->contains($member)) {
+            $this->members->add($member);
+        }
+        return $this;
+    }
+
+    public function removeMember(User $member): static
+    {
+        $this->members->removeElement($member);
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Task>
+     */
+    public function getTasks(): Collection
+    {
+        return $this->tasks;
+    }
+}

--- a/api/src/Entity/Task.php
+++ b/api/src/Entity/Task.php
@@ -27,13 +27,13 @@ use Symfony\Component\Validator\Constraints as Assert;
             processor: TaskOwnerProcessor::class,
         ),
         new Get(
-            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getOwner() == user)",
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getOwner() == user or (object.getProject() !== null and object.getProject().getMembers().contains(user)))",
         ),
         new Patch(
-            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getOwner() == user)",
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getOwner() == user or (object.getProject() !== null and object.getProject().getMembers().contains(user)))",
         ),
         new Delete(
-            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getOwner() == user)",
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getOwner() == user or (object.getProject() !== null and object.getProject().getMembers().contains(user)))",
         ),
     ],
     normalizationContext: ['groups' => ['task:read']],
@@ -44,6 +44,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ORM\Table(name: 'task')]
 #[ORM\Index(columns: ['owner_id'], name: 'idx_task_owner')]
 #[ORM\Index(columns: ['owner_id', 'position'], name: 'idx_task_owner_position')]
+#[ORM\Index(columns: ['project_id'], name: 'idx_task_project')]
 class Task
 {
     #[ORM\Id]
@@ -57,6 +58,16 @@ class Task
     #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
     #[Groups(['task:read'])]
     private ?User $owner = null;
+
+    /**
+     * Optional project the task belongs to. When set, every project member
+     * can read and edit the task alongside its owner. Personal tasks leave
+     * this null.
+     */
+    #[ORM\ManyToOne(targetEntity: Project::class, inversedBy: 'tasks')]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    #[Groups(['task:read', 'task:write'])]
+    private ?Project $project = null;
 
     #[ORM\Column(length: 255)]
     #[Assert\NotBlank(message: 'Title is required.')]
@@ -120,6 +131,17 @@ class Task
     public function setOwner(?User $owner): static
     {
         $this->owner = $owner;
+        return $this;
+    }
+
+    public function getProject(): ?Project
+    {
+        return $this->project;
+    }
+
+    public function setProject(?Project $project): static
+    {
+        $this->project = $project;
         return $this;
     }
 

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -33,13 +33,13 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column(type: 'uuid', unique: true)]
     #[ORM\GeneratedValue(strategy: 'CUSTOM')]
     #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
-    #[Groups(['user:read'])]
+    #[Groups(['user:read', 'project:read'])]
     private ?Uuid $id = null;
 
     #[ORM\Column(length: 180, unique: true)]
     #[Assert\NotBlank]
     #[Assert\Email]
-    #[Groups(['user:read', 'user:write'])]
+    #[Groups(['user:read', 'user:write', 'project:read'])]
     private string $email = '';
 
     #[ORM\Column]

--- a/api/src/Repository/ProjectRepository.php
+++ b/api/src/Repository/ProjectRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Project;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Project>
+ */
+final class ProjectRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Project::class);
+    }
+}

--- a/api/src/State/ProjectOwnerProcessor.php
+++ b/api/src/State/ProjectOwnerProcessor.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\Entity\Project;
+use App\Entity\User;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+
+/**
+ * Stamps the creator as owner of a new Project and adds them to the member
+ * set, so access checks can rely solely on `members` without a special case
+ * for the owner.
+ *
+ * @implements ProcessorInterface<Project, Project>
+ */
+final class ProjectOwnerProcessor implements ProcessorInterface
+{
+    /**
+     * @param ProcessorInterface<Project, Project> $persistProcessor
+     */
+    public function __construct(
+        #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
+        private ProcessorInterface $persistProcessor,
+        private Security $security,
+    ) {
+    }
+
+    /**
+     * @param Project $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Project
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new UnauthorizedHttpException('Bearer', 'You must be authenticated to create a project.');
+        }
+
+        $data->setOwner($user);
+        $data->addMember($user);
+
+        return $this->persistProcessor->process($data, $operation, $uriVariables, $context);
+    }
+}

--- a/api/tests/Api/ProjectTest.php
+++ b/api/tests/Api/ProjectTest.php
@@ -1,0 +1,319 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\Project;
+use App\Entity\Task;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+class ProjectTest extends ApiTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $this->entityManager = $kernel->getContainer()
+            ->get('doctrine')
+            ->getManager();
+
+        // project_member and task.project_id cascade/null via FK, so deleting
+        // the parents is enough to clean state between tests.
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testListProjectsUnauthenticated(): void
+    {
+        static::createClient()->request('GET', '/projects');
+        $this->assertResponseStatusCodeSame(401);
+    }
+
+    public function testCreateProjectAuthenticated(): void
+    {
+        $user = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($user);
+        $client->request('POST', '/projects', [
+            'json' => [
+                'title' => 'Launch plan',
+                'description' => 'Q3 marketing push',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertJsonContains([
+            '@type' => 'Project',
+            'title' => 'Launch plan',
+            'description' => 'Q3 marketing push',
+        ]);
+
+        $project = $this->reloadProjectByTitle('Launch plan');
+        $this->assertTrue($user->getId()->equals($project->getOwner()?->getId()));
+        // Creator is auto-added to members so access checks only need to
+        // look at the member set.
+        $this->assertCount(1, $project->getMembers());
+        $this->assertTrue($user->getId()->equals($project->getMembers()->first()->getId()));
+    }
+
+    public function testCreateProjectRequiresTitle(): void
+    {
+        $user = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($user);
+        $client->request('POST', '/projects', [
+            'json' => ['title' => ''],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testListProjectsOnlyShowsMemberProjects(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+
+        $this->createProject($alice, 'Alice solo', [$alice]);
+        $this->createProject($bob, 'Bob solo', [$bob]);
+        $this->createProject($alice, 'Shared', [$alice, $bob]);
+
+        $client = static::createClient();
+        $client->loginUser($bob);
+        $client->request('GET', '/projects');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains(['totalItems' => 2]);
+    }
+
+    public function testGetOtherUsersProjectReturns404(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $bobsProject = $this->createProject($bob, 'Bob private', [$bob]);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        // Mirrors the task extension: 404 rather than 403 so the endpoint
+        // doesn't confirm the project exists.
+        $client->request('GET', '/projects/' . $bobsProject->getId());
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testMemberCanUpdateProject(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $project = $this->createProject($alice, 'Shared', [$alice, $bob]);
+
+        $client = static::createClient();
+        $client->loginUser($bob);
+        $client->request('PATCH', '/projects/' . $project->getId(), [
+            'json' => ['description' => 'Updated by non-owner member'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testMemberCanAddAnotherMember(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $carol = $this->createUser('carol@example.com');
+        $project = $this->createProject($alice, 'Shared', [$alice, $bob]);
+
+        $client = static::createClient();
+        $client->loginUser($bob);
+        $client->request('PATCH', '/projects/' . $project->getId(), [
+            'json' => [
+                'members' => [
+                    '/users/' . $alice->getId(),
+                    '/users/' . $bob->getId(),
+                    '/users/' . $carol->getId(),
+                ],
+            ],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+
+        $this->entityManager->clear();
+        $reloaded = $this->entityManager->getRepository(Project::class)->find($project->getId());
+        $this->assertCount(3, $reloaded->getMembers());
+    }
+
+    public function testMemberCanDeleteProject(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $project = $this->createProject($alice, 'Shared', [$alice, $bob]);
+
+        $client = static::createClient();
+        $client->loginUser($bob);
+        $client->request('DELETE', '/projects/' . $project->getId());
+
+        $this->assertResponseStatusCodeSame(204);
+    }
+
+    public function testMemberSeesTasksFromSharedProject(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $project = $this->createProject($alice, 'Shared', [$alice, $bob]);
+
+        // Alice's personal task should not leak to Bob; the project task
+        // should. This is the key behavior change vs. pre-Projects Tasks.
+        $this->createTask($alice, 'Alice personal', null);
+        $this->createTask($alice, 'Alice project task', $project);
+
+        $client = static::createClient();
+        $client->loginUser($bob);
+        $client->request('GET', '/tasks');
+
+        $this->assertResponseIsSuccessful();
+        $response = $client->getResponse()->toArray();
+        $titles = array_map(fn ($t) => $t['title'], $response['member']);
+        $this->assertSame(['Alice project task'], $titles);
+    }
+
+    public function testNonMemberCannotSeeProjectTask(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $carol = $this->createUser('carol@example.com');
+        $project = $this->createProject($alice, 'Alice+Bob', [$alice, $bob]);
+        $task = $this->createTask($alice, 'Private project task', $project);
+
+        $client = static::createClient();
+        $client->loginUser($carol);
+        $client->request('GET', '/tasks/' . $task->getId());
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testMemberCanEditProjectTaskOwnedByAnother(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $project = $this->createProject($alice, 'Shared', [$alice, $bob]);
+        $task = $this->createTask($alice, 'Alice owns this', $project);
+
+        $client = static::createClient();
+        $client->loginUser($bob);
+        $client->request('PATCH', '/tasks/' . $task->getId(), [
+            'json' => ['title' => 'Edited by Bob'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->entityManager->clear();
+        $reloaded = $this->entityManager->getRepository(Task::class)->find($task->getId());
+        $this->assertSame('Edited by Bob', $reloaded->getTitle());
+    }
+
+    public function testCreateTaskWithProject(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Mine', [$alice]);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks', [
+            'json' => [
+                'title' => 'In the project',
+                'project' => '/projects/' . $project->getId(),
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+
+        $this->entityManager->clear();
+        $task = $this->entityManager->getRepository(Task::class)->findOneBy(['title' => 'In the project']);
+        $this->assertNotNull($task->getProject());
+        $this->assertTrue($project->getId()->equals($task->getProject()->getId()));
+    }
+
+    public function testPersonalTasksStillOwnerScopedForCreator(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $this->createTask($alice, 'Alice personal', null);
+        $this->createTask($bob, 'Bob personal', null);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/tasks');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains(['totalItems' => 1]);
+    }
+
+    /**
+     * @param string[] $roles
+     */
+    private function createUser(string $email, array $roles = ['ROLE_USER']): User
+    {
+        $container = static::getContainer();
+        /** @var UserPasswordHasherInterface $hasher */
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles($roles);
+        $user->setPassword($hasher->hashPassword($user, 'password123'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+
+    /**
+     * @param User[] $members
+     */
+    private function createProject(User $owner, string $title, array $members): Project
+    {
+        $project = new Project();
+        $project->setOwner($owner);
+        $project->setTitle($title);
+        foreach ($members as $member) {
+            $project->addMember($member);
+        }
+
+        $this->entityManager->persist($project);
+        $this->entityManager->flush();
+
+        return $project;
+    }
+
+    private function createTask(User $owner, string $title, ?Project $project): Task
+    {
+        $task = new Task();
+        $task->setOwner($owner);
+        $task->setTitle($title);
+        $task->setProject($project);
+
+        $this->entityManager->persist($task);
+        $this->entityManager->flush();
+
+        return $task;
+    }
+
+    private function reloadProjectByTitle(string $title): Project
+    {
+        $this->entityManager->clear();
+        $project = $this->entityManager->getRepository(Project::class)->findOneBy(['title' => $title]);
+        self::assertNotNull($project, sprintf('Expected to find Project with title "%s".', $title));
+        return $project;
+    }
+}


### PR DESCRIPTION
## Description

Adds a Projects feature so tasks can be grouped under a shared membership. Every member (the creator included) has full access — read, edit, add/remove members, delete the project, and see/edit every task attached to it. `task.project` is nullable so existing personal tasks keep their owner-only scope.

## Type of Change

- [x] New feature

## Component

- [x] API (PHP/Symfony)

## How Has This Been Tested?

- New `api/tests/Api/ProjectTest.php` covers creation, validation, auto-enrollment of the creator as a member, member-scoped listing, 404-on-non-member, cross-member edit/delete/add-member, creating a task with a project, project-member visibility of each other's project tasks, and preserved owner-scoping for personal (projectless) tasks.
- Full phpunit suite: `php bin/phpunit` → 71 tests, 141 assertions, all green.

## Notes for reviewers

- Shared access is implemented by extending `TaskOwnerExtension` to surface tasks owned by the user *or* attached to a project they belong to. Item-level security expressions mirror the same rule.
- `ProjectAccessExtension` uses an `EXISTS` subquery rather than a JOIN on `members`. A root-query join — even without `addSelect` — ends up partial-hydrating the `members` collection during a write, and Doctrine then mis-diffs inserts on flush (reproducible as `project_member_pkey` unique-violation on PATCH). The subquery keeps the root query's join graph clean.
- The creator is auto-added to `members` in `ProjectOwnerProcessor` so access checks only need to inspect the member set; `owner` remains for display/audit.
- New migration `Version20260422130000` creates `project`, `project_member`, and adds `task.project_id` (ON DELETE SET NULL so deleting a project detaches tasks rather than deleting them).

## Checklist

- [x] My code follows the project's conventions
- [x] I have added tests that prove my fix or feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed