### PR TITLE
fix(security): SSRF in project detail + read-only workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: Tests

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: Tests

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -88,7 +88,7 @@ const ProjectDetail = () => {
     setError(null);
     setIsLoading(true);
     try {
-      const projectRes = await fetch(`${ENTRYPOINT}/projects/${projectId}`, {
+      const projectRes = await fetch(`${ENTRYPOINT}/projects/${encodeURIComponent(projectId)}`, {
         credentials: "include",
         headers: { Accept: "application/ld+json" },
       });


### PR DESCRIPTION
## Summary
- Wrap `projectId` (from `router.query`) in `encodeURIComponent` before interpolating into the project detail fetch URL. Resolves CodeQL `js/request-forgery` (alert #5, critical).
- Add top-level `permissions: contents: read` to both `ci.yml` and `e2e.yml`. Resolves CodeQL `actions/missing-workflow-permissions` (alerts #2, #3, #4).

## Out of scope
The 24 open Dependabot alerts (postcss, dompurify, undici, lodash, picomatch, brace-expansion, path-to-regexp, flatted, yaml, uuid) are all transitive in `pwa/pnpm-lock.yaml`. They will be addressed in a follow-up lockfile-refresh PR via `docker compose run pwa pnpm update`. Mixing that diff here would obscure the source review.

## Test plan
- [ ] CI green (Tests, E2E, Docker Lint, CodeQL)
- [ ] Manually load `/projects/<id>` after deploy and confirm the page renders