### PR TITLE
chore(e2e): bump playwright to 1.59.1 with matching docker image

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,4 +55,4 @@ jobs:
         name: Playwright
         # Run chromium only in CI for fast feedback — the full firefox/webkit
         # matrix is available locally via `npx playwright test`.
-        run: docker run --network host -w /app -v ./e2e:/app --rm --ipc=host -e CI=true mcr.microsoft.com/playwright:v1.50.0-noble /bin/sh -c 'npm i; npx playwright test --project=chromium;'
+        run: docker run --network host -w /app -v ./e2e:/app --rm --ipc=host -e CI=true mcr.microsoft.com/playwright:v1.59.1-noble /bin/sh -c 'npm i; npx playwright test --project=chromium;'

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -14,13 +14,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.0.tgz",
-      "integrity": "sha512-ZGNXbt+d65EGjBORQHuYKj+XhCewlwpnSd/EDuLPZGSiEWmgOJB5RmMCCYGy5aMfTs9wx61RivfDKi8H/hcMvw==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.50.0"
+        "playwright": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -55,13 +55,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.0.tgz",
-      "integrity": "sha512-+GinGfGTrd2IfX1TA4N2gNmeIksSb+IAe589ZH+FlmpV3MYTx6+buChGIuDLQwrGNCw2lWibqV50fU510N7S+w==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.50.0"
+        "playwright-core": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -74,9 +74,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.0.tgz",
-      "integrity": "sha512-CXkSSlr4JaZs2tZHI40DsZUN/NIwgaUPsyLuOAaIZp2CyF2sN5MM5NJsyB188lFSSozFxQ5fPT4qM+f0tH/6wQ==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -8,7 +8,7 @@
   "license": "ISC",
   "description": "",
   "devDependencies": {
-    "@playwright/test": "^1.50.0",
+    "@playwright/test": "^1.59.1",
     "@types/node": "^22.9.0"
   }
 }


### PR DESCRIPTION
## Summary
Dependabot's [#55](https://github.com/roboparker/Aura/pull/55) bumps `@playwright/test` to 1.59.1 but the Playwright Docker image used in CI is hard-pinned to `v1.50.0-noble`, so all 40 E2E tests fail with:

> Looks like Playwright was just updated to 1.59.1. Please update docker image as well.

This bundles both updates so they ship together.

- `e2e/package.json`: bump `@playwright/test` constraint to `^1.59.1`
- `e2e/package-lock.json`: regenerated with playwright 1.59.1
- `.github/workflows/e2e.yml`: bump image tag to `mcr.microsoft.com/playwright:v1.59.1-noble`

Closes #55.

## Test plan
- [ ] CI green (E2E specifically)