### PR TITLE
chore(deps): upgrade intervention/image to v4

### DIFF
--- a/api/composer.json
+++ b/api/composer.json
@@ -10,7 +10,7 @@
         "doctrine/doctrine-bundle": "^2.7",
         "doctrine/doctrine-migrations-bundle": "^3.2",
         "doctrine/orm": "^3.0",
-        "intervention/image": "^3.7",
+        "intervention/image": "^4.0",
         "league/flysystem-bundle": "^3.3",
         "nelmio/cors-bundle": "^2.2",
         "phpdocumentor/reflection-docblock": "^6.0",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "edd242e61502c5919981c7c604d38389",
+    "content-hash": "ef9d5ab0493fd1b4c0262d1d03beaabd",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -2510,26 +2510,26 @@
         },
         {
             "name": "intervention/gif",
-            "version": "4.2.4",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Intervention/gif.git",
-                "reference": "c3598a16ebe7690cd55640c44144a9df383ea73c"
+                "reference": "d856f59205aec768059d837148d755c079cdb94a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Intervention/gif/zipball/c3598a16ebe7690cd55640c44144a9df383ea73c",
-                "reference": "c3598a16ebe7690cd55640c44144a9df383ea73c",
+                "url": "https://api.github.com/repos/Intervention/gif/zipball/d856f59205aec768059d837148d755c079cdb94a",
+                "reference": "d856f59205aec768059d837148d755c079cdb94a",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.1"
+                "php": "^8.3"
             },
             "require-dev": {
                 "phpstan/phpstan": "^2.1",
-                "phpunit/phpunit": "^10.0 || ^11.0  || ^12.0",
+                "phpunit/phpunit": "^12.0",
                 "slevomat/coding-standard": "~8.0",
-                "squizlabs/php_codesniffer": "^3.8"
+                "squizlabs/php_codesniffer": "^4"
             },
             "type": "library",
             "autoload": {
@@ -2548,7 +2548,7 @@
                     "homepage": "https://intervention.io/"
                 }
             ],
-            "description": "Native PHP GIF Encoder/Decoder",
+            "description": "PHP GIF Encoder/Decoder",
             "homepage": "https://github.com/intervention/gif",
             "keywords": [
                 "animation",
@@ -2558,7 +2558,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Intervention/gif/issues",
-                "source": "https://github.com/Intervention/gif/tree/4.2.4"
+                "source": "https://github.com/Intervention/gif/tree/5.0.0"
             },
             "funding": [
                 {
@@ -2574,33 +2574,33 @@
                     "type": "ko_fi"
                 }
             ],
-            "time": "2026-01-04T09:27:23+00:00"
+            "time": "2026-03-21T05:08:17+00:00"
         },
         {
             "name": "intervention/image",
-            "version": "3.11.7",
+            "version": "4.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Intervention/image.git",
-                "reference": "2159bcccff18f09d2a392679b81a82c5a003f9bb"
+                "reference": "3c449518c7782ea7454d18c4a7a54e6c2250e889"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Intervention/image/zipball/2159bcccff18f09d2a392679b81a82c5a003f9bb",
-                "reference": "2159bcccff18f09d2a392679b81a82c5a003f9bb",
+                "url": "https://api.github.com/repos/Intervention/image/zipball/3c449518c7782ea7454d18c4a7a54e6c2250e889",
+                "reference": "3c449518c7782ea7454d18c4a7a54e6c2250e889",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "intervention/gif": "^4.2",
-                "php": "^8.1"
+                "intervention/gif": "^5",
+                "php": "^8.3"
             },
             "require-dev": {
                 "mockery/mockery": "^1.6",
                 "phpstan/phpstan": "^2.1",
-                "phpunit/phpunit": "^10.0 || ^11.0 || ^12.0",
+                "phpunit/phpunit": "^12.0",
                 "slevomat/coding-standard": "~8.0",
-                "squizlabs/php_codesniffer": "^3.8"
+                "squizlabs/php_codesniffer": "^4"
             },
             "suggest": {
                 "ext-exif": "Recommended to be able to read EXIF data properly."
@@ -2634,7 +2634,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Intervention/image/issues",
-                "source": "https://github.com/Intervention/image/tree/3.11.7"
+                "source": "https://github.com/Intervention/image/tree/4.0.2"
             },
             "funding": [
                 {
@@ -2650,7 +2650,7 @@
                     "type": "ko_fi"
                 }
             ],
-            "time": "2026-02-19T13:11:17+00:00"
+            "time": "2026-04-24T13:57:17+00:00"
         },
         {
             "name": "lcobucci/jwt",

--- a/api/src/Service/ImageUploadService.php
+++ b/api/src/Service/ImageUploadService.php
@@ -6,6 +6,7 @@ use App\Entity\MediaObject;
 use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
 use Intervention\Image\Drivers\Gd\Driver;
+use Intervention\Image\Encoders\WebpEncoder;
 use Intervention\Image\ImageManager;
 use League\Flysystem\FilesystemOperator;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -41,17 +42,19 @@ final class ImageUploadService
         $this->assertValidImage($file);
 
         $manager = new ImageManager(new Driver());
-        $image = $manager->read($file->getPathname());
+        $image = $manager->decode($file->getPathname());
 
         $uuid = (string) Uuid::v7();
         $profilePath = sprintf('avatars/%s-profile.webp', $uuid);
         $thumbPath = sprintf('avatars/%s-thumb.webp', $uuid);
 
+        $webp = new WebpEncoder(self::WEBP_QUALITY);
+
         $profile = (clone $image)->cover(self::AVATAR_PROFILE_SIZE, self::AVATAR_PROFILE_SIZE);
-        $this->storage->write($profilePath, (string) $profile->toWebp(self::WEBP_QUALITY));
+        $this->storage->write($profilePath, (string) $profile->encode($webp));
 
         $thumb = (clone $image)->cover(self::AVATAR_THUMB_SIZE, self::AVATAR_THUMB_SIZE);
-        $this->storage->write($thumbPath, (string) $thumb->toWebp(self::WEBP_QUALITY));
+        $this->storage->write($thumbPath, (string) $thumb->encode($webp));
 
         $media = new MediaObject();
         $media->setOwner($owner);


### PR DESCRIPTION
## Summary
Picks up Dependabot's `intervention/image` 3.11.7 → 4.0.2 (#48) and migrates the only consumer, [ImageUploadService](api/src/Service/ImageUploadService.php).

## v4 API changes used here
- `ImageManager::read()` was removed → use `ImageManager::decode($pathname)` (or `decodePath()`).
- `Image::toWebp($quality)` shortcut was removed → use `Image::encode(new WebpEncoder($quality))`.

The rest of the pipeline (`new ImageManager(new Driver())`, `cover(w, h)`, `clone $image`, casting `EncodedImageInterface` to string) works unchanged in v4.

## Test plan
- [ ] `MediaObjectTest::testAuthenticatedUploadSucceeds` passes
- [ ] `MediaObjectTest::testPatchUserAvatarLinksMediaObject` passes
- [ ] CI green

Closes #48.