### PR TITLE
chore(compose): keep node_modules and vendor in container volumes

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -7,11 +7,13 @@ services:
     volumes:
       - ./api:/app
       - /app/var
+      # Keep vendor/ inside the container instead of the host bind-mount.
+      # Required on Windows/macOS — pnpm/composer's symlink-heavy installs
+      # corrupt the WSL or osxfs share when written through a bind-mount.
+      # Named (vs. anonymous) so it persists across `compose run --rm`.
+      - api_vendor:/app/vendor
       - ./api/frankenphp/Caddyfile:/etc/frankenphp/Caddyfile:ro
       - ./api/frankenphp/conf.d/20-app.dev.ini:/usr/local/etc/php/app.conf.d/20-app.dev.ini:ro
-      # If you develop on Mac or Windows you can remove the vendor/ directory
-      #  from the bind-mount for better performance by enabling the next line:
-      #- /app/vendor
     environment:
       FRANKENPHP_WORKER_CONFIG: watch
       MERCURE_EXTRA_DIRECTIVES: demo
@@ -28,6 +30,9 @@ services:
       target: dev
     volumes:
       - ./pwa:/srv/app
+      # See note on `/app/vendor` above — keeps pnpm's symlinked store
+      # off the host filesystem so installs don't corrupt the WSL share.
+      - pwa_node_modules:/srv/app/node_modules
     environment:
       API_PLATFORM_CREATE_CLIENT_ENTRYPOINT: http://php
       API_PLATFORM_CREATE_CLIENT_OUTPUT: .
@@ -44,3 +49,7 @@ services:
 
 ###> symfony/mercure-bundle ###
 ###< symfony/mercure-bundle ###
+
+volumes:
+  api_vendor:
+  pwa_node_modules:


### PR DESCRIPTION
## Summary
Bind-mounting the worktree from WSL into the dev containers causes pnpm's symlinked install layout (and to a lesser degree composer's `vendor/`) to corrupt the Windows `\wsl\$\` fileshare daemon. After a single `pnpm install` the WSL mount starts returning `EIO` for any read of files in the worktree, only recoverable by `wsl --shutdown`.

This fixes it the same way the file already had a TODO for: bind-mount the source tree, but keep the dependency directories as anonymous Docker volumes.

- `php`: enable the previously commented-out `/app/vendor` volume.
- `pwa`: add `/srv/app/node_modules`.

## Tradeoff
IDE TypeScript / PHPStan intellisense based on host-side `node_modules` / `vendor` will need a host-side install (e.g. `pnpm install` directly in a WSL shell). The dev container itself installs cleanly inside its own filesystem.

## Test plan
- [x] `docker compose run --rm pwa pnpm install` completes without symlink errors
- [x] Worktree files remain readable after install (no `EIO`)
- [ ] Dev container `pnpm dev` still serves the PWA
- [ ] CI green