### PR TITLE
chore(deps): override transitive postcss to >=8.5.10

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -7,11 +7,13 @@ services:
     volumes:
       - ./api:/app
       - /app/var
+      # Keep vendor/ inside the container instead of the host bind-mount.
+      # Required on Windows/macOS — pnpm/composer's symlink-heavy installs
+      # corrupt the WSL or osxfs share when written through a bind-mount.
+      # Named (vs. anonymous) so it persists across `compose run --rm`.
+      - api_vendor:/app/vendor
       - ./api/frankenphp/Caddyfile:/etc/frankenphp/Caddyfile:ro
       - ./api/frankenphp/conf.d/20-app.dev.ini:/usr/local/etc/php/app.conf.d/20-app.dev.ini:ro
-      # If you develop on Mac or Windows you can remove the vendor/ directory
-      #  from the bind-mount for better performance by enabling the next line:
-      #- /app/vendor
     environment:
       FRANKENPHP_WORKER_CONFIG: watch
       MERCURE_EXTRA_DIRECTIVES: demo
@@ -28,6 +30,9 @@ services:
       target: dev
     volumes:
       - ./pwa:/srv/app
+      # See note on `/app/vendor` above — keeps pnpm's symlinked store
+      # off the host filesystem so installs don't corrupt the WSL share.
+      - pwa_node_modules:/srv/app/node_modules
     environment:
       API_PLATFORM_CREATE_CLIENT_ENTRYPOINT: http://php
       API_PLATFORM_CREATE_CLIENT_OUTPUT: .
@@ -44,3 +49,7 @@ services:
 
 ###> symfony/mercure-bundle ###
 ###< symfony/mercure-bundle ###
+
+volumes:
+  api_vendor:
+  pwa_node_modules:

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -57,5 +57,10 @@
     "@babel/core": "^7.19.0",
     "@popperjs/core": "^2.11.6"
   },
+  "pnpm": {
+    "overrides": {
+      "postcss@<8.5.10": "^8.5.10"
+    }
+  },
   "packageManager": "pnpm@9.1.3+sha512.7c2ea089e1a6af306409c4fc8c4f0897bdac32b772016196c469d9428f1fe2d5a21daf8ad6512762654ac645b5d9136bb210ec9a00afa8dbc4677843ba362ecd"
 }

--- a/pwa/pnpm-lock.yaml
+++ b/pwa/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  postcss@<8.5.10: ^8.5.10
+
 importers:
 
   .:
@@ -2942,10 +2945,6 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
-
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.12:
     resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
@@ -6859,7 +6858,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.23
       caniuse-lite: 1.0.30001791
-      postcss: 8.4.31
+      postcss: 8.5.12
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.5)
@@ -7007,12 +7006,6 @@ snapshots:
   picomatch@4.0.4: {}
 
   possible-typed-array-names@1.1.0: {}
-
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.12:
     dependencies:


### PR DESCRIPTION
## Summary
Next.js 16 ships postcss 8.4.31 internally for its CSS pipeline, which triggers Dependabot alert #75 (PostCSS XSS via unescaped `</style>` in stringify output). The fix is in 8.5.10, but Vercel hasn't rolled it into a Next 16 patch release yet.

This adds a `pnpm.overrides` entry for `postcss@<8.5.10 → ^8.5.10`. Same major version (8 → 8), no breaking changes.

## Test plan
- [x] `pnpm install` succeeds
- [x] `pnpm exec tsc --noEmit` passes
- [x] `pnpm lint` passes
- [x] `pnpm build` produces a valid production bundle (all pages prerendered)
- [ ] CI green

## Stacked on
[#60](https://github.com/roboparker/Aura/pull/60) (compose volume fix). This PR depends on that landing first.

Resolves Dependabot alert #75.