### PR TITLE
chore(deps): override transitive undici to ^6.24.0

### DIFF
--- a/pwa/package.json
+++ b/pwa/package.json
@@ -59,7 +59,8 @@
   },
   "pnpm": {
     "overrides": {
-      "postcss@<8.5.10": "^8.5.10"
+      "postcss@<8.5.10": "^8.5.10",
+      "undici@<6.24.0": "^6.24.0"
     }
   },
   "packageManager": "pnpm@9.1.3+sha512.7c2ea089e1a6af306409c4fc8c4f0897bdac32b772016196c469d9428f1fe2d5a21daf8ad6512762654ac645b5d9136bb210ec9a00afa8dbc4677843ba362ecd"

--- a/pwa/pnpm-lock.yaml
+++ b/pwa/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   postcss@<8.5.10: ^8.5.10
+  undici@<6.24.0: ^6.24.0
 
 importers:
 
@@ -370,10 +371,6 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@fastify/busboy@2.1.1':
-    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
-    engines: {node: '>=14'}
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -3524,9 +3521,9 @@ packages:
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
-  undici@5.29.0:
-    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
-    engines: {node: '>=14.0'}
+  undici@6.25.0:
+    resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
+    engines: {node: '>=18.17'}
 
   unfetch@5.0.0:
     resolution: {integrity: sha512-3xM2c89siXg0nHvlmYsQ2zkLASvVMBisZm5lF3gFDqfF2xonNStDJyMpvaOBe0a1Edxmqrf2E0HBdmy9QyZaeg==}
@@ -3954,7 +3951,7 @@ snapshots:
     dependencies:
       ky: 0.33.3
       ky-universal: 0.11.0(ky@0.33.3)(web-streams-polyfill@4.1.0)
-      undici: 5.29.0
+      undici: 6.25.0
     transitivePeerDependencies:
       - web-streams-polyfill
 
@@ -4129,8 +4126,6 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
-
-  '@fastify/busboy@2.1.1': {}
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -7761,9 +7756,7 @@ snapshots:
 
   undici-types@7.19.2: {}
 
-  undici@5.29.0:
-    dependencies:
-      '@fastify/busboy': 2.1.1
+  undici@6.25.0: {}
 
   unfetch@5.0.0: {}
 


### PR DESCRIPTION
## Summary
`@digitalbazaar/http-client@3.4.1` (used by jsonld via the `@api-platform/admin` route) pins `undici@5.29.0`, which has four open Dependabot advisories (#46, #47, #48, #49):

- HTTP Request/Response Smuggling
- CRLF Injection via `upgrade` option
- Unhandled Exception in WebSocket Client
- Unbounded Memory Consumption in WebSocket permessage-deflate

All four are patched in 6.24.0.

## Risk
undici 5 → 6 is a major version bump, but `@digitalbazaar/http-client` only uses the stable `fetch` API surface, which behaves identically across both majors. Verified locally:

- `pnpm install` succeeds
- `pnpm exec tsc --noEmit` passes
- `pnpm lint` passes
- `pnpm build` produces a valid bundle
- `pnpm audit --prod` reports **zero vulnerabilities**
- Manual smoke test: `pnpm dev` running, signed in as admin, `/admin` lists Users — exercises the full jsonld context-fetching path through undici

## Test plan
- [ ] CI green