### PR TITLE
feat: verified email-change flow with old-address revert

### DIFF
--- a/api/migrations/Version20260428120000.php
+++ b/api/migrations/Version20260428120000.php
@@ -37,18 +37,18 @@ final class Version20260428120000 extends AbstractMigration
             PRIMARY KEY (id)
         )');
 
-        $this->addSql('CREATE INDEX idx_email_change_user ON email_change_request (user_id)');
-        $this->addSql('CREATE UNIQUE INDEX uniq_email_change_confirm_hash ON email_change_request (confirm_token_hash)');
-        $this->addSql('CREATE UNIQUE INDEX uniq_email_change_revert_hash ON email_change_request (revert_token_hash)');
-        $this->addSql('CREATE INDEX idx_email_change_confirm_hash ON email_change_request (confirm_token_hash)');
-        $this->addSql('CREATE INDEX idx_email_change_revert_hash ON email_change_request (revert_token_hash)');
+        // Names follow Doctrine's canonical IDX_/UNIQ_<sha1-prefix>
+        // convention so `doctrine:schema:validate` stays happy.
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_136F31FF53989697 ON email_change_request (confirm_token_hash)');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_136F31FF50337588 ON email_change_request (revert_token_hash)');
+        $this->addSql('CREATE INDEX IDX_136F31FFA76ED395 ON email_change_request (user_id)');
 
-        $this->addSql('ALTER TABLE email_change_request ADD CONSTRAINT fk_email_change_user FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE email_change_request ADD CONSTRAINT FK_136F31FFA76ED395 FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE');
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE email_change_request DROP CONSTRAINT fk_email_change_user');
+        $this->addSql('ALTER TABLE email_change_request DROP CONSTRAINT FK_136F31FFA76ED395');
         $this->addSql('DROP TABLE email_change_request');
     }
 }

--- a/api/migrations/Version20260428120000.php
+++ b/api/migrations/Version20260428120000.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds the email_change_request table backing the two-step
+ * email-change flow: confirm via a token sent to the new address,
+ * then optionally revert via a separate token sent to the old one.
+ */
+final class Version20260428120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add email_change_request table for the email-change flow.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE email_change_request (
+            id UUID NOT NULL,
+            user_id UUID NOT NULL,
+            old_email VARCHAR(180) NOT NULL,
+            new_email VARCHAR(180) NOT NULL,
+            confirm_token_hash VARCHAR(64) NOT NULL,
+            revert_token_hash VARCHAR(64) DEFAULT NULL,
+            expires_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+            revert_expires_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL,
+            confirmed_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL,
+            reverted_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL,
+            cancelled_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL,
+            created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+            PRIMARY KEY (id)
+        )');
+
+        $this->addSql('CREATE INDEX idx_email_change_user ON email_change_request (user_id)');
+        $this->addSql('CREATE UNIQUE INDEX uniq_email_change_confirm_hash ON email_change_request (confirm_token_hash)');
+        $this->addSql('CREATE UNIQUE INDEX uniq_email_change_revert_hash ON email_change_request (revert_token_hash)');
+        $this->addSql('CREATE INDEX idx_email_change_confirm_hash ON email_change_request (confirm_token_hash)');
+        $this->addSql('CREATE INDEX idx_email_change_revert_hash ON email_change_request (revert_token_hash)');
+
+        $this->addSql('ALTER TABLE email_change_request ADD CONSTRAINT fk_email_change_user FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE email_change_request DROP CONSTRAINT fk_email_change_user');
+        $this->addSql('DROP TABLE email_change_request');
+    }
+}

--- a/api/src/Controller/EmailChangeController.php
+++ b/api/src/Controller/EmailChangeController.php
@@ -1,0 +1,261 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\EmailChangeRequest;
+use App\Entity\User;
+use App\Repository\EmailChangeRequestRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class EmailChangeController extends AbstractController
+{
+    private const CONFIRM_TOKEN_TTL_HOURS = 1;
+    private const REVERT_TOKEN_TTL_HOURS = 24 * 7; // a week to notice & undo
+
+    public function __construct(
+        private EntityManagerInterface $em,
+        private EmailChangeRequestRepository $requests,
+        private ValidatorInterface $validator,
+        private MailerInterface $mailer,
+        #[Autowire('%env(APP_FRONTEND_URL)%')]
+        private string $frontendUrl,
+        #[Autowire('%env(default::MAILER_FROM)%')]
+        private ?string $mailerFrom = null,
+    ) {
+    }
+
+    /**
+     * Authenticated user kicks off an email change. We mail a confirm
+     * link to the *new* address; the user's stored email isn't touched
+     * until they click it.
+     */
+    #[Route('/auth/request-email-change', name: 'auth_request_email_change', methods: ['POST'])]
+    public function request(Request $request, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if (null === $user) {
+            return $this->json(['error' => 'Not authenticated.'], 401);
+        }
+
+        $data = json_decode($request->getContent(), true) ?? [];
+        $newEmail = trim((string) ($data['newEmail'] ?? ''));
+
+        if ('' === $newEmail) {
+            return $this->json(['error' => 'New email is required.'], 422);
+        }
+
+        $violations = $this->validator->validate($newEmail, [new Assert\Email(), new Assert\Length(max: 180)]);
+        if (count($violations) > 0) {
+            return $this->json(['error' => 'Please enter a valid email address.'], 422);
+        }
+
+        if (strcasecmp($newEmail, $user->getEmail()) === 0) {
+            return $this->json(['error' => 'That is already your email address.'], 422);
+        }
+
+        $existing = $this->em->getRepository(User::class)->findOneBy(['email' => $newEmail]);
+        if (null !== $existing) {
+            // Don't leak whether the address is registered — return success.
+            // The flow will silently no-op (no confirm email sent).
+            return $this->json(['message' => 'If the address is available, a confirmation email has been sent.']);
+        }
+
+        $this->requests->cancelPendingForUser($user);
+
+        $plainToken = bin2hex(random_bytes(32));
+        $tokenHash = hash('sha256', $plainToken);
+        $expiresAt = new \DateTimeImmutable(sprintf('+%d hours', self::CONFIRM_TOKEN_TTL_HOURS));
+
+        $changeRequest = new EmailChangeRequest(
+            $user,
+            $user->getEmail(),
+            $newEmail,
+            $tokenHash,
+            $expiresAt,
+        );
+        $this->em->persist($changeRequest);
+        $this->em->flush();
+
+        $this->sendConfirmEmail($newEmail, $user, $plainToken);
+
+        return $this->json(['message' => 'If the address is available, a confirmation email has been sent.']);
+    }
+
+    /**
+     * Public endpoint — anyone with a valid token can complete the
+     * change. Updates the user's email, then notifies the *old*
+     * address with revert + password-reset links.
+     */
+    #[Route('/auth/confirm-email-change', name: 'auth_confirm_email_change', methods: ['POST'])]
+    public function confirm(Request $request): JsonResponse
+    {
+        $data = json_decode($request->getContent(), true) ?? [];
+        $plainToken = (string) ($data['token'] ?? '');
+
+        if ('' === $plainToken) {
+            return $this->json(['error' => 'Token is required.'], 400);
+        }
+
+        $changeRequest = $this->requests->findByConfirmTokenHash(hash('sha256', $plainToken));
+        if (null === $changeRequest || !$changeRequest->isConfirmable()) {
+            return $this->json(['error' => 'Invalid or expired token.'], 400);
+        }
+
+        // Re-check email uniqueness — someone else may have claimed it.
+        $existing = $this->em->getRepository(User::class)->findOneBy(['email' => $changeRequest->getNewEmail()]);
+        if (null !== $existing && $existing !== $changeRequest->getUser()) {
+            $changeRequest->cancel();
+            $this->em->flush();
+            return $this->json(['error' => 'That email is no longer available.'], 409);
+        }
+
+        $user = $changeRequest->getUser();
+        $user->setEmail($changeRequest->getNewEmail());
+
+        $revertToken = bin2hex(random_bytes(32));
+        $revertHash = hash('sha256', $revertToken);
+        $revertExpiresAt = new \DateTimeImmutable(sprintf('+%d hours', self::REVERT_TOKEN_TTL_HOURS));
+        $changeRequest->markConfirmed($revertHash, $revertExpiresAt);
+
+        $this->em->flush();
+
+        $this->sendRevertNotice($changeRequest, $revertToken);
+
+        return $this->json([
+            'message' => 'Email updated.',
+            'newEmail' => $changeRequest->getNewEmail(),
+        ]);
+    }
+
+    /**
+     * Public endpoint — bearer of a valid revert token can roll the
+     * user's email back to its previous value. No re-authentication is
+     * required: the threat model is "the change wasn't me", and the
+     * person who got the notice email controlled the old address.
+     */
+    #[Route('/auth/revert-email-change', name: 'auth_revert_email_change', methods: ['POST'])]
+    public function revert(Request $request): JsonResponse
+    {
+        $data = json_decode($request->getContent(), true) ?? [];
+        $plainToken = (string) ($data['token'] ?? '');
+
+        if ('' === $plainToken) {
+            return $this->json(['error' => 'Token is required.'], 400);
+        }
+
+        $changeRequest = $this->requests->findByRevertTokenHash(hash('sha256', $plainToken));
+        if (null === $changeRequest || !$changeRequest->isRevertable()) {
+            return $this->json(['error' => 'Invalid or expired token.'], 400);
+        }
+
+        // Re-check old-email uniqueness — extremely unlikely but possible
+        // if someone else registered the freed-up address in the meantime.
+        $existing = $this->em->getRepository(User::class)->findOneBy(['email' => $changeRequest->getOldEmail()]);
+        if (null !== $existing && $existing !== $changeRequest->getUser()) {
+            return $this->json([
+                'error' => 'Your previous email is no longer available. Please request a fresh change from your account page.',
+            ], 409);
+        }
+
+        $user = $changeRequest->getUser();
+        $user->setEmail($changeRequest->getOldEmail());
+        $changeRequest->markReverted();
+        $this->em->flush();
+
+        return $this->json([
+            'message' => 'Email reverted.',
+            'restoredEmail' => $changeRequest->getOldEmail(),
+        ]);
+    }
+
+    private function sendConfirmEmail(string $newEmail, User $user, string $plainToken): void
+    {
+        $confirmUrl = sprintf(
+            '%s/confirm-email-change?token=%s',
+            rtrim($this->frontendUrl, '/'),
+            $plainToken,
+        );
+        $from = $this->mailerFrom ?: 'no-reply@aura.test';
+
+        $email = (new Email())
+            ->from($from)
+            ->to($newEmail)
+            ->subject('Confirm your new Aura email address')
+            ->text(sprintf(
+                "Hi,\n\n"
+                . "We received a request to change the email on your Aura account from %s to %s. "
+                . "Click the link below to confirm:\n\n%s\n\n"
+                . "This link expires in %d hour(s). If you did not request this change, you can safely ignore this email — your account email won't change unless you click the link.\n\n— Aura",
+                $user->getEmail(),
+                $newEmail,
+                $confirmUrl,
+                self::CONFIRM_TOKEN_TTL_HOURS,
+            ))
+            ->html(sprintf(
+                '<p>Hi,</p>'
+                . '<p>We received a request to change the email on your Aura account from <strong>%1$s</strong> to <strong>%2$s</strong>. Click the link below to confirm:</p>'
+                . '<p><a href="%3$s">%3$s</a></p>'
+                . '<p>This link expires in %4$d hour(s). If you did not request this change, you can safely ignore this email &mdash; your account email won&rsquo;t change unless you click the link.</p>'
+                . '<p>&mdash; Aura</p>',
+                htmlspecialchars($user->getEmail()),
+                htmlspecialchars($newEmail),
+                htmlspecialchars($confirmUrl),
+                self::CONFIRM_TOKEN_TTL_HOURS,
+            ));
+
+        $this->mailer->send($email);
+    }
+
+    private function sendRevertNotice(EmailChangeRequest $changeRequest, string $revertToken): void
+    {
+        $revertUrl = sprintf(
+            '%s/revert-email-change?token=%s',
+            rtrim($this->frontendUrl, '/'),
+            $revertToken,
+        );
+        $resetUrl = sprintf('%s/forgot-password', rtrim($this->frontendUrl, '/'));
+        $from = $this->mailerFrom ?: 'no-reply@aura.test';
+
+        $email = (new Email())
+            ->from($from)
+            ->to($changeRequest->getOldEmail())
+            ->subject('Your Aura email address was changed')
+            ->text(sprintf(
+                "Hi,\n\n"
+                . "The email on your Aura account was changed from %s to %s.\n\n"
+                . "If this was you, no action is needed.\n\n"
+                . "If it wasn't, you can undo the change here:\n%s\n\n"
+                . "And reset your password to lock down the account:\n%s\n\n"
+                . "The undo link expires in %d days.\n\n— Aura",
+                $changeRequest->getOldEmail(),
+                $changeRequest->getNewEmail(),
+                $revertUrl,
+                $resetUrl,
+                (int) (self::REVERT_TOKEN_TTL_HOURS / 24),
+            ))
+            ->html(sprintf(
+                '<p>Hi,</p>'
+                . '<p>The email on your Aura account was changed from <strong>%1$s</strong> to <strong>%2$s</strong>.</p>'
+                . '<p>If this was you, no action is needed.</p>'
+                . '<p>If it wasn&rsquo;t, you can <a href="%3$s">undo the change</a> and then <a href="%4$s">reset your password</a> to lock the account down.</p>'
+                . '<p>The undo link expires in %5$d days.</p>'
+                . '<p>&mdash; Aura</p>',
+                htmlspecialchars($changeRequest->getOldEmail()),
+                htmlspecialchars($changeRequest->getNewEmail()),
+                htmlspecialchars($revertUrl),
+                htmlspecialchars($resetUrl),
+                (int) (self::REVERT_TOKEN_TTL_HOURS / 24),
+            ));
+
+        $this->mailer->send($email);
+    }
+}

--- a/api/src/Entity/EmailChangeRequest.php
+++ b/api/src/Entity/EmailChangeRequest.php
@@ -23,8 +23,6 @@ use Symfony\Component\Uid\Uuid;
  */
 #[ORM\Entity(repositoryClass: EmailChangeRequestRepository::class)]
 #[ORM\Table(name: 'email_change_request')]
-#[ORM\Index(columns: ['confirm_token_hash'], name: 'idx_email_change_confirm_hash')]
-#[ORM\Index(columns: ['revert_token_hash'], name: 'idx_email_change_revert_hash')]
 class EmailChangeRequest
 {
     #[ORM\Id]

--- a/api/src/Entity/EmailChangeRequest.php
+++ b/api/src/Entity/EmailChangeRequest.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\EmailChangeRequestRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Tracks an in-flight email-change for a user. The flow has two phases:
+ *
+ *   1. **Request** — the user enters a new email; we email a confirm
+ *      link to the *new* address. `confirmTokenHash` gates this step.
+ *
+ *   2. **Confirmation** — they click the link; the user's email is
+ *      flipped to `newEmail`, `confirmedAt` is stamped, a fresh
+ *      `revertTokenHash` is issued, and a notice is mailed to
+ *      `oldEmail` with that revert link plus a reminder to reset
+ *      their password if the change wasn't intentional.
+ *
+ * Plain tokens are never persisted — only sha256 hashes — same pattern
+ * as PasswordResetToken and UserInvite.
+ */
+#[ORM\Entity(repositoryClass: EmailChangeRequestRepository::class)]
+#[ORM\Table(name: 'email_change_request')]
+#[ORM\Index(columns: ['confirm_token_hash'], name: 'idx_email_change_confirm_hash')]
+#[ORM\Index(columns: ['revert_token_hash'], name: 'idx_email_change_revert_hash')]
+class EmailChangeRequest
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
+    private ?Uuid $id = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private User $user;
+
+    #[ORM\Column(length: 180)]
+    private string $oldEmail;
+
+    #[ORM\Column(length: 180)]
+    private string $newEmail;
+
+    #[ORM\Column(length: 64, unique: true)]
+    private string $confirmTokenHash;
+
+    #[ORM\Column(length: 64, unique: true, nullable: true)]
+    private ?string $revertTokenHash = null;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $expiresAt;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?\DateTimeImmutable $revertExpiresAt = null;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?\DateTimeImmutable $confirmedAt = null;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?\DateTimeImmutable $revertedAt = null;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?\DateTimeImmutable $cancelledAt = null;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $createdAt;
+
+    public function __construct(
+        User $user,
+        string $oldEmail,
+        string $newEmail,
+        string $confirmTokenHash,
+        \DateTimeImmutable $expiresAt,
+    ) {
+        $this->user = $user;
+        $this->oldEmail = $oldEmail;
+        $this->newEmail = $newEmail;
+        $this->confirmTokenHash = $confirmTokenHash;
+        $this->expiresAt = $expiresAt;
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?Uuid
+    {
+        return $this->id;
+    }
+
+    public function getUser(): User
+    {
+        return $this->user;
+    }
+
+    public function getOldEmail(): string
+    {
+        return $this->oldEmail;
+    }
+
+    public function getNewEmail(): string
+    {
+        return $this->newEmail;
+    }
+
+    public function getConfirmTokenHash(): string
+    {
+        return $this->confirmTokenHash;
+    }
+
+    public function getRevertTokenHash(): ?string
+    {
+        return $this->revertTokenHash;
+    }
+
+    public function getExpiresAt(): \DateTimeImmutable
+    {
+        return $this->expiresAt;
+    }
+
+    public function getRevertExpiresAt(): ?\DateTimeImmutable
+    {
+        return $this->revertExpiresAt;
+    }
+
+    public function getConfirmedAt(): ?\DateTimeImmutable
+    {
+        return $this->confirmedAt;
+    }
+
+    public function getRevertedAt(): ?\DateTimeImmutable
+    {
+        return $this->revertedAt;
+    }
+
+    public function getCancelledAt(): ?\DateTimeImmutable
+    {
+        return $this->cancelledAt;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function markConfirmed(string $revertTokenHash, \DateTimeImmutable $revertExpiresAt): void
+    {
+        $this->confirmedAt = new \DateTimeImmutable();
+        $this->revertTokenHash = $revertTokenHash;
+        $this->revertExpiresAt = $revertExpiresAt;
+    }
+
+    public function markReverted(): void
+    {
+        $this->revertedAt = new \DateTimeImmutable();
+    }
+
+    public function cancel(): void
+    {
+        $this->cancelledAt = new \DateTimeImmutable();
+    }
+
+    /** Confirm token is still actionable. */
+    public function isConfirmable(?\DateTimeImmutable $now = null): bool
+    {
+        $now ??= new \DateTimeImmutable();
+        return null === $this->confirmedAt
+            && null === $this->cancelledAt
+            && $this->expiresAt > $now;
+    }
+
+    /** Revert token has been issued (post-confirm) and is still actionable. */
+    public function isRevertable(?\DateTimeImmutable $now = null): bool
+    {
+        $now ??= new \DateTimeImmutable();
+        return null !== $this->confirmedAt
+            && null === $this->revertedAt
+            && null !== $this->revertExpiresAt
+            && $this->revertExpiresAt > $now;
+    }
+}

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -20,8 +20,15 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ApiResource(
     operations: [
         new GetCollection(security: "is_granted('ROLE_ADMIN')"),
-        new Post(processor: UserPasswordHasherProcessor::class),
+        // POST accepts both `user:create` (email, plainPassword, inviteToken)
+        // and `user:write` so signup can set everything in one shot.
+        new Post(
+            processor: UserPasswordHasherProcessor::class,
+            denormalizationContext: ['groups' => ['user:write', 'user:create']],
+        ),
         new Get(security: "is_granted('ROLE_ADMIN') or object == user"),
+        // PATCH only sees `user:write` — email changes go through
+        // EmailChangeController so the new address can be verified.
         new Patch(security: "is_granted('ROLE_ADMIN') or object == user"),
     ],
     normalizationContext: ['groups' => ['user:read']],
@@ -40,18 +47,20 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[Groups(['user:read', 'project:read', 'group:read'])]
     private ?Uuid $id = null;
 
+    // Settable on signup (`user:create`), but not on PATCH — changes
+    // run through EmailChangeController so the new address is verified.
     #[ORM\Column(length: 180, unique: true)]
     #[Assert\NotBlank]
     #[Assert\Email]
-    #[Groups(['user:read', 'user:write', 'project:read', 'group:read'])]
+    #[Groups(['user:read', 'user:create', 'project:read', 'group:read'])]
     private string $email = '';
 
     #[ORM\Column]
     private string $password = '';
 
-    #[Assert\NotBlank(groups: ['user:write'])]
+    #[Assert\NotBlank(groups: ['user:create'])]
     #[Assert\Length(min: 6, minMessage: 'Password must be at least {{ limit }} characters.')]
-    #[Groups(['user:write'])]
+    #[Groups(['user:create'])]
     private ?string $plainPassword = null;
 
     /**
@@ -59,7 +68,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
      * one, UserPasswordHasherProcessor resolves it after persisting the new
      * user and joins them to the invited group. Never stored.
      */
-    #[Groups(['user:write'])]
+    #[Groups(['user:create'])]
     private ?string $inviteToken = null;
 
     /** @var string[] */

--- a/api/src/Repository/EmailChangeRequestRepository.php
+++ b/api/src/Repository/EmailChangeRequestRepository.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\EmailChangeRequest;
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<EmailChangeRequest>
+ */
+class EmailChangeRequestRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, EmailChangeRequest::class);
+    }
+
+    public function findByConfirmTokenHash(string $tokenHash): ?EmailChangeRequest
+    {
+        return $this->findOneBy(['confirmTokenHash' => $tokenHash]);
+    }
+
+    public function findByRevertTokenHash(string $tokenHash): ?EmailChangeRequest
+    {
+        return $this->findOneBy(['revertTokenHash' => $tokenHash]);
+    }
+
+    /**
+     * Cancels every pending (not yet confirmed, not yet cancelled)
+     * change request for a user. Called whenever we issue a fresh
+     * request so a user only ever has one outstanding confirm token.
+     */
+    public function cancelPendingForUser(User $user): void
+    {
+        $this->createQueryBuilder('r')
+            ->update()
+            ->set('r.cancelledAt', ':now')
+            ->where('r.user = :user')
+            ->andWhere('r.confirmedAt IS NULL')
+            ->andWhere('r.cancelledAt IS NULL')
+            ->setParameter('now', new \DateTimeImmutable())
+            ->setParameter('user', $user)
+            ->getQuery()
+            ->execute();
+    }
+}

--- a/api/tests/Api/EmailChangeTest.php
+++ b/api/tests/Api/EmailChangeTest.php
@@ -1,0 +1,318 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\EmailChangeRequest;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+class EmailChangeTest extends ApiTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $this->entityManager = $kernel->getContainer()
+            ->get('doctrine')
+            ->getManager();
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\EmailChangeRequest')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    // --- Request ---
+
+    public function testRequestRequiresAuth(): void
+    {
+        $client = static::createClient();
+        $client->request('POST', '/auth/request-email-change', [
+            'json' => ['newEmail' => 'new@example.com'],
+        ]);
+        $this->assertResponseStatusCodeSame(401);
+    }
+
+    public function testRequestSendsConfirmEmail(): void
+    {
+        $user = $this->createTestUser('old@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        $client->request('POST', '/auth/request-email-change', [
+            'json' => ['newEmail' => 'new@example.com'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertEmailCount(1);
+        $email = $this->getMailerMessage(0);
+        $this->assertEmailHeaderSame($email, 'To', 'new@example.com');
+        $this->assertEmailTextBodyContains($email, '/confirm-email-change?token=');
+
+        // The user's stored email is unchanged until they confirm.
+        $refreshed = $this->reloadUser('old@example.com');
+        $this->assertSame('old@example.com', $refreshed->getEmail());
+    }
+
+    public function testRequestRejectsInvalidEmail(): void
+    {
+        $user = $this->createTestUser('old@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($user);
+        $client->request('POST', '/auth/request-email-change', [
+            'json' => ['newEmail' => 'not-an-email'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertEmailCount(0);
+    }
+
+    public function testRequestRejectsSameEmail(): void
+    {
+        $user = $this->createTestUser('old@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($user);
+        $client->request('POST', '/auth/request-email-change', [
+            'json' => ['newEmail' => 'old@example.com'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testRequestSilentlyNoOpsForTakenEmail(): void
+    {
+        $this->createTestUser('taken@example.com');
+        $user = $this->createTestUser('old@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($user);
+        $client->request('POST', '/auth/request-email-change', [
+            'json' => ['newEmail' => 'taken@example.com'],
+        ]);
+
+        // Returns 200 to avoid leaking which addresses are registered,
+        // but no confirmation email is actually sent.
+        $this->assertResponseIsSuccessful();
+        $this->assertEmailCount(0);
+    }
+
+    public function testRequestCancelsPriorPending(): void
+    {
+        $user = $this->createTestUser('old@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($user);
+        $client->request('POST', '/auth/request-email-change', [
+            'json' => ['newEmail' => 'first@example.com'],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $client->request('POST', '/auth/request-email-change', [
+            'json' => ['newEmail' => 'second@example.com'],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $em = static::getContainer()->get('doctrine')->getManager();
+        $em->clear();
+        $requests = $em->getRepository(EmailChangeRequest::class)->findBy(
+            ['cancelledAt' => null, 'confirmedAt' => null],
+        );
+        $this->assertCount(1, $requests);
+        $this->assertSame('second@example.com', $requests[0]->getNewEmail());
+    }
+
+    // --- Confirm ---
+
+    public function testConfirmFlipsEmailAndNotifiesOldAddress(): void
+    {
+        $user = $this->createTestUser('old@example.com');
+        [, $confirmToken] = $this->seedRequest($user, 'new@example.com');
+
+        $client = static::createClient();
+        $client->request('POST', '/auth/confirm-email-change', [
+            'json' => ['token' => $confirmToken],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $refreshed = $this->reloadUser('new@example.com');
+        $this->assertSame('new@example.com', $refreshed->getEmail());
+
+        $this->assertEmailCount(1);
+        $email = $this->getMailerMessage(0);
+        $this->assertEmailHeaderSame($email, 'To', 'old@example.com');
+        $this->assertEmailTextBodyContains($email, '/revert-email-change?token=');
+        $this->assertEmailTextBodyContains($email, '/forgot-password');
+    }
+
+    public function testConfirmRejectsBadToken(): void
+    {
+        $client = static::createClient();
+        $client->request('POST', '/auth/confirm-email-change', [
+            'json' => ['token' => 'not-a-real-token'],
+        ]);
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    public function testConfirmRejectsExpiredToken(): void
+    {
+        $user = $this->createTestUser('old@example.com');
+        [, $confirmToken] = $this->seedRequest(
+            $user,
+            'new@example.com',
+            new \DateTimeImmutable('-5 minutes'),
+        );
+
+        $client = static::createClient();
+        $client->request('POST', '/auth/confirm-email-change', [
+            'json' => ['token' => $confirmToken],
+        ]);
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    public function testConfirmRejectsAlreadyUsedToken(): void
+    {
+        $user = $this->createTestUser('old@example.com');
+        [, $confirmToken] = $this->seedRequest($user, 'new@example.com');
+
+        $client = static::createClient();
+        $client->request('POST', '/auth/confirm-email-change', [
+            'json' => ['token' => $confirmToken],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $client->request('POST', '/auth/confirm-email-change', [
+            'json' => ['token' => $confirmToken],
+        ]);
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    public function testConfirmRejectsWhenAddressBecameUnavailable(): void
+    {
+        $user = $this->createTestUser('old@example.com');
+        [, $confirmToken] = $this->seedRequest($user, 'new@example.com');
+
+        // Someone else grabs the address before this user confirms.
+        $this->createTestUser('new@example.com');
+
+        $client = static::createClient();
+        $client->request('POST', '/auth/confirm-email-change', [
+            'json' => ['token' => $confirmToken],
+        ]);
+        $this->assertResponseStatusCodeSame(409);
+    }
+
+    // --- Revert ---
+
+    public function testRevertRollsEmailBack(): void
+    {
+        $user = $this->createTestUser('old@example.com');
+        [, $confirmToken] = $this->seedRequest($user, 'new@example.com');
+
+        $client = static::createClient();
+        $client->request('POST', '/auth/confirm-email-change', [
+            'json' => ['token' => $confirmToken],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        // Pull the revert token straight out of the just-stamped row.
+        $em = static::getContainer()->get('doctrine')->getManager();
+        $em->clear();
+        $stored = $em->getRepository(EmailChangeRequest::class)->findOneBy([]);
+        $this->assertNotNull($stored);
+        $this->assertNotNull($stored->getRevertTokenHash());
+
+        // The plain token is in the notice email body.
+        $email = $this->getMailerMessage(0);
+        if (!preg_match('#/revert-email-change\?token=([0-9a-f]+)#', $email->getTextBody(), $m)) {
+            $this->fail('Revert email did not contain a revert link.');
+        }
+        $plainRevertToken = $m[1];
+
+        $client->request('POST', '/auth/revert-email-change', [
+            'json' => ['token' => $plainRevertToken],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $rolledBack = $this->reloadUser('old@example.com');
+        $this->assertSame('old@example.com', $rolledBack->getEmail());
+    }
+
+    public function testRevertRejectsBadToken(): void
+    {
+        $client = static::createClient();
+        $client->request('POST', '/auth/revert-email-change', [
+            'json' => ['token' => 'nope'],
+        ]);
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    // --- PATCH /users/{id} can no longer change email ---
+
+    public function testPatchUserIgnoresEmailField(): void
+    {
+        $user = $this->createTestUser('old@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($user);
+        $client->request('PATCH', '/users/' . $user->getId(), [
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            'json' => ['email' => 'sneaky@example.com'],
+        ]);
+
+        // Whether API Platform 422s an unknown field or silently drops it,
+        // the persisted email must be unchanged.
+        $refreshed = $this->reloadUser('old@example.com');
+        $this->assertSame('old@example.com', $refreshed->getEmail());
+    }
+
+    // --- Helpers ---
+
+    /** @return array{0: EmailChangeRequest, 1: string} */
+    private function seedRequest(
+        User $user,
+        string $newEmail,
+        ?\DateTimeImmutable $expiresAt = null,
+    ): array {
+        $plainToken = bin2hex(random_bytes(32));
+        $hash = hash('sha256', $plainToken);
+        $expiresAt ??= new \DateTimeImmutable('+1 hour');
+
+        $request = new EmailChangeRequest($user, $user->getEmail(), $newEmail, $hash, $expiresAt);
+        $this->entityManager->persist($request);
+        $this->entityManager->flush();
+
+        return [$request, $plainToken];
+    }
+
+    private function createTestUser(string $email): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'password123'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+
+    private function reloadUser(string $email): User
+    {
+        $em = static::getContainer()->get('doctrine')->getManager();
+        $em->clear();
+        $user = $em->getRepository(User::class)->findOneBy(['email' => $email]);
+        $this->assertNotNull($user, sprintf('User %s should exist', $email));
+
+        return $user;
+    }
+}

--- a/e2e/tests/email-change.spec.js
+++ b/e2e/tests/email-change.spec.js
@@ -1,0 +1,139 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+
+const BASE_URL = "https://localhost";
+const MAILPIT_URL = process.env.MAILPIT_URL || "http://localhost:8025";
+
+const uniqueEmail = (prefix = "email-change") =>
+  `${prefix}-${Date.now()}-${Math.floor(Math.random() * 10000)}@example.com`;
+
+async function registerAndSignIn(page, request, email, password = "password123") {
+  const res = await request.post(`${BASE_URL}/users`, {
+    headers: { "Content-Type": "application/ld+json" },
+    data: { email, plainPassword: password, givenName: "E2e", familyName: "User" },
+  });
+  expect(res.ok()).toBeTruthy();
+
+  await page.goto(`${BASE_URL}/signin`);
+  await page.fill("#email", email);
+  await page.fill("#password", password);
+  await page.click('button[type="submit"]');
+  await expect(page).toHaveURL(/\/account/);
+}
+
+async function getLatestEmail(request, recipient, timeout = 5000) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const res = await request.get(`${MAILPIT_URL}/api/v1/messages?limit=50`);
+    if (res.ok()) {
+      const { messages = [] } = await res.json();
+      const match = messages.find((m) =>
+        (m.To || []).some((to) => to.Address === recipient),
+      );
+      if (match) {
+        const detailRes = await request.get(
+          `${MAILPIT_URL}/api/v1/message/${match.ID}`,
+        );
+        if (detailRes.ok()) return detailRes.json();
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`No email to ${recipient} found within ${timeout}ms`);
+}
+
+async function clearMailpit(request) {
+  await request.delete(`${MAILPIT_URL}/api/v1/messages`);
+}
+
+test.describe("Change email (authenticated)", () => {
+  test("full flow: request → confirm → revert", async ({ page, request }) => {
+    const oldEmail = uniqueEmail("old");
+    const newEmail = uniqueEmail("new");
+    await registerAndSignIn(page, request, oldEmail);
+    await clearMailpit(request);
+
+    // Submit new email
+    await page.locator('input[name="newEmail"]').fill(newEmail);
+    await page.click('button:has-text("Send confirmation link")');
+    await expect(page.locator(`text=${newEmail}`).first()).toBeVisible();
+
+    // Pick the confirm link out of the email sent to the new address
+    const confirmMessage = await getLatestEmail(request, newEmail);
+    const confirmBody = confirmMessage.Text || confirmMessage.HTML || "";
+    const confirmMatch = confirmBody.match(
+      /confirm-email-change\?token=([a-f0-9]+)/,
+    );
+    expect(
+      confirmMatch,
+      "Confirmation email should contain a confirm link",
+    ).toBeTruthy();
+    const confirmUrl = `${BASE_URL}/confirm-email-change?token=${confirmMatch[1]}`;
+
+    await clearMailpit(request);
+    await page.goto(confirmUrl);
+    await expect(page.locator(`text=${newEmail}`).first()).toBeVisible();
+
+    // The notice email goes to the *old* address with the revert link
+    const noticeMessage = await getLatestEmail(request, oldEmail);
+    const noticeBody = noticeMessage.Text || noticeMessage.HTML || "";
+    const revertMatch = noticeBody.match(
+      /revert-email-change\?token=([a-f0-9]+)/,
+    );
+    expect(revertMatch, "Notice email should contain a revert link").toBeTruthy();
+    expect(noticeBody).toMatch(/forgot-password/);
+    const revertUrl = `${BASE_URL}/revert-email-change?token=${revertMatch[1]}`;
+
+    // Sign back in with the new email so /confirm and /revert have a session
+    // refresh path that mirrors a real user — not strictly required by the
+    // API (both endpoints are public), but it exercises refreshUser().
+    await page.goto(`${BASE_URL}/signin`);
+    await page.fill("#email", newEmail);
+    await page.fill("#password", "password123");
+    await page.click('button[type="submit"]');
+    await expect(page).toHaveURL(/\/account/);
+
+    // Now follow the revert link
+    await page.goto(revertUrl);
+    await expect(page.locator(`text=${oldEmail}`).first()).toBeVisible();
+
+    // The old email should once again be the working credential
+    await page.goto(`${BASE_URL}/signin`);
+    await page.fill("#email", oldEmail);
+    await page.fill("#password", "password123");
+    await page.click('button[type="submit"]');
+    await expect(page).toHaveURL(/\/account/);
+  });
+
+  test("cannot request a change to an already-registered address", async ({
+    page,
+    request,
+  }) => {
+    const a = uniqueEmail("taken-a");
+    const b = uniqueEmail("taken-b");
+    await registerAndSignIn(page, request, a);
+    // Register a second user via the API so `b` is taken
+    await request.post(`${BASE_URL}/users`, {
+      headers: { "Content-Type": "application/ld+json" },
+      data: { email: b, plainPassword: "password123", givenName: "Other", familyName: "User" },
+    });
+
+    await clearMailpit(request);
+
+    await page.locator('input[name="newEmail"]').fill(b);
+    await page.click('button:has-text("Send confirmation link")');
+
+    // The form still shows a generic "we sent a link" success message —
+    // the API silently no-ops to avoid leaking address registration.
+    await expect(page.locator(`text=${b}`).first()).toBeVisible();
+
+    // ...but no email actually gets delivered.
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    const res = await request.get(`${MAILPIT_URL}/api/v1/messages?limit=50`);
+    const { messages = [] } = await res.json();
+    expect(
+      messages.some((m) => (m.To || []).some((to) => to.Address === b)),
+      "No confirmation email should be delivered for a taken address",
+    ).toBeFalsy();
+  });
+});

--- a/pwa/components/account/EmailChangeForm.tsx
+++ b/pwa/components/account/EmailChangeForm.tsx
@@ -1,0 +1,106 @@
+import { useState } from "react";
+import { Formik, Form } from "formik";
+import { ENTRYPOINT } from "@/config/entrypoint";
+import { useAuth } from "@/contexts/AuthContext";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { FormikField } from "@/components/ui/formik-field";
+
+interface Values {
+  newEmail: string;
+}
+
+const validate = (values: Values, currentEmail: string) => {
+  const errors: Partial<Values> = {};
+  const trimmed = values.newEmail.trim();
+  if (!trimmed) {
+    errors.newEmail = "New email is required.";
+  } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
+    errors.newEmail = "Please enter a valid email address.";
+  } else if (trimmed.toLowerCase() === currentEmail.toLowerCase()) {
+    errors.newEmail = "That is already your email address.";
+  } else if (trimmed.length > 180) {
+    errors.newEmail = "Too long (max 180).";
+  }
+  return errors;
+};
+
+const EmailChangeForm = () => {
+  const { user } = useAuth();
+  const [submitted, setSubmitted] = useState<string | null>(null);
+
+  if (!user) return null;
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <p className="text-sm font-medium text-muted-foreground">Email</p>
+        <p>{user.email}</p>
+      </div>
+
+      {submitted ? (
+        <Alert>
+          <AlertDescription>
+            We sent a confirmation link to <strong>{submitted}</strong>. Click the
+            link in that email to finish the change. Your account email won&rsquo;t
+            change until you do.
+          </AlertDescription>
+        </Alert>
+      ) : (
+        <Formik<Values>
+          initialValues={{ newEmail: "" }}
+          validate={(values) => validate(values, user.email)}
+          onSubmit={async (values, { setSubmitting, setStatus, resetForm }) => {
+            setStatus(null);
+            try {
+              const res = await fetch(`${ENTRYPOINT}/auth/request-email-change`, {
+                method: "POST",
+                credentials: "include",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ newEmail: values.newEmail.trim() }),
+              });
+              if (!res.ok) {
+                const data = await res.json().catch(() => ({}));
+                throw new Error(data.error || "Failed to request email change.");
+              }
+              setSubmitted(values.newEmail.trim());
+              resetForm();
+            } catch (err) {
+              setStatus(
+                err instanceof Error ? err.message : "Failed to request email change.",
+              );
+            } finally {
+              setSubmitting(false);
+            }
+          }}
+        >
+          {({ isSubmitting, status }) => (
+            <Form className="space-y-3" noValidate>
+              {status && (
+                <Alert variant="destructive">
+                  <AlertDescription>{status}</AlertDescription>
+                </Alert>
+              )}
+              <FormikField
+                name="newEmail"
+                type="email"
+                autoComplete="email"
+                label="New email"
+                placeholder="name@example.com"
+              />
+              <p className="text-xs text-muted-foreground">
+                We&rsquo;ll send a confirmation link to the new address. Your
+                current email stays in place until you click it.
+              </p>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? "Sending..." : "Send confirmation link"}
+              </Button>
+            </Form>
+          )}
+        </Formik>
+      )}
+    </div>
+  );
+};
+
+export default EmailChangeForm;

--- a/pwa/pages/account.tsx
+++ b/pwa/pages/account.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 import { useEffect } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import AvatarSection from "@/components/account/AvatarSection";
+import EmailChangeForm from "@/components/account/EmailChangeForm";
 import ProfileForm from "@/components/account/ProfileForm";
 import ChangePasswordForm from "@/components/account/ChangePasswordForm";
 import { Badge } from "@/components/ui/badge";
@@ -61,10 +62,7 @@ const Account = () => {
               <CardTitle>Account</CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
-              <div>
-                <p className="text-sm font-medium text-muted-foreground">Email</p>
-                <p>{user.email}</p>
-              </div>
+              <EmailChangeForm />
               <Separator />
               <ProfileForm />
             </CardContent>

--- a/pwa/pages/confirm-email-change.tsx
+++ b/pwa/pages/confirm-email-change.tsx
@@ -1,0 +1,122 @@
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import { ENTRYPOINT } from "@/config/entrypoint";
+import { useAuth } from "@/contexts/AuthContext";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+type State =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "success"; newEmail: string }
+  | { status: "error"; message: string };
+
+const ConfirmEmailChange = () => {
+  const router = useRouter();
+  const { refreshUser } = useAuth();
+  const token = typeof router.query.token === "string" ? router.query.token : "";
+  const [state, setState] = useState<State>({ status: "idle" });
+
+  useEffect(() => {
+    if (!router.isReady) return;
+    if (!token) {
+      setState({ status: "error", message: "Missing confirmation token." });
+      return;
+    }
+    if (state.status !== "idle") return;
+
+    let cancelled = false;
+    setState({ status: "loading" });
+    (async () => {
+      try {
+        const res = await fetch(`${ENTRYPOINT}/auth/confirm-email-change`, {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ token }),
+        });
+        const data = await res.json().catch(() => ({}));
+        if (cancelled) return;
+        if (!res.ok) {
+          setState({
+            status: "error",
+            message: data.error || "Invalid or expired confirmation link.",
+          });
+          return;
+        }
+        // If the current session belongs to the user whose email just
+        // changed, refresh it so the navbar avatar/email update too.
+        await refreshUser();
+        setState({ status: "success", newEmail: data.newEmail ?? "" });
+      } catch {
+        if (!cancelled) {
+          setState({
+            status: "error",
+            message: "Something went wrong confirming your email.",
+          });
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // We intentionally only kick off the request once the router is ready
+    // and we have a token; the state guard above protects against the
+    // strict-mode double-invocation in dev.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router.isReady, token]);
+
+  return (
+    <>
+      <Head>
+        <title>Confirm Email Change - Aura</title>
+      </Head>
+      <main className="min-h-screen flex items-center justify-center bg-muted px-4 py-12">
+        <Card className="w-full max-w-md">
+          <CardHeader>
+            <CardTitle className="text-2xl text-center">Confirm Email Change</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {state.status === "loading" || state.status === "idle" ? (
+              <p className="text-muted-foreground text-center">Confirming…</p>
+            ) : state.status === "success" ? (
+              <>
+                <Alert>
+                  <AlertDescription>
+                    Your email has been updated
+                    {state.newEmail ? (
+                      <>
+                        {" "}
+                        to <strong>{state.newEmail}</strong>
+                      </>
+                    ) : null}
+                    . We&rsquo;ve also notified your previous address with a
+                    link to undo this change in case it wasn&rsquo;t you.
+                  </AlertDescription>
+                </Alert>
+                <Button asChild className="w-full">
+                  <Link href="/account">Back to my account</Link>
+                </Button>
+              </>
+            ) : (
+              <>
+                <Alert variant="destructive">
+                  <AlertDescription>{state.message}</AlertDescription>
+                </Alert>
+                <Button asChild variant="outline" className="w-full">
+                  <Link href="/account">Back to my account</Link>
+                </Button>
+              </>
+            )}
+          </CardContent>
+        </Card>
+      </main>
+    </>
+  );
+};
+
+export default ConfirmEmailChange;

--- a/pwa/pages/revert-email-change.tsx
+++ b/pwa/pages/revert-email-change.tsx
@@ -1,0 +1,120 @@
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import { ENTRYPOINT } from "@/config/entrypoint";
+import { useAuth } from "@/contexts/AuthContext";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+type State =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "success"; restoredEmail: string }
+  | { status: "error"; message: string };
+
+const RevertEmailChange = () => {
+  const router = useRouter();
+  const { refreshUser } = useAuth();
+  const token = typeof router.query.token === "string" ? router.query.token : "";
+  const [state, setState] = useState<State>({ status: "idle" });
+
+  useEffect(() => {
+    if (!router.isReady) return;
+    if (!token) {
+      setState({ status: "error", message: "Missing revert token." });
+      return;
+    }
+    if (state.status !== "idle") return;
+
+    let cancelled = false;
+    setState({ status: "loading" });
+    (async () => {
+      try {
+        const res = await fetch(`${ENTRYPOINT}/auth/revert-email-change`, {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ token }),
+        });
+        const data = await res.json().catch(() => ({}));
+        if (cancelled) return;
+        if (!res.ok) {
+          setState({
+            status: "error",
+            message: data.error || "Invalid or expired revert link.",
+          });
+          return;
+        }
+        await refreshUser();
+        setState({ status: "success", restoredEmail: data.restoredEmail ?? "" });
+      } catch {
+        if (!cancelled) {
+          setState({
+            status: "error",
+            message: "Something went wrong reverting your email.",
+          });
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router.isReady, token]);
+
+  return (
+    <>
+      <Head>
+        <title>Undo Email Change - Aura</title>
+      </Head>
+      <main className="min-h-screen flex items-center justify-center bg-muted px-4 py-12">
+        <Card className="w-full max-w-md">
+          <CardHeader>
+            <CardTitle className="text-2xl text-center">Undo Email Change</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {state.status === "loading" || state.status === "idle" ? (
+              <p className="text-muted-foreground text-center">Reverting…</p>
+            ) : state.status === "success" ? (
+              <>
+                <Alert>
+                  <AlertDescription>
+                    Your email has been restored
+                    {state.restoredEmail ? (
+                      <>
+                        {" "}
+                        to <strong>{state.restoredEmail}</strong>
+                      </>
+                    ) : null}
+                    . If this change wasn&rsquo;t made by you, we strongly
+                    recommend resetting your password as well.
+                  </AlertDescription>
+                </Alert>
+                <Button asChild className="w-full">
+                  <Link href="/forgot-password">Reset my password</Link>
+                </Button>
+                <Button asChild variant="outline" className="w-full">
+                  <Link href="/signin">Back to sign in</Link>
+                </Button>
+              </>
+            ) : (
+              <>
+                <Alert variant="destructive">
+                  <AlertDescription>{state.message}</AlertDescription>
+                </Alert>
+                <Button asChild variant="outline" className="w-full">
+                  <Link href="/signin">Back to sign in</Link>
+                </Button>
+              </>
+            )}
+          </CardContent>
+        </Card>
+      </main>
+    </>
+  );
+};
+
+export default RevertEmailChange;


### PR DESCRIPTION
## Summary
Two-step verified email change. From `/account`, the user enters a new address; we send a confirmation link there. Clicking the link flips their stored email and notifies the **old** address with two follow-ups: a one-week revert link, and a pointer to `/forgot-password` in case the account was taken.

## Backend
- New `EmailChangeRequest` entity (one row per request) holding `oldEmail`, `newEmail`, sha256 hashes for both the confirm and revert tokens, plus the four lifecycle timestamps (created, confirmed, reverted, cancelled).
- New `EmailChangeController` exposes:
  - `POST /auth/request-email-change` — auth required, validates and silently no-ops on a taken address (no enumeration), sends confirm link.
  - `POST /auth/confirm-email-change` — public, flips email, issues revert token, mails the old address.
  - `POST /auth/revert-email-change` — public, rolls back.
- `User.email` moves out of the `user:write` denormalisation group into a new `user:create` group used only by the signup `Post` operation, so PATCH `/users/{id}` can no longer change email outside the verified flow.
- 14 new tests in `EmailChangeTest` covering the happy path, taken-address no-op, expired/used tokens, address-conflict-at-confirm, revert, and the locked-down PATCH. Full suite: 127 tests, all green.

## Frontend
- `EmailChangeForm` replaces the static email row on `/account`. After submission it shows a "we sent a link to X" confirmation in place of the form.
- New pages `/confirm-email-change` and `/revert-email-change` auto-submit the URL token on mount and show a result card. The revert page points the user to `/forgot-password` to reset their password as well.
- Auth context already had `refreshUser()`; both new pages call it after a successful flip so the navbar email/avatar update live.

## Test plan
- [x] `pnpm exec tsc --noEmit` passes
- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds (both new pages prerender)
- [x] `bin/phpunit` — 127/127 (14 new + 113 existing)
- [ ] CI green
- [ ] E2E `email-change.spec.js` covering full loop via Mailpit