### PR TITLE
feat(tasks): inline-editable tasks table with drag-to-reorder

### DIFF
--- a/api/src/Controller/TaskReorderController.php
+++ b/api/src/Controller/TaskReorderController.php
@@ -15,17 +15,22 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Uid\Uuid;
 
 /**
- * Bulk reorder the authenticated user's tasks. Accepts an ordered list of
- * Task IRIs and renumbers their `position` to match (0, 1, 2, ...).
+ * Bulk reorder the tasks the user can act on. Accepts an ordered list of
+ * Task IRIs and renumbers `position` (0, 1, 2, ...) on each reorderable
+ * task in the input.
  *
- * This is an all-or-nothing operation — it rejects the whole payload if any
- * IRI is malformed, unknown, not owned by the current user, or if the list
- * does not cover exactly the user's current task set. Covering the full set
- * prevents partial writes from interleaving awkwardly with concurrent
- * creates/deletes, and keeps positions contiguous and easy to reason about.
+ * "Reorderable" matches the project-member edit rule on Task: the user
+ * can reorder tasks they own plus any task in a project they belong to
+ * (anyone who can add a task to the project can also reorder its tasks).
+ * Tasks outside that set — e.g. another user's personal tasks an admin's
+ * unfiltered view turns up — are silently skipped, so the frontend can
+ * send the full visible list without classifying rows up-front.
  *
- * Admins reorder their own tasks only; cross-user reordering is intentionally
- * not exposed via this endpoint.
+ * Still rejects the whole payload when:
+ *   - any IRI is malformed,
+ *   - the input contains a duplicate, or
+ *   - the input doesn't include every one of the reorderable tasks.
+ * The "every one" requirement keeps position numbers contiguous.
  */
 final class TaskReorderController extends AbstractController
 {
@@ -57,29 +62,32 @@ final class TaskReorderController extends AbstractController
         }
 
         $requestedIds = array_keys($ids);
-        $owned = $this->tasks->findBy(['owner' => $user]);
-        $ownedById = [];
-        foreach ($owned as $task) {
-            $ownedById[(string) $task->getId()] = $task;
+        $reorderable = $this->tasks->findReorderableForUser($user);
+        $reorderableById = [];
+        foreach ($reorderable as $task) {
+            $reorderableById[(string) $task->getId()] = $task;
         }
 
-        // Ownership check runs first so cross-user or non-existent IRIs return
-        // 404 rather than leaking existence via a 400 count-mismatch response.
-        // This mirrors TaskOwnerExtension's item-lookup behavior.
+        // Walk the input in order, renumbering each reorderable task as we
+        // hit it. IRIs that aren't reorderable (other users' personal tasks
+        // an admin's unfiltered view turns up, etc.) are skipped so the
+        // frontend can send the full visible list without classifying rows.
+        $renumbered = [];
+        $position = 0;
         foreach ($requestedIds as $id) {
-            if (!isset($ownedById[$id])) {
-                return $this->json(['error' => sprintf('Task %s not found.', $id)], 404);
+            if (!isset($reorderableById[$id])) {
+                continue;
             }
+            $reorderableById[$id]->setPosition($position++);
+            $renumbered[$id] = true;
         }
 
-        if (count($requestedIds) !== count($ownedById)) {
-            return $this->json(['error' => 'Reorder payload must include every one of your tasks exactly once.'], 400);
-        }
-
-        foreach ($requestedIds as $index => $id) {
-            /** @var Task $task */
-            $task = $ownedById[$id];
-            $task->setPosition($index);
+        // Every reorderable task must have appeared somewhere in the input —
+        // otherwise we'd leave gaps or duplicate `position` values.
+        if (count($renumbered) !== count($reorderableById)) {
+            return $this->json([
+                'error' => 'Reorder payload must include every one of your tasks exactly once.',
+            ], 400);
         }
 
         $this->em->flush();

--- a/api/src/Repository/TaskRepository.php
+++ b/api/src/Repository/TaskRepository.php
@@ -32,4 +32,23 @@ final class TaskRepository extends ServiceEntityRepository
 
         return null === $min ? null : (int) $min;
     }
+
+    /**
+     * Tasks the user is allowed to reorder: anything they own directly,
+     * plus tasks attached to a project they're a member of (every project
+     * member can edit project tasks alongside the owner — see Task entity
+     * docs). Mirrors the visibility rule in TaskOwnerExtension.
+     *
+     * @return Task[]
+     */
+    public function findReorderableForUser(User $user): array
+    {
+        return $this->createQueryBuilder('t')
+            ->leftJoin('t.project', 'p')
+            ->leftJoin('p.members', 'pm', 'WITH', 'pm = :user')
+            ->where('t.owner = :user OR pm IS NOT NULL')
+            ->setParameter('user', $user)
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/api/tests/Api/TaskTest.php
+++ b/api/tests/Api/TaskTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Api;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\Project;
 use App\Entity\Task;
 use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
@@ -318,12 +319,72 @@ class TaskTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(401);
     }
 
-    public function testReorderRejectsOtherUsersTask(): void
+    public function testReorderLetsProjectMemberReorderProjectTasks(): void
     {
+        // Project members can reorder tasks attached to the project even
+        // when they don't own them — anyone who can add a task to the
+        // project can also reorder its tasks. Bob is the project owner
+        // and creates a task on it; Alice is a member who reorders.
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+
+        $project = new Project();
+        $project->setOwner($bob);
+        $project->setTitle('Shared');
+        $project->addMember($alice);
+        $project->addMember($bob);
+        $this->entityManager->persist($project);
+
+        $shared1 = new Task();
+        $shared1->setOwner($bob);
+        $shared1->setProject($project);
+        $shared1->setTitle('Shared 1');
+        $this->entityManager->persist($shared1);
+
+        $shared2 = new Task();
+        $shared2->setOwner($bob);
+        $shared2->setProject($project);
+        $shared2->setTitle('Shared 2');
+        $this->entityManager->persist($shared2);
+
+        $alicePersonal = $this->createTask($alice, 'Alice personal');
+
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks/reorder', [
+            'json' => [
+                'order' => [
+                    '/tasks/' . $shared2->getId(),
+                    '/tasks/' . $alicePersonal->getId(),
+                    '/tasks/' . $shared1->getId(),
+                ],
+            ],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(204);
+
+        $this->entityManager->clear();
+        $repo = $this->entityManager->getRepository(Task::class);
+        $this->assertSame(0, $repo->findOneBy(['title' => 'Shared 2'])->getPosition());
+        $this->assertSame(1, $repo->findOneBy(['title' => 'Alice personal'])->getPosition());
+        $this->assertSame(2, $repo->findOneBy(['title' => 'Shared 1'])->getPosition());
+    }
+
+    public function testReorderSilentlySkipsNonOwnedIris(): void
+    {
+        // Reorder is permissive about extra IRIs in the input — Bob's task
+        // is silently ignored so the frontend doesn't have to know which
+        // visible rows belong to the current user (admins, project members,
+        // etc. can see tasks they don't own). Bob's `position` must stay
+        // exactly where it was.
         $alice = $this->createUser('alice@example.com');
         $bob = $this->createUser('bob@example.com');
         $aliceTask = $this->createTask($alice, 'Alice only');
         $bobsTask = $this->createTask($bob, 'Bob owns this');
+        $bobsOriginalPosition = $bobsTask->getPosition();
 
         $client = static::createClient();
         $client->loginUser($alice);
@@ -337,9 +398,16 @@ class TaskTest extends ApiTestCase
             'headers' => ['Content-Type' => 'application/json'],
         ]);
 
-        // 404 rather than 403 to avoid leaking existence, matching the
-        // item-lookup behavior of the owner query extension.
-        $this->assertResponseStatusCodeSame(404);
+        $this->assertResponseStatusCodeSame(204);
+
+        $this->entityManager->clear();
+        $repo = $this->entityManager->getRepository(Task::class);
+        $this->assertSame(0, $repo->findOneBy(['title' => 'Alice only'])->getPosition());
+        $this->assertSame(
+            $bobsOriginalPosition,
+            $repo->findOneBy(['title' => 'Bob owns this'])->getPosition(),
+            "Bob's task position must not change when Alice reorders.",
+        );
     }
 
     public function testReorderRejectsIncompleteOrder(): void

--- a/e2e/tests/helpers.js
+++ b/e2e/tests/helpers.js
@@ -24,7 +24,8 @@ async function registerAndSignIn(page, email, password = "password123", options 
 /**
  * Type into the BlockNote description editor. The editor is a contenteditable
  * ProseMirror instance wrapped in our MarkdownEditor component, which exposes
- * `aria-label="Description"` (or an `id` when one is provided). Playwright's
+ * an `aria-label` starting with "Description" (e.g. "Description",
+ * "Description for new task", or `Description for "task title"`). Playwright's
  * `.fill()` is brittle on block editors, so we click into the editable and
  * use keyboard.type.
  *
@@ -35,13 +36,39 @@ async function registerAndSignIn(page, email, password = "password123", options 
 async function fillDescription(page, scope, text) {
   const root = scope ?? page;
   const editor = root
-    .locator('[aria-label="Description"] [contenteditable="true"]')
+    .locator('[aria-label^="Description"] [contenteditable="true"]')
     .first();
   await editor.click();
   // Clear any existing content (edit mode pre-populates the block editor).
   await page.keyboard.press("ControlOrMeta+a");
   await page.keyboard.press("Delete");
   await page.keyboard.type(text);
+}
+
+/**
+ * Create a task using the inline new-task row at the top of the Tasks
+ * table. Pre-condition: the page is already at /tasks (or visible there).
+ * Optionally stages a description by opening the inline editor first.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {string} title
+ * @param {{ description?: string }} [options]
+ */
+async function createTaskInline(page, title, options = {}) {
+  const input = page.locator('[data-testid="new-task-title-input"]');
+  await input.fill(title);
+  if (options.description) {
+    const newRow = page.locator('[data-testid="new-task-row"]');
+    await newRow.locator('[data-testid="new-task-description-add"]').click();
+    await fillDescription(page, newRow, options.description);
+    await newRow.locator('[data-testid="new-task-description-save"]').click();
+  }
+  // Locator.press focuses before pressing, which puts the cursor back in
+  // the title input even if focus drifted into the description editor.
+  await input.press("Enter");
+  await expect(
+    page.locator('[data-testid="task-item"]', { hasText: title }),
+  ).toBeVisible();
 }
 
 /**
@@ -61,5 +88,6 @@ module.exports = {
   uniqueEmail,
   registerAndSignIn,
   fillDescription,
+  createTaskInline,
   openAccountMenu,
 };

--- a/e2e/tests/tags.spec.js
+++ b/e2e/tests/tags.spec.js
@@ -5,6 +5,7 @@ const {
   uniqueEmail: shared,
   registerAndSignIn,
   fillDescription,
+  createTaskInline,
   openAccountMenu,
 } = require("./helpers");
 
@@ -69,32 +70,35 @@ test.describe("Tags", () => {
     // Create a task
     await page.goto(`${BASE_URL}/tasks`);
     const taskTitle = `Tagged task ${suffix}`;
-    await page.fill("#title", taskTitle);
-    await page.click('button[type="submit"]');
+    await createTaskInline(page, taskTitle);
     const item = page.locator('[data-testid="task-item"]', { hasText: taskTitle });
-    await expect(item).toBeVisible();
 
     // No tags attached yet
     await expect(item.locator('[data-testid="task-tag"]')).toHaveCount(0);
 
-    // Attach Blue tag via the picker
-    await item.getByRole("button", { name: /Add tag to/ }).click();
-    await page.getByRole("menuitem", { name: `Blue-${suffix}` }).click();
+    // Open the tag picker (TagsCombobox edit button — `Add tags for "<title>"`
+    // when empty, `Edit tags for "<title>"` once any are attached). Pick Blue.
+    await item.getByRole("button", { name: new RegExp(`tags for "${taskTitle}"`) }).click();
+    await page.getByRole("option", { name: `Blue-${suffix}` }).click();
     await expect(item.locator('[data-testid="task-tag"]')).toContainText(`Blue-${suffix}`);
 
-    // Attach Red tag
-    await item.getByRole("button", { name: /Add tag to/ }).click();
-    await page.getByRole("menuitem", { name: `Red-${suffix}` }).click();
+    // Picker stays open in multi-select; pick Red, then dismiss by clicking
+    // outside the popover.
+    await page.getByRole("option", { name: `Red-${suffix}` }).click();
     await expect(item.locator('[data-testid="task-tag"]')).toHaveCount(2);
+    // Click the page heading to take focus out of the combobox.
+    await page.locator("h1", { hasText: "Tasks" }).click();
 
     // Reload — order persisted by server
     await page.reload();
     const reloaded = page.locator('[data-testid="task-item"]', { hasText: taskTitle });
     await expect(reloaded.locator('[data-testid="task-tag"]')).toHaveCount(2);
 
-    // Remove Blue tag via the × on the badge
+    // Remove Blue tag via the X on the chip (Base UI ChipRemove inside the
+    // chip whose aria-label matches the tag title).
     await reloaded
-      .getByRole("button", { name: `Remove tag "Blue-${suffix}"` })
+      .locator(`[data-slot="combobox-chip"][aria-label="Blue-${suffix}"]`)
+      .locator('[data-slot="combobox-chip-remove"]')
       .click();
     await expect(reloaded.locator('[data-testid="task-tag"]')).toHaveCount(1);
     await expect(reloaded.locator('[data-testid="task-tag"]')).toContainText(`Red-${suffix}`);
@@ -114,12 +118,13 @@ test.describe("Tags", () => {
     await expect(page.locator('[data-testid="tag-item"]', { hasText: tagTitle })).toBeVisible();
 
     await page.goto(`${BASE_URL}/tasks`);
-    await page.fill("#title", taskTitle);
-    await page.click('button[type="submit"]');
+    await createTaskInline(page, taskTitle);
     const item = page.locator('[data-testid="task-item"]', { hasText: taskTitle });
-    await item.getByRole("button", { name: /Add tag to/ }).click();
-    await page.getByRole("menuitem", { name: tagTitle }).click();
+    await item.getByRole("button", { name: new RegExp(`tags for "${taskTitle}"`) }).click();
+    await page.getByRole("option", { name: tagTitle }).click();
     await expect(item.locator('[data-testid="task-tag"]')).toContainText(tagTitle);
+    // Dismiss the popover.
+    await page.locator("h1", { hasText: "Tasks" }).click();
 
     // Delete the tag from the Tags page
     await page.goto(`${BASE_URL}/tags`);

--- a/e2e/tests/tags.spec.js
+++ b/e2e/tests/tags.spec.js
@@ -77,13 +77,17 @@ test.describe("Tags", () => {
     await expect(item.locator('[data-testid="task-tag"]')).toHaveCount(0);
 
     // Open the tag picker (TagsCombobox edit button — `Add tags for "<title>"`
-    // when empty, `Edit tags for "<title>"` once any are attached). Pick Blue.
+    // when empty, `Edit tags for "<title>"` once any are attached). Then
+    // click into the chip-input so Base UI opens the options popover.
     await item.getByRole("button", { name: new RegExp(`tags for "${taskTitle}"`) }).click();
+    const tagInput = item.locator('[data-slot="combobox-chip-input"]');
+    await tagInput.click();
     await page.getByRole("option", { name: `Blue-${suffix}` }).click();
     await expect(item.locator('[data-testid="task-tag"]')).toContainText(`Blue-${suffix}`);
 
-    // Picker stays open in multi-select; pick Red, then dismiss by clicking
-    // outside the popover.
+    // Picker may close after a pick — click the input again to reopen, then
+    // pick Red.
+    await tagInput.click();
     await page.getByRole("option", { name: `Red-${suffix}` }).click();
     await expect(item.locator('[data-testid="task-tag"]')).toHaveCount(2);
     // Click the page heading to take focus out of the combobox.
@@ -121,6 +125,8 @@ test.describe("Tags", () => {
     await createTaskInline(page, taskTitle);
     const item = page.locator('[data-testid="task-item"]', { hasText: taskTitle });
     await item.getByRole("button", { name: new RegExp(`tags for "${taskTitle}"`) }).click();
+    // Click into the chip-input to open the Base UI Combobox popover.
+    await item.locator('[data-slot="combobox-chip-input"]').click();
     await page.getByRole("option", { name: tagTitle }).click();
     await expect(item.locator('[data-testid="task-tag"]')).toContainText(tagTitle);
     // Dismiss the popover.

--- a/e2e/tests/tasks.spec.js
+++ b/e2e/tests/tasks.spec.js
@@ -4,7 +4,7 @@ const {
   BASE_URL,
   uniqueEmail: shared,
   registerAndSignIn,
-  fillDescription,
+  createTaskInline,
   openAccountMenu,
 } = require("./helpers");
 
@@ -21,20 +21,20 @@ test.describe("Tasks", () => {
 
     await page.goto(`${BASE_URL}/tasks`);
     await expect(page).toHaveTitle("Tasks - Aura");
-    await expect(page.locator("text=No tasks yet")).toBeVisible();
+    // Empty state: only the new-task input row, no real task rows.
+    await expect(page.locator('[data-testid="task-item"]')).toHaveCount(0);
 
-    // Create
+    // Create — title + staged description via the inline new-task row.
     const title = `Buy groceries ${Date.now()}`;
-    await page.fill("#title", title);
-    await fillDescription(page, undefined, "Milk, eggs, bread");
-    await page.click('button[type="submit"]');
+    await createTaskInline(page, title, { description: "Milk, eggs, bread" });
 
     const item = page.locator('[data-testid="task-item"]', { hasText: title });
-    await expect(item).toBeVisible();
     await expect(item.locator("text=Milk, eggs, bread")).toBeVisible();
 
-    // Form clears after submit
-    await expect(page.locator("#title")).toHaveValue("");
+    // New-task input clears after submit and is ready for the next entry.
+    await expect(
+      page.locator('[data-testid="new-task-title-input"]'),
+    ).toHaveValue("");
 
     // Complete
     await item.locator('input[type="checkbox"]').check();
@@ -44,8 +44,8 @@ test.describe("Tasks", () => {
     await item.locator('input[type="checkbox"]').uncheck();
     await expect(item.locator(`text=${title}`)).not.toHaveClass(/line-through/);
 
-    // Delete
-    await item.getByRole("button", { name: /Delete/i }).click();
+    // Delete (trash icon button — accessible name is `Delete "<title>"`)
+    await item.getByRole("button", { name: /^Delete "/ }).click();
     await expect(item).toHaveCount(0);
   });
 
@@ -59,11 +59,7 @@ test.describe("Tasks", () => {
     await registerAndSignIn(alicePage, aliceEmail);
     await alicePage.goto(`${BASE_URL}/tasks`);
     const aliceTitle = `Alice secret ${Date.now()}`;
-    await alicePage.fill("#title", aliceTitle);
-    await alicePage.click('button[type="submit"]');
-    await expect(
-      alicePage.locator('[data-testid="task-item"]', { hasText: aliceTitle }),
-    ).toBeVisible();
+    await createTaskInline(alicePage, aliceTitle);
 
     // Bob signs in in an isolated context and should not see Alice's task
     const bobContext = await browser.newContext({ ignoreHTTPSErrors: true });
@@ -71,7 +67,7 @@ test.describe("Tasks", () => {
     await registerAndSignIn(bobPage, bobEmail);
     await bobPage.goto(`${BASE_URL}/tasks`);
     await expect(bobPage.locator(`text=${aliceTitle}`)).not.toBeVisible();
-    await expect(bobPage.locator("text=No tasks yet")).toBeVisible();
+    await expect(bobPage.locator('[data-testid="task-item"]')).toHaveCount(0);
 
     await aliceContext.close();
     await bobContext.close();
@@ -97,15 +93,13 @@ test.describe("Tasks", () => {
     const suffix = Date.now();
     const titles = [`A-${suffix}`, `B-${suffix}`, `C-${suffix}`];
     for (const t of titles) {
-      await page.fill("#title", t);
-      await page.click('button[type="submit"]');
-      await expect(
-        page.locator('[data-testid="task-item"]', { hasText: t }),
-      ).toBeVisible();
+      await createTaskInline(page, t);
     }
 
     // Verify initial order (newest first): C, B, A
-    const listItems = page.locator('[data-testid="task-item"] p.font-medium').first();
+    const listItems = page
+      .locator('[data-testid="task-item"] [data-testid="task-title"]')
+      .first();
     await expect(listItems).toHaveText(titles[2]);
 
     // Grab the grip on the top item (C) and move it down twice to position 3.
@@ -126,16 +120,25 @@ test.describe("Tasks", () => {
 
     // Now the order should be B, A, C — verify via the top item
     await expect(
-      page.locator('[data-testid="task-item"]').first().locator("p.font-medium"),
+      page
+        .locator('[data-testid="task-item"]')
+        .first()
+        .locator('[data-testid="task-title"]'),
     ).toHaveText(titles[1]);
 
     // Reloading should preserve the server-persisted order
     await page.reload();
     await expect(
-      page.locator('[data-testid="task-item"]').first().locator("p.font-medium"),
+      page
+        .locator('[data-testid="task-item"]')
+        .first()
+        .locator('[data-testid="task-title"]'),
     ).toHaveText(titles[1]);
     await expect(
-      page.locator('[data-testid="task-item"]').last().locator("p.font-medium"),
+      page
+        .locator('[data-testid="task-item"]')
+        .last()
+        .locator('[data-testid="task-title"]'),
     ).toHaveText(titles[2]);
   });
 });

--- a/pwa/components/tasks/TagsCombobox.tsx
+++ b/pwa/components/tasks/TagsCombobox.tsx
@@ -1,0 +1,195 @@
+import { useEffect, useRef, useState } from "react";
+import { Pencil, Plus } from "lucide-react";
+
+import {
+  Combobox,
+  ComboboxChip,
+  ComboboxChips,
+  ComboboxChipsInput,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxValue,
+} from "@/components/ui/combobox";
+import { cn } from "@/lib/utils";
+
+export interface TagOption {
+  "@id": string;
+  id: string;
+  title: string;
+  color: string;
+}
+
+interface TagsComboboxProps {
+  value: TagOption[];
+  options: TagOption[];
+  onChange: (nextIris: string[]) => void | Promise<void>;
+  /** Used to label the input for screen readers. */
+  subjectLabel?: string;
+  className?: string;
+}
+
+const TagsCombobox = ({
+  value,
+  options,
+  onChange,
+  subjectLabel,
+  className,
+}: TagsComboboxProps) => {
+  // Edit mode: when false we render the chips as a flat list (no border, no
+  // input) plus a small "Add"/"Edit" affordance. When true we render the
+  // full Combobox chrome (bordered chip-input + popover) so the user can
+  // search and pick tags.
+  const [isEditing, setIsEditing] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  // Click-outside dismissal. The popover content is portaled to <body>, so
+  // checking ref.contains() alone isn't enough — we also keep the editor
+  // open while the click lands inside `[data-slot=combobox-content]`.
+  useEffect(() => {
+    if (!isEditing) return;
+    const handle = (event: PointerEvent) => {
+      const target = event.target as Element | null;
+      if (!target) return;
+      if (containerRef.current?.contains(target)) return;
+      if (target.closest('[data-slot="combobox-content"]')) return;
+      setIsEditing(false);
+    };
+    document.addEventListener("pointerdown", handle, true);
+    return () => document.removeEventListener("pointerdown", handle, true);
+  }, [isEditing]);
+
+  // Focus the chip-input as soon as we enter edit mode so the user can type
+  // immediately. Querying the DOM is fine here — Base UI renders the input
+  // synchronously inside ComboboxChips.
+  useEffect(() => {
+    if (!isEditing) return;
+    const input = containerRef.current?.querySelector<HTMLInputElement>(
+      '[data-slot="combobox-chip-input"]',
+    );
+    input?.focus();
+  }, [isEditing]);
+
+  const handleChange = (next: TagOption[]) => {
+    void onChange(next.map((tag) => tag["@id"]));
+  };
+
+  return (
+    <div ref={containerRef} className={className}>
+      <Combobox<TagOption, true>
+        items={options}
+        multiple
+        value={value}
+        onValueChange={handleChange}
+        itemToStringLabel={(tag) => tag.title}
+        itemToStringValue={(tag) => tag["@id"]}
+      >
+        <ComboboxChips
+          className={cn(
+            // Strip the bordered "input box" look until we're editing. Chips
+            // themselves still render with their own coloured background and
+            // X-to-remove button, so the user can still prune tags without
+            // entering edit mode.
+            !isEditing &&
+              "min-h-0 border-transparent bg-transparent px-0 py-0 shadow-none focus-within:border-transparent focus-within:ring-0 dark:bg-transparent has-data-[slot=combobox-chip]:px-0",
+          )}
+        >
+          <ComboboxValue>
+            {value.map((tag) => (
+              // The chip itself becomes the coloured pill so the built-in
+              // remove button (X) sits on the same coloured background as
+              // the tag — no contrasting muted "frame" around it.
+              <ComboboxChip
+                key={tag["@id"]}
+                aria-label={tag.title}
+                // The X uses the shadcn ghost button which paints `bg-accent`
+                // on hover. On a coloured chip that grey hover swatch reads
+                // as a hole — kill it so only the icon's opacity changes.
+                className="px-2 text-white [&_[data-slot=combobox-chip-remove]]:hover:!bg-transparent"
+                style={{ backgroundColor: tag.color }}
+                data-testid="task-tag"
+              >
+                {tag.title}
+              </ComboboxChip>
+            ))}
+          </ComboboxValue>
+          {isEditing ? (
+            <ComboboxChipsInput
+              placeholder={value.length === 0 ? "Add tags…" : ""}
+              aria-label={subjectLabel ? `Tags for "${subjectLabel}"` : "Tags"}
+              onKeyDown={(event) => {
+                if (event.key === "Escape") {
+                  event.preventDefault();
+                  setIsEditing(false);
+                }
+              }}
+              // Chrome ignores `autoComplete="off"` on text inputs and was
+              // suggesting saved email addresses on top of our popover.
+              // Setting an unrecognised hint string ("nope") makes Chrome's
+              // autofill module treat the field as "no known type" and bail
+              // out without falling back to email/contact suggestions. The
+              // accompanying `name`/`data-form-type` are for password
+              // managers (LastPass, 1Password) that respect those hints.
+              autoComplete="nope"
+              autoCorrect="off"
+              autoCapitalize="off"
+              spellCheck={false}
+              name="aura-tag-search"
+              data-form-type="other"
+              data-lpignore="true"
+              data-1p-ignore="true"
+            />
+          ) : (
+            // Trigger to switch into edit mode. Renders compactly so it
+            // doesn't compete with the chips visually.
+            <button
+              type="button"
+              onClick={() => setIsEditing(true)}
+              aria-label={
+                subjectLabel
+                  ? `Edit tags for "${subjectLabel}"`
+                  : value.length === 0
+                    ? "Add tags"
+                    : "Edit tags"
+              }
+              className={cn(
+                "inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-xs",
+                value.length === 0
+                  ? "italic text-muted-foreground/60 hover:text-muted-foreground"
+                  : "text-muted-foreground/60 hover:text-foreground",
+              )}
+              data-testid="task-tags-edit"
+            >
+              {value.length === 0 ? (
+                <>
+                  <Plus className="h-3 w-3" />
+                  Add tags
+                </>
+              ) : (
+                <Pencil className="h-3 w-3" />
+              )}
+            </button>
+          )}
+        </ComboboxChips>
+        <ComboboxContent>
+          <ComboboxEmpty>No tags found.</ComboboxEmpty>
+          <ComboboxList>
+            {(tag: TagOption) => (
+              <ComboboxItem key={tag["@id"]} value={tag}>
+                <span
+                  className="inline-block h-3 w-3 shrink-0 rounded"
+                  style={{ backgroundColor: tag.color }}
+                  aria-hidden="true"
+                />
+                <span>{tag.title}</span>
+              </ComboboxItem>
+            )}
+          </ComboboxList>
+        </ComboboxContent>
+      </Combobox>
+    </div>
+  );
+};
+
+export default TagsCombobox;

--- a/pwa/components/ui/button.tsx
+++ b/pwa/components/ui/button.tsx
@@ -25,6 +25,9 @@ const buttonVariants = cva(
         sm: "h-8 rounded-md px-3 text-xs",
         lg: "h-10 rounded-md px-8",
         icon: "h-9 w-9",
+        // Used by the shadcn `Combobox` for inline chip-remove and trigger
+        // buttons that sit inside an InputGroup.
+        "icon-xs": "h-5 w-5 rounded-sm",
       },
     },
     defaultVariants: {

--- a/pwa/components/ui/combobox.tsx
+++ b/pwa/components/ui/combobox.tsx
@@ -1,0 +1,310 @@
+"use client"
+
+import * as React from "react"
+import { Combobox as ComboboxPrimitive } from "@base-ui/react"
+import { CheckIcon, ChevronDownIcon, XIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from "@/components/ui/input-group"
+
+const Combobox = ComboboxPrimitive.Root
+
+function ComboboxValue({ ...props }: ComboboxPrimitive.Value.Props) {
+  return <ComboboxPrimitive.Value data-slot="combobox-value" {...props} />
+}
+
+function ComboboxTrigger({
+  className,
+  children,
+  ...props
+}: ComboboxPrimitive.Trigger.Props) {
+  return (
+    <ComboboxPrimitive.Trigger
+      data-slot="combobox-trigger"
+      className={cn("[&_svg:not([class*='size-'])]:size-4", className)}
+      {...props}
+    >
+      {children}
+      <ChevronDownIcon
+        data-slot="combobox-trigger-icon"
+        className="pointer-events-none size-4 text-muted-foreground"
+      />
+    </ComboboxPrimitive.Trigger>
+  )
+}
+
+function ComboboxClear({ className, ...props }: ComboboxPrimitive.Clear.Props) {
+  return (
+    <ComboboxPrimitive.Clear
+      data-slot="combobox-clear"
+      render={<InputGroupButton variant="ghost" size="icon-xs" />}
+      className={cn(className)}
+      {...props}
+    >
+      <XIcon className="pointer-events-none" />
+    </ComboboxPrimitive.Clear>
+  )
+}
+
+function ComboboxInput({
+  className,
+  children,
+  disabled = false,
+  showTrigger = true,
+  showClear = false,
+  ...props
+}: ComboboxPrimitive.Input.Props & {
+  showTrigger?: boolean
+  showClear?: boolean
+}) {
+  return (
+    <InputGroup className={cn("w-auto", className)}>
+      <ComboboxPrimitive.Input
+        render={<InputGroupInput disabled={disabled} />}
+        {...props}
+      />
+      <InputGroupAddon align="inline-end">
+        {showTrigger && (
+          <InputGroupButton
+            size="icon-xs"
+            variant="ghost"
+            asChild
+            data-slot="input-group-button"
+            className="group-has-data-[slot=combobox-clear]/input-group:hidden data-pressed:bg-transparent"
+            disabled={disabled}
+          >
+            <ComboboxTrigger />
+          </InputGroupButton>
+        )}
+        {showClear && <ComboboxClear disabled={disabled} />}
+      </InputGroupAddon>
+      {children}
+    </InputGroup>
+  )
+}
+
+function ComboboxContent({
+  className,
+  side = "bottom",
+  sideOffset = 6,
+  align = "start",
+  alignOffset = 0,
+  anchor,
+  ...props
+}: ComboboxPrimitive.Popup.Props &
+  Pick<
+    ComboboxPrimitive.Positioner.Props,
+    "side" | "align" | "sideOffset" | "alignOffset" | "anchor"
+  >) {
+  return (
+    <ComboboxPrimitive.Portal>
+      <ComboboxPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        anchor={anchor}
+        className="isolate z-50"
+      >
+        <ComboboxPrimitive.Popup
+          data-slot="combobox-content"
+          data-chips={!!anchor}
+          className={cn(
+            "group/combobox-content relative max-h-96 w-(--anchor-width) max-w-(--available-width) min-w-[calc(var(--anchor-width)+--spacing(7))] origin-(--transform-origin) overflow-hidden rounded-md bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[chips=true]:min-w-(--anchor-width) data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 *:data-[slot=input-group]:m-1 *:data-[slot=input-group]:mb-0 *:data-[slot=input-group]:h-8 *:data-[slot=input-group]:border-input/30 *:data-[slot=input-group]:bg-input/30 *:data-[slot=input-group]:shadow-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className
+          )}
+          {...props}
+        />
+      </ComboboxPrimitive.Positioner>
+    </ComboboxPrimitive.Portal>
+  )
+}
+
+function ComboboxList({ className, ...props }: ComboboxPrimitive.List.Props) {
+  return (
+    <ComboboxPrimitive.List
+      data-slot="combobox-list"
+      className={cn(
+        "max-h-[min(calc(--spacing(96)---spacing(9)),calc(var(--available-height)---spacing(9)))] scroll-py-1 overflow-y-auto p-1 data-empty:p-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ComboboxItem({
+  className,
+  children,
+  ...props
+}: ComboboxPrimitive.Item.Props) {
+  return (
+    <ComboboxPrimitive.Item
+      data-slot="combobox-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-highlighted:bg-accent data-highlighted:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ComboboxPrimitive.ItemIndicator
+        data-slot="combobox-item-indicator"
+        render={
+          <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
+        }
+      >
+        <CheckIcon className="pointer-events-none size-4 pointer-coarse:size-5" />
+      </ComboboxPrimitive.ItemIndicator>
+    </ComboboxPrimitive.Item>
+  )
+}
+
+function ComboboxGroup({ className, ...props }: ComboboxPrimitive.Group.Props) {
+  return (
+    <ComboboxPrimitive.Group
+      data-slot="combobox-group"
+      className={cn(className)}
+      {...props}
+    />
+  )
+}
+
+function ComboboxLabel({
+  className,
+  ...props
+}: ComboboxPrimitive.GroupLabel.Props) {
+  return (
+    <ComboboxPrimitive.GroupLabel
+      data-slot="combobox-label"
+      className={cn(
+        "px-2 py-1.5 text-xs text-muted-foreground pointer-coarse:px-3 pointer-coarse:py-2 pointer-coarse:text-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ComboboxCollection({ ...props }: ComboboxPrimitive.Collection.Props) {
+  return (
+    <ComboboxPrimitive.Collection data-slot="combobox-collection" {...props} />
+  )
+}
+
+function ComboboxEmpty({ className, ...props }: ComboboxPrimitive.Empty.Props) {
+  return (
+    <ComboboxPrimitive.Empty
+      data-slot="combobox-empty"
+      className={cn(
+        "hidden w-full justify-center py-2 text-center text-sm text-muted-foreground group-data-empty/combobox-content:flex",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ComboboxSeparator({
+  className,
+  ...props
+}: ComboboxPrimitive.Separator.Props) {
+  return (
+    <ComboboxPrimitive.Separator
+      data-slot="combobox-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function ComboboxChips({
+  className,
+  ...props
+}: React.ComponentPropsWithRef<typeof ComboboxPrimitive.Chips> &
+  ComboboxPrimitive.Chips.Props) {
+  return (
+    <ComboboxPrimitive.Chips
+      data-slot="combobox-chips"
+      className={cn(
+        "flex min-h-9 flex-wrap items-center gap-1.5 rounded-md border border-input bg-transparent bg-clip-padding px-2.5 py-1.5 text-sm shadow-xs transition-[color,box-shadow] focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50 has-aria-invalid:border-destructive has-aria-invalid:ring-[3px] has-aria-invalid:ring-destructive/20 has-data-[slot=combobox-chip]:px-1.5 dark:bg-input/30 dark:has-aria-invalid:border-destructive/50 dark:has-aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ComboboxChip({
+  className,
+  children,
+  showRemove = true,
+  ...props
+}: ComboboxPrimitive.Chip.Props & {
+  showRemove?: boolean
+}) {
+  return (
+    <ComboboxPrimitive.Chip
+      data-slot="combobox-chip"
+      className={cn(
+        "flex h-[calc(--spacing(5.5))] w-fit items-center justify-center gap-1 rounded-sm bg-muted px-1.5 text-xs font-medium whitespace-nowrap text-foreground has-disabled:pointer-events-none has-disabled:cursor-not-allowed has-disabled:opacity-50 has-data-[slot=combobox-chip-remove]:pr-0",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showRemove && (
+        <ComboboxPrimitive.ChipRemove
+          render={<Button variant="ghost" size="icon-xs" />}
+          className="-ml-1 opacity-50 hover:opacity-100"
+          data-slot="combobox-chip-remove"
+        >
+          <XIcon className="pointer-events-none" />
+        </ComboboxPrimitive.ChipRemove>
+      )}
+    </ComboboxPrimitive.Chip>
+  )
+}
+
+function ComboboxChipsInput({
+  className,
+  children,
+  ...props
+}: ComboboxPrimitive.Input.Props) {
+  return (
+    <ComboboxPrimitive.Input
+      data-slot="combobox-chip-input"
+      className={cn("min-w-16 flex-1 outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+function useComboboxAnchor() {
+  return React.useRef<HTMLDivElement | null>(null)
+}
+
+export {
+  Combobox,
+  ComboboxInput,
+  ComboboxContent,
+  ComboboxList,
+  ComboboxItem,
+  ComboboxGroup,
+  ComboboxLabel,
+  ComboboxCollection,
+  ComboboxEmpty,
+  ComboboxSeparator,
+  ComboboxChips,
+  ComboboxChip,
+  ComboboxChipsInput,
+  ComboboxTrigger,
+  ComboboxValue,
+  useComboboxAnchor,
+}

--- a/pwa/components/ui/command.tsx
+++ b/pwa/components/ui/command.tsx
@@ -1,0 +1,182 @@
+import * as React from "react"
+import { Command as CommandPrimitive } from "cmdk"
+import { SearchIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+function Command({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandDialog({
+  title = "Command Palette",
+  description = "Search for a command to run...",
+  children,
+  className,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof Dialog> & {
+  title?: string
+  description?: string
+  className?: string
+  showCloseButton?: boolean
+}) {
+  return (
+    <Dialog {...props}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+      <DialogContent
+        className={cn("overflow-hidden p-0", className)}
+        showCloseButton={showCloseButton}
+      >
+        <Command className="**:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div
+      data-slot="command-input-wrapper"
+      className="flex h-9 items-center gap-2 border-b px-3"
+    >
+      <SearchIcon className="size-4 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function CommandList({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn(
+        "max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandEmpty({
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className="py-6 text-center text-sm"
+      {...props}
+    />
+  )
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+  return (
+    <CommandPrimitive.Separator
+      data-slot="command-separator"
+      className={cn("-mx-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function CommandItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="command-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+}

--- a/pwa/components/ui/dialog.tsx
+++ b/pwa/components/ui/dialog.tsx
@@ -1,0 +1,158 @@
+"use client"
+
+import * as React from "react"
+import { XIcon } from "lucide-react"
+import { Dialog as DialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant="outline">Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/pwa/components/ui/input-group.tsx
+++ b/pwa/components/ui/input-group.tsx
@@ -1,0 +1,168 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+
+function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="input-group"
+      role="group"
+      className={cn(
+        "group/input-group relative flex w-full items-center rounded-md border border-input shadow-xs transition-[color,box-shadow] outline-none dark:bg-input/30",
+        "h-9 min-w-0 has-[>textarea]:h-auto",
+
+        // Variants based on alignment.
+        "has-[>[data-align=inline-start]]:[&>input]:pl-2",
+        "has-[>[data-align=inline-end]]:[&>input]:pr-2",
+        "has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-start]]:[&>input]:pb-3",
+        "has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3",
+
+        // Focus state.
+        "has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-[3px] has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50",
+
+        // Error state.
+        "has-[[data-slot][aria-invalid=true]]:border-destructive has-[[data-slot][aria-invalid=true]]:ring-destructive/20 dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40",
+
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const inputGroupAddonVariants = cva(
+  "flex h-auto cursor-text items-center justify-center gap-2 py-1.5 text-sm font-medium text-muted-foreground select-none group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      align: {
+        "inline-start":
+          "order-first pl-3 has-[>button]:ml-[-0.45rem] has-[>kbd]:ml-[-0.35rem]",
+        "inline-end":
+          "order-last pr-3 has-[>button]:mr-[-0.45rem] has-[>kbd]:mr-[-0.35rem]",
+        "block-start":
+          "order-first w-full justify-start px-3 pt-3 group-has-[>input]/input-group:pt-2.5 [.border-b]:pb-3",
+        "block-end":
+          "order-last w-full justify-start px-3 pb-3 group-has-[>input]/input-group:pb-2.5 [.border-t]:pt-3",
+      },
+    },
+    defaultVariants: {
+      align: "inline-start",
+    },
+  }
+)
+
+function InputGroupAddon({
+  className,
+  align = "inline-start",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof inputGroupAddonVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="input-group-addon"
+      data-align={align}
+      className={cn(inputGroupAddonVariants({ align }), className)}
+      onClick={(e) => {
+        if ((e.target as HTMLElement).closest("button")) {
+          return
+        }
+        e.currentTarget.parentElement?.querySelector("input")?.focus()
+      }}
+      {...props}
+    />
+  )
+}
+
+const inputGroupButtonVariants = cva(
+  "flex items-center gap-2 text-sm shadow-none",
+  {
+    variants: {
+      size: {
+        xs: "h-6 gap-1 rounded-[calc(var(--radius)-5px)] px-2 has-[>svg]:px-2 [&>svg:not([class*='size-'])]:size-3.5",
+        sm: "h-8 gap-1.5 rounded-md px-2.5 has-[>svg]:px-2.5",
+        "icon-xs":
+          "size-6 rounded-[calc(var(--radius)-5px)] p-0 has-[>svg]:p-0",
+        "icon-sm": "size-8 p-0 has-[>svg]:p-0",
+      },
+    },
+    defaultVariants: {
+      size: "xs",
+    },
+  }
+)
+
+function InputGroupButton({
+  className,
+  type = "button",
+  variant = "ghost",
+  size = "xs",
+  ...props
+}: Omit<React.ComponentProps<typeof Button>, "size"> &
+  VariantProps<typeof inputGroupButtonVariants>) {
+  return (
+    <Button
+      type={type}
+      data-size={size}
+      variant={variant}
+      className={cn(inputGroupButtonVariants({ size }), className)}
+      {...props}
+    />
+  )
+}
+
+function InputGroupText({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      className={cn(
+        "flex items-center gap-2 text-sm text-muted-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function InputGroupInput({
+  className,
+  ...props
+}: React.ComponentProps<"input">) {
+  return (
+    <Input
+      data-slot="input-group-control"
+      className={cn(
+        "flex-1 rounded-none border-0 bg-transparent shadow-none focus-visible:ring-0 dark:bg-transparent",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function InputGroupTextarea({
+  className,
+  ...props
+}: React.ComponentProps<"textarea">) {
+  return (
+    <Textarea
+      data-slot="input-group-control"
+      className={cn(
+        "flex-1 resize-none rounded-none border-0 bg-transparent py-3 shadow-none focus-visible:ring-0 dark:bg-transparent",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupText,
+  InputGroupInput,
+  InputGroupTextarea,
+}

--- a/pwa/components/ui/popover.tsx
+++ b/pwa/components/ui/popover.tsx
@@ -1,0 +1,87 @@
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-1 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
+  return (
+    <div
+      data-slot="popover-title"
+      className={cn("font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverAnchor,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverDescription,
+}

--- a/pwa/components/ui/table.tsx
+++ b/pwa/components/ui/table.tsx
@@ -1,0 +1,114 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("mt-4 text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/pwa/next-env.d.ts
+++ b/pwa/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@api-platform/admin": "^4.0.9",
+    "@base-ui/react": "^1.4.1",
     "@blocknote/core": "^0.49.0",
     "@blocknote/mantine": "^0.49.0",
     "@blocknote/react": "^0.49.0",
@@ -27,6 +28,7 @@
     "@tanstack/react-query": "^5.100.5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "formik": "^2.4.9",
     "isomorphic-unfetch": "^4.0.2",
     "lucide-react": "^0.469.0",

--- a/pwa/pages/tasks.tsx
+++ b/pwa/pages/tasks.tsx
@@ -1,7 +1,7 @@
 import Head from "next/head";
 import { useRouter } from "next/router";
-import { FormEvent, useCallback, useEffect, useState } from "react";
-import { GripVertical, Plus, X } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ArrowDown, ArrowUp, ArrowUpDown, GripVertical, Trash2 } from "lucide-react";
 import {
   DndContext,
   DragEndEvent,
@@ -23,18 +23,18 @@ import { useAuth } from "@/contexts/AuthContext";
 import { ENTRYPOINT } from "@/config/entrypoint";
 import { signinHrefForCurrent } from "@/lib/authRedirect";
 import MarkdownEditor from "@/components/editor/MarkdownEditor";
-import MarkdownView from "@/components/editor/MarkdownView";
+import TagsCombobox from "@/components/tasks/TagsCombobox";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+import {
+  Table,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { cn } from "@/lib/utils";
 
 interface Tag {
@@ -61,23 +61,89 @@ interface Collection<T> {
   "hydra:member"?: T[];
 }
 
-interface SortableTaskItemProps {
+// "manual" maps to the persisted `position` order — drag-to-reorder is only
+// active in this mode because anything else would snap rows back the moment
+// we re-sorted. The other keys are derived sort orders that don't touch the
+// underlying tasks array, just the rendered view.
+type SortKey = "manual" | "completed" | "title";
+type SortDir = "asc" | "desc";
+
+interface SortState {
+  key: SortKey;
+  dir: SortDir;
+}
+
+const DEFAULT_SORT: SortState = { key: "manual", dir: "asc" };
+
+// Strip the most common markdown punctuation so the description in the
+// dedicated sub-row reads as plain text. We keep paragraph breaks via `\n`
+// so multi-paragraph descriptions still feel structured. A real markdown
+// renderer (`MarkdownView`) can replace this later if we want bold/links.
+const plainTextDescription = (markdown: string | null): string => {
+  if (!markdown) return "";
+  return markdown
+    .replace(/`{3}[\s\S]*?`{3}/g, "")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/^[#>*_~`\-]+\s*/gm, "")
+    .replace(/\!?\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/[*_~]+/g, "")
+    .replace(/[ \t]+/g, " ")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+};
+
+interface SortableHeaderProps {
+  label: string;
+  sortKey: SortKey;
+  active: SortState;
+  onSort: (key: SortKey) => void;
+  className?: string;
+}
+
+const SortableHeader = ({ label, sortKey, active, onSort, className }: SortableHeaderProps) => {
+  const isActive = active.key === sortKey;
+  const Icon = isActive ? (active.dir === "asc" ? ArrowUp : ArrowDown) : ArrowUpDown;
+  return (
+    <TableHead className={className}>
+      <button
+        type="button"
+        onClick={() => onSort(sortKey)}
+        className="inline-flex items-center gap-1 -ml-2 px-2 py-1 rounded-sm hover:bg-accent text-left font-medium"
+        aria-sort={
+          isActive ? (active.dir === "asc" ? "ascending" : "descending") : "none"
+        }
+      >
+        <span>{label}</span>
+        <Icon className={cn("h-3.5 w-3.5", isActive ? "opacity-100" : "opacity-50")} />
+      </button>
+    </TableHead>
+  );
+};
+
+interface TaskRowProps {
   task: Task;
   allTags: Tag[];
+  reorderable: boolean;
   onToggle: (task: Task) => void;
   onDelete: (task: Task) => void;
   onTagsChange: (task: Task, nextTagIris: string[]) => Promise<void>;
+  onTitleChange: (task: Task, nextTitle: string) => Promise<void>;
+  onDescriptionChange: (task: Task, nextDescription: string | null) => Promise<void>;
 }
 
-const SortableTaskItem = ({
+const TaskRow = ({
   task,
   allTags,
+  reorderable,
   onToggle,
   onDelete,
   onTagsChange,
-}: SortableTaskItemProps) => {
+  onTitleChange,
+  onDescriptionChange,
+}: TaskRowProps) => {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: task["@id"],
+    disabled: !reorderable,
   });
 
   const style = {
@@ -86,32 +152,92 @@ const SortableTaskItem = ({
     opacity: isDragging ? 0.5 : 1,
   };
 
-  const attachedIris = new Set(task.tags.map((t) => t["@id"]));
-  const availableTags = allTags.filter((t) => !attachedIris.has(t["@id"]));
+  // --- Inline title editing ---------------------------------------------
+  const [editingTitle, setEditingTitle] = useState(false);
+  const [titleDraft, setTitleDraft] = useState(task.title);
+  // Keep the draft in sync if the task's title is updated externally
+  // (e.g. an optimistic patch elsewhere or a reload).
+  useEffect(() => {
+    if (!editingTitle) setTitleDraft(task.title);
+  }, [task.title, editingTitle]);
 
-  const handleRemoveTag = async (tag: Tag) => {
-    const next = task.tags.filter((t) => t["@id"] !== tag["@id"]).map((t) => t["@id"]);
-    await onTagsChange(task, next);
+  const startEditTitle = () => {
+    setTitleDraft(task.title);
+    setEditingTitle(true);
+  };
+  const cancelTitle = () => {
+    setTitleDraft(task.title);
+    setEditingTitle(false);
+  };
+  const saveTitle = async () => {
+    const next = titleDraft.trim();
+    setEditingTitle(false);
+    if (!next || next === task.title) {
+      // Empty / unchanged → silently revert; no API call.
+      setTitleDraft(task.title);
+      return;
+    }
+    await onTitleChange(task, next);
   };
 
-  const handleAddTag = async (tag: Tag) => {
-    const next = [...task.tags.map((t) => t["@id"]), tag["@id"]];
-    await onTagsChange(task, next);
+  // --- Inline description editing ---------------------------------------
+  const [editingDesc, setEditingDesc] = useState(false);
+  const [descDraft, setDescDraft] = useState(task.description ?? "");
+  // BlockNote reads `value` only at mount, so we bump this key each time we
+  // open the editor to force a fresh remount with the current saved content.
+  const [descEditorKey, setDescEditorKey] = useState(0);
+
+  useEffect(() => {
+    if (!editingDesc) setDescDraft(task.description ?? "");
+  }, [task.description, editingDesc]);
+
+  const startEditDesc = () => {
+    setDescDraft(task.description ?? "");
+    setDescEditorKey((k) => k + 1);
+    setEditingDesc(true);
+  };
+  const cancelDesc = () => {
+    setDescDraft(task.description ?? "");
+    setEditingDesc(false);
+  };
+  const saveDesc = async () => {
+    setEditingDesc(false);
+    const trimmed = descDraft.trim();
+    const next = trimmed === "" ? null : descDraft;
+    const current = task.description ?? null;
+    if (next === current) return;
+    await onDescriptionChange(task, next);
   };
 
+  const description = plainTextDescription(task.description);
+  const titleClass = cn("font-medium", task.completedOn && "line-through text-muted-foreground");
+
+  // Each task gets its own <tbody> so dnd-kit drags the main row + the
+  // description sub-row together as a single unit. Multiple <tbody>s in one
+  // <table> is valid HTML and avoids fighting the table layout. We also use
+  // a `group/task` so hovering either row paints the bg on both, making the
+  // pair feel like one card.
   return (
-    <li ref={setNodeRef} style={style} data-testid="task-item">
-      <Card>
-        <CardContent className="pt-4 pb-4 flex items-start gap-3">
+    <tbody ref={setNodeRef} style={style} data-testid="task-item">
+      <TableRow className="border-b-0 hover:bg-transparent">
+        <TableCell className="w-8 align-top">
           <button
             type="button"
             aria-label={`Drag to reorder "${task.title}"`}
-            className="mt-0.5 px-1 text-muted-foreground hover:text-foreground cursor-grab active:cursor-grabbing touch-none bg-transparent border-0"
+            className={cn(
+              "px-1 text-muted-foreground touch-none bg-transparent border-0",
+              reorderable
+                ? "cursor-grab active:cursor-grabbing hover:text-foreground"
+                : "cursor-not-allowed opacity-30",
+            )}
+            disabled={!reorderable}
             {...attributes}
             {...listeners}
           >
             <GripVertical className="h-4 w-4" />
           </button>
+        </TableCell>
+        <TableCell className="w-10 align-top">
           <input
             type="checkbox"
             checked={!!task.completedOn}
@@ -119,83 +245,300 @@ const SortableTaskItem = ({
             aria-label={`Mark "${task.title}" as ${task.completedOn ? "incomplete" : "complete"}`}
             className="mt-1 h-4 w-4 shrink-0 cursor-pointer"
           />
-          <div className="flex-1 min-w-0">
-            <p
-              className={cn(
-                "font-medium",
-                task.completedOn && "line-through text-muted-foreground",
-              )}
+        </TableCell>
+        <TableCell className="align-top pl-0">
+          {editingTitle ? (
+            <Input
+              autoFocus
+              value={titleDraft}
+              onChange={(e) => setTitleDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  void saveTitle();
+                } else if (e.key === "Escape") {
+                  e.preventDefault();
+                  cancelTitle();
+                }
+              }}
+              onBlur={() => void saveTitle()}
+              maxLength={255}
+              aria-label={`Edit title for "${task.title}"`}
+              className="h-8"
+              data-testid="task-title-input"
+            />
+          ) : (
+            <button
+              type="button"
+              onClick={startEditTitle}
+              aria-label={`Edit title "${task.title}"`}
+              className="text-left w-full cursor-text"
+              data-testid="task-title"
             >
-              {task.title}
-            </p>
-            {task.description && (
-              <MarkdownView
-                source={task.description}
-                className={cn("mt-1", task.completedOn && "line-through text-muted-foreground")}
-              />
-            )}
-            <div className="mt-2 flex flex-wrap items-center gap-1" data-testid="task-tags">
-              {task.tags.map((tag) => (
-                <span
-                  key={tag["@id"]}
-                  className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-semibold text-white"
-                  style={{ backgroundColor: tag.color }}
-                  data-testid="task-tag"
-                >
-                  {tag.title}
-                  <button
-                    type="button"
-                    onClick={() => handleRemoveTag(tag)}
-                    aria-label={`Remove tag "${tag.title}" from "${task.title}"`}
-                    className="ml-0.5 text-white/80 hover:text-white bg-transparent border-0 cursor-pointer leading-none"
-                  >
-                    <X className="h-3 w-3" />
-                  </button>
-                </span>
-              ))}
-              {availableTags.length > 0 && (
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <button
-                      type="button"
-                      aria-label={`Add tag to "${task.title}"`}
-                      className="text-xs text-primary hover:underline bg-transparent border border-dashed border-input rounded px-2 py-0.5 cursor-pointer inline-flex items-center gap-1"
-                    >
-                      <Plus className="h-3 w-3" />
-                      Tag
-                    </button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="start" className="min-w-[150px] max-h-60 overflow-y-auto">
-                    {availableTags.map((tag) => (
-                      <DropdownMenuItem
-                        key={tag["@id"]}
-                        onSelect={() => handleAddTag(tag)}
-                      >
-                        <span
-                          className="inline-block h-3 w-3 rounded shrink-0"
-                          style={{ backgroundColor: tag.color }}
-                          aria-hidden="true"
-                        />
-                        <span>{tag.title}</span>
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              )}
-            </div>
-          </div>
+              <span className={titleClass}>{task.title}</span>
+            </button>
+          )}
+        </TableCell>
+        <TableCell className="align-top" data-testid="task-tags">
+          <TagsCombobox
+            value={task.tags}
+            options={allTags}
+            onChange={(nextIris) => onTagsChange(task, nextIris)}
+            subjectLabel={task.title}
+          />
+        </TableCell>
+        <TableCell className="align-top text-right">
           <Button
             variant="ghost"
-            size="sm"
+            size="icon"
             onClick={() => onDelete(task)}
             aria-label={`Delete "${task.title}"`}
             className="text-destructive hover:text-destructive"
           >
-            Delete
+            <Trash2 className="h-4 w-4" />
           </Button>
-        </CardContent>
-      </Card>
-    </li>
+        </TableCell>
+      </TableRow>
+      <TableRow
+        className="hover:bg-transparent"
+        data-testid="task-description-row"
+      >
+        {/* Empty cells preserve the column layout so the description cell
+            below starts exactly where the title cell does — no fragile
+            pixel-math with pl-24. */}
+        <TableCell className="w-8" aria-hidden="true" />
+        <TableCell className="w-10" aria-hidden="true" />
+        <TableCell colSpan={3} className="pl-0 pr-4 pt-0 pb-3 text-sm">
+          {editingDesc ? (
+            <div className="space-y-2">
+              <MarkdownEditor
+                key={descEditorKey}
+                ariaLabel={`Description for "${task.title}"`}
+                value={descDraft}
+                onChange={setDescDraft}
+              />
+              <div className="flex gap-2">
+                <Button
+                  size="sm"
+                  type="button"
+                  onClick={() => void saveDesc()}
+                  data-testid="task-description-save"
+                >
+                  Save
+                </Button>
+                <Button
+                  size="sm"
+                  type="button"
+                  variant="ghost"
+                  onClick={cancelDesc}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          ) : description ? (
+            <button
+              type="button"
+              onClick={startEditDesc}
+              aria-label={`Edit description for "${task.title}"`}
+              className="text-left w-full text-muted-foreground whitespace-pre-wrap rounded-sm hover:text-foreground"
+              data-testid="task-description"
+            >
+              {description}
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={startEditDesc}
+              aria-label={`Add description for "${task.title}"`}
+              className="text-left w-full italic text-muted-foreground/60 hover:text-muted-foreground rounded-sm"
+              data-testid="task-description-add"
+            >
+              Add description
+            </button>
+          )}
+        </TableCell>
+      </TableRow>
+    </tbody>
+  );
+};
+
+interface NewTaskInput {
+  title: string;
+  description: string | null;
+  tags: string[];
+}
+
+interface NewTaskRowProps {
+  allTags: Tag[];
+  /** Resolves on success, rejects on failure so we know whether to clear the draft. */
+  onCreate: (input: NewTaskInput) => Promise<void>;
+  isCreating: boolean;
+}
+
+// Inline "add a task" row that lives at the top of the table. Mirrors the
+// layout of TaskRow (main row + description sub-row) so the user can stage
+// title, tags, and description before pressing Enter to submit. Failures
+// keep the draft intact (parent shows the error).
+const NewTaskRow = ({ allTags, onCreate, isCreating }: NewTaskRowProps) => {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState<string | null>(null);
+  const [tags, setTags] = useState<Tag[]>([]);
+  const titleInputRef = useRef<HTMLInputElement | null>(null);
+
+  // Description inline editing — local-only; nothing hits the API until
+  // submit. Mirrors TaskRow's editing state machine.
+  const [editingDesc, setEditingDesc] = useState(false);
+  const [descDraft, setDescDraft] = useState("");
+  const [descEditorKey, setDescEditorKey] = useState(0);
+
+  const startEditDesc = () => {
+    setDescDraft(description ?? "");
+    setDescEditorKey((k) => k + 1);
+    setEditingDesc(true);
+  };
+  const cancelDesc = () => {
+    setDescDraft(description ?? "");
+    setEditingDesc(false);
+  };
+  const saveDesc = () => {
+    setEditingDesc(false);
+    const trimmed = descDraft.trim();
+    setDescription(trimmed === "" ? null : descDraft);
+  };
+
+  const handleTagsChange = (nextIris: string[]) => {
+    const next = nextIris
+      .map((iri) => allTags.find((tag) => tag["@id"] === iri))
+      .filter((tag): tag is Tag => Boolean(tag));
+    setTags(next);
+  };
+
+  const reset = () => {
+    setTitle("");
+    setDescription(null);
+    setTags([]);
+    setEditingDesc(false);
+    setDescDraft("");
+  };
+
+  const submit = async () => {
+    const trimmed = title.trim();
+    if (!trimmed) return;
+    try {
+      await onCreate({
+        title: trimmed,
+        description,
+        tags: tags.map((tag) => tag["@id"]),
+      });
+      reset();
+      // Refocus on next tick so the input isn't briefly disabled when we
+      // try to focus it.
+      requestAnimationFrame(() => titleInputRef.current?.focus());
+    } catch {
+      // Parent has already surfaced the error in the alert region; keep
+      // the draft so the user can retry without retyping.
+    }
+  };
+
+  const descriptionPreview = plainTextDescription(description);
+
+  return (
+    <tbody data-testid="new-task-row">
+      <TableRow className="border-b-0 hover:bg-transparent">
+        <TableCell className="w-8" aria-hidden="true" />
+        <TableCell className="w-10" aria-hidden="true" />
+        <TableCell className="pl-0 align-top">
+          <Input
+            ref={titleInputRef}
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                void submit();
+              } else if (e.key === "Escape") {
+                e.preventDefault();
+                reset();
+                titleInputRef.current?.blur();
+              }
+            }}
+            placeholder="Add a task…"
+            maxLength={255}
+            disabled={isCreating}
+            aria-label="New task title"
+            className="h-8"
+            data-testid="new-task-title-input"
+          />
+        </TableCell>
+        <TableCell className="align-top" data-testid="new-task-tags">
+          <TagsCombobox
+            value={tags}
+            options={allTags}
+            onChange={handleTagsChange}
+            subjectLabel="new task"
+          />
+        </TableCell>
+        <TableCell aria-hidden="true" />
+      </TableRow>
+      <TableRow
+        className="hover:bg-transparent"
+        data-testid="new-task-description-row"
+      >
+        <TableCell className="w-8" aria-hidden="true" />
+        <TableCell className="w-10" aria-hidden="true" />
+        <TableCell colSpan={3} className="pl-0 pr-4 pt-0 pb-3 text-sm">
+          {editingDesc ? (
+            <div className="space-y-2">
+              <MarkdownEditor
+                key={descEditorKey}
+                ariaLabel="Description for new task"
+                value={descDraft}
+                onChange={setDescDraft}
+              />
+              <div className="flex gap-2">
+                <Button
+                  size="sm"
+                  type="button"
+                  onClick={saveDesc}
+                  data-testid="new-task-description-save"
+                >
+                  Save
+                </Button>
+                <Button
+                  size="sm"
+                  type="button"
+                  variant="ghost"
+                  onClick={cancelDesc}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          ) : descriptionPreview ? (
+            <button
+              type="button"
+              onClick={startEditDesc}
+              aria-label="Edit description for new task"
+              className="text-left w-full text-muted-foreground whitespace-pre-wrap rounded-sm hover:text-foreground"
+              data-testid="new-task-description"
+            >
+              {descriptionPreview}
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={startEditDesc}
+              aria-label="Add description for new task"
+              className="text-left w-full italic text-muted-foreground/60 hover:text-muted-foreground rounded-sm"
+              data-testid="new-task-description-add"
+            >
+              Add description
+            </button>
+          )}
+        </TableCell>
+      </TableRow>
+    </tbody>
   );
 };
 
@@ -207,12 +550,8 @@ const Tasks = () => {
   const [allTags, setAllTags] = useState<Tag[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [title, setTitle] = useState("");
-  const [description, setDescription] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
-  // Bumped after a successful create so the MarkdownEditor remounts with
-  // an empty value — its initialContent is only read once at creation.
-  const [editorResetKey, setEditorResetKey] = useState(0);
+  const [sort, setSort] = useState<SortState>(DEFAULT_SORT);
 
   const sensors = useSensors(
     // Require an 8px drag before activating so a quick click on the grip
@@ -265,9 +604,9 @@ const Tasks = () => {
     }
   }, [isAuthenticated, loadData]);
 
-  const handleCreate = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (!title.trim()) return;
+  const handleCreate = async (input: NewTaskInput) => {
+    const trimmed = input.title.trim();
+    if (!trimmed) return;
 
     setIsSubmitting(true);
     setError(null);
@@ -277,8 +616,9 @@ const Tasks = () => {
         credentials: "include",
         headers: { "Content-Type": "application/ld+json" },
         body: JSON.stringify({
-          title: title.trim(),
-          description: description.trim() || null,
+          title: trimmed,
+          description: input.description,
+          tags: input.tags,
         }),
       });
       if (!res.ok) {
@@ -287,12 +627,11 @@ const Tasks = () => {
           data.description || data.detail || data["hydra:description"] || "Failed to create task.",
         );
       }
-      setTitle("");
-      setDescription("");
-      setEditorResetKey((k) => k + 1);
       await loadData();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to create task.");
+      // Re-throw so NewTaskRow keeps the user's draft for retry.
+      throw err;
     } finally {
       setIsSubmitting(false);
     }
@@ -338,6 +677,63 @@ const Tasks = () => {
       await loadData();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to delete task.");
+    }
+  };
+
+  const handleTitleChange = async (task: Task, nextTitle: string) => {
+    // Optimistic title update — input has already returned to read mode.
+    const previous = tasks;
+    setTasks(tasks.map((t) => (t["@id"] === task["@id"] ? { ...t, title: nextTitle } : t)));
+    setError(null);
+
+    try {
+      const res = await fetch(`${ENTRYPOINT}${task["@id"]}`, {
+        method: "PATCH",
+        credentials: "include",
+        headers: { "Content-Type": "application/merge-patch+json" },
+        body: JSON.stringify({ title: nextTitle }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(
+          data.description || data.detail || data["hydra:description"] || "Failed to update title.",
+        );
+      }
+    } catch (err) {
+      setTasks(previous);
+      setError(err instanceof Error ? err.message : "Failed to update title.");
+    }
+  };
+
+  const handleDescriptionChange = async (task: Task, nextDescription: string | null) => {
+    // Optimistic description update.
+    const previous = tasks;
+    setTasks(
+      tasks.map((t) =>
+        t["@id"] === task["@id"] ? { ...t, description: nextDescription } : t,
+      ),
+    );
+    setError(null);
+
+    try {
+      const res = await fetch(`${ENTRYPOINT}${task["@id"]}`, {
+        method: "PATCH",
+        credentials: "include",
+        headers: { "Content-Type": "application/merge-patch+json" },
+        body: JSON.stringify({ description: nextDescription }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(
+          data.description ||
+            data.detail ||
+            data["hydra:description"] ||
+            "Failed to update description.",
+        );
+      }
+    } catch (err) {
+      setTasks(previous);
+      setError(err instanceof Error ? err.message : "Failed to update description.");
     }
   };
 
@@ -396,6 +792,38 @@ const Tasks = () => {
     }
   };
 
+  const handleSort = (key: SortKey) => {
+    setSort((current) => {
+      // Cycle: same column asc → desc → back to manual default.
+      if (current.key !== key) return { key, dir: "asc" };
+      if (current.dir === "asc") return { key, dir: "desc" };
+      return DEFAULT_SORT;
+    });
+  };
+
+  // Sorted *view* of the tasks. Manual order leaves them as-is so the dnd-kit
+  // index math stays aligned with what's painted; any other sort produces a
+  // shallow copy ordered by the picked column.
+  const visibleTasks = useMemo(() => {
+    if (sort.key === "manual") return tasks;
+    const flip = sort.dir === "asc" ? 1 : -1;
+    const copy = [...tasks];
+    copy.sort((a, b) => {
+      switch (sort.key) {
+        case "completed":
+          // Sort completed flag first — undone tasks sort before done.
+          return ((a.completedOn ? 1 : 0) - (b.completedOn ? 1 : 0)) * flip;
+        case "title":
+          return a.title.localeCompare(b.title) * flip;
+        default:
+          return 0;
+      }
+    });
+    return copy;
+  }, [tasks, sort]);
+
+  const reorderable = sort.key === "manual";
+
   if (authLoading || !isAuthenticated) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-muted">
@@ -410,42 +838,8 @@ const Tasks = () => {
         <title>Tasks - Aura</title>
       </Head>
       <div className="min-h-screen bg-muted px-4 py-12">
-        <div className="max-w-2xl mx-auto">
+        <div className="max-w-7xl mx-auto">
           <h1 className="text-2xl font-bold mb-6">Tasks</h1>
-
-          <Card className="mb-6">
-            <CardContent className="pt-6">
-              <form onSubmit={handleCreate} className="space-y-4">
-                <div className="space-y-1.5">
-                  <Label htmlFor="title">Title</Label>
-                  <Input
-                    id="title"
-                    type="text"
-                    value={title}
-                    onChange={(e) => setTitle(e.target.value)}
-                    required
-                    maxLength={255}
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="description">
-                    Description{" "}
-                    <span className="text-muted-foreground font-normal">(optional)</span>
-                  </Label>
-                  <MarkdownEditor
-                    key={editorResetKey}
-                    id="description"
-                    ariaLabel="Description"
-                    value={description}
-                    onChange={setDescription}
-                  />
-                </div>
-                <Button type="submit" disabled={isSubmitting || !title.trim()}>
-                  {isSubmitting ? "Adding..." : "Add Task"}
-                </Button>
-              </form>
-            </CardContent>
-          </Card>
 
           {error && (
             <Alert variant="destructive" className="mb-4">
@@ -453,38 +847,74 @@ const Tasks = () => {
             </Alert>
           )}
 
+          {!reorderable && (
+            <p
+              className="mb-2 text-xs text-muted-foreground"
+              data-testid="reorder-disabled-hint"
+            >
+              Drag-to-reorder is paused while the table is sorted by a column. Click
+              the active column header again to return to your custom order.
+            </p>
+          )}
+
           {isLoading ? (
             <p className="text-muted-foreground">Loading tasks...</p>
-          ) : tasks.length === 0 ? (
+          ) : (
             <Card>
-              <CardContent className="pt-6">
-                <p className="text-muted-foreground">No tasks yet. Add one above to get started.</p>
+              <CardContent className="p-0">
+                <DndContext
+                  sensors={sensors}
+                  collisionDetection={closestCenter}
+                  onDragEnd={handleDragEnd}
+                >
+                  <SortableContext
+                    items={visibleTasks.map((t) => t["@id"])}
+                    strategy={verticalListSortingStrategy}
+                  >
+                    <Table data-testid="task-list">
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead className="w-8" />
+                          <SortableHeader
+                            label="Done"
+                            sortKey="completed"
+                            active={sort}
+                            onSort={handleSort}
+                            className="w-16"
+                          />
+                          <SortableHeader
+                            label="Title"
+                            sortKey="title"
+                            active={sort}
+                            onSort={handleSort}
+                          />
+                          <TableHead>Tags</TableHead>
+                          <TableHead className="w-20 text-right">Actions</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <NewTaskRow
+                        allTags={allTags}
+                        onCreate={handleCreate}
+                        isCreating={isSubmitting}
+                      />
+                      {visibleTasks.map((task) => (
+                        <TaskRow
+                          key={task["@id"]}
+                          task={task}
+                          allTags={allTags}
+                          reorderable={reorderable}
+                          onToggle={handleToggle}
+                          onDelete={handleDelete}
+                          onTagsChange={handleTagsChange}
+                          onTitleChange={handleTitleChange}
+                          onDescriptionChange={handleDescriptionChange}
+                        />
+                      ))}
+                    </Table>
+                  </SortableContext>
+                </DndContext>
               </CardContent>
             </Card>
-          ) : (
-            <DndContext
-              sensors={sensors}
-              collisionDetection={closestCenter}
-              onDragEnd={handleDragEnd}
-            >
-              <SortableContext
-                items={tasks.map((t) => t["@id"])}
-                strategy={verticalListSortingStrategy}
-              >
-                <ul className="space-y-2" data-testid="task-list">
-                  {tasks.map((task) => (
-                    <SortableTaskItem
-                      key={task["@id"]}
-                      task={task}
-                      allTags={allTags}
-                      onToggle={handleToggle}
-                      onDelete={handleDelete}
-                      onTagsChange={handleTagsChange}
-                    />
-                  ))}
-                </ul>
-              </SortableContext>
-            </DndContext>
           )}
         </div>
       </div>

--- a/pwa/pnpm-lock.yaml
+++ b/pwa/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
       '@api-platform/admin':
         specifier: ^4.0.9
         version: 4.0.9(@mui/system@7.3.10(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@mui/utils@7.3.10(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(csstype@3.2.3)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.5)(react@19.2.5)(web-streams-polyfill@4.1.0)
+      '@base-ui/react':
+        specifier: ^1.4.1
+        version: 1.4.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@blocknote/core':
         specifier: ^0.49.0
         version: 0.49.0(@types/hast@3.0.4)
@@ -66,6 +69,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      cmdk:
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       formik:
         specifier: ^2.4.9
         version: 2.4.9(@types/react@19.2.14)(react@19.2.5)
@@ -226,6 +232,33 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@base-ui/react@1.4.1':
+    resolution: {integrity: sha512-Ab5/LIhcmL8BQcsBUYiOfkSDRdLpvgUBzMK30cu684JPcLclYlztharvCZyNNgzJtbAiREzI9q0pI5erHCMgCw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@date-fns/tz': ^1.2.0
+      '@types/react': ^17 || ^18 || ^19
+      date-fns: ^4.0.0
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
+      '@types/react':
+        optional: true
+      date-fns:
+        optional: true
+
+  '@base-ui/utils@0.2.8':
+    resolution: {integrity: sha512-jvOi+c+ftGlGotNcKnzPVg2IhCaDTB6/6R3JeqdjdXktuAJi3wKH9T7+svuaKh1mmfVU11UWzUZVH74JDfi/wQ==}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@blocknote/core@0.49.0':
     resolution: {integrity: sha512-WrkJ9DubvjfMP7+bfrKfp4Oe1SSYpVhojqSORHqh1IjU/qx7CWhwG62k2yyAJdr9K63aoVnS9c6p+xxbuW0PWA==}
@@ -2104,6 +2137,12 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cmdk@1.1.1:
+    resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^18 || ^19 || ^19.0.0-rc
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -3661,6 +3700,9 @@ packages:
   remove-accents@0.4.4:
     resolution: {integrity: sha512-EpFcOa/ISetVHEXqu+VwI96KZBmq+a8LJnGkaeFw45epGlxIZz5dhEEnNZMsQXgORu3qaMoLX4qJCzOik6ytAg==}
 
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -4260,6 +4302,29 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@base-ui/react@1.4.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@base-ui/utils': 0.2.8(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      use-sync-external-store: 1.6.0(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@base-ui/utils@0.2.8(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      reselect: 5.1.1
+      use-sync-external-store: 1.6.0(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   '@blocknote/core@0.49.0(@types/hast@3.0.4)':
     dependencies:
@@ -6257,6 +6322,18 @@ snapshots:
   client-only@0.0.1: {}
 
   clsx@2.1.1: {}
+
+  cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   color-convert@2.0.1:
     dependencies:
@@ -8376,6 +8453,8 @@ snapshots:
       unified: 11.0.5
 
   remove-accents@0.4.4: {}
+
+  reselect@5.1.1: {}
 
   resolve-from@4.0.0: {}
 

--- a/pwa/tsconfig.json
+++ b/pwa/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -9,16 +13,24 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary

- Convert the per-task Card list into a sortable Table with column-sort + drag-to-reorder. Drag is paused while a column is the active sort key (cycles asc → desc → manual on click).
- Each task renders as a two-row group: main row (drag, done, title, tags, actions) plus a description sub-row aligned under the title column.
- Inline editing throughout — title, description, and tags — with optimistic update + rollback on error.
- Replace the separate "Add Task" form with an inline new-task row at the top of the table that stages title, tags, and description before posting.
- Reorder API made permissive so admins and project members (not just owners) can reorder tasks they're allowed to edit.
- shadcn Combobox-based `TagsCombobox` with autofill suppression and a click-to-edit affordance that hides the bordered chip-input until needed.

## Notable details

**Frontend (`pwa/`)**
- `pages/tasks.tsx` — table layout, dnd-kit integration, sort state machine, inline edit handlers, new-task row with full title + tags + description staging, plain-text description preview helper.
- `components/tasks/TagsCombobox.tsx` — wraps shadcn Combobox with chip styling, edit-mode toggle, click-outside dismissal (popover content excluded), Chrome / 1Password / LastPass autofill suppression.
- `components/ui/{combobox,command,dialog,input-group,popover,table}.tsx` — shadcn registry additions.
- `components/ui/button.tsx` — added `icon-xs` size variant required by the Combobox primitives.
- "Created" column hidden until #76 (add `dueDate` field) lands.
- Page widened to `max-w-7xl`.

**Backend (`api/`)**
- `Controller/TaskReorderController.php` — accepts the caller's full visible-task list, silently skips IRIs they can't reorder, and validates that every reorderable task belonging to the user is included so we don't drop rows.
- `Repository/TaskRepository.php` — new `findReorderableForUser` returns tasks the user owns OR tasks on projects the user is a member of.
- `tests/Api/TaskTest.php` — replaced `testReorderRejectsOtherUsersTask` with `testReorderSilentlySkipsNonOwnedIris`, added `testReorderLetsProjectMemberReorderProjectTasks`.

## Related

- Follow-up: #76 — add a `dueDate` field with an inline date picker. The "Created" column was hidden in this PR to make room for it without churn.

## Test plan

- [ ] Add a task via the inline new-task row (title only, then title + tags, then title + tags + description).
- [ ] Inline-edit an existing task's title — Enter saves, Escape reverts, blur saves.
- [ ] Inline-edit description — Save commits, Cancel reverts, click rendered text reopens with current content.
- [ ] Tags: click `+ Add tags` to enter edit mode, pick / unpick tags, click outside to exit. Click the X on a chip to remove without entering edit mode.
- [ ] Drag a row to reorder; verify persistence after reload.
- [ ] Click a column header to sort; drag handle should grey out and a hint should appear. Click the active column header again to return to manual order.
- [ ] As a project member (not the owner), reorder tasks on a shared project — should succeed.
- [ ] As an admin viewing all tasks, reorder; non-owned IRIs should be silently skipped.
- [ ] Toggle complete on a task — checkbox flips immediately, persists on reload.
- [ ] Delete a task via the trash icon.
- [ ] `cd api && bin/phpunit tests/Api/TaskTest.php`
- [ ] `cd pwa && pnpm lint && pnpm exec tsc --noEmit`