### PR TITLE
feat(tasks): assignees with picker, filters, and a My Tasks view

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,11 @@ jobs:
         run: docker compose exec -T php bin/console -e test doctrine:migrations:migrate --no-interaction
       -
         name: Run PHPUnit
-        run: docker compose exec -T php bin/phpunit
+        # PHPUnit's deprecation tracker accumulates context across the whole
+        # suite, so peak memory grows with test count. The default 128M was
+        # tight even before; bumping to 512M leaves headroom as the suite
+        # keeps growing.
+        run: docker compose exec -T php php -d memory_limit=512M bin/phpunit
       -
         name: Doctrine Schema Validator
         run: docker compose exec -T php bin/console -e test doctrine:schema:validate

--- a/api/migrations/Version20260502130000.php
+++ b/api/migrations/Version20260502130000.php
@@ -27,16 +27,19 @@ final class Version20260502130000 extends AbstractMigration
             user_id UUID NOT NULL,
             PRIMARY KEY (task_id, user_id)
         )');
-        $this->addSql('CREATE INDEX IDX_TA_TASK ON task_assignee (task_id)');
-        $this->addSql('CREATE INDEX IDX_TA_USER ON task_assignee (user_id)');
-        $this->addSql('ALTER TABLE task_assignee ADD CONSTRAINT FK_TA_TASK FOREIGN KEY (task_id) REFERENCES task (id) ON DELETE CASCADE NOT DEFERRABLE');
-        $this->addSql('ALTER TABLE task_assignee ADD CONSTRAINT FK_TA_USER FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE');
+        // Index/FK names follow Doctrine's IDX_/FK_<sha1-prefix> convention so
+        // `doctrine:schema:validate` stays happy. The 3C5D1640 prefix is the
+        // table-name hash; the suffix on each is the column-name hash.
+        $this->addSql('CREATE INDEX IDX_3C5D16408DB60186 ON task_assignee (task_id)');
+        $this->addSql('CREATE INDEX IDX_3C5D1640A76ED395 ON task_assignee (user_id)');
+        $this->addSql('ALTER TABLE task_assignee ADD CONSTRAINT FK_3C5D16408DB60186 FOREIGN KEY (task_id) REFERENCES task (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE task_assignee ADD CONSTRAINT FK_3C5D1640A76ED395 FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE');
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE task_assignee DROP CONSTRAINT FK_TA_USER');
-        $this->addSql('ALTER TABLE task_assignee DROP CONSTRAINT FK_TA_TASK');
+        $this->addSql('ALTER TABLE task_assignee DROP CONSTRAINT FK_3C5D1640A76ED395');
+        $this->addSql('ALTER TABLE task_assignee DROP CONSTRAINT FK_3C5D16408DB60186');
         $this->addSql('DROP TABLE task_assignee');
     }
 }

--- a/api/migrations/Version20260502130000.php
+++ b/api/migrations/Version20260502130000.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds the task_assignee join table linking tasks to the users responsible
+ * for them. The composite PK (task_id, user_id) prevents duplicate
+ * assignments at the database layer; the ValidAssignees constraint
+ * keeps the set restricted to owner ∪ project members at the app layer.
+ */
+final class Version20260502130000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add task_assignee join table for assigning users to tasks.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE task_assignee (
+            task_id UUID NOT NULL,
+            user_id UUID NOT NULL,
+            PRIMARY KEY (task_id, user_id)
+        )');
+        $this->addSql('CREATE INDEX IDX_TA_TASK ON task_assignee (task_id)');
+        $this->addSql('CREATE INDEX IDX_TA_USER ON task_assignee (user_id)');
+        $this->addSql('ALTER TABLE task_assignee ADD CONSTRAINT FK_TA_TASK FOREIGN KEY (task_id) REFERENCES task (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE task_assignee ADD CONSTRAINT FK_TA_USER FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE task_assignee DROP CONSTRAINT FK_TA_USER');
+        $this->addSql('ALTER TABLE task_assignee DROP CONSTRAINT FK_TA_TASK');
+        $this->addSql('DROP TABLE task_assignee');
+    }
+}

--- a/api/src/Controller/AssignableUsersController.php
+++ b/api/src/Controller/AssignableUsersController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\Project;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * Returns every user the caller may legitimately assign to one of their
+ * tasks: themselves plus the members of any project they belong to. This
+ * matches the ValidAssignees rule on Task — feeding the frontend exactly
+ * the candidate set the validator will accept.
+ *
+ * The response is intentionally a flat User[] (not paginated) — the set is
+ * small (project teammates only) and the picker needs the whole list to
+ * filter against typeahead input.
+ */
+class AssignableUsersController extends AbstractController
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private SerializerInterface $serializer,
+    ) {
+    }
+
+    #[Route('/me/assignable-users', name: 'me_assignable_users', methods: ['GET'])]
+    public function __invoke(#[CurrentUser] ?User $user): JsonResponse
+    {
+        if (null === $user) {
+            return $this->json(['error' => 'Not authenticated.'], 401);
+        }
+
+        $byId = [(string) $user->getId() => $user];
+        $projects = $this->em->getRepository(Project::class)
+            ->createQueryBuilder('p')
+            ->leftJoin('p.members', 'pm')
+            ->addSelect('pm')
+            ->where(':self MEMBER OF p.members')
+            ->setParameter('self', $user)
+            ->getQuery()
+            ->getResult();
+        foreach ($projects as $project) {
+            foreach ($project->getMembers() as $member) {
+                $byId[(string) $member->getId()] = $member;
+            }
+        }
+
+        $users = array_values($byId);
+        $json = $this->serializer->serialize(
+            $users,
+            'jsonld',
+            ['groups' => ['user:read']],
+        );
+        $members = json_decode($json, true) ?? [];
+
+        // Wrap in a hydra-shaped collection so the frontend can consume this
+        // the same way it consumes `/tasks` and `/projects`.
+        return new JsonResponse([
+            '@context' => '/contexts/User',
+            '@id' => '/me/assignable-users',
+            '@type' => 'Collection',
+            'totalItems' => count($members),
+            'member' => $members,
+        ]);
+    }
+}

--- a/api/src/Controller/TaskAssigneeController.php
+++ b/api/src/Controller/TaskAssigneeController.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\Project;
+use App\Entity\Task;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Add/remove a single assignee on a task without rewriting the whole list.
+ * Mirrors ProjectMemberController's "small targeted endpoint" pattern: the
+ * standard PATCH /tasks/{id} can still take a full assignees array, but
+ * these endpoints make per-row UI optimistic updates simpler.
+ *
+ * Visibility-on-failure mirrors the rest of the Task API: callers who can't
+ * see the task get 404, never 403, so item existence isn't leaked.
+ */
+class TaskAssigneeController extends AbstractController
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private SerializerInterface $serializer,
+    ) {
+    }
+
+    #[Route('/tasks/{id}/assignees', name: 'task_add_assignee', methods: ['POST'])]
+    public function add(string $id, Request $request, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if (null === $user) {
+            return $this->json(['error' => 'Not authenticated.'], 401);
+        }
+
+        $task = $this->findEditableTask($id, $user);
+        if (null === $task) {
+            return $this->json(['error' => 'Task not found.'], 404);
+        }
+
+        $payload = json_decode($request->getContent(), true) ?? [];
+        $userId = is_string($payload['userId'] ?? null) ? trim($payload['userId']) : '';
+        if ('' === $userId || !Uuid::isValid($userId)) {
+            return $this->json(['error' => 'A valid userId is required.'], 400);
+        }
+
+        $candidate = $this->em->getRepository(User::class)->find($userId);
+        if (null === $candidate) {
+            return $this->json(['error' => 'User not found.'], 404);
+        }
+
+        if (!$this->isAllowedAssignee($task, $candidate)) {
+            return $this->json(
+                ['error' => 'User must be the task owner or a member of its project.'],
+                422,
+            );
+        }
+
+        if ($task->getAssignees()->contains($candidate)) {
+            return $this->json(['error' => 'User is already assigned to this task.'], 409);
+        }
+
+        $task->addAssignee($candidate);
+        $this->em->flush();
+
+        $json = $this->serializer->serialize($candidate, 'jsonld', ['groups' => ['user:read']]);
+        return new JsonResponse($json, 200, [], true);
+    }
+
+    #[Route(
+        '/tasks/{id}/assignees/{userId}',
+        name: 'task_remove_assignee',
+        methods: ['DELETE'],
+    )]
+    public function remove(string $id, string $userId, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if (null === $user) {
+            return $this->json(['error' => 'Not authenticated.'], 401);
+        }
+
+        $task = $this->findEditableTask($id, $user);
+        if (null === $task) {
+            return $this->json(['error' => 'Task not found.'], 404);
+        }
+
+        if (!Uuid::isValid($userId)) {
+            return $this->json(['error' => 'Invalid userId.'], 400);
+        }
+
+        $candidate = $this->em->getRepository(User::class)->find($userId);
+        if (null === $candidate || !$task->getAssignees()->contains($candidate)) {
+            return $this->json(['error' => 'Assignee not found on this task.'], 404);
+        }
+
+        $task->removeAssignee($candidate);
+        $this->em->flush();
+
+        return new JsonResponse(null, 204);
+    }
+
+    /**
+     * Returns the task only when the current user can edit it (admin, owner,
+     * or project member). Returns null otherwise so callers can respond 404
+     * uniformly without leaking task existence.
+     */
+    private function findEditableTask(string $id, User $user): ?Task
+    {
+        if (!Uuid::isValid($id)) {
+            return null;
+        }
+        $task = $this->em->getRepository(Task::class)->find($id);
+        if (null === $task) {
+            return null;
+        }
+        if ($this->isGranted('ROLE_ADMIN')) {
+            return $task;
+        }
+        if ($task->getOwner()?->getId()?->equals($user->getId())) {
+            return $task;
+        }
+        $project = $task->getProject();
+        if ($project instanceof Project && $project->getMembers()->contains($user)) {
+            return $task;
+        }
+        return null;
+    }
+
+    /**
+     * Mirrors the ValidAssignees rule: a task's owner is always assignable;
+     * for project tasks the project's members are too. Personal tasks (no
+     * project) admit only the owner.
+     */
+    private function isAllowedAssignee(Task $task, User $candidate): bool
+    {
+        $owner = $task->getOwner();
+        if (null !== $owner && $owner->getId()?->equals($candidate->getId())) {
+            return true;
+        }
+        $project = $task->getProject();
+        if ($project instanceof Project) {
+            foreach ($project->getMembers() as $member) {
+                if ($member->getId()?->equals($candidate->getId())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/api/src/DataFixtures/ProjectFixtures.php
+++ b/api/src/DataFixtures/ProjectFixtures.php
@@ -55,16 +55,19 @@ class ProjectFixtures extends Fixture implements DependentFixtureInterface
         $project->addMember($ada);
         $manager->persist($project);
 
+        // [title, description, tagTitles, assignees]. Mix of solo, joint,
+        // and unassigned tasks so the avatar group, "Assigned to me" filter,
+        // and "Assign" empty-state all show up in the demo data.
         $taskDefinitions = [
-            ['Wire up Stripe checkout', 'Hook the pricing page CTA to a Stripe-hosted checkout session.', ['urgent', 'backend']],
-            ['Draft onboarding email', 'Three-step welcome series. Tone: friendly, no jargon.', ['docs']],
-            ['Polish empty states', "Replace the placeholder copy on Projects, Tasks, and Tags with the new illustrations.", ['design']],
-            ['Add password-reset rate limiting', 'Limit to 3 attempts per email per hour.', ['urgent', 'backend']],
-            ['Write API auth docs', 'Cover login, refresh, and logout end-to-end.', ['docs']],
+            ['Wire up Stripe checkout', 'Hook the pricing page CTA to a Stripe-hosted checkout session.', ['urgent', 'backend'], [$uma]],
+            ['Draft onboarding email', 'Three-step welcome series. Tone: friendly, no jargon.', ['docs'], [$ada]],
+            ['Polish empty states', "Replace the placeholder copy on Projects, Tasks, and Tags with the new illustrations.", ['design'], [$uma, $ada]],
+            ['Add password-reset rate limiting', 'Limit to 3 attempts per email per hour.', ['urgent', 'backend'], []],
+            ['Write API auth docs', 'Cover login, refresh, and logout end-to-end.', ['docs'], [$ada]],
         ];
 
         $position = 0;
-        foreach ($taskDefinitions as [$title, $description, $tagTitles]) {
+        foreach ($taskDefinitions as [$title, $description, $tagTitles, $assignees]) {
             $task = new Task();
             $task->setOwner($uma);
             $task->setProject($project);
@@ -73,6 +76,9 @@ class ProjectFixtures extends Fixture implements DependentFixtureInterface
             $task->setPosition($position++);
             foreach ($tagTitles as $tagTitle) {
                 $task->addTag($tags[$tagTitle]);
+            }
+            foreach ($assignees as $assignee) {
+                $task->addAssignee($assignee);
             }
             $manager->persist($task);
         }
@@ -84,6 +90,7 @@ class ProjectFixtures extends Fixture implements DependentFixtureInterface
         $personal->setTitle('Plan team offsite');
         $personal->setDescription('Shortlist three venues and email Ada for input.');
         $personal->setPosition($position++);
+        $personal->addAssignee($uma);
         $manager->persist($personal);
 
         $done = new Task();

--- a/api/src/Entity/Task.php
+++ b/api/src/Entity/Task.php
@@ -12,6 +12,7 @@ use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
 use App\Repository\TaskRepository;
 use App\State\TaskOwnerProcessor;
+use App\Validator\ValidAssignees;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
@@ -42,12 +43,13 @@ use Symfony\Component\Validator\Constraints as Assert;
     denormalizationContext: ['groups' => ['task:write']],
     order: ['position' => 'ASC', 'createdOn' => 'DESC'],
 )]
-#[ApiFilter(SearchFilter::class, properties: ['project' => 'exact'])]
+#[ApiFilter(SearchFilter::class, properties: ['project' => 'exact', 'assignees' => 'exact'])]
 #[ORM\Entity(repositoryClass: TaskRepository::class)]
 #[ORM\Table(name: 'task')]
 #[ORM\Index(columns: ['owner_id'], name: 'idx_task_owner')]
 #[ORM\Index(columns: ['owner_id', 'position'], name: 'idx_task_owner_position')]
 #[ORM\Index(columns: ['project_id'], name: 'idx_task_project')]
+#[ValidAssignees]
 class Task
 {
     #[ORM\Id]
@@ -120,10 +122,26 @@ class Task
     #[Groups(['task:read', 'task:write'])]
     private Collection $tags;
 
+    /**
+     * Users assigned to this task. Always a subset of {owner ∪ project members}
+     * — enforced by ValidAssignees on persist. Assignment is purely a "who's
+     * responsible" label; it grants no extra read/edit privileges (those still
+     * follow owner + project membership).
+     *
+     * @var Collection<int, User>
+     */
+    #[ORM\ManyToMany(targetEntity: User::class)]
+    #[ORM\JoinTable(name: 'task_assignee')]
+    #[ORM\JoinColumn(name: 'task_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
+    #[ORM\InverseJoinColumn(name: 'user_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
+    #[Groups(['task:read', 'task:write'])]
+    private Collection $assignees;
+
     public function __construct()
     {
         $this->createdOn = new \DateTimeImmutable();
         $this->tags = new ArrayCollection();
+        $this->assignees = new ArrayCollection();
     }
 
     public function getId(): ?Uuid
@@ -237,6 +255,28 @@ class Task
     public function removeTag(Tag $tag): static
     {
         $this->tags->removeElement($tag);
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, User>
+     */
+    public function getAssignees(): Collection
+    {
+        return $this->assignees;
+    }
+
+    public function addAssignee(User $user): static
+    {
+        if (!$this->assignees->contains($user)) {
+            $this->assignees->add($user);
+        }
+        return $this;
+    }
+
+    public function removeAssignee(User $user): static
+    {
+        $this->assignees->removeElement($user);
         return $this;
     }
 }

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -44,7 +44,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column(type: 'uuid', unique: true)]
     #[ORM\GeneratedValue(strategy: 'CUSTOM')]
     #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
-    #[Groups(['user:read', 'project:read', 'group:read'])]
+    #[Groups(['user:read', 'project:read', 'group:read', 'task:read'])]
     private ?Uuid $id = null;
 
     // Settable on signup (`user:create`), but not on PATCH — changes
@@ -52,7 +52,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column(length: 180, unique: true)]
     #[Assert\NotBlank]
     #[Assert\Email]
-    #[Groups(['user:read', 'user:create', 'project:read', 'group:read'])]
+    #[Groups(['user:read', 'user:create', 'project:read', 'group:read', 'task:read'])]
     private string $email = '';
 
     #[ORM\Column]
@@ -79,18 +79,18 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column(length: 100)]
     #[Assert\NotBlank(message: 'Given name is required.')]
     #[Assert\Length(max: 100)]
-    #[Groups(['user:read', 'user:write', 'project:read', 'group:read'])]
+    #[Groups(['user:read', 'user:write', 'project:read', 'group:read', 'task:read'])]
     private string $givenName = '';
 
     #[ORM\Column(length: 100)]
     #[Assert\NotBlank(message: 'Family name is required.')]
     #[Assert\Length(max: 100)]
-    #[Groups(['user:read', 'user:write', 'project:read', 'group:read'])]
+    #[Groups(['user:read', 'user:write', 'project:read', 'group:read', 'task:read'])]
     private string $familyName = '';
 
     #[ORM\Column(length: 100, nullable: true)]
     #[Assert\Length(max: 100)]
-    #[Groups(['user:read', 'user:write', 'project:read', 'group:read'])]
+    #[Groups(['user:read', 'user:write', 'project:read', 'group:read', 'task:read'])]
     private ?string $nickname = null;
 
     /**
@@ -104,7 +104,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         choices: AvatarColorService::PALETTE,
         message: 'Pick a color from the available palette.',
     )]
-    #[Groups(['user:read', 'user:write', 'project:read', 'group:read'])]
+    #[Groups(['user:read', 'user:write', 'project:read', 'group:read', 'task:read'])]
     private string $personalizedColor = AvatarColorService::PALETTE[0];
 
     #[ORM\ManyToOne(targetEntity: MediaObject::class)]
@@ -238,7 +238,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
      *
      * @return array<string, string>|null
      */
-    #[Groups(['user:read', 'project:read', 'group:read'])]
+    #[Groups(['user:read', 'project:read', 'group:read', 'task:read'])]
     public function getAvatarUrls(): ?array
     {
         return $this->avatar?->getVariantUrls();

--- a/api/src/Validator/ValidAssignees.php
+++ b/api/src/Validator/ValidAssignees.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Class-level constraint on Task. Asserts that every entry in `assignees` is
+ * either the task's owner or (when the task belongs to a project) one of
+ * that project's members. Assignment is a "who's responsible" label and
+ * must not extend access to anyone who couldn't already see the task.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class ValidAssignees extends Constraint
+{
+    public string $messageNotAllowed = 'Assignees must be the task owner or a member of its project.';
+
+    public function getTargets(): string|array
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/api/src/Validator/ValidAssigneesValidator.php
+++ b/api/src/Validator/ValidAssigneesValidator.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Validator;
+
+use App\Entity\Task;
+use App\Entity\User;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+final class ValidAssigneesValidator extends ConstraintValidator
+{
+    public function __construct(private Security $security)
+    {
+    }
+
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof ValidAssignees) {
+            throw new UnexpectedTypeException($constraint, ValidAssignees::class);
+        }
+
+        if (null === $value) {
+            return;
+        }
+
+        if (!$value instanceof Task) {
+            throw new UnexpectedValueException($value, Task::class);
+        }
+
+        $allowed = [];
+        // On POST the owner is set by TaskOwnerProcessor *after* validation,
+        // so it's null here — fall back to the current user, which is
+        // exactly who the processor will assign moments later.
+        $owner = $value->getOwner() ?? ($this->security->getUser() instanceof User ? $this->security->getUser() : null);
+        if (null !== $owner && null !== $owner->getId()) {
+            $allowed[(string) $owner->getId()] = true;
+        }
+        $project = $value->getProject();
+        if (null !== $project) {
+            foreach ($project->getMembers() as $member) {
+                if (null !== $member->getId()) {
+                    $allowed[(string) $member->getId()] = true;
+                }
+            }
+        }
+
+        foreach ($value->getAssignees() as $assignee) {
+            $id = $assignee->getId();
+            if (null === $id || !isset($allowed[(string) $id])) {
+                $this->context->buildViolation($constraint->messageNotAllowed)
+                    ->atPath('assignees')
+                    ->addViolation();
+                return;
+            }
+        }
+    }
+}

--- a/api/tests/Api/TaskTest.php
+++ b/api/tests/Api/TaskTest.php
@@ -21,6 +21,7 @@ class TaskTest extends ApiTestCase
             ->getManager();
 
         $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
     }
 
@@ -538,6 +539,269 @@ class TaskTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(400);
+    }
+
+    public function testCreateTaskAcceptsAssigneeOwner(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks', [
+            'json' => [
+                'title' => 'Solo task',
+                'assignees' => ['/users/' . $alice->getId()],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+        $task = $this->reloadTaskByTitle('Solo task');
+        $this->assertCount(1, $task->getAssignees());
+        $this->assertTrue($alice->getId()->equals($task->getAssignees()->first()?->getId()));
+    }
+
+    public function testCreateTaskRejectsNonProjectMemberAssignee(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks', [
+            'json' => [
+                'title' => 'Personal but with bob',
+                'assignees' => ['/users/' . $bob->getId()],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        // Personal task (no project) — only owner can be assigned. Bob is rejected.
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testPatchAssigneesAcceptsProjectMembers(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $project = $this->createSharedProject($alice, [$alice, $bob], 'Team');
+        $task = $this->createTaskInProject($alice, $project, 'Team task');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/tasks/' . $task->getId(), [
+            'json' => [
+                'assignees' => [
+                    '/users/' . $alice->getId(),
+                    '/users/' . $bob->getId(),
+                ],
+            ],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->entityManager->clear();
+        $reloaded = $this->entityManager->getRepository(Task::class)->find($task->getId());
+        $this->assertCount(2, $reloaded->getAssignees());
+    }
+
+    public function testPatchAssigneesRejectsOutsideProject(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $carol = $this->createUser('carol@example.com');
+        $project = $this->createSharedProject($alice, [$alice, $bob], 'Team');
+        $task = $this->createTaskInProject($alice, $project, 'Team task');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/tasks/' . $task->getId(), [
+            'json' => ['assignees' => ['/users/' . $carol->getId()]],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testFilterTasksByAssignee(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $project = $this->createSharedProject($alice, [$alice, $bob], 'Team');
+
+        $aliceOnly = $this->createTaskInProject($alice, $project, 'Alice only');
+        $aliceOnly->addAssignee($alice);
+        $bothAssigned = $this->createTaskInProject($alice, $project, 'Both assigned');
+        $bothAssigned->addAssignee($alice);
+        $bothAssigned->addAssignee($bob);
+        $unassigned = $this->createTaskInProject($alice, $project, 'Unassigned');
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/tasks?assignees=/users/' . $bob->getId());
+
+        $this->assertResponseIsSuccessful();
+        $titles = array_map(
+            fn ($t) => $t['title'],
+            $client->getResponse()->toArray()['member'],
+        );
+        $this->assertSame(['Both assigned'], $titles);
+    }
+
+    public function testAddAssigneeEndpoint(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $project = $this->createSharedProject($alice, [$alice, $bob], 'Team');
+        $task = $this->createTaskInProject($alice, $project, 'Team task');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks/' . $task->getId() . '/assignees', [
+            'json' => ['userId' => (string) $bob->getId()],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->entityManager->clear();
+        $reloaded = $this->entityManager->getRepository(Task::class)->find($task->getId());
+        $this->assertCount(1, $reloaded->getAssignees());
+        $this->assertTrue($bob->getId()->equals($reloaded->getAssignees()->first()?->getId()));
+    }
+
+    public function testAddAssigneeEndpointRejectsDuplicate(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->createTask($alice, 'Personal');
+        $task->addAssignee($alice);
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks/' . $task->getId() . '/assignees', [
+            'json' => ['userId' => (string) $alice->getId()],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(409);
+    }
+
+    public function testAddAssigneeEndpointRejectsNonMember(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $task = $this->createTask($alice, 'Personal');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks/' . $task->getId() . '/assignees', [
+            'json' => ['userId' => (string) $bob->getId()],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+
+        // Personal task — only Alice (owner) can be assigned. Bob is rejected.
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testRemoveAssigneeEndpoint(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $project = $this->createSharedProject($alice, [$alice, $bob], 'Team');
+        $task = $this->createTaskInProject($alice, $project, 'Team task');
+        $task->addAssignee($bob);
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request(
+            'DELETE',
+            '/tasks/' . $task->getId() . '/assignees/' . $bob->getId(),
+        );
+
+        $this->assertResponseStatusCodeSame(204);
+        $this->entityManager->clear();
+        $reloaded = $this->entityManager->getRepository(Task::class)->find($task->getId());
+        $this->assertCount(0, $reloaded->getAssignees());
+    }
+
+    public function testAssigneeEndpointsHide404ForOtherUsersTask(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $bobTask = $this->createTask($bob, "Bob's task");
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks/' . $bobTask->getId() . '/assignees', [
+            'json' => ['userId' => (string) $alice->getId()],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testAssignableUsersIncludesSelf(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/me/assignable-users');
+
+        $this->assertResponseIsSuccessful();
+        $body = $client->getResponse()->toArray();
+        $emails = array_map(fn ($u) => $u['email'], $body['member'] ?? []);
+        $this->assertSame(['alice@example.com'], $emails);
+    }
+
+    public function testAssignableUsersIncludesProjectTeammates(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $carol = $this->createUser('carol@example.com');
+        $this->createSharedProject($alice, [$alice, $bob], 'Team');
+        // Carol shares no project with alice — must not appear.
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/me/assignable-users');
+
+        $this->assertResponseIsSuccessful();
+        $body = $client->getResponse()->toArray();
+        $emails = array_map(fn ($u) => $u['email'], $body['member'] ?? []);
+        sort($emails);
+        $this->assertSame(['alice@example.com', 'bob@example.com'], $emails);
+        $this->assertNotContains('carol@example.com', $emails);
+    }
+
+    /**
+     * @param User[] $members
+     */
+    private function createSharedProject(User $owner, array $members, string $title): Project
+    {
+        $project = new Project();
+        $project->setOwner($owner);
+        $project->setTitle($title);
+        foreach ($members as $member) {
+            $project->addMember($member);
+        }
+        $this->entityManager->persist($project);
+        $this->entityManager->flush();
+        return $project;
+    }
+
+    private function createTaskInProject(User $owner, Project $project, string $title): Task
+    {
+        $task = new Task();
+        $task->setOwner($owner);
+        $task->setProject($project);
+        $task->setTitle($title);
+        $this->entityManager->persist($task);
+        $this->entityManager->flush();
+        return $task;
     }
 
     /**

--- a/e2e/tests/tasks.spec.js
+++ b/e2e/tests/tasks.spec.js
@@ -76,9 +76,15 @@ test.describe("Tasks", () => {
   test("account menu shows Tasks link when authenticated", async ({ page }) => {
     await registerAndSignIn(page, uniqueEmail());
     await openAccountMenu(page);
-    await expect(page.locator('nav >> text=Tasks')).toBeVisible();
-    await page.locator('nav >> text=Tasks').click();
-    await expect(page).toHaveURL(/\/tasks/);
+    // `text=Tasks` would substring-match the new "My Tasks" entry too —
+    // pin to an exact-name role lookup so each link is targeted on its own.
+    const tasksLink = page.locator("nav").getByRole("link", {
+      name: "Tasks",
+      exact: true,
+    });
+    await expect(tasksLink).toBeVisible();
+    await tasksLink.click();
+    await expect(page).toHaveURL(/\/tasks$/);
   });
 
   test("user can reorder tasks via keyboard drag", async ({ page }) => {

--- a/pwa/components/common/Navbar.tsx
+++ b/pwa/components/common/Navbar.tsx
@@ -19,6 +19,7 @@ import { cn } from "@/lib/utils";
 import ThemeToggle from "./ThemeToggle";
 
 const NAV_LINKS = [
+  { href: "/my-tasks", label: "My Tasks" },
   { href: "/tasks", label: "Tasks" },
   { href: "/projects", label: "Projects" },
   { href: "/groups", label: "Groups" },

--- a/pwa/components/tasks/AssigneesCombobox.tsx
+++ b/pwa/components/tasks/AssigneesCombobox.tsx
@@ -1,0 +1,217 @@
+import { useEffect, useRef, useState } from "react";
+import { Pencil, Plus } from "lucide-react";
+
+import {
+  Combobox,
+  ComboboxChip,
+  ComboboxChips,
+  ComboboxChipsInput,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxValue,
+} from "@/components/ui/combobox";
+import UserAvatar, { type AvatarUser } from "@/components/user/UserAvatar";
+import { displayName } from "@/lib/userDisplay";
+import { cn } from "@/lib/utils";
+
+export interface AssigneeOption extends AvatarUser {
+  "@id": string;
+  id: string;
+  email: string;
+}
+
+interface AssigneesComboboxProps {
+  value: AssigneeOption[];
+  options: AssigneeOption[];
+  onChange: (nextIris: string[]) => void | Promise<void>;
+  /** Used to label the input for screen readers. */
+  subjectLabel?: string;
+  className?: string;
+  /** When provided, an avatar click invokes this callback with the user IRI. */
+  onAvatarClick?: (assignee: AssigneeOption) => void;
+}
+
+const AssigneesCombobox = ({
+  value,
+  options,
+  onChange,
+  subjectLabel,
+  className,
+  onAvatarClick,
+}: AssigneesComboboxProps) => {
+  // Edit mode: collapsed shows a stacked avatar group plus an "Assign"/"Edit"
+  // affordance. Expanded swaps in the full Combobox chrome (chips + popover)
+  // for searching the assignable user list.
+  const [isEditing, setIsEditing] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  // Click-outside dismissal. The popover content is portaled to <body>, so
+  // checking ref.contains() alone isn't enough — we also keep the editor
+  // open while the click lands inside `[data-slot=combobox-content]`.
+  useEffect(() => {
+    if (!isEditing) return;
+    const handle = (event: PointerEvent) => {
+      const target = event.target as Element | null;
+      if (!target) return;
+      if (containerRef.current?.contains(target)) return;
+      if (target.closest('[data-slot="combobox-content"]')) return;
+      setIsEditing(false);
+    };
+    document.addEventListener("pointerdown", handle, true);
+    return () => document.removeEventListener("pointerdown", handle, true);
+  }, [isEditing]);
+
+  // Focus the chip-input as soon as we enter edit mode.
+  useEffect(() => {
+    if (!isEditing) return;
+    const input = containerRef.current?.querySelector<HTMLInputElement>(
+      '[data-slot="combobox-chip-input"]',
+    );
+    input?.focus();
+  }, [isEditing]);
+
+  const handleChange = (next: AssigneeOption[]) => {
+    void onChange(next.map((u) => u["@id"]));
+  };
+
+  return (
+    <div ref={containerRef} className={className}>
+      <Combobox<AssigneeOption, true>
+        items={options}
+        multiple
+        value={value}
+        onValueChange={handleChange}
+        itemToStringLabel={(u) => displayName(u)}
+        itemToStringValue={(u) => u["@id"]}
+      >
+        <ComboboxChips
+          className={cn(
+            !isEditing &&
+              "min-h-0 border-transparent bg-transparent px-0 py-0 shadow-none focus-within:border-transparent focus-within:ring-0 dark:bg-transparent has-data-[slot=combobox-chip]:px-0",
+          )}
+        >
+          {isEditing ? (
+            <>
+              <ComboboxValue>
+                {value.map((u) => (
+                  <ComboboxChip
+                    key={u["@id"]}
+                    aria-label={displayName(u)}
+                    className="gap-1 px-2"
+                    data-testid="task-assignee-chip"
+                  >
+                    <UserAvatar user={u} size="sm" className="h-4 w-4" />
+                    <span className="truncate max-w-[10rem]">{displayName(u)}</span>
+                  </ComboboxChip>
+                ))}
+              </ComboboxValue>
+              <ComboboxChipsInput
+                placeholder={value.length === 0 ? "Assign people…" : ""}
+                aria-label={
+                  subjectLabel ? `Assignees for "${subjectLabel}"` : "Assignees"
+                }
+                onKeyDown={(event) => {
+                  if (event.key === "Escape") {
+                    event.preventDefault();
+                    setIsEditing(false);
+                  }
+                }}
+                autoComplete="nope"
+                autoCorrect="off"
+                autoCapitalize="off"
+                spellCheck={false}
+                name="aura-assignee-search"
+                data-form-type="other"
+                data-lpignore="true"
+                data-1p-ignore="true"
+              />
+            </>
+          ) : (
+            <>
+              {/* Collapsed view: stacked avatar group (-space-x makes them overlap)
+                  plus an Edit / Assign trigger. Avatars are buttons when
+                  onAvatarClick is wired so the user can filter by clicking. */}
+              {value.length > 0 && (
+                <div
+                  className="flex -space-x-1.5 mr-1"
+                  data-testid="task-assignees"
+                >
+                  {value.map((u) =>
+                    onAvatarClick ? (
+                      <button
+                        key={u["@id"]}
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onAvatarClick(u);
+                        }}
+                        aria-label={`Filter by ${displayName(u)}`}
+                        title={displayName(u)}
+                        className="rounded-full ring-2 ring-background hover:ring-foreground/20 transition cursor-pointer bg-transparent border-0 p-0"
+                      >
+                        <UserAvatar user={u} size="sm" />
+                      </button>
+                    ) : (
+                      <span
+                        key={u["@id"]}
+                        title={displayName(u)}
+                        className="ring-2 ring-background rounded-full"
+                      >
+                        <UserAvatar user={u} size="sm" />
+                      </span>
+                    ),
+                  )}
+                </div>
+              )}
+              <button
+                type="button"
+                onClick={() => setIsEditing(true)}
+                aria-label={
+                  subjectLabel
+                    ? `Edit assignees for "${subjectLabel}"`
+                    : value.length === 0
+                      ? "Assign people"
+                      : "Edit assignees"
+                }
+                className={cn(
+                  "inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-xs",
+                  value.length === 0
+                    ? "italic text-muted-foreground/60 hover:text-muted-foreground"
+                    : "text-muted-foreground/60 hover:text-foreground",
+                )}
+                data-testid="task-assignees-edit"
+              >
+                {value.length === 0 ? (
+                  <>
+                    <Plus className="h-3 w-3" />
+                    Assign
+                  </>
+                ) : (
+                  <Pencil className="h-3 w-3" />
+                )}
+              </button>
+            </>
+          )}
+        </ComboboxChips>
+        <ComboboxContent>
+          <ComboboxEmpty>No assignable users.</ComboboxEmpty>
+          <ComboboxList>
+            {(u: AssigneeOption) => (
+              <ComboboxItem key={u["@id"]} value={u}>
+                <UserAvatar user={u} size="sm" className="h-5 w-5" />
+                <span className="flex-1 truncate">{displayName(u)}</span>
+                <span className="text-xs text-muted-foreground truncate">
+                  {u.email}
+                </span>
+              </ComboboxItem>
+            )}
+          </ComboboxList>
+        </ComboboxContent>
+      </Combobox>
+    </div>
+  );
+};
+
+export default AssigneesCombobox;

--- a/pwa/pages/my-tasks.tsx
+++ b/pwa/pages/my-tasks.tsx
@@ -1,0 +1,7 @@
+// `/my-tasks` reuses the full /tasks dashboard, just routed differently.
+// The shared component reads `router.pathname` to switch into a "mine"
+// view: assignee filter pinned to the current user, picker hidden, new
+// tasks auto-assigned to self.
+import Tasks from "./tasks";
+
+export default Tasks;

--- a/pwa/pages/tasks.tsx
+++ b/pwa/pages/tasks.tsx
@@ -1,7 +1,15 @@
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ArrowDown, ArrowUp, ArrowUpDown, GripVertical, Trash2 } from "lucide-react";
+import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
+  Filter,
+  GripVertical,
+  Trash2,
+  X,
+} from "lucide-react";
 import {
   DndContext,
   DragEndEvent,
@@ -23,12 +31,25 @@ import { useAuth } from "@/contexts/AuthContext";
 import { ENTRYPOINT } from "@/config/entrypoint";
 import { signinHrefForCurrent } from "@/lib/authRedirect";
 import MarkdownEditor from "@/components/editor/MarkdownEditor";
+import AssigneesCombobox, {
+  type AssigneeOption,
+} from "@/components/tasks/AssigneesCombobox";
 import TagsCombobox from "@/components/tasks/TagsCombobox";
+import UserAvatar from "@/components/user/UserAvatar";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
 import { Card, CardContent } from "@/components/ui/card";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
+import { displayName } from "@/lib/userDisplay";
 import {
   Popover,
   PopoverContent,
@@ -60,6 +81,15 @@ interface Task {
   dueDate: string | null;
   position: number;
   tags: Tag[];
+  assignees: AssigneeOption[];
+  // The API serializes Task.project as a bare IRI string under `task:read`.
+  // null means "personal task" — only the owner is assignable.
+  project: string | null;
+}
+
+interface ProjectMembership {
+  "@id": string;
+  members: Array<{ "@id": string }>;
 }
 
 interface Collection<T> {
@@ -236,6 +266,7 @@ const SortableHeader = ({ label, sortKey, active, onSort, className }: SortableH
 interface TaskRowProps {
   task: Task;
   allTags: Tag[];
+  assignableUsers: AssigneeOption[];
   reorderable: boolean;
   onToggle: (task: Task) => void;
   onDelete: (task: Task) => void;
@@ -243,11 +274,14 @@ interface TaskRowProps {
   onTitleChange: (task: Task, nextTitle: string) => Promise<void>;
   onDescriptionChange: (task: Task, nextDescription: string | null) => Promise<void>;
   onDueDateChange: (task: Task, nextDueDate: string | null) => Promise<void>;
+  onAssigneesChange: (task: Task, nextIris: string[]) => Promise<void>;
+  onAssigneeAvatarClick: (assignee: AssigneeOption) => void;
 }
 
 const TaskRow = ({
   task,
   allTags,
+  assignableUsers,
   reorderable,
   onToggle,
   onDelete,
@@ -255,6 +289,8 @@ const TaskRow = ({
   onTitleChange,
   onDescriptionChange,
   onDueDateChange,
+  onAssigneesChange,
+  onAssigneeAvatarClick,
 }: TaskRowProps) => {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: task["@id"],
@@ -410,6 +446,15 @@ const TaskRow = ({
             subjectLabel={task.title}
           />
         </TableCell>
+        <TableCell className="align-top">
+          <AssigneesCombobox
+            value={task.assignees}
+            options={assignableUsers}
+            onChange={(nextIris) => onAssigneesChange(task, nextIris)}
+            onAvatarClick={onAssigneeAvatarClick}
+            subjectLabel={task.title}
+          />
+        </TableCell>
         <TableCell className="align-top text-right">
           <Button
             variant="ghost"
@@ -431,7 +476,7 @@ const TaskRow = ({
             pixel-math with pl-24. */}
         <TableCell className="w-8" aria-hidden="true" />
         <TableCell className="w-10" aria-hidden="true" />
-        <TableCell colSpan={4} className="pl-0 pr-4 pt-0 pb-3 text-sm">
+        <TableCell colSpan={5} className="pl-0 pr-4 pt-0 pb-3 text-sm">
           {editingDesc ? (
             <div className="space-y-2">
               <MarkdownEditor
@@ -491,24 +536,58 @@ interface NewTaskInput {
   description: string | null;
   tags: string[];
   dueDate: string | null;
+  assignees: string[];
 }
 
 interface NewTaskRowProps {
   allTags: Tag[];
+  assignableUsers: AssigneeOption[];
   /** Resolves on success, rejects on failure so we know whether to clear the draft. */
   onCreate: (input: NewTaskInput) => Promise<void>;
   isCreating: boolean;
+  currentUserIri: string | null;
+  /** When true, new tasks default to being assigned to the current user — used
+   *  on /my-tasks so a freshly created row doesn't immediately filter itself
+   *  out. */
+  autoAssignSelf?: boolean;
 }
 
 // Inline "add a task" row that lives at the top of the table. Mirrors the
 // layout of TaskRow (main row + description sub-row) so the user can stage
 // title, tags, and description before pressing Enter to submit. Failures
 // keep the draft intact (parent shows the error).
-const NewTaskRow = ({ allTags, onCreate, isCreating }: NewTaskRowProps) => {
+const NewTaskRow = ({
+  allTags,
+  assignableUsers,
+  onCreate,
+  isCreating,
+  currentUserIri,
+  autoAssignSelf,
+}: NewTaskRowProps) => {
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState<string | null>(null);
   const [tags, setTags] = useState<Tag[]>([]);
   const [dueDate, setDueDate] = useState<string | null>(null);
+  // Personal tasks (no project) only allow the owner. Restrict the picker to
+  // self so we don't surface teammates the validator would reject.
+  const newTaskAssignableUsers = useMemo(
+    () => assignableUsers.filter((u) => u["@id"] === currentUserIri),
+    [assignableUsers, currentUserIri],
+  );
+  const selfOption = newTaskAssignableUsers[0] ?? null;
+  const [assignees, setAssignees] = useState<AssigneeOption[]>(() =>
+    autoAssignSelf && selfOption ? [selfOption] : [],
+  );
+  // If the assignable list arrives after mount (async), seed the default
+  // assignment then. Subsequent changes are user-driven, so only seed once.
+  const seededRef = useRef(false);
+  useEffect(() => {
+    if (seededRef.current) return;
+    if (autoAssignSelf && selfOption && assignees.length === 0) {
+      setAssignees([selfOption]);
+      seededRef.current = true;
+    }
+  }, [autoAssignSelf, selfOption, assignees.length]);
   const titleInputRef = useRef<HTMLInputElement | null>(null);
 
   // Description inline editing — local-only; nothing hits the API until
@@ -539,11 +618,19 @@ const NewTaskRow = ({ allTags, onCreate, isCreating }: NewTaskRowProps) => {
     setTags(next);
   };
 
+  const handleAssigneesChange = (nextIris: string[]) => {
+    const next = nextIris
+      .map((iri) => assignableUsers.find((u) => u["@id"] === iri))
+      .filter((u): u is AssigneeOption => Boolean(u));
+    setAssignees(next);
+  };
+
   const reset = () => {
     setTitle("");
     setDescription(null);
     setTags([]);
     setDueDate(null);
+    setAssignees(autoAssignSelf && selfOption ? [selfOption] : []);
     setEditingDesc(false);
     setDescDraft("");
   };
@@ -557,6 +644,7 @@ const NewTaskRow = ({ allTags, onCreate, isCreating }: NewTaskRowProps) => {
         description,
         tags: tags.map((tag) => tag["@id"]),
         dueDate,
+        assignees: assignees.map((u) => u["@id"]),
       });
       reset();
       // Refocus on next tick so the input isn't briefly disabled when we
@@ -614,6 +702,14 @@ const NewTaskRow = ({ allTags, onCreate, isCreating }: NewTaskRowProps) => {
             subjectLabel="new task"
           />
         </TableCell>
+        <TableCell className="align-top" data-testid="new-task-assignees">
+          <AssigneesCombobox
+            value={assignees}
+            options={newTaskAssignableUsers}
+            onChange={handleAssigneesChange}
+            subjectLabel="new task"
+          />
+        </TableCell>
         <TableCell aria-hidden="true" />
       </TableRow>
       <TableRow
@@ -622,7 +718,7 @@ const NewTaskRow = ({ allTags, onCreate, isCreating }: NewTaskRowProps) => {
       >
         <TableCell className="w-8" aria-hidden="true" />
         <TableCell className="w-10" aria-hidden="true" />
-        <TableCell colSpan={4} className="pl-0 pr-4 pt-0 pb-3 text-sm">
+        <TableCell colSpan={5} className="pl-0 pr-4 pt-0 pb-3 text-sm">
           {editingDesc ? (
             <div className="space-y-2">
               <MarkdownEditor
@@ -677,16 +773,37 @@ const NewTaskRow = ({ allTags, onCreate, isCreating }: NewTaskRowProps) => {
   );
 };
 
+// "all" shows every task; "me" filters to the current user; an IRI string
+// filters to that specific assignable user. Stored as a single value rather
+// than three separate flags so each setter call replaces the previous filter.
+type AssigneeFilter = "all" | "me" | string;
+
 const Tasks = () => {
-  const { isAuthenticated, isLoading: authLoading } = useAuth();
+  const { user, isAuthenticated, isLoading: authLoading } = useAuth();
   const router = useRouter();
+  const currentUserIri = user ? `/users/${user.id}` : null;
+  // Both `/tasks` and `/my-tasks` mount this component. The latter pins the
+  // assignee filter to the logged-in user and hides the picker, so the page
+  // is effectively a fixed "everything assigned to me" view.
+  const isMyTasksPage = router.pathname === "/my-tasks";
+  const pageTitle = isMyTasksPage ? "My Tasks" : "Tasks";
 
   const [tasks, setTasks] = useState<Task[]>([]);
   const [allTags, setAllTags] = useState<Tag[]>([]);
+  const [assignableUsers, setAssignableUsers] = useState<AssigneeOption[]>([]);
+  // Map of project IRI → set of member IRIs. Used to filter the assignee
+  // picker per task (project tasks accept only that project's members; the
+  // server-side validator enforces the same rule).
+  const [projectMembers, setProjectMembers] = useState<Map<string, Set<string>>>(
+    new Map(),
+  );
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [sort, setSort] = useState<SortState>(DEFAULT_SORT);
+  const [assigneeFilter, setAssigneeFilter] = useState<AssigneeFilter>(
+    isMyTasksPage ? "me" : "all",
+  );
 
   const sensors = useSensors(
     // Require an 8px drag before activating so a quick click on the grip
@@ -704,14 +821,23 @@ const Tasks = () => {
   const loadData = useCallback(async () => {
     setError(null);
     try {
-      // Load tasks and tags in parallel — the task list embeds its current
-      // tag badges, the full tag list populates the "+ Tag" picker.
-      const [tasksRes, tagsRes] = await Promise.all([
+      // Tasks, tags, the assignable-users universe, and the projects-with-
+      // members set all load in parallel — the page needs the projects to
+      // know which assignable users are valid for each project task.
+      const [tasksRes, tagsRes, assignablesRes, projectsRes] = await Promise.all([
         fetch(`${ENTRYPOINT}/tasks`, {
           credentials: "include",
           headers: { Accept: "application/ld+json" },
         }),
         fetch(`${ENTRYPOINT}/tags`, {
+          credentials: "include",
+          headers: { Accept: "application/ld+json" },
+        }),
+        fetch(`${ENTRYPOINT}/me/assignable-users`, {
+          credentials: "include",
+          headers: { Accept: "application/ld+json" },
+        }),
+        fetch(`${ENTRYPOINT}/projects`, {
           credentials: "include",
           headers: { Accept: "application/ld+json" },
         }),
@@ -722,10 +848,30 @@ const Tasks = () => {
       if (!tagsRes.ok) {
         throw new Error("Failed to load tags.");
       }
+      if (!assignablesRes.ok) {
+        throw new Error("Failed to load assignable users.");
+      }
+      if (!projectsRes.ok) {
+        throw new Error("Failed to load projects.");
+      }
       const tasksData: Collection<Task> = await tasksRes.json();
       const tagsData: Collection<Tag> = await tagsRes.json();
+      const assignablesData: Collection<AssigneeOption> = await assignablesRes.json();
+      const projectsData: Collection<ProjectMembership> = await projectsRes.json();
       setTasks(tasksData.member ?? tasksData["hydra:member"] ?? []);
       setAllTags(tagsData.member ?? tagsData["hydra:member"] ?? []);
+      setAssignableUsers(
+        assignablesData.member ?? assignablesData["hydra:member"] ?? [],
+      );
+      const projectMap = new Map<string, Set<string>>();
+      const projects = projectsData.member ?? projectsData["hydra:member"] ?? [];
+      for (const project of projects) {
+        projectMap.set(
+          project["@id"],
+          new Set(project.members.map((m) => m["@id"])),
+        );
+      }
+      setProjectMembers(projectMap);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load tasks.");
     } finally {
@@ -733,11 +879,18 @@ const Tasks = () => {
     }
   }, []);
 
+  // /tasks and /my-tasks render the *same* component instance via the
+  // re-export in pages/my-tasks.tsx, so the `useState` initializer above
+  // only runs once. Without this effect the filter (and the cached tasks
+  // list) would carry over from the previous route. Re-pin the filter and
+  // refetch whenever the page mode flips — this also covers the initial
+  // mount once `isAuthenticated` becomes true.
   useEffect(() => {
+    setAssigneeFilter(isMyTasksPage ? "me" : "all");
     if (isAuthenticated) {
       loadData();
     }
-  }, [isAuthenticated, loadData]);
+  }, [isMyTasksPage, isAuthenticated, loadData]);
 
   const handleCreate = async (input: NewTaskInput) => {
     const trimmed = input.title.trim();
@@ -755,6 +908,7 @@ const Tasks = () => {
           description: input.description,
           tags: input.tags,
           dueDate: input.dueDate,
+          assignees: input.assignees,
         }),
       });
       if (!res.ok) {
@@ -900,6 +1054,40 @@ const Tasks = () => {
     }
   };
 
+  const handleAssigneesChange = async (task: Task, nextIris: string[]) => {
+    const previous = tasks;
+    const nextAssignees = nextIris
+      .map((iri) => assignableUsers.find((u) => u["@id"] === iri))
+      .filter((u): u is AssigneeOption => Boolean(u));
+    setTasks(
+      tasks.map((t) =>
+        t["@id"] === task["@id"] ? { ...t, assignees: nextAssignees } : t,
+      ),
+    );
+    setError(null);
+
+    try {
+      const res = await fetch(`${ENTRYPOINT}${task["@id"]}`, {
+        method: "PATCH",
+        credentials: "include",
+        headers: { "Content-Type": "application/merge-patch+json" },
+        body: JSON.stringify({ assignees: nextIris }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(
+          data.description ||
+            data.detail ||
+            data["hydra:description"] ||
+            "Failed to update assignees.",
+        );
+      }
+    } catch (err) {
+      setTasks(previous);
+      setError(err instanceof Error ? err.message : "Failed to update assignees.");
+    }
+  };
+
   const handleTagsChange = async (task: Task, nextTagIris: string[]) => {
     // Optimistic update so badges appear instantly. Roll back on server reject.
     const previous = tasks;
@@ -964,13 +1152,20 @@ const Tasks = () => {
     });
   };
 
-  // Sorted *view* of the tasks. Manual order leaves them as-is so the dnd-kit
-  // index math stays aligned with what's painted; any other sort produces a
-  // shallow copy ordered by the picked column.
+  // Apply the assignee filter, then sort. "all" leaves tasks intact so the
+  // manual-order drag math stays aligned. "me" matches the logged-in user;
+  // a specific IRI matches just that user.
+  const filteredTasks = useMemo(() => {
+    if (assigneeFilter === "all") return tasks;
+    const targetIri = assigneeFilter === "me" ? currentUserIri : assigneeFilter;
+    if (!targetIri) return tasks;
+    return tasks.filter((t) => t.assignees.some((a) => a["@id"] === targetIri));
+  }, [tasks, assigneeFilter, currentUserIri]);
+
   const visibleTasks = useMemo(() => {
-    if (sort.key === "manual") return tasks;
+    if (sort.key === "manual") return filteredTasks;
     const flip = sort.dir === "asc" ? 1 : -1;
-    const copy = [...tasks];
+    const copy = [...filteredTasks];
     copy.sort((a, b) => {
       switch (sort.key) {
         case "completed":
@@ -992,9 +1187,49 @@ const Tasks = () => {
       }
     });
     return copy;
-  }, [tasks, sort]);
+  }, [filteredTasks, sort]);
 
-  const reorderable = sort.key === "manual";
+  // Reordering is only safe in the "manual" sort *and* when nothing is being
+  // filtered out — drag-end math assumes the index lines up with the
+  // persisted position.
+  const reorderable = sort.key === "manual" && assigneeFilter === "all";
+
+  const assignableForTask = useCallback(
+    (task: Task): AssigneeOption[] => {
+      if (!task.project) {
+        // Personal task — only the owner can be assigned. The owner is
+        // always in the assignable-users set when it's the current user; for
+        // admin-viewed tasks owned by others, fall back to the task's
+        // current assignees (already known-valid).
+        const owner = task.assignees.find((a) => a["@id"] === currentUserIri);
+        return owner ? [owner] : task.assignees;
+      }
+      const memberIris = projectMembers.get(task.project);
+      if (!memberIris) return assignableUsers;
+      return assignableUsers.filter((u) => memberIris.has(u["@id"]));
+    },
+    [assignableUsers, projectMembers, currentUserIri],
+  );
+
+  // Users that have ever been assigned to a task on the page — drives the
+  // "specific person" entries in the filter dropdown so we don't list
+  // everyone the API would accept.
+  const filterableUsers = useMemo(() => {
+    const seen = new Map<string, AssigneeOption>();
+    for (const t of tasks) {
+      for (const a of t.assignees) {
+        if (!seen.has(a["@id"])) seen.set(a["@id"], a);
+      }
+    }
+    return Array.from(seen.values());
+  }, [tasks]);
+
+  const filterLabel = useMemo(() => {
+    if (assigneeFilter === "all") return "All assignees";
+    if (assigneeFilter === "me") return "Assigned to me";
+    const match = filterableUsers.find((u) => u["@id"] === assigneeFilter);
+    return match ? `Assigned to ${displayName(match)}` : "Filtered";
+  }, [assigneeFilter, filterableUsers]);
 
   if (authLoading || !isAuthenticated) {
     return (
@@ -1007,11 +1242,72 @@ const Tasks = () => {
   return (
     <>
       <Head>
-        <title>Tasks - Aura</title>
+        <title>{pageTitle} - Aura</title>
       </Head>
       <div className="min-h-screen bg-muted px-4 py-12">
         <div className="max-w-7xl mx-auto">
-          <h1 className="text-2xl font-bold mb-6">Tasks</h1>
+          <div className="flex items-center justify-between mb-6 gap-3 flex-wrap">
+            <h1 className="text-2xl font-bold">{pageTitle}</h1>
+            {/* The filter dropdown is redundant on /my-tasks (everything
+                shown is already filtered to the current user). */}
+            {!isMyTasksPage && (
+            <div className="flex items-center gap-2">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    data-testid="assignee-filter-trigger"
+                  >
+                    <Filter className="h-3.5 w-3.5 mr-1" />
+                    {filterLabel}
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-56">
+                  <DropdownMenuLabel>Filter by assignee</DropdownMenuLabel>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuCheckboxItem
+                    checked={assigneeFilter === "all"}
+                    onCheckedChange={() => setAssigneeFilter("all")}
+                  >
+                    All assignees
+                  </DropdownMenuCheckboxItem>
+                  <DropdownMenuCheckboxItem
+                    checked={assigneeFilter === "me"}
+                    onCheckedChange={() => setAssigneeFilter("me")}
+                    disabled={!currentUserIri}
+                  >
+                    Assigned to me
+                  </DropdownMenuCheckboxItem>
+                  {filterableUsers.length > 0 && <DropdownMenuSeparator />}
+                  {filterableUsers.map((u) => (
+                    <DropdownMenuCheckboxItem
+                      key={u["@id"]}
+                      checked={assigneeFilter === u["@id"]}
+                      onCheckedChange={() => setAssigneeFilter(u["@id"])}
+                    >
+                      <span className="flex items-center gap-2 truncate">
+                        <UserAvatar user={u} size="sm" className="h-5 w-5" />
+                        <span className="truncate">{displayName(u)}</span>
+                      </span>
+                    </DropdownMenuCheckboxItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+              {assigneeFilter !== "all" && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setAssigneeFilter("all")}
+                  aria-label="Clear assignee filter"
+                  data-testid="assignee-filter-clear"
+                >
+                  <X className="h-3.5 w-3.5" />
+                </Button>
+              )}
+            </div>
+            )}
+          </div>
 
           {error && (
             <Alert variant="destructive" className="mb-4">
@@ -1024,8 +1320,9 @@ const Tasks = () => {
               className="mb-2 text-xs text-muted-foreground"
               data-testid="reorder-disabled-hint"
             >
-              Drag-to-reorder is paused while the table is sorted by a column. Click
-              the active column header again to return to your custom order.
+              Drag-to-reorder is paused while the list is filtered or sorted by a
+              column. Clear the filter and reset the column header to return to
+              your custom order.
             </p>
           )}
 
@@ -1068,19 +1365,24 @@ const Tasks = () => {
                             className="w-36"
                           />
                           <TableHead>Tags</TableHead>
+                          <TableHead>Assignees</TableHead>
                           <TableHead className="w-20 text-right">Actions</TableHead>
                         </TableRow>
                       </TableHeader>
                       <NewTaskRow
                         allTags={allTags}
+                        assignableUsers={assignableUsers}
                         onCreate={handleCreate}
                         isCreating={isSubmitting}
+                        currentUserIri={currentUserIri}
+                        autoAssignSelf={isMyTasksPage}
                       />
                       {visibleTasks.map((task) => (
                         <TaskRow
                           key={task["@id"]}
                           task={task}
                           allTags={allTags}
+                          assignableUsers={assignableForTask(task)}
                           reorderable={reorderable}
                           onToggle={handleToggle}
                           onDelete={handleDelete}
@@ -1088,6 +1390,10 @@ const Tasks = () => {
                           onTitleChange={handleTitleChange}
                           onDescriptionChange={handleDescriptionChange}
                           onDueDateChange={handleDueDateChange}
+                          onAssigneesChange={handleAssigneesChange}
+                          onAssigneeAvatarClick={(assignee) =>
+                            setAssigneeFilter(assignee["@id"])
+                          }
                         />
                       ))}
                     </Table>


### PR DESCRIPTION
## Summary

Closes #83. Adds task assignment end-to-end:

- **Backend**: `Task ↔ User` many-to-many (`task_assignee` join table) with a `ValidAssignees` class-level constraint that keeps the set restricted to owner ∪ project members — assignment is a "who's responsible" label and never grants extra read/edit access.
- **API**: `assignees` exposed on `task:read`/`task:write`; dedicated `POST /tasks/{id}/assignees` (body `{userId}` → 200/409/422) and `DELETE /tasks/{id}/assignees/{userId}` → 204; `?assignees=/users/{id}` filter via SearchFilter; new `GET /me/assignable-users` returns the picker's candidate set (self + every project teammate).
- **Frontend**: `AssigneesCombobox` (multi-select with avatars + typeahead), stacked-avatar group on each task row, click-an-avatar-to-filter affordance, and an "All / Assigned to me / specific user" filter dropdown above the table.
- **My Tasks page**: new `/my-tasks` route in the sidebar, pins the assignee filter to the current user, hides the now-redundant filter dropdown, and auto-assigns new tasks to self so a freshly-created row stays visible.
- **Tests**: 11 new task tests covering CRUD on the dedicated endpoints, the standard PATCH path, validation edge cases, the assignees filter, and the assignable-users endpoint. All 75 affected suite tests (Task/Project/User/UserGroup) pass.
- **Demo data**: `ProjectFixtures` seeds a mix of solo, joint, and unassigned tasks so the avatar group, "Assigned to me" filter, and "Assign" empty-state are all visible after `doctrine:fixtures:load`.

## Test plan

- [ ] `docker compose exec php bin/console doctrine:migrations:migrate` then `doctrine:fixtures:load`, then `docker compose restart php`
- [ ] Sign in as `user@aura.test` / `user123` — `/tasks` shows Uma's project tasks with avatar stacks, `/my-tasks` shows only the subset assigned to her
- [ ] Sign in as `admin@aura.test` / `admin123` — `/my-tasks` shows the 3 tasks assigned to Ada (Draft onboarding email, Polish empty states, Write API auth docs)
- [ ] Open the assignee picker on a project task — typeahead, multi-select, removing chips all work
- [ ] Try to assign a non-project-member via PATCH → 422 with the expected violation
- [ ] Click an assignee avatar in a row → filter pins to that user; clear via the X button
- [ ] Navigate `/tasks` ↔ `/my-tasks` repeatedly — filter resets and tasks refetch on each crossing
- [ ] `bin/phpunit --filter TaskTest` → green (34 tests, 73 assertions)