### PR TITLE
docs: credit API Platform template in contributors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,3 +5,7 @@ Thanks to everyone who has contributed to Aura!
 ## Maintainers
 
 - [Robert Parker](https://github.com/roboparker)
+
+## Acknowledgments
+
+Aura was bootstrapped from the [API Platform Distribution](https://github.com/api-platform/api-platform) template, and stands on the work of its maintainers and contributors.


### PR DESCRIPTION
## Summary
- Adds an Acknowledgments section to `CONTRIBUTORS.md` crediting the [API Platform Distribution](https://github.com/api-platform/api-platform) template that Aura was bootstrapped from.

## Test plan
- [x] `git diff` shows only the 4-line addition