### PR TITLE
feat(tasks): recurring due dates (daily/weekly/monthly/yearly)

### DIFF
--- a/api/migrations/Version20260503120000.php
+++ b/api/migrations/Version20260503120000.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds a nullable recurrence_rule column to the task table. Stores the
+ * recurrence pattern as a JSON object (frequency + interval); see
+ * App\Entity\Task::$recurrenceRule.
+ */
+final class Version20260503120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add task.recurrence_rule for recurring tasks.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE task ADD recurrence_rule JSON DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE task DROP recurrence_rule');
+    }
+}

--- a/api/src/Entity/Task.php
+++ b/api/src/Entity/Task.php
@@ -12,7 +12,9 @@ use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
 use App\Repository\TaskRepository;
 use App\State\TaskOwnerProcessor;
+use App\State\TaskUpdateProcessor;
 use App\Validator\ValidAssignees;
+use App\Validator\ValidRecurrence;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
@@ -34,6 +36,7 @@ use Symfony\Component\Validator\Constraints as Assert;
         ),
         new Patch(
             security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getOwner() == user or (object.getProject() !== null and object.getProject().getMembers().contains(user)))",
+            processor: TaskUpdateProcessor::class,
         ),
         new Delete(
             security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getOwner() == user or (object.getProject() !== null and object.getProject().getMembers().contains(user)))",
@@ -50,6 +53,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ORM\Index(columns: ['owner_id', 'position'], name: 'idx_task_owner_position')]
 #[ORM\Index(columns: ['project_id'], name: 'idx_task_project')]
 #[ValidAssignees]
+#[ValidRecurrence]
 class Task
 {
     #[ORM\Id]
@@ -96,6 +100,20 @@ class Task
     #[ORM\Column(type: 'datetime_immutable', nullable: true)]
     #[Groups(['task:read', 'task:write'])]
     private ?\DateTimeImmutable $dueDate = null;
+
+    /**
+     * Optional recurrence rule. Persisted as a JSON object with shape
+     * `{"frequency": "daily"|"weekly"|"monthly"|"yearly", "interval": int}`.
+     * Validated in detail by {@see ValidRecurrence}; the cross-field rule
+     * (recurrence requires a due date) lives there too. When set, completing
+     * the task triggers {@see TaskUpdateProcessor} to clone the next
+     * occurrence with `dueDate` advanced by the rule.
+     *
+     * @var array{frequency: string, interval: int}|null
+     */
+    #[ORM\Column(type: 'json', nullable: true)]
+    #[Groups(['task:read', 'task:write'])]
+    private ?array $recurrenceRule = null;
 
     /**
      * Per-owner sort key. Lower positions render first. Set server-side:
@@ -222,6 +240,23 @@ class Task
     public function setDueDate(?\DateTimeImmutable $dueDate): static
     {
         $this->dueDate = $dueDate;
+        return $this;
+    }
+
+    /**
+     * @return array{frequency: string, interval: int}|null
+     */
+    public function getRecurrenceRule(): ?array
+    {
+        return $this->recurrenceRule;
+    }
+
+    /**
+     * @param array{frequency: string, interval: int}|null $recurrenceRule
+     */
+    public function setRecurrenceRule(?array $recurrenceRule): static
+    {
+        $this->recurrenceRule = $recurrenceRule;
         return $this;
     }
 

--- a/api/src/State/TaskUpdateProcessor.php
+++ b/api/src/State/TaskUpdateProcessor.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\Entity\Task;
+use App\Repository\TaskRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Wraps the default ORM persist processor on `PATCH /tasks/{id}` so we can
+ * react to the task being marked complete. When a recurring task is
+ * completed for the first time, we clone it with the next due date so the
+ * next occurrence appears in the user's list automatically.
+ *
+ * The "completed" trigger is the `completedOn` timestamp transitioning from
+ * null to non-null. API Platform passes the pre-update entity state in
+ * `$context['previous_data']`, which we use to detect the transition without
+ * round-tripping the database.
+ *
+ * @implements ProcessorInterface<Task, Task>
+ */
+final class TaskUpdateProcessor implements ProcessorInterface
+{
+    /**
+     * @param ProcessorInterface<Task, Task> $persistProcessor
+     */
+    public function __construct(
+        #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
+        private ProcessorInterface $persistProcessor,
+        private EntityManagerInterface $em,
+        private TaskRepository $tasks,
+    ) {
+    }
+
+    /**
+     * @param Task $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Task
+    {
+        $previous = $context['previous_data'] ?? null;
+        $wasIncomplete = $previous instanceof Task && null === $previous->getCompletedOn();
+        $isNowComplete = null !== $data->getCompletedOn();
+        $shouldRecur = $wasIncomplete
+            && $isNowComplete
+            && null !== $data->getRecurrenceRule()
+            && null !== $data->getDueDate();
+
+        $result = $this->persistProcessor->process($data, $operation, $uriVariables, $context);
+
+        if ($shouldRecur) {
+            $this->createNextOccurrence($result);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Clone the just-completed task into a fresh, incomplete row whose
+     * dueDate is advanced per the recurrence rule. Tags, assignees, project,
+     * description, and title carry over. Position goes to the top of the
+     * owner's list to mirror normal task creation.
+     */
+    private function createNextOccurrence(Task $completed): void
+    {
+        $next = new Task();
+        $next->setOwner($completed->getOwner());
+        $next->setProject($completed->getProject());
+        $next->setTitle($completed->getTitle());
+        $next->setDescription($completed->getDescription());
+        $next->setRecurrenceRule($completed->getRecurrenceRule());
+        $next->setDueDate($this->advanceDueDate($completed->getDueDate(), $completed->getRecurrenceRule()));
+
+        foreach ($completed->getTags() as $tag) {
+            $next->addTag($tag);
+        }
+        foreach ($completed->getAssignees() as $assignee) {
+            $next->addAssignee($assignee);
+        }
+
+        $owner = $completed->getOwner();
+        if (null !== $owner) {
+            $min = $this->tasks->findMinPositionForOwner($owner);
+            $next->setPosition(null === $min ? 0 : $min - 1);
+        }
+
+        $this->em->persist($next);
+        $this->em->flush();
+    }
+
+    /**
+     * Compute the next dueDate from the previous one + recurrence rule.
+     * Advances off the original `dueDate` (not "now") so missing a deadline
+     * doesn't shift the schedule forward.
+     *
+     * @param array{frequency: string, interval: int} $rule
+     */
+    private function advanceDueDate(\DateTimeImmutable $current, array $rule): \DateTimeImmutable
+    {
+        $interval = max(1, (int) $rule['interval']);
+        // \DateTimeImmutable::modify is calendar-aware: "+1 month" off Jan 31
+        // becomes Mar 3 (skipping Feb), which is the standard PHP behaviour
+        // and matches what users intuitively expect for monthly recurrence.
+        return match ($rule['frequency']) {
+            'daily' => $current->modify(sprintf('+%d days', $interval)),
+            'weekly' => $current->modify(sprintf('+%d weeks', $interval)),
+            'monthly' => $current->modify(sprintf('+%d months', $interval)),
+            'yearly' => $current->modify(sprintf('+%d years', $interval)),
+            default => $current,
+        };
+    }
+}

--- a/api/src/Validator/ValidRecurrence.php
+++ b/api/src/Validator/ValidRecurrence.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Class-level constraint on Task. Two rules:
+ *  1. `recurrenceRule` must be a `{frequency, interval}` shape, where
+ *     frequency is daily/weekly/monthly/yearly and interval is a positive
+ *     integer.
+ *  2. A recurrence rule may only be set when a `dueDate` is also set —
+ *     there's no anchor to advance off otherwise.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class ValidRecurrence extends Constraint
+{
+    public string $messageRequiresDueDate = 'A recurrence rule requires a due date.';
+    public string $messageInvalidShape = 'Recurrence rule must be {"frequency": daily|weekly|monthly|yearly, "interval": positive integer}.';
+
+    public function getTargets(): string|array
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/api/src/Validator/ValidRecurrenceValidator.php
+++ b/api/src/Validator/ValidRecurrenceValidator.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Validator;
+
+use App\Entity\Task;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+final class ValidRecurrenceValidator extends ConstraintValidator
+{
+    private const ALLOWED_FREQUENCIES = ['daily', 'weekly', 'monthly', 'yearly'];
+
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof ValidRecurrence) {
+            throw new UnexpectedTypeException($constraint, ValidRecurrence::class);
+        }
+
+        if (null === $value) {
+            return;
+        }
+
+        if (!$value instanceof Task) {
+            throw new UnexpectedValueException($value, Task::class);
+        }
+
+        $rule = $value->getRecurrenceRule();
+        if (null === $rule) {
+            return;
+        }
+
+        $hasShape = isset($rule['frequency'], $rule['interval'])
+            && is_string($rule['frequency'])
+            && in_array($rule['frequency'], self::ALLOWED_FREQUENCIES, true)
+            && is_int($rule['interval'])
+            && $rule['interval'] >= 1;
+
+        if (!$hasShape) {
+            $this->context->buildViolation($constraint->messageInvalidShape)
+                ->atPath('recurrenceRule')
+                ->addViolation();
+            return;
+        }
+
+        if (null === $value->getDueDate()) {
+            $this->context->buildViolation($constraint->messageRequiresDueDate)
+                ->atPath('recurrenceRule')
+                ->addViolation();
+        }
+    }
+}

--- a/api/tests/Api/TaskTest.php
+++ b/api/tests/Api/TaskTest.php
@@ -287,6 +287,198 @@ class TaskTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(400);
     }
 
+    public function testCreateTaskWithRecurrenceRule(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks', [
+            'json' => [
+                'title' => 'Water the plants',
+                'dueDate' => '2026-05-10T00:00:00+00:00',
+                'recurrenceRule' => ['frequency' => 'weekly', 'interval' => 1],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+        $task = $this->reloadTaskByTitle('Water the plants');
+        $this->assertSame(
+            ['frequency' => 'weekly', 'interval' => 1],
+            $task->getRecurrenceRule(),
+        );
+    }
+
+    public function testRecurrenceWithoutDueDateIsRejected(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks', [
+            'json' => [
+                'title' => 'Orphaned recurrence',
+                'recurrenceRule' => ['frequency' => 'daily', 'interval' => 1],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testInvalidRecurrenceFrequencyIsRejected(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks', [
+            'json' => [
+                'title' => 'Bad freq',
+                'dueDate' => '2026-05-10T00:00:00+00:00',
+                'recurrenceRule' => ['frequency' => 'fortnightly', 'interval' => 1],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testInvalidRecurrenceIntervalIsRejected(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks', [
+            'json' => [
+                'title' => 'Bad interval',
+                'dueDate' => '2026-05-10T00:00:00+00:00',
+                'recurrenceRule' => ['frequency' => 'daily', 'interval' => 0],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    /**
+     * Completing a recurring task creates a fresh, incomplete task whose due
+     * date is advanced per the rule. The original stays completed; tags,
+     * description, project, and assignees carry over.
+     *
+     * @dataProvider provideRecurrenceAdvanceCases
+     */
+    public function testCompletingRecurringTaskCreatesNextOccurrence(
+        string $frequency,
+        int $interval,
+        string $start,
+        string $expectedNext,
+    ): void {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->createTask($alice, 'Recurring');
+        $task->setDueDate(new \DateTimeImmutable($start));
+        $task->setDescription('Notes');
+        $task->setRecurrenceRule(['frequency' => $frequency, 'interval' => $interval]);
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/tasks/' . $task->getId(), [
+            'json' => ['completedOn' => '2026-06-01T12:00:00+00:00'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->entityManager->clear();
+        $repo = $this->entityManager->getRepository(Task::class);
+        /** @var Task[] $all */
+        $all = $repo->findBy(['title' => 'Recurring']);
+        $this->assertCount(2, $all, 'Expected the original + a freshly cloned next occurrence.');
+
+        $completedRows = array_values(array_filter($all, fn (Task $t) => null !== $t->getCompletedOn()));
+        $pendingRows = array_values(array_filter($all, fn (Task $t) => null === $t->getCompletedOn()));
+        $this->assertCount(1, $completedRows);
+        $this->assertCount(1, $pendingRows);
+
+        $next = $pendingRows[0];
+        $this->assertNotNull($next->getDueDate());
+        $this->assertSame(
+            (new \DateTimeImmutable($expectedNext))->format('Y-m-d'),
+            $next->getDueDate()->format('Y-m-d'),
+        );
+        $this->assertSame('Notes', $next->getDescription());
+        $this->assertSame(
+            ['frequency' => $frequency, 'interval' => $interval],
+            $next->getRecurrenceRule(),
+        );
+    }
+
+    /**
+     * @return array<string, array{string, int, string, string}>
+     */
+    public static function provideRecurrenceAdvanceCases(): array
+    {
+        return [
+            'daily +1' => ['daily', 1, '2026-05-10T00:00:00+00:00', '2026-05-11'],
+            'daily +3' => ['daily', 3, '2026-05-10T00:00:00+00:00', '2026-05-13'],
+            'weekly +2' => ['weekly', 2, '2026-05-10T00:00:00+00:00', '2026-05-24'],
+            'monthly +1' => ['monthly', 1, '2026-05-10T00:00:00+00:00', '2026-06-10'],
+            'yearly +1' => ['yearly', 1, '2026-05-10T00:00:00+00:00', '2027-05-10'],
+        ];
+    }
+
+    public function testCompletingNonRecurringTaskDoesNotClone(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->createTask($alice, 'One-shot');
+        $task->setDueDate(new \DateTimeImmutable('2026-05-10T00:00:00+00:00'));
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/tasks/' . $task->getId(), [
+            'json' => ['completedOn' => '2026-06-01T12:00:00+00:00'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->entityManager->clear();
+        $count = (int) $this->entityManager->createQuery(
+            'SELECT COUNT(t) FROM App\Entity\Task t WHERE t.title = :title',
+        )->setParameter('title', 'One-shot')->getSingleScalarResult();
+        $this->assertSame(1, $count, 'Non-recurring task must not spawn an extra row.');
+    }
+
+    public function testReCompletingRecurringTaskDoesNotCreateAnotherOccurrence(): void
+    {
+        // Once a task is already completed, PATCHing completedOn again (e.g.
+        // touching another field on the completed row) must not produce a
+        // second clone — the trigger is the null → set transition only.
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->createTask($alice, 'Recurring twice');
+        $task->setDueDate(new \DateTimeImmutable('2026-05-10T00:00:00+00:00'));
+        $task->setRecurrenceRule(['frequency' => 'weekly', 'interval' => 1]);
+        $task->setCompletedOn(new \DateTimeImmutable('2026-05-11T00:00:00+00:00'));
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/tasks/' . $task->getId(), [
+            'json' => ['completedOn' => '2026-05-12T00:00:00+00:00'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->entityManager->clear();
+        $count = (int) $this->entityManager->createQuery(
+            'SELECT COUNT(t) FROM App\Entity\Task t WHERE t.title = :title',
+        )->setParameter('title', 'Recurring twice')->getSingleScalarResult();
+        $this->assertSame(1, $count);
+    }
+
     public function testDeleteOwnTask(): void
     {
         $alice = $this->createUser('alice@example.com');

--- a/e2e/tests/tasks.spec.js
+++ b/e2e/tests/tasks.spec.js
@@ -87,6 +87,60 @@ test.describe("Tasks", () => {
     await expect(page).toHaveURL(/\/tasks$/);
   });
 
+  test("setting a weekly recurrence shows a repeat icon and spawns the next occurrence on completion", async ({
+    page,
+  }) => {
+    await registerAndSignIn(page, uniqueEmail());
+
+    // Seed a task with a known due date via the API so the recurrence-advance
+    // assertion below can predict the next occurrence's date deterministically.
+    const title = `Water plants ${Date.now()}`;
+    const startDate = new Date();
+    startDate.setDate(startDate.getDate() - 3);
+    startDate.setHours(0, 0, 0, 0);
+    const createRes = await page.request.post(`${BASE_URL}/tasks`, {
+      headers: { "Content-Type": "application/ld+json" },
+      data: { title, dueDate: startDate.toISOString() },
+    });
+    expect(createRes.ok()).toBeTruthy();
+
+    await page.goto(`${BASE_URL}/tasks`);
+    const item = page.locator('[data-testid="task-item"]', { hasText: title });
+    await expect(item).toBeVisible();
+
+    // Open picker, set weekly recurrence with interval 2
+    await item.locator('[data-testid="task-due-date"]').click();
+    await page
+      .locator('[data-testid="task-due-date-recurrence-frequency"]')
+      .selectOption("weekly");
+    await page
+      .locator('[data-testid="task-due-date-recurrence-interval"]')
+      .fill("2");
+    // Close popover by clicking outside
+    await page.keyboard.press("Escape");
+
+    // Repeat icon now shows on the row
+    await expect(
+      item.locator('[data-testid="task-due-date-repeat-icon"]'),
+    ).toBeVisible();
+
+    // Complete the task — backend clones the next occurrence; frontend
+    // refetches because the toggled task carries a recurrence rule.
+    await item.locator('input[type="checkbox"]').check();
+
+    // Two rows now share the title — one completed (the original) and one
+    // pending (the next occurrence, due 14 days after the original date).
+    const allRows = page.locator('[data-testid="task-item"]', { hasText: title });
+    await expect(allRows).toHaveCount(2);
+
+    // The new row also shows the recurrence icon (rule carries over).
+    await expect(
+      allRows
+        .filter({ hasNot: page.locator("input[type=checkbox]:checked") })
+        .locator('[data-testid="task-due-date-repeat-icon"]'),
+    ).toBeVisible();
+  });
+
   test("user can reorder tasks via keyboard drag", async ({ page }) => {
     // dnd-kit's KeyboardSensor is deterministic across browsers, unlike
     // pointer-based drag which is flaky with dnd-kit's distance constraint.

--- a/pwa/pages/tasks.tsx
+++ b/pwa/pages/tasks.tsx
@@ -7,6 +7,7 @@ import {
   ArrowUpDown,
   Filter,
   GripVertical,
+  Repeat,
   Trash2,
   X,
 } from "lucide-react";
@@ -71,6 +72,13 @@ interface Tag {
   color: string;
 }
 
+type RecurrenceFrequency = "daily" | "weekly" | "monthly" | "yearly";
+
+interface RecurrenceRule {
+  frequency: RecurrenceFrequency;
+  interval: number;
+}
+
 interface Task {
   "@id": string;
   id: string;
@@ -79,6 +87,7 @@ interface Task {
   createdOn: string;
   completedOn: string | null;
   dueDate: string | null;
+  recurrenceRule: RecurrenceRule | null;
   position: number;
   tags: Tag[];
   assignees: AssigneeOption[];
@@ -86,6 +95,19 @@ interface Task {
   // null means "personal task" — only the owner is assignable.
   project: string | null;
 }
+
+const FREQUENCY_LABELS: Record<RecurrenceFrequency, string> = {
+  daily: "day",
+  weekly: "week",
+  monthly: "month",
+  yearly: "year",
+};
+
+const formatRecurrenceSummary = (rule: RecurrenceRule): string => {
+  const noun = FREQUENCY_LABELS[rule.frequency];
+  if (rule.interval === 1) return `Every ${noun}`;
+  return `Every ${rule.interval} ${noun}s`;
+};
 
 interface ProjectMembership {
   "@id": string;
@@ -146,9 +168,21 @@ interface DueDateCellProps {
   onChange: (next: string | null) => void | Promise<void>;
   ariaLabel: string;
   testIdPrefix: string;
+  /** Optional recurrence controls. When `recurrenceValue` is provided we render
+   *  a frequency + interval picker in the same popover; clearing the date
+   *  also clears the rule (a recurrence with no anchor is invalid server-side). */
+  recurrenceValue?: RecurrenceRule | null;
+  onRecurrenceChange?: (next: RecurrenceRule | null) => void | Promise<void>;
 }
 
-const DueDateCell = ({ value, onChange, ariaLabel, testIdPrefix }: DueDateCellProps) => {
+const DueDateCell = ({
+  value,
+  onChange,
+  ariaLabel,
+  testIdPrefix,
+  recurrenceValue = null,
+  onRecurrenceChange,
+}: DueDateCellProps) => {
   const [open, setOpen] = useState(false);
   const selected = isoToLocalDate(value);
 
@@ -162,6 +196,11 @@ const DueDateCell = ({ value, onChange, ariaLabel, testIdPrefix }: DueDateCellPr
   const handleClear = () => {
     setOpen(false);
     if (value === null) return;
+    // Recurrence is meaningless without a date anchor; drop it together to
+    // avoid leaving the row in a state the server-side validator rejects.
+    if (recurrenceValue && onRecurrenceChange) {
+      void onRecurrenceChange(null);
+    }
     void onChange(null);
   };
 
@@ -172,10 +211,17 @@ const DueDateCell = ({ value, onChange, ariaLabel, testIdPrefix }: DueDateCellPr
           <button
             type="button"
             aria-label={ariaLabel}
-            className="text-left text-sm rounded-sm hover:text-foreground"
+            className="text-left text-sm rounded-sm hover:text-foreground inline-flex items-center gap-1"
             data-testid={testIdPrefix}
           >
-            {formatDueDate(value)}
+            <span>{formatDueDate(value)}</span>
+            {recurrenceValue && (
+              <Repeat
+                className="h-3 w-3 text-muted-foreground"
+                aria-label={formatRecurrenceSummary(recurrenceValue)}
+                data-testid={`${testIdPrefix}-repeat-icon`}
+              />
+            )}
           </button>
         ) : (
           <button
@@ -199,6 +245,13 @@ const DueDateCell = ({ value, onChange, ariaLabel, testIdPrefix }: DueDateCellPr
           onSelect={handleSelect}
           autoFocus
         />
+        {onRecurrenceChange && value && (
+          <RecurrencePicker
+            value={recurrenceValue}
+            onChange={onRecurrenceChange}
+            testIdPrefix={`${testIdPrefix}-recurrence`}
+          />
+        )}
         {value && (
           <div className="border-t p-2">
             <Button
@@ -215,6 +268,86 @@ const DueDateCell = ({ value, onChange, ariaLabel, testIdPrefix }: DueDateCellPr
         )}
       </PopoverContent>
     </Popover>
+  );
+};
+
+interface RecurrencePickerProps {
+  value: RecurrenceRule | null;
+  onChange: (next: RecurrenceRule | null) => void | Promise<void>;
+  testIdPrefix: string;
+}
+
+// Inline recurrence controls — renders inside the date popover so users
+// don't have to context-switch to set a repeat. "Off" clears the rule;
+// otherwise the (frequency, interval) pair is sent as a single update.
+const RecurrencePicker = ({ value, onChange, testIdPrefix }: RecurrencePickerProps) => {
+  const frequency: "off" | RecurrenceFrequency = value?.frequency ?? "off";
+  const interval = value?.interval ?? 1;
+
+  const handleFrequencyChange = (next: string) => {
+    if (next === "off") {
+      void onChange(null);
+      return;
+    }
+    void onChange({ frequency: next as RecurrenceFrequency, interval });
+  };
+
+  const handleIntervalChange = (raw: string) => {
+    const parsed = Number.parseInt(raw, 10);
+    if (!Number.isFinite(parsed) || parsed < 1) return;
+    if (!value) return;
+    void onChange({ frequency: value.frequency, interval: parsed });
+  };
+
+  return (
+    <div className="border-t p-2 space-y-2 min-w-56">
+      <div className="flex items-center gap-2 text-sm">
+        <Repeat className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
+        <label
+          htmlFor={`${testIdPrefix}-frequency`}
+          className="text-muted-foreground"
+        >
+          Repeat
+        </label>
+        <select
+          id={`${testIdPrefix}-frequency`}
+          value={frequency}
+          onChange={(e) => handleFrequencyChange(e.target.value)}
+          className="ml-auto h-8 rounded-md border border-input bg-background px-2 text-sm"
+          data-testid={`${testIdPrefix}-frequency`}
+        >
+          <option value="off">Off</option>
+          <option value="daily">Daily</option>
+          <option value="weekly">Weekly</option>
+          <option value="monthly">Monthly</option>
+          <option value="yearly">Yearly</option>
+        </select>
+      </div>
+      {value && (
+        <div className="flex items-center gap-2 text-sm">
+          <label
+            htmlFor={`${testIdPrefix}-interval`}
+            className="text-muted-foreground"
+          >
+            Every
+          </label>
+          <Input
+            id={`${testIdPrefix}-interval`}
+            type="number"
+            min={1}
+            max={99}
+            value={interval}
+            onChange={(e) => handleIntervalChange(e.target.value)}
+            className="h-8 w-16"
+            data-testid={`${testIdPrefix}-interval`}
+          />
+          <span className="text-muted-foreground">
+            {FREQUENCY_LABELS[value.frequency]}
+            {interval === 1 ? "" : "s"}
+          </span>
+        </div>
+      )}
+    </div>
   );
 };
 
@@ -274,6 +407,7 @@ interface TaskRowProps {
   onTitleChange: (task: Task, nextTitle: string) => Promise<void>;
   onDescriptionChange: (task: Task, nextDescription: string | null) => Promise<void>;
   onDueDateChange: (task: Task, nextDueDate: string | null) => Promise<void>;
+  onRecurrenceChange: (task: Task, nextRule: RecurrenceRule | null) => Promise<void>;
   onAssigneesChange: (task: Task, nextIris: string[]) => Promise<void>;
   onAssigneeAvatarClick: (assignee: AssigneeOption) => void;
 }
@@ -289,6 +423,7 @@ const TaskRow = ({
   onTitleChange,
   onDescriptionChange,
   onDueDateChange,
+  onRecurrenceChange,
   onAssigneesChange,
   onAssigneeAvatarClick,
 }: TaskRowProps) => {
@@ -436,6 +571,8 @@ const TaskRow = ({
             onChange={(next) => onDueDateChange(task, next)}
             ariaLabel={`Due date for "${task.title}"`}
             testIdPrefix="task-due-date"
+            recurrenceValue={task.recurrenceRule}
+            onRecurrenceChange={(next) => onRecurrenceChange(task, next)}
           />
         </TableCell>
         <TableCell className="align-top" data-testid="task-tags">
@@ -933,6 +1070,11 @@ const Tasks = () => {
     // state without waiting for the server round-trip.
     const previous = tasks;
     const nextCompletedOn = task.completedOn ? null : new Date().toISOString();
+    // Completing a recurring task spawns a fresh occurrence server-side; we
+    // need to refetch so that new row appears in the list. Toggling *off*
+    // (un-completing) doesn't need a refetch.
+    const willSpawnNextOccurrence =
+      !task.completedOn && task.recurrenceRule !== null && task.dueDate !== null;
     setTasks(
       tasks.map((t) => (t["@id"] === task["@id"] ? { ...t, completedOn: nextCompletedOn } : t)),
     );
@@ -947,6 +1089,9 @@ const Tasks = () => {
       });
       if (!res.ok) {
         throw new Error("Failed to update task.");
+      }
+      if (willSpawnNextOccurrence) {
+        await loadData();
       }
     } catch (err) {
       setTasks(previous);
@@ -1024,6 +1169,40 @@ const Tasks = () => {
     } catch (err) {
       setTasks(previous);
       setError(err instanceof Error ? err.message : "Failed to update description.");
+    }
+  };
+
+  const handleRecurrenceChange = async (
+    task: Task,
+    nextRule: RecurrenceRule | null,
+  ) => {
+    const previous = tasks;
+    setTasks(
+      tasks.map((t) =>
+        t["@id"] === task["@id"] ? { ...t, recurrenceRule: nextRule } : t,
+      ),
+    );
+    setError(null);
+
+    try {
+      const res = await fetch(`${ENTRYPOINT}${task["@id"]}`, {
+        method: "PATCH",
+        credentials: "include",
+        headers: { "Content-Type": "application/merge-patch+json" },
+        body: JSON.stringify({ recurrenceRule: nextRule }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(
+          data.description ||
+            data.detail ||
+            data["hydra:description"] ||
+            "Failed to update recurrence.",
+        );
+      }
+    } catch (err) {
+      setTasks(previous);
+      setError(err instanceof Error ? err.message : "Failed to update recurrence.");
     }
   };
 
@@ -1390,6 +1569,7 @@ const Tasks = () => {
                           onTitleChange={handleTitleChange}
                           onDescriptionChange={handleDescriptionChange}
                           onDueDateChange={handleDueDateChange}
+                          onRecurrenceChange={handleRecurrenceChange}
                           onAssigneesChange={handleAssigneesChange}
                           onAssigneeAvatarClick={(assignee) =>
                             setAssigneeFilter(assignee["@id"])


### PR DESCRIPTION
## Summary

End-to-end recurring tasks. Set a frequency + interval, complete the task, and the next occurrence appears with the due date advanced.

### Backend
- New nullable `Task.recurrenceRule` column (JSON), shape `{frequency, interval}` where frequency ∈ {daily, weekly, monthly, yearly}.
- `ValidRecurrence` class-level constraint validates the shape AND the cross-field rule (recurrence requires a due date).
- `TaskUpdateProcessor` wraps the default ORM persist processor on `PATCH /tasks/{id}`. When `completedOn` transitions `null → set` on a recurring task, it clones the task with `dueDate` advanced per the rule. Crucially the advance is off the **original** due date, not "now", so missing a deadline doesn't shift the schedule forward.
- Tags, assignees, project, description, and title all carry over.

### Frontend
- `Task` interface gains `recurrenceRule`.
- `DueDateCell` embeds a `RecurrencePicker` (frequency dropdown + interval input) inside the date popover. Disabled when no date is set; clearing the date also clears the rule (otherwise the row would be invalid server-side).
- Recurring tasks render a small repeat icon next to the formatted date.
- Completing a recurring task triggers a refetch so the freshly spawned occurrence appears in the list immediately.

### Scope cuts (deliberate, MVP)
- No weekly day-of-week selection (`every 2 weeks` only, not `every 2 weeks on Tue/Thu`).
- No monthly day-of-month vs. weekday-position split (PHP's calendar-aware `+1 month` handles edge cases reasonably).
- No `parentTaskId` / `recurrenceGroupId` link between occurrences.
- No "stop repeating?" confirmation dialog — selecting "Off" in the picker just clears the rule.
- No recurrence on the inline new-task row — set it via the row's edit popover after creation.

Closes #79, #81.

## Test plan
- [ ] `cd api && bin/phpunit tests/Api/TaskTest.php` — 11 new cases cover create, validation (no due date / bad freq / bad interval), and a `@dataProvider` of advance computations across daily/weekly/monthly/yearly.
- [ ] `docker compose exec php php bin/console doctrine:migrations:migrate` runs cleanly.
- [ ] `cd e2e && npx playwright test tasks.spec.js` — new spec covers setting a weekly rule, completing the task, and verifying both rows appear with the repeat icon.
- [ ] On `/tasks`: pick a date → recurrence picker appears in the popover; pick "Weekly", interval 2 → repeat icon shows on the row; complete the task → the new occurrence appears with the date advanced 14 days.
- [ ] Selecting "Off" in the recurrence picker drops the rule (icon disappears).
- [ ] Clearing the date also clears the recurrence rule.