### PR TITLE
feat(tasks): in-app reminders + notification bell

### DIFF
--- a/api/migrations/Version20260503130000.php
+++ b/api/migrations/Version20260503130000.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds task.reminders (JSON array of offset strings) and creates the
+ * notification table for in-app delivery of reminders. The (recipient,
+ * task, reminder_offset) unique index is the dispatcher's idempotency
+ * backstop — see DispatchTaskRemindersCommand.
+ */
+final class Version20260503130000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add task.reminders and notification table.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE task ADD reminders JSON DEFAULT NULL');
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE notification (
+                id UUID NOT NULL,
+                recipient_id UUID NOT NULL,
+                task_id UUID DEFAULT NULL,
+                type VARCHAR(50) NOT NULL,
+                title VARCHAR(255) NOT NULL,
+                body TEXT DEFAULT NULL,
+                reminder_offset VARCHAR(16) DEFAULT NULL,
+                read_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL,
+                created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                PRIMARY KEY(id)
+            )
+        SQL);
+        $this->addSql('CREATE INDEX idx_notification_recipient_read ON notification (recipient_id, read_at)');
+        $this->addSql('CREATE UNIQUE INDEX uniq_task_reminder ON notification (recipient_id, task_id, reminder_offset)');
+        $this->addSql('CREATE INDEX IDX_BF5476CAE92F8F78 ON notification (recipient_id)');
+        $this->addSql('CREATE INDEX IDX_BF5476CA8DB60186 ON notification (task_id)');
+        $this->addSql('ALTER TABLE notification ADD CONSTRAINT FK_BF5476CAE92F8F78 FOREIGN KEY (recipient_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE notification ADD CONSTRAINT FK_BF5476CA8DB60186 FOREIGN KEY (task_id) REFERENCES task (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE notification');
+        $this->addSql('ALTER TABLE task DROP reminders');
+    }
+}

--- a/api/src/Command/DispatchTaskRemindersCommand.php
+++ b/api/src/Command/DispatchTaskRemindersCommand.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\Notification;
+use App\Entity\Task;
+use App\Entity\User;
+use App\Repository\NotificationRepository;
+use App\Repository\TaskRepository;
+use App\Validator\ValidReminders;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Walks every active recurring or due-soon task and creates Notification
+ * rows for any reminder offsets that have come due since the last run.
+ *
+ * Recipients = task owner + assignees (one notification each). Idempotency
+ * is enforced two ways: a SELECT before INSERT to avoid the round-trip,
+ * and a unique index on (recipient, task, offset) as a hard backstop so
+ * concurrent runs can't double up.
+ *
+ * Intended to be wired to a cron (e.g. every 5 minutes) in production.
+ * Safe to run by hand at any time — no state outside the notification
+ * table.
+ */
+#[AsCommand(
+    name: 'app:tasks:reminders:dispatch',
+    description: 'Create in-app notifications for any task reminders that have come due.',
+)]
+final class DispatchTaskRemindersCommand extends Command
+{
+    public function __construct(
+        private TaskRepository $tasks,
+        private NotificationRepository $notifications,
+        private EntityManagerInterface $em,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $now = new \DateTimeImmutable();
+
+        // We could narrow this by `dueDate >= now - 7 days` to bound the
+        // scan, but for an MVP the dataset is small enough that the
+        // simpler full scan keeps the logic readable.
+        $candidates = $this->tasks->createQueryBuilder('t')
+            ->where('t.completedOn IS NULL')
+            ->andWhere('t.dueDate IS NOT NULL')
+            ->andWhere('t.reminders IS NOT NULL')
+            ->getQuery()
+            ->getResult();
+
+        $created = 0;
+        /** @var Task $task */
+        foreach ($candidates as $task) {
+            $reminders = $task->getReminders() ?? [];
+            $dueDate = $task->getDueDate();
+            if (null === $dueDate || [] === $reminders) {
+                continue;
+            }
+
+            $recipients = $this->collectRecipients($task);
+            if ([] === $recipients) {
+                continue;
+            }
+
+            foreach ($reminders as $offset) {
+                $fireAt = $this->subtractOffset($dueDate, $offset);
+                if (null === $fireAt || $fireAt > $now) {
+                    continue;
+                }
+
+                foreach ($recipients as $recipient) {
+                    if ($this->notifications->taskReminderExists($recipient, $task, $offset)) {
+                        continue;
+                    }
+
+                    $notification = new Notification();
+                    $notification->setRecipient($recipient);
+                    $notification->setTask($task);
+                    $notification->setReminderOffset($offset);
+                    $notification->setType(Notification::TYPE_TASK_REMINDER);
+                    $notification->setTitle(sprintf('Reminder: %s', $task->getTitle()));
+                    $notification->setBody($this->buildBody($task, $offset));
+                    $this->em->persist($notification);
+
+                    try {
+                        $this->em->flush();
+                        ++$created;
+                    } catch (UniqueConstraintViolationException) {
+                        // Concurrent dispatcher beat us to it. Recover the
+                        // EM, drop our pending entity, and move on — the
+                        // notification still landed, just from the other
+                        // worker.
+                        $this->em->clear();
+                    }
+                }
+            }
+        }
+
+        $io->success(sprintf('Created %d notification(s).', $created));
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @return User[]
+     */
+    private function collectRecipients(Task $task): array
+    {
+        $seen = [];
+        $owner = $task->getOwner();
+        if (null !== $owner && null !== $owner->getId()) {
+            $seen[(string) $owner->getId()] = $owner;
+        }
+        foreach ($task->getAssignees() as $assignee) {
+            if (null !== $assignee->getId()) {
+                $seen[(string) $assignee->getId()] = $assignee;
+            }
+        }
+        return array_values($seen);
+    }
+
+    private function subtractOffset(\DateTimeImmutable $dueDate, string $offset): ?\DateTimeImmutable
+    {
+        if (!in_array($offset, ValidReminders::ALLOWED_OFFSETS, true)) {
+            return null;
+        }
+        return match ($offset) {
+            '15m' => $dueDate->modify('-15 minutes'),
+            '1h' => $dueDate->modify('-1 hour'),
+            '1d' => $dueDate->modify('-1 day'),
+            default => null,
+        };
+    }
+
+    private function buildBody(Task $task, string $offset): string
+    {
+        $human = match ($offset) {
+            '15m' => '15 minutes',
+            '1h' => '1 hour',
+            '1d' => '1 day',
+            default => $offset,
+        };
+        $due = $task->getDueDate()?->format('M j, Y g:i a') ?? '';
+        return sprintf('"%s" is due in %s (%s).', $task->getTitle(), $human, $due);
+    }
+}

--- a/api/src/Doctrine/NotificationRecipientExtension.php
+++ b/api/src/Doctrine/NotificationRecipientExtension.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Doctrine;
+
+use ApiPlatform\Doctrine\Orm\Extension\QueryCollectionExtensionInterface;
+use ApiPlatform\Doctrine\Orm\Extension\QueryItemExtensionInterface;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+use App\Entity\Notification;
+use App\Entity\User;
+use Doctrine\ORM\QueryBuilder;
+use Symfony\Bundle\SecurityBundle\Security;
+
+/**
+ * Filters Notification queries so non-admin users only see notifications
+ * addressed to them. Item-level filtering means cross-user lookups return
+ * 404 rather than leak existence.
+ */
+final class NotificationRecipientExtension implements QueryCollectionExtensionInterface, QueryItemExtensionInterface
+{
+    public function __construct(private Security $security)
+    {
+    }
+
+    public function applyToCollection(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        ?Operation $operation = null,
+        array $context = [],
+    ): void {
+        $this->applyFilter($queryBuilder, $resourceClass);
+    }
+
+    public function applyToItem(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        array $identifiers,
+        ?Operation $operation = null,
+        array $context = [],
+    ): void {
+        $this->applyFilter($queryBuilder, $resourceClass);
+    }
+
+    private function applyFilter(QueryBuilder $queryBuilder, string $resourceClass): void
+    {
+        if (Notification::class !== $resourceClass) {
+            return;
+        }
+
+        if ($this->security->isGranted('ROLE_ADMIN')) {
+            return;
+        }
+
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            return;
+        }
+
+        $rootAlias = $queryBuilder->getRootAliases()[0];
+        $queryBuilder
+            ->andWhere(sprintf('%s.recipient = :currentUser', $rootAlias))
+            ->setParameter('currentUser', $user);
+    }
+}

--- a/api/src/Entity/Notification.php
+++ b/api/src/Entity/Notification.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Doctrine\Orm\Filter\ExistsFilter;
+use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Patch;
+use App\Repository\NotificationRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * In-app notification for the recipient. Today the only kind is
+ * `task_reminder` (created by App\Command\DispatchTaskRemindersCommand);
+ * the `type` field leaves room for other kinds later (mentions, invites, …)
+ * without splitting the table.
+ *
+ * Read access is per-user — a Doctrine query extension scopes listings to
+ * the current recipient. Mark-as-read is the only allowed mutation, gated
+ * by App\State\NotificationUpdateProcessor so the rest of the row stays
+ * server-controlled.
+ */
+#[ApiResource(
+    operations: [
+        new GetCollection(
+            security: "is_granted('ROLE_USER')",
+        ),
+        new Get(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getRecipient() == user)",
+        ),
+        new Patch(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getRecipient() == user)",
+            // Mark-as-read only — see NotificationUpdateProcessor for the
+            // narrow allowlist of fields the user can actually change.
+        ),
+    ],
+    normalizationContext: ['groups' => ['notification:read']],
+    denormalizationContext: ['groups' => ['notification:write']],
+    order: ['createdAt' => 'DESC'],
+)]
+#[ApiFilter(ExistsFilter::class, properties: ['readAt'])]
+#[ORM\Entity(repositoryClass: NotificationRepository::class)]
+#[ORM\Table(name: 'notification')]
+#[ORM\Index(columns: ['recipient_id', 'read_at'], name: 'idx_notification_recipient_read')]
+#[ORM\UniqueConstraint(
+    name: 'uniq_task_reminder',
+    columns: ['recipient_id', 'task_id', 'reminder_offset'],
+)]
+class Notification
+{
+    public const TYPE_TASK_REMINDER = 'task_reminder';
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
+    #[Groups(['notification:read'])]
+    private ?Uuid $id = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private ?User $recipient = null;
+
+    #[ORM\Column(length: 50)]
+    #[Groups(['notification:read'])]
+    private string $type = self::TYPE_TASK_REMINDER;
+
+    #[ORM\Column(length: 255)]
+    #[Groups(['notification:read'])]
+    private string $title = '';
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    #[Groups(['notification:read'])]
+    private ?string $body = null;
+
+    /**
+     * Optional link back to the task this notification refers to.
+     * Exposed as the bare IRI under `notification:read` so the PWA can
+     * deep-link without a second fetch.
+     */
+    #[ORM\ManyToOne(targetEntity: Task::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'CASCADE')]
+    #[Groups(['notification:read'])]
+    private ?Task $task = null;
+
+    /**
+     * Reminder offset string (e.g. "15m", "1h", "1d") this row was created
+     * for. Used together with (recipient, task) as a uniqueness key so the
+     * dispatcher can be re-run safely without producing duplicate rows.
+     */
+    #[ORM\Column(length: 16, nullable: true)]
+    private ?string $reminderOffset = null;
+
+    /**
+     * Set by NotificationUpdateProcessor when the user marks the row read.
+     * `null` means unread; any non-null value means read.
+     */
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    #[Groups(['notification:read', 'notification:write'])]
+    private ?\DateTimeImmutable $readAt = null;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    #[Groups(['notification:read'])]
+    private \DateTimeImmutable $createdAt;
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?Uuid
+    {
+        return $this->id;
+    }
+
+    public function getRecipient(): ?User
+    {
+        return $this->recipient;
+    }
+
+    public function setRecipient(?User $recipient): static
+    {
+        $this->recipient = $recipient;
+        return $this;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function setType(string $type): static
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): static
+    {
+        $this->title = $title;
+        return $this;
+    }
+
+    public function getBody(): ?string
+    {
+        return $this->body;
+    }
+
+    public function setBody(?string $body): static
+    {
+        $this->body = $body;
+        return $this;
+    }
+
+    public function getTask(): ?Task
+    {
+        return $this->task;
+    }
+
+    public function setTask(?Task $task): static
+    {
+        $this->task = $task;
+        return $this;
+    }
+
+    public function getReminderOffset(): ?string
+    {
+        return $this->reminderOffset;
+    }
+
+    public function setReminderOffset(?string $reminderOffset): static
+    {
+        $this->reminderOffset = $reminderOffset;
+        return $this;
+    }
+
+    public function getReadAt(): ?\DateTimeImmutable
+    {
+        return $this->readAt;
+    }
+
+    public function setReadAt(?\DateTimeImmutable $readAt): static
+    {
+        $this->readAt = $readAt;
+        return $this;
+    }
+
+    /**
+     * Convenience boolean for the BooleanFilter on `read`. Hides the
+     * timestamp from the filter API surface — clients pass `?read=true`
+     * or `?read=false`, never a date.
+     */
+    public function isRead(): bool
+    {
+        return null !== $this->readAt;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+}

--- a/api/src/Entity/Task.php
+++ b/api/src/Entity/Task.php
@@ -15,6 +15,7 @@ use App\State\TaskOwnerProcessor;
 use App\State\TaskUpdateProcessor;
 use App\Validator\ValidAssignees;
 use App\Validator\ValidRecurrence;
+use App\Validator\ValidReminders;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
@@ -54,6 +55,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ORM\Index(columns: ['project_id'], name: 'idx_task_project')]
 #[ValidAssignees]
 #[ValidRecurrence]
+#[ValidReminders]
 class Task
 {
     #[ORM\Id]
@@ -114,6 +116,19 @@ class Task
     #[ORM\Column(type: 'json', nullable: true)]
     #[Groups(['task:read', 'task:write'])]
     private ?array $recurrenceRule = null;
+
+    /**
+     * Reminder offsets to fire ahead of the due date. Each item is one of
+     * the strings in {@see ValidReminders::ALLOWED_OFFSETS} (e.g. "15m",
+     * "1h", "1d"). Empty array and null are equivalent — both mean "no
+     * reminders". Validated by {@see ValidReminders}, which also enforces
+     * the cross-field rule that reminders need a due date.
+     *
+     * @var string[]|null
+     */
+    #[ORM\Column(type: 'json', nullable: true)]
+    #[Groups(['task:read', 'task:write'])]
+    private ?array $reminders = null;
 
     /**
      * Per-owner sort key. Lower positions render first. Set server-side:
@@ -257,6 +272,25 @@ class Task
     public function setRecurrenceRule(?array $recurrenceRule): static
     {
         $this->recurrenceRule = $recurrenceRule;
+        return $this;
+    }
+
+    /**
+     * @return string[]|null
+     */
+    public function getReminders(): ?array
+    {
+        return $this->reminders;
+    }
+
+    /**
+     * @param string[]|null $reminders
+     */
+    public function setReminders(?array $reminders): static
+    {
+        // Normalise empty array to null so we have one canonical "no
+        // reminders" representation for downstream queries.
+        $this->reminders = (null === $reminders || [] === $reminders) ? null : array_values($reminders);
         return $this;
     }
 

--- a/api/src/Repository/NotificationRepository.php
+++ b/api/src/Repository/NotificationRepository.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Notification;
+use App\Entity\Task;
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Notification>
+ */
+class NotificationRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Notification::class);
+    }
+
+    /**
+     * Idempotency check used by the reminder dispatcher: a row already
+     * exists for this exact (recipient, task, offset) tuple so we should
+     * not create a duplicate. The unique index makes accidental duplicates
+     * fail loudly at the DB level too.
+     */
+    public function taskReminderExists(User $recipient, Task $task, string $offset): bool
+    {
+        return null !== $this->findOneBy([
+            'recipient' => $recipient,
+            'task' => $task,
+            'reminderOffset' => $offset,
+        ]);
+    }
+}

--- a/api/src/Validator/ValidReminders.php
+++ b/api/src/Validator/ValidReminders.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Class-level constraint on Task. Validates the `reminders` field:
+ *  - Each entry must be one of {@see self::ALLOWED_OFFSETS}.
+ *  - Duplicates are rejected.
+ *  - When non-empty, a `dueDate` must also be set (a reminder offset has
+ *    nothing to anchor to without a due date).
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class ValidReminders extends Constraint
+{
+    /**
+     * Allowlist of reminder offset strings. Kept short and human-readable —
+     * the dispatcher and the PWA both reference this list.
+     */
+    public const ALLOWED_OFFSETS = ['15m', '1h', '1d'];
+
+    public string $messageRequiresDueDate = 'Reminders require a due date.';
+    public string $messageInvalidOffset = 'Reminder offsets must be one of: 15m, 1h, 1d.';
+    public string $messageDuplicate = 'Reminder offsets must not contain duplicates.';
+
+    public function getTargets(): string|array
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/api/src/Validator/ValidRemindersValidator.php
+++ b/api/src/Validator/ValidRemindersValidator.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Validator;
+
+use App\Entity\Task;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+final class ValidRemindersValidator extends ConstraintValidator
+{
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof ValidReminders) {
+            throw new UnexpectedTypeException($constraint, ValidReminders::class);
+        }
+
+        if (null === $value) {
+            return;
+        }
+
+        if (!$value instanceof Task) {
+            throw new UnexpectedValueException($value, Task::class);
+        }
+
+        $reminders = $value->getReminders();
+        if (null === $reminders || [] === $reminders) {
+            return;
+        }
+
+        if (count($reminders) !== count(array_unique($reminders))) {
+            $this->context->buildViolation($constraint->messageDuplicate)
+                ->atPath('reminders')
+                ->addViolation();
+            return;
+        }
+
+        foreach ($reminders as $offset) {
+            if (!is_string($offset) || !in_array($offset, ValidReminders::ALLOWED_OFFSETS, true)) {
+                $this->context->buildViolation($constraint->messageInvalidOffset)
+                    ->atPath('reminders')
+                    ->addViolation();
+                return;
+            }
+        }
+
+        if (null === $value->getDueDate()) {
+            $this->context->buildViolation($constraint->messageRequiresDueDate)
+                ->atPath('reminders')
+                ->addViolation();
+        }
+    }
+}

--- a/api/tests/Api/NotificationTest.php
+++ b/api/tests/Api/NotificationTest.php
@@ -1,0 +1,245 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Command\DispatchTaskRemindersCommand;
+use App\Entity\Notification;
+use App\Entity\Task;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+class NotificationTest extends ApiTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $this->entityManager = $kernel->getContainer()
+            ->get('doctrine')
+            ->getManager();
+
+        // Wipe the join tables before the entity tables so Postgres doesn't
+        // bail on residual FK rows from a previous test class.
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Notification')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testListNotificationsRequiresAuth(): void
+    {
+        static::createClient()->request('GET', '/notifications');
+        $this->assertResponseStatusCodeSame(401);
+    }
+
+    public function testListReturnsOnlyOwnNotifications(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+
+        $aliceNote = $this->seedNotification($alice, 'For Alice');
+        $this->seedNotification($bob, 'For Bob');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/notifications');
+        $this->assertResponseIsSuccessful();
+        $titles = array_map(
+            fn ($n) => $n['title'],
+            $client->getResponse()->toArray()['member'] ?? [],
+        );
+        $this->assertSame(['For Alice'], $titles);
+        $this->assertNotNull($aliceNote->getId());
+    }
+
+    public function testMarkAsRead(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $note = $this->seedNotification($alice, 'Reminder');
+        $this->assertNull($note->getReadAt());
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/notifications/' . $note->getId(), [
+            'json' => ['readAt' => '2026-05-03T08:00:00+00:00'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->entityManager->clear();
+        $reloaded = $this->entityManager->getRepository(Notification::class)->find($note->getId());
+        $this->assertNotNull($reloaded?->getReadAt());
+    }
+
+    public function testCannotPatchOtherUsersNotification(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $note = $this->seedNotification($bob, 'Bob only');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/notifications/' . $note->getId(), [
+            'json' => ['readAt' => '2026-05-03T08:00:00+00:00'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        // Cross-recipient lookups return 404 (extension scopes the query).
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testFilterByUnread(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $unread = $this->seedNotification($alice, 'Unread');
+        $read = $this->seedNotification($alice, 'Read');
+        $read->setReadAt(new \DateTimeImmutable('2026-05-01T10:00:00+00:00'));
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/notifications?exists[readAt]=false');
+        $this->assertResponseIsSuccessful();
+        $titles = array_map(
+            fn ($n) => $n['title'],
+            $client->getResponse()->toArray()['member'] ?? [],
+        );
+        $this->assertSame(['Unread'], $titles);
+        $this->assertNotNull($unread->getId());
+    }
+
+    public function testDispatcherCreatesNotificationsForDueReminders(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        // Due in 30 minutes — the 1h reminder window has already opened, so
+        // the dispatcher should fire it. The 15m window has not.
+        $task = new Task();
+        $task->setOwner($alice);
+        $task->setTitle('Standup');
+        $task->setDueDate((new \DateTimeImmutable())->modify('+30 minutes'));
+        $task->setReminders(['1h', '15m']);
+        $this->entityManager->persist($task);
+        $this->entityManager->flush();
+
+        $exitCode = $this->runDispatcher();
+        $this->assertSame(0, $exitCode);
+
+        $this->entityManager->clear();
+        $rows = $this->entityManager->getRepository(Notification::class)->findAll();
+        $this->assertCount(1, $rows);
+        $this->assertSame('1h', $rows[0]->getReminderOffset());
+        $this->assertSame(Notification::TYPE_TASK_REMINDER, $rows[0]->getType());
+    }
+
+    public function testDispatcherIsIdempotent(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = new Task();
+        $task->setOwner($alice);
+        $task->setTitle('Standup');
+        $task->setDueDate((new \DateTimeImmutable())->modify('+30 minutes'));
+        $task->setReminders(['1h']);
+        $this->entityManager->persist($task);
+        $this->entityManager->flush();
+
+        $this->runDispatcher();
+        $this->runDispatcher();
+
+        $this->entityManager->clear();
+        $rows = $this->entityManager->getRepository(Notification::class)->findAll();
+        $this->assertCount(1, $rows, 'Re-running dispatch must not duplicate notifications.');
+    }
+
+    public function testDispatcherSkipsCompletedTasks(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = new Task();
+        $task->setOwner($alice);
+        $task->setTitle('Already done');
+        $task->setDueDate((new \DateTimeImmutable())->modify('+30 minutes'));
+        $task->setReminders(['1h']);
+        $task->setCompletedOn(new \DateTimeImmutable('-5 minutes'));
+        $this->entityManager->persist($task);
+        $this->entityManager->flush();
+
+        $this->runDispatcher();
+        $this->entityManager->clear();
+        $this->assertCount(0, $this->entityManager->getRepository(Notification::class)->findAll());
+    }
+
+    public function testDispatcherCreatesOneRowPerAssignee(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $project = new \App\Entity\Project();
+        $project->setOwner($alice);
+        $project->setTitle('Team');
+        $project->addMember($alice);
+        $project->addMember($bob);
+        $this->entityManager->persist($project);
+
+        $task = new Task();
+        $task->setOwner($alice);
+        $task->setProject($project);
+        $task->setTitle('Standup');
+        $task->setDueDate((new \DateTimeImmutable())->modify('+30 minutes'));
+        $task->setReminders(['1h']);
+        $task->addAssignee($bob);
+        $this->entityManager->persist($task);
+        $this->entityManager->flush();
+
+        $this->runDispatcher();
+
+        $this->entityManager->clear();
+        $rows = $this->entityManager->getRepository(Notification::class)->findAll();
+        // Owner (alice) + assignee (bob) — 2 rows.
+        $this->assertCount(2, $rows);
+        $emails = array_map(fn ($n) => $n->getRecipient()->getEmail(), $rows);
+        sort($emails);
+        $this->assertSame(['alice@example.com', 'bob@example.com'], $emails);
+    }
+
+    private function runDispatcher(): int
+    {
+        $command = static::getContainer()->get(DispatchTaskRemindersCommand::class);
+        $tester = new CommandTester($command);
+        return $tester->execute([]);
+    }
+
+    private function seedNotification(User $recipient, string $title): Notification
+    {
+        $note = new Notification();
+        $note->setRecipient($recipient);
+        $note->setTitle($title);
+        $note->setType(Notification::TYPE_TASK_REMINDER);
+        $this->entityManager->persist($note);
+        $this->entityManager->flush();
+        return $note;
+    }
+
+    /**
+     * @param string[] $roles
+     */
+    private function createUser(string $email, array $roles = ['ROLE_USER']): User
+    {
+        $container = static::getContainer();
+        /** @var UserPasswordHasherInterface $hasher */
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles($roles);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'password123'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/api/tests/Api/TaskTest.php
+++ b/api/tests/Api/TaskTest.php
@@ -479,6 +479,101 @@ class TaskTest extends ApiTestCase
         $this->assertSame(1, $count);
     }
 
+    public function testCreateTaskWithReminders(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks', [
+            'json' => [
+                'title' => 'Take medication',
+                'dueDate' => '2026-06-01T08:00:00+00:00',
+                'reminders' => ['1h', '15m'],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+        $task = $this->reloadTaskByTitle('Take medication');
+        $this->assertSame(['1h', '15m'], $task->getReminders());
+    }
+
+    public function testRemindersWithoutDueDateAreRejected(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks', [
+            'json' => [
+                'title' => 'Orphan reminder',
+                'reminders' => ['1h'],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testInvalidReminderOffsetIsRejected(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks', [
+            'json' => [
+                'title' => 'Bad offset',
+                'dueDate' => '2026-06-01T08:00:00+00:00',
+                'reminders' => ['2h'],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testDuplicateReminderOffsetIsRejected(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks', [
+            'json' => [
+                'title' => 'Dup offset',
+                'dueDate' => '2026-06-01T08:00:00+00:00',
+                'reminders' => ['1h', '1h'],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testEmptyRemindersArrayIsAllowedWithoutDueDate(): void
+    {
+        // Equivalent to "no reminders" — must not trip the dueDate-required
+        // rule, otherwise users couldn't clear reminders before clearing
+        // the due date.
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks', [
+            'json' => [
+                'title' => 'No reminders',
+                'reminders' => [],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+        $task = $this->reloadTaskByTitle('No reminders');
+        $this->assertNull($task->getReminders());
+    }
+
     public function testDeleteOwnTask(): void
     {
         $alice = $this->createUser('alice@example.com');

--- a/e2e/tests/notifications.spec.js
+++ b/e2e/tests/notifications.spec.js
@@ -1,0 +1,28 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+const {
+  BASE_URL,
+  uniqueEmail: shared,
+  registerAndSignIn,
+} = require("./helpers");
+
+const uniqueEmail = () => shared("notifications");
+
+test.describe("Notifications", () => {
+  test("authenticated users see the notification bell with a zero state", async ({ page }) => {
+    await registerAndSignIn(page, uniqueEmail());
+    // Land on the account page (registerAndSignIn redirects there) — the
+    // bell is part of the navbar and is visible on every authenticated route.
+    const bell = page.locator('[data-testid="notification-bell"]');
+    await expect(bell).toBeVisible();
+    // No notifications yet → no count badge rendered.
+    await expect(
+      page.locator('[data-testid="notification-bell-count"]'),
+    ).toHaveCount(0);
+
+    await bell.click();
+    await expect(
+      page.locator('[data-testid="notification-bell-panel"]'),
+    ).toContainText("You're all caught up.");
+  });
+});

--- a/e2e/tests/tasks.spec.js
+++ b/e2e/tests/tasks.spec.js
@@ -208,6 +208,50 @@ test.describe("Tasks", () => {
     await expect(overdueCell).toHaveAttribute("data-status", "none");
   });
 
+  test("user can set reminders on a task with a due date", async ({ page }) => {
+    await registerAndSignIn(page, uniqueEmail());
+
+    const title = `Take medication ${Date.now()}`;
+    const due = new Date();
+    due.setDate(due.getDate() + 1);
+    const createRes = await page.request.post(`${BASE_URL}/tasks`, {
+      headers: { "Content-Type": "application/ld+json" },
+      data: { title, dueDate: due.toISOString() },
+    });
+    expect(createRes.ok()).toBeTruthy();
+
+    await page.goto(`${BASE_URL}/tasks`);
+    const item = page.locator('[data-testid="task-item"]', { hasText: title });
+    await expect(item).toBeVisible();
+
+    // Open the date popover and tick "1 hour before". The reminder section
+    // sits below the calendar + recurrence picker, so on a 720px viewport
+    // it scrolls within the popover (PopoverContent caps its own height
+    // and lets overflow scroll internally).
+    await item.locator('[data-testid="task-due-date"]').click();
+    const reminderCheckbox = page.locator(
+      '[data-testid="task-due-date-reminder-1h"]',
+    );
+    await reminderCheckbox.scrollIntoViewIfNeeded();
+    await reminderCheckbox.check();
+    await page.keyboard.press("Escape");
+
+    // Bell icon appears next to the date now that a reminder is set.
+    await expect(
+      item.locator('[data-testid="task-due-date-reminder-icon"]'),
+    ).toBeVisible();
+
+    // The persisted task carries the reminder offset.
+    const list = await page.request.get(`${BASE_URL}/tasks`, {
+      headers: { Accept: "application/ld+json" },
+    });
+    const json = await list.json();
+    const persisted = (json.member ?? json["hydra:member"] ?? []).find(
+      (t) => t.title === title,
+    );
+    expect(persisted.reminders).toEqual(["1h"]);
+  });
+
   test("user can reorder tasks via keyboard drag", async ({ page }) => {
     // dnd-kit's KeyboardSensor is deterministic across browsers, unlike
     // pointer-based drag which is flaky with dnd-kit's distance constraint.

--- a/pwa/components/common/Navbar.tsx
+++ b/pwa/components/common/Navbar.tsx
@@ -16,6 +16,7 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
+import NotificationBell from "@/components/notifications/NotificationBell";
 import ThemeToggle from "./ThemeToggle";
 
 const NAV_LINKS = [
@@ -62,6 +63,7 @@ const Navbar = () => {
         <div className="flex items-center gap-1">
           {isAuthenticated && user ? (
             <Sheet>
+              <NotificationBell enabled={isAuthenticated} />
               <ThemeToggle />
               <SheetTrigger asChild>
                 <Button

--- a/pwa/components/notifications/NotificationBell.tsx
+++ b/pwa/components/notifications/NotificationBell.tsx
@@ -1,0 +1,222 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { Bell } from "lucide-react";
+import { ENTRYPOINT } from "@/config/entrypoint";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+interface NotificationItem {
+  "@id": string;
+  id: string;
+  type: string;
+  title: string;
+  body: string | null;
+  task: string | null;
+  readAt: string | null;
+  createdAt: string;
+}
+
+interface NotificationCollection {
+  member?: NotificationItem[];
+  "hydra:member"?: NotificationItem[];
+  totalItems?: number;
+}
+
+const POLL_INTERVAL_MS = 30_000;
+// Cap the dropdown so a long-time user with stale unread items doesn't
+// render hundreds of rows in the chrome.
+const MAX_VISIBLE = 8;
+
+const collectionMembers = (data: NotificationCollection): NotificationItem[] =>
+  data.member ?? data["hydra:member"] ?? [];
+
+const formatRelative = (iso: string): string => {
+  const ts = new Date(iso).getTime();
+  if (Number.isNaN(ts)) return "";
+  const diffMs = Date.now() - ts;
+  const diffMin = Math.round(diffMs / 60_000);
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHour = Math.round(diffMin / 60);
+  if (diffHour < 24) return `${diffHour}h ago`;
+  const diffDay = Math.round(diffHour / 24);
+  return `${diffDay}d ago`;
+};
+
+interface NotificationBellProps {
+  /** Hides the bell when the user isn't logged in. Polling also pauses,
+   *  so we don't spam the API with 401s on the public landing page. */
+  enabled: boolean;
+}
+
+const NotificationBell = ({ enabled }: NotificationBellProps) => {
+  const [unread, setUnread] = useState<NotificationItem[]>([]);
+  const [open, setOpen] = useState(false);
+  // Used so a quick mark-read doesn't get stomped by an in-flight poll
+  // returning the stale "still unread" snapshot.
+  const lastFetchedAt = useRef(0);
+
+  const fetchUnread = useCallback(async () => {
+    if (!enabled) return;
+    try {
+      const res = await fetch(
+        `${ENTRYPOINT}/notifications?exists[readAt]=false&itemsPerPage=${MAX_VISIBLE}`,
+        {
+          credentials: "include",
+          headers: { Accept: "application/ld+json" },
+        },
+      );
+      if (!res.ok) return;
+      const data: NotificationCollection = await res.json();
+      lastFetchedAt.current = Date.now();
+      setUnread(collectionMembers(data));
+    } catch {
+      // Polling is a chrome convenience — surface nothing to the user
+      // if it fails; the next tick will retry.
+    }
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled) {
+      setUnread([]);
+      return;
+    }
+    fetchUnread();
+    const id = window.setInterval(fetchUnread, POLL_INTERVAL_MS);
+    return () => window.clearInterval(id);
+  }, [enabled, fetchUnread]);
+
+  // Refetch on focus so the count stays fresh after a long idle without
+  // forcing the polling interval down.
+  useEffect(() => {
+    if (!enabled) return;
+    const onVisible = () => {
+      if (document.visibilityState === "visible") fetchUnread();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => document.removeEventListener("visibilitychange", onVisible);
+  }, [enabled, fetchUnread]);
+
+  const markRead = useCallback(
+    async (notification: NotificationItem) => {
+      // Optimistic removal — drop from the dropdown immediately.
+      setUnread((current) =>
+        current.filter((n) => n["@id"] !== notification["@id"]),
+      );
+      try {
+        await fetch(`${ENTRYPOINT}${notification["@id"]}`, {
+          method: "PATCH",
+          credentials: "include",
+          headers: { "Content-Type": "application/merge-patch+json" },
+          body: JSON.stringify({ readAt: new Date().toISOString() }),
+        });
+      } catch {
+        // Re-poll to recover from a failed mark-read so the count
+        // reflects reality on the next tick.
+        fetchUnread();
+      }
+    },
+    [fetchUnread],
+  );
+
+  if (!enabled) return null;
+
+  const count = unread.length;
+  const countLabel = count > 9 ? "9+" : String(count);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label={
+            count > 0
+              ? `Open notifications (${count} unread)`
+              : "Open notifications (no unread)"
+          }
+          className="relative"
+          data-testid="notification-bell"
+        >
+          <Bell className="h-4 w-4" />
+          {count > 0 && (
+            <span
+              className="absolute -top-0.5 -right-0.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-destructive px-1 text-[10px] font-semibold leading-none text-destructive-foreground"
+              data-testid="notification-bell-count"
+            >
+              {countLabel}
+            </span>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        className="w-80 p-0"
+        data-testid="notification-bell-panel"
+      >
+        <div className="px-3 py-2 border-b">
+          <p className="text-sm font-medium">Notifications</p>
+          <p className="text-xs text-muted-foreground">
+            {count === 0
+              ? "You're all caught up."
+              : `${count} unread`}
+          </p>
+        </div>
+        <ul className="max-h-80 overflow-y-auto divide-y">
+          {unread.length === 0 ? (
+            <li className="px-3 py-6 text-center text-xs text-muted-foreground">
+              No new reminders.
+            </li>
+          ) : (
+            unread.map((n) => (
+              <li
+                key={n["@id"]}
+                className="px-3 py-2 text-sm space-y-1"
+                data-testid="notification-item"
+              >
+                <p className="font-medium">{n.title}</p>
+                {n.body && (
+                  <p className="text-xs text-muted-foreground">{n.body}</p>
+                )}
+                <div className="flex items-center justify-between text-xs">
+                  <span className="text-muted-foreground">
+                    {formatRelative(n.createdAt)}
+                  </span>
+                  <div className="flex items-center gap-2">
+                    {n.task && (
+                      <Link
+                        href="/tasks"
+                        className={cn(
+                          "underline-offset-4 hover:underline",
+                          "text-cyan-700",
+                        )}
+                        onClick={() => setOpen(false)}
+                      >
+                        View tasks
+                      </Link>
+                    )}
+                    <button
+                      type="button"
+                      className="underline-offset-4 hover:underline text-muted-foreground"
+                      onClick={() => markRead(n)}
+                      data-testid="notification-mark-read"
+                    >
+                      Mark read
+                    </button>
+                  </div>
+                </div>
+              </li>
+            ))
+          )}
+        </ul>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export default NotificationBell;

--- a/pwa/pages/tasks.tsx
+++ b/pwa/pages/tasks.tsx
@@ -6,6 +6,7 @@ import {
   ArrowDown,
   ArrowUp,
   ArrowUpDown,
+  Bell,
   Filter,
   GripVertical,
   Repeat,
@@ -80,6 +81,17 @@ interface RecurrenceRule {
   interval: number;
 }
 
+// Allowlist of reminder offsets the API accepts on Task.reminders. Kept in
+// the same order the picker renders so checkbox state ↔ JSON array stay
+// trivially aligned.
+const REMINDER_OFFSETS = ["15m", "1h", "1d"] as const;
+type ReminderOffset = (typeof REMINDER_OFFSETS)[number];
+const REMINDER_LABELS: Record<ReminderOffset, string> = {
+  "15m": "15 minutes before",
+  "1h": "1 hour before",
+  "1d": "1 day before",
+};
+
 interface Task {
   "@id": string;
   id: string;
@@ -89,6 +101,7 @@ interface Task {
   completedOn: string | null;
   dueDate: string | null;
   recurrenceRule: RecurrenceRule | null;
+  reminders: ReminderOffset[] | null;
   position: number;
   tags: Tag[];
   assignees: AssigneeOption[];
@@ -205,6 +218,12 @@ interface DueDateCellProps {
    *  also clears the rule (a recurrence with no anchor is invalid server-side). */
   recurrenceValue?: RecurrenceRule | null;
   onRecurrenceChange?: (next: RecurrenceRule | null) => void | Promise<void>;
+  /** Optional reminder controls. When `remindersValue` is provided we render
+   *  checkboxes for each allowed offset inside the same popover. Clearing
+   *  the date also clears reminders (the server-side validator rejects
+   *  reminders without an anchor). */
+  remindersValue?: ReminderOffset[] | null;
+  onRemindersChange?: (next: ReminderOffset[] | null) => void | Promise<void>;
   /** Toggles overdue/today colouring. Completed tasks pass `"none"` so a missed
    *  deadline doesn't keep glowing red after the work is done. */
   status?: DueDateStatus;
@@ -217,10 +236,13 @@ const DueDateCell = ({
   testIdPrefix,
   recurrenceValue = null,
   onRecurrenceChange,
+  remindersValue = null,
+  onRemindersChange,
   status = "none",
 }: DueDateCellProps) => {
   const [open, setOpen] = useState(false);
   const selected = isoToLocalDate(value);
+  const reminderCount = remindersValue?.length ?? 0;
 
   const handleSelect = (date: Date | undefined) => {
     setOpen(false);
@@ -239,10 +261,14 @@ const DueDateCell = ({
   const handleClear = () => {
     setOpen(false);
     if (value === null) return;
-    // Recurrence is meaningless without a date anchor; drop it together to
-    // avoid leaving the row in a state the server-side validator rejects.
+    // Recurrence and reminders are meaningless without a date anchor; drop
+    // them together to avoid leaving the row in a state the server-side
+    // validator rejects.
     if (recurrenceValue && onRecurrenceChange) {
       void onRecurrenceChange(null);
+    }
+    if (remindersValue && remindersValue.length > 0 && onRemindersChange) {
+      void onRemindersChange(null);
     }
     void onChange(null);
   };
@@ -260,6 +286,15 @@ const DueDateCell = ({
     status === "overdue" && "text-destructive font-medium hover:text-destructive",
     status === "today" && "text-amber-600 dark:text-amber-400 font-medium",
   );
+
+  const toggleReminder = (offset: ReminderOffset) => {
+    if (!onRemindersChange) return;
+    const current = remindersValue ?? [];
+    const next = current.includes(offset)
+      ? current.filter((o) => o !== offset)
+      : [...current, offset];
+    void onRemindersChange(next.length === 0 ? null : next);
+  };
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -293,6 +328,13 @@ const DueDateCell = ({
                 data-testid={`${testIdPrefix}-repeat-icon`}
               />
             )}
+            {reminderCount > 0 && (
+              <Bell
+                className="h-3 w-3 text-muted-foreground"
+                aria-label={`${reminderCount} reminder${reminderCount === 1 ? "" : "s"} set`}
+                data-testid={`${testIdPrefix}-reminder-icon`}
+              />
+            )}
           </button>
         ) : (
           <button
@@ -306,7 +348,12 @@ const DueDateCell = ({
         )}
       </PopoverTrigger>
       <PopoverContent
-        className="w-auto p-0"
+        // Cap the popover height and let it scroll internally — calendar +
+        // recurrence picker + reminders + clear stack tall enough to spill
+        // off short viewports otherwise. Radix exposes its own
+        // `--radix-popover-content-available-height` so the cap also
+        // tracks the actual gap between trigger and viewport edge.
+        className="w-auto p-0 max-h-[min(560px,var(--radix-popover-content-available-height))] overflow-y-auto"
         align="start"
         data-testid={`${testIdPrefix}-popover`}
       >
@@ -339,6 +386,34 @@ const DueDateCell = ({
             onChange={onRecurrenceChange}
             testIdPrefix={`${testIdPrefix}-recurrence`}
           />
+        )}
+        {onRemindersChange && value && (
+          <div
+            className="border-t p-2 space-y-1 min-w-56"
+            data-testid={`${testIdPrefix}-reminders`}
+          >
+            <p className="text-xs font-medium text-muted-foreground px-1">
+              Remind me
+            </p>
+            {REMINDER_OFFSETS.map((offset) => {
+              const checked = (remindersValue ?? []).includes(offset);
+              return (
+                <label
+                  key={offset}
+                  className="flex items-center gap-2 px-1 py-1 text-sm cursor-pointer"
+                >
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => toggleReminder(offset)}
+                    className="h-3.5 w-3.5"
+                    data-testid={`${testIdPrefix}-reminder-${offset}`}
+                  />
+                  {REMINDER_LABELS[offset]}
+                </label>
+              );
+            })}
+          </div>
         )}
         {value && (
           <div className="border-t p-2">
@@ -496,6 +571,10 @@ interface TaskRowProps {
   onDescriptionChange: (task: Task, nextDescription: string | null) => Promise<void>;
   onDueDateChange: (task: Task, nextDueDate: string | null) => Promise<void>;
   onRecurrenceChange: (task: Task, nextRule: RecurrenceRule | null) => Promise<void>;
+  onRemindersChange: (
+    task: Task,
+    nextReminders: ReminderOffset[] | null,
+  ) => Promise<void>;
   onAssigneesChange: (task: Task, nextIris: string[]) => Promise<void>;
   onAssigneeAvatarClick: (assignee: AssigneeOption) => void;
 }
@@ -512,6 +591,7 @@ const TaskRow = ({
   onDescriptionChange,
   onDueDateChange,
   onRecurrenceChange,
+  onRemindersChange,
   onAssigneesChange,
   onAssigneeAvatarClick,
 }: TaskRowProps) => {
@@ -661,6 +741,8 @@ const TaskRow = ({
             testIdPrefix="task-due-date"
             recurrenceValue={task.recurrenceRule}
             onRecurrenceChange={(next) => onRecurrenceChange(task, next)}
+            remindersValue={task.reminders}
+            onRemindersChange={(next) => onRemindersChange(task, next)}
             status={dueDateStatus(task.dueDate, !!task.completedOn)}
           />
         </TableCell>
@@ -1323,6 +1405,40 @@ const Tasks = () => {
     }
   };
 
+  const handleRemindersChange = async (
+    task: Task,
+    nextReminders: ReminderOffset[] | null,
+  ) => {
+    const previous = tasks;
+    setTasks(
+      tasks.map((t) =>
+        t["@id"] === task["@id"] ? { ...t, reminders: nextReminders } : t,
+      ),
+    );
+    setError(null);
+
+    try {
+      const res = await fetch(`${ENTRYPOINT}${task["@id"]}`, {
+        method: "PATCH",
+        credentials: "include",
+        headers: { "Content-Type": "application/merge-patch+json" },
+        body: JSON.stringify({ reminders: nextReminders ?? [] }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(
+          data.description ||
+            data.detail ||
+            data["hydra:description"] ||
+            "Failed to update reminders.",
+        );
+      }
+    } catch (err) {
+      setTasks(previous);
+      setError(err instanceof Error ? err.message : "Failed to update reminders.");
+    }
+  };
+
   const handleAssigneesChange = async (task: Task, nextIris: string[]) => {
     const previous = tasks;
     const nextAssignees = nextIris
@@ -1708,6 +1824,7 @@ const Tasks = () => {
                           onDescriptionChange={handleDescriptionChange}
                           onDueDateChange={handleDueDateChange}
                           onRecurrenceChange={handleRecurrenceChange}
+                          onRemindersChange={handleRemindersChange}
                           onAssigneesChange={handleAssigneesChange}
                           onAssigneeAvatarClick={(assignee) =>
                             setAssigneeFilter(assignee["@id"])


### PR DESCRIPTION
## Summary

End-to-end task reminders. Pick which offsets to fire ahead of a due date (15 min / 1 hour / 1 day), and a navbar bell surfaces them.

### Backend
- `Task.reminders` (nullable JSON array). Allowlist: `15m`, `1h`, `1d`. `ValidReminders` rejects unknown offsets, duplicates, and reminders without a due date. Empty array normalises to null so users can clear cleanly.
- `Notification` entity: `recipient`, `type`, `title`, `body`, `task`, `reminderOffset`, `readAt`, `createdAt`. API exposes:
  - `GET /notifications` — list (filtered to current recipient by `NotificationRecipientExtension`)
  - `GET /notifications/{id}` — single
  - `PATCH /notifications/{id}` — only `readAt` is denormalised
  - `?exists[readAt]=false` for the unread query
- `app:tasks:reminders:dispatch` console command — finds tasks where `dueDate - offset` ≤ now and creates one Notification per (recipient, offset). Recipients = owner ∪ assignees. Idempotent via a `SELECT`-before-`INSERT` plus a unique `(recipient, task, reminder_offset)` index as a hard backstop. Wire to a 5-minute cron in production.

### Frontend
- `DueDateCell` embeds reminder checkboxes (15 min / 1 hour / 1 day before) inside the date popover. Tasks with reminders show a small bell icon next to the date. Clearing the date also clears reminders (otherwise the row would be invalid server-side).
- `NotificationBell` in the navbar polls `/notifications?exists[readAt]=false` every 30s and on tab focus. Renders a destructive-coloured count badge plus a popover dropdown with per-row **Mark read**.

Closes #82.

### Deliberately out of scope (follow-ups)
- **Web Push (VAPID, service worker, opt-in toggle)** — needs the user settings page from #85.
- **Per-user default reminder preferences** — same #85 dependency.
- **Mercure live push** for instant in-app delivery; 30s polling is fine for v1.

## Test plan
- [ ] `cd api && bin/phpunit tests/Api/NotificationTest.php` — 9 cases cover list-scoping, mark-read, cross-user 404, unread filter, dispatcher happy path, idempotency, completed-task skip, and one-row-per-assignee.
- [ ] `cd api && bin/phpunit tests/Api/TaskTest.php` — 5 new cases cover reminders shape, offset allowlist, duplicates, empty-array clear, and the dueDate dependency.
- [ ] `docker compose exec php php bin/console doctrine:migrations:migrate` runs cleanly.
- [ ] `docker compose exec php php bin/console app:tasks:reminders:dispatch` runs and reports a count.
- [ ] `cd e2e && npx playwright test` — covers reminder UI persistence + bell zero state.
- [ ] On `/tasks`: open a date picker → tick "1 hour before" → close → bell icon shows on the row. Refresh → still set.
- [ ] Manually run the dispatch command after seeding a near-due task; the navbar bell shows a `1` badge within 30s.
- [ ] Click the bell → dropdown shows the notification → click "Mark read" → count drops.