### PR TITLE
feat(settings): user settings page (theme + notification preferences)

### DIFF
--- a/api/migrations/Version20260503180000.php
+++ b/api/migrations/Version20260503180000.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds a nullable `preferences` JSON column on the user table for
+ * theme + notification settings (see App\Entity\User::DEFAULT_PREFERENCES).
+ * Existing rows stay null and the entity getter merges defaults in.
+ */
+final class Version20260503180000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add user.preferences for theme and notification settings.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "user" ADD preferences JSON DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "user" DROP preferences');
+    }
+}

--- a/api/src/Controller/AuthController.php
+++ b/api/src/Controller/AuthController.php
@@ -46,6 +46,9 @@ class AuthController extends AbstractController
             'nickname' => $user->getNickname(),
             'personalizedColor' => $user->getPersonalizedColor(),
             'avatarUrls' => $user->getAvatarUrls(),
+            // Inlined so the PWA can apply the saved theme on initial render
+            // without an extra round-trip to /me/preferences.
+            'preferences' => $user->getPreferences(),
         ];
     }
 }

--- a/api/src/Controller/UserPreferencesController.php
+++ b/api/src/Controller/UserPreferencesController.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+
+/**
+ * Self-service preferences for the current user. Lives outside the generic
+ * `Patch` operation on User so we can keep the allowed-keys + enum
+ * validation tight without spreading serializer groups across the entity.
+ *
+ * Partial updates are merged over the existing preference object so the
+ * client only has to send the keys that changed.
+ */
+class UserPreferencesController extends AbstractController
+{
+    public function __construct(private EntityManagerInterface $em)
+    {
+    }
+
+    #[Route('/me/preferences', name: 'me_preferences_get', methods: ['GET'])]
+    public function get(#[CurrentUser] ?User $user): JsonResponse
+    {
+        if (null === $user) {
+            return $this->json(['error' => 'Not authenticated.'], 401);
+        }
+        return $this->json($user->getPreferences());
+    }
+
+    #[Route('/me/preferences', name: 'me_preferences_patch', methods: ['PATCH'])]
+    public function patch(Request $request, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if (null === $user) {
+            return $this->json(['error' => 'Not authenticated.'], 401);
+        }
+
+        $payload = json_decode($request->getContent(), true);
+        // `array_is_list` catches the JSON-array case (e.g. `["a","b"]`)
+        // that decodes to an array but isn't a key→value object.
+        if (!is_array($payload) || array_is_list($payload)) {
+            return $this->json(['error' => 'Body must be a JSON object.'], 400);
+        }
+
+        $current = $user->getPreferences();
+        $next = $current;
+
+        foreach ($payload as $key => $value) {
+            if (!array_key_exists($key, User::DEFAULT_PREFERENCES)) {
+                return $this->json([
+                    'error' => sprintf('Unknown preference key: %s.', $key),
+                ], 422);
+            }
+
+            $error = $this->validateValue($key, $value);
+            if (null !== $error) {
+                return $this->json(['error' => $error], 422);
+            }
+            $next[$key] = $value;
+        }
+
+        $user->setPreferences($next);
+        $this->em->flush();
+
+        return $this->json($user->getPreferences());
+    }
+
+    /**
+     * Returns the validation error message if `$value` is invalid for `$key`,
+     * or null when the value is acceptable. Keys are guaranteed by the caller
+     * to be one of the known preference fields.
+     */
+    private function validateValue(string $key, mixed $value): ?string
+    {
+        return match ($key) {
+            'theme' => is_string($value) && in_array($value, User::ALLOWED_THEMES, true)
+                ? null
+                : 'theme must be one of: light, dark, system.',
+            'notificationFrequency' => is_string($value) && in_array($value, User::ALLOWED_FREQUENCIES, true)
+                ? null
+                : 'notificationFrequency must be one of: realtime, hourly, daily.',
+            'emailNotificationsEnabled', 'pushNotificationsEnabled' => is_bool($value)
+                ? null
+                : sprintf('%s must be a boolean.', $key),
+            default => sprintf('Unknown preference key: %s.', $key),
+        };
+    }
+}

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -112,6 +112,31 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[Groups(['user:write'])]
     private ?MediaObject $avatar = null;
 
+    /**
+     * Per-user preferences (theme, notification toggles, frequency). Stored
+     * as a JSON object so we can extend the shape without a migration each
+     * time. The canonical defaults live in {@see DEFAULT_PREFERENCES} and are
+     * merged in by the getter, so older rows don't need backfilling and
+     * partial PATCH updates Just Work.
+     *
+     * Mutated only via App\Controller\UserPreferencesController so the
+     * allowed-keys + enum-values constraints stay enforced — never exposed
+     * on the generic Patch operation above.
+     *
+     * @var array<string, mixed>|null
+     */
+    #[ORM\Column(type: 'json', nullable: true)]
+    private ?array $preferences = null;
+
+    public const ALLOWED_THEMES = ['light', 'dark', 'system'];
+    public const ALLOWED_FREQUENCIES = ['realtime', 'hourly', 'daily'];
+    public const DEFAULT_PREFERENCES = [
+        'theme' => 'system',
+        'emailNotificationsEnabled' => true,
+        'pushNotificationsEnabled' => false,
+        'notificationFrequency' => 'realtime',
+    ];
+
     public function getId(): ?Uuid
     {
         return $this->id;
@@ -253,5 +278,30 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     {
         $this->plainPassword = null;
         $this->inviteToken = null;
+    }
+
+    /**
+     * Always returns the full preference set, defaults merged in for any
+     * keys the stored row is missing. Callers can read e.g.
+     * `$user->getPreferences()['theme']` without null-checks.
+     *
+     * @return array<string, mixed>
+     */
+    public function getPreferences(): array
+    {
+        return array_merge(self::DEFAULT_PREFERENCES, $this->preferences ?? []);
+    }
+
+    /**
+     * Replaces the stored preferences. Pass an already-validated, full
+     * preference array (callers should merge over {@see getPreferences()}
+     * for partial updates).
+     *
+     * @param array<string, mixed> $preferences
+     */
+    public function setPreferences(array $preferences): static
+    {
+        $this->preferences = $preferences;
+        return $this;
     }
 }

--- a/api/tests/Api/UserPreferencesTest.php
+++ b/api/tests/Api/UserPreferencesTest.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+class UserPreferencesTest extends ApiTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $this->entityManager = $kernel->getContainer()
+            ->get('doctrine')
+            ->getManager();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testGetRequiresAuth(): void
+    {
+        static::createClient()->request('GET', '/me/preferences');
+        $this->assertResponseStatusCodeSame(401);
+    }
+
+    public function testGetReturnsDefaultsWhenUnset(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/me/preferences');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains(User::DEFAULT_PREFERENCES);
+    }
+
+    public function testPatchUpdatesIndividualKeys(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/me/preferences', [
+            'json' => ['theme' => 'dark'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $body = $client->getResponse()->toArray();
+        $this->assertSame('dark', $body['theme']);
+        // Other keys untouched.
+        $this->assertSame(true, $body['emailNotificationsEnabled']);
+        $this->assertSame('realtime', $body['notificationFrequency']);
+    }
+
+    public function testPatchUpdatesMultipleKeysAtOnce(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/me/preferences', [
+            'json' => [
+                'theme' => 'light',
+                'pushNotificationsEnabled' => true,
+                'notificationFrequency' => 'daily',
+            ],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $body = $client->getResponse()->toArray();
+        $this->assertSame('light', $body['theme']);
+        $this->assertSame(true, $body['pushNotificationsEnabled']);
+        $this->assertSame('daily', $body['notificationFrequency']);
+    }
+
+    public function testPatchPersistsAcrossRequests(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/me/preferences', [
+            'json' => ['theme' => 'dark'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        // Fresh request — value survives a roundtrip through the database.
+        $client->request('GET', '/me/preferences');
+        $this->assertResponseIsSuccessful();
+        $body = $client->getResponse()->toArray();
+        $this->assertSame('dark', $body['theme']);
+    }
+
+    public function testPatchRejectsUnknownKey(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/me/preferences', [
+            'json' => ['language' => 'eo'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testPatchRejectsInvalidThemeValue(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/me/preferences', [
+            'json' => ['theme' => 'sepia'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testPatchRejectsInvalidFrequencyValue(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/me/preferences', [
+            'json' => ['notificationFrequency' => 'monthly'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testPatchRejectsNonBooleanForToggle(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/me/preferences', [
+            'json' => ['emailNotificationsEnabled' => 'yes'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testPatchRejectsNonObjectBody(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/me/preferences', [
+            'json' => ['dark', 'realtime'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        // Top-level array (rather than object) — caller error, 400.
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    public function testApiMeReturnsPreferencesInline(): void
+    {
+        // The PWA reads preferences off the existing /api/me payload so the
+        // theme can apply on first paint without a second round-trip.
+        $alice = $this->createUser('alice@example.com');
+        $alice->setPreferences(array_merge(User::DEFAULT_PREFERENCES, ['theme' => 'dark']));
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/api/me');
+
+        $this->assertResponseIsSuccessful();
+        $body = $client->getResponse()->toArray();
+        $this->assertArrayHasKey('preferences', $body);
+        $this->assertSame('dark', $body['preferences']['theme']);
+    }
+
+    /**
+     * @param string[] $roles
+     */
+    private function createUser(string $email, array $roles = ['ROLE_USER']): User
+    {
+        $container = static::getContainer();
+        /** @var UserPasswordHasherInterface $hasher */
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles($roles);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'password123'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/e2e/tests/settings.spec.js
+++ b/e2e/tests/settings.spec.js
@@ -1,0 +1,78 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+const {
+  BASE_URL,
+  uniqueEmail: shared,
+  registerAndSignIn,
+} = require("./helpers");
+
+const uniqueEmail = () => shared("settings");
+
+test.describe("Settings", () => {
+  test("unauthenticated visitors are redirected to sign in", async ({ page }) => {
+    await page.goto(`${BASE_URL}/settings`);
+    await expect(page).toHaveURL(/\/signin/);
+  });
+
+  test("user can change theme and notification preferences and they persist", async ({
+    page,
+  }) => {
+    await registerAndSignIn(page, uniqueEmail());
+    await page.goto(`${BASE_URL}/settings`);
+    await expect(page).toHaveTitle("Settings - Aura");
+
+    // Defaults: system theme + realtime frequency + email on, push off.
+    const systemTheme = page.locator('[data-testid="settings-theme-system"]');
+    await expect(systemTheme).toHaveAttribute("aria-checked", "true");
+    await expect(
+      page.locator('[data-testid="settings-email-toggle"]'),
+    ).toBeChecked();
+    await expect(
+      page.locator('[data-testid="settings-push-toggle"]'),
+    ).not.toBeChecked();
+    await expect(
+      page.locator('[data-testid="settings-frequency-realtime"]'),
+    ).toHaveAttribute("aria-checked", "true");
+
+    // Switch to dark — settings auto-save.
+    await page.locator('[data-testid="settings-theme-dark"]').click();
+    await expect(
+      page.locator('[data-testid="settings-theme-dark"]'),
+    ).toHaveAttribute("aria-checked", "true");
+    // Wait for the "Saved" toast as confirmation that the PATCH landed.
+    await expect(page.locator('[data-testid="settings-save-saved"]')).toBeVisible();
+
+    // Disable email + flip frequency to daily.
+    await page.locator('[data-testid="settings-email-toggle"]').uncheck();
+    await page.locator('[data-testid="settings-frequency-daily"]').click();
+    await expect(
+      page.locator('[data-testid="settings-frequency-daily"]'),
+    ).toHaveAttribute("aria-checked", "true");
+
+    // Reload — preferences came from the server, not just local state.
+    await page.reload();
+    await expect(page.locator('[data-testid="settings-theme-dark"]')).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    await expect(
+      page.locator('[data-testid="settings-email-toggle"]'),
+    ).not.toBeChecked();
+    await expect(
+      page.locator('[data-testid="settings-frequency-daily"]'),
+    ).toHaveAttribute("aria-checked", "true");
+
+    // Theme is also reflected on the <html> element via next-themes.
+    const htmlClass = await page.locator("html").getAttribute("class");
+    expect(htmlClass).toContain("dark");
+  });
+
+  test("settings link appears in the account menu", async ({ page }) => {
+    await registerAndSignIn(page, uniqueEmail());
+    await page.click('button[aria-label="Open my account menu"]');
+    const settingsLink = page.getByRole("link", { name: "Settings" });
+    await expect(settingsLink).toBeVisible();
+    await settingsLink.click();
+    await expect(page).toHaveURL(/\/settings$/);
+  });
+});

--- a/pwa/components/common/Navbar.tsx
+++ b/pwa/components/common/Navbar.tsx
@@ -88,7 +88,17 @@ const Navbar = () => {
                         <Link href="/account">My Account</Link>
                       </Button>
                     </SheetClose>
-                    <Button variant="outline" size="sm" onClick={logout}>
+                    <SheetClose asChild>
+                      <Button asChild variant="outline" size="sm">
+                        <Link href="/settings">Settings</Link>
+                      </Button>
+                    </SheetClose>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={logout}
+                      className="col-span-2"
+                    >
                       Sign Out
                     </Button>
                   </div>

--- a/pwa/contexts/AuthContext.tsx
+++ b/pwa/contexts/AuthContext.tsx
@@ -1,5 +1,16 @@
 import React, { createContext, useContext, useState, useEffect, useCallback, ReactNode } from "react";
+import { useTheme } from "next-themes";
 import { ENTRYPOINT } from "../config/entrypoint";
+
+export type ThemePreference = "light" | "dark" | "system";
+export type NotificationFrequency = "realtime" | "hourly" | "daily";
+
+export interface UserPreferences {
+  theme: ThemePreference;
+  emailNotificationsEnabled: boolean;
+  pushNotificationsEnabled: boolean;
+  notificationFrequency: NotificationFrequency;
+}
 
 export interface User {
   id: string;
@@ -10,6 +21,9 @@ export interface User {
   nickname: string | null;
   personalizedColor: string;
   avatarUrls: { thumb?: string; profile?: string } | null;
+  // Inlined on /api/me so the PWA can apply the saved theme on first paint.
+  // Always present — the API merges in defaults for older rows.
+  preferences: UserPreferences;
 }
 
 export interface RegisterInput {
@@ -46,8 +60,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const { setTheme } = useTheme();
 
   const clearError = useCallback(() => setError(null), []);
+
+  // Apply the user's saved theme whenever the profile changes (login, refresh,
+  // settings update via updateUserLocally). This makes the theme follow the
+  // user across devices instead of being pinned to whatever localStorage on
+  // *this* browser remembers from a prior visit.
+  useEffect(() => {
+    const theme = user?.preferences?.theme;
+    if (theme) setTheme(theme);
+  }, [user?.preferences?.theme, setTheme]);
 
   const fetchMe = useCallback(async () => {
     try {

--- a/pwa/pages/settings.tsx
+++ b/pwa/pages/settings.tsx
@@ -1,0 +1,359 @@
+import Head from "next/head";
+import { useRouter } from "next/router";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Check, Loader2, Monitor, Moon, Sun } from "lucide-react";
+import { useAuth, type UserPreferences } from "@/contexts/AuthContext";
+import { ENTRYPOINT } from "@/config/entrypoint";
+import { signinHrefForCurrent } from "@/lib/authRedirect";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
+
+const THEME_OPTIONS: Array<{
+  value: UserPreferences["theme"];
+  label: string;
+  Icon: typeof Sun;
+}> = [
+  { value: "light", label: "Light", Icon: Sun },
+  { value: "dark", label: "Dark", Icon: Moon },
+  { value: "system", label: "System", Icon: Monitor },
+];
+
+const FREQUENCY_OPTIONS: Array<{
+  value: UserPreferences["notificationFrequency"];
+  label: string;
+  description: string;
+}> = [
+  {
+    value: "realtime",
+    label: "Real-time",
+    description: "Send each reminder as soon as it triggers.",
+  },
+  {
+    value: "hourly",
+    label: "Hourly digest",
+    description: "Group reminders into one email per hour.",
+  },
+  {
+    value: "daily",
+    label: "Daily digest",
+    description: "Group reminders into a single morning email.",
+  },
+];
+
+type SaveStatus = "idle" | "saving" | "saved" | "error";
+
+const Settings = () => {
+  const { user, isAuthenticated, isLoading, updateUserLocally } = useAuth();
+  const router = useRouter();
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle");
+  const [saveError, setSaveError] = useState<string | null>(null);
+  // Each in-flight PATCH increments this so a slow-then-fast pair doesn't
+  // overwrite the newer state with the older response.
+  const pendingRequestId = useRef(0);
+  const savedToastTimer = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated) {
+      router.replace(signinHrefForCurrent(router.asPath));
+    }
+  }, [isLoading, isAuthenticated, router]);
+
+  useEffect(() => {
+    return () => {
+      if (savedToastTimer.current !== null) {
+        window.clearTimeout(savedToastTimer.current);
+      }
+    };
+  }, []);
+
+  const persist = useCallback(
+    async (patch: Partial<UserPreferences>) => {
+      if (!user) return;
+      // Optimistic merge: surface the change instantly. The server response
+      // (or rollback below) becomes the source of truth.
+      const previous = user.preferences;
+      const next = { ...previous, ...patch };
+      updateUserLocally({ preferences: next });
+      setSaveStatus("saving");
+      setSaveError(null);
+
+      const requestId = ++pendingRequestId.current;
+      try {
+        const res = await fetch(`${ENTRYPOINT}/me/preferences`, {
+          method: "PATCH",
+          credentials: "include",
+          headers: { "Content-Type": "application/merge-patch+json" },
+          body: JSON.stringify(patch),
+        });
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          throw new Error(data.error || "Failed to save preferences.");
+        }
+        // Drop the response if a newer request has already fired so we don't
+        // clobber the user's latest change with a stale snapshot.
+        if (requestId !== pendingRequestId.current) return;
+        const body = (await res.json()) as UserPreferences;
+        updateUserLocally({ preferences: body });
+        setSaveStatus("saved");
+        if (savedToastTimer.current !== null) {
+          window.clearTimeout(savedToastTimer.current);
+        }
+        savedToastTimer.current = window.setTimeout(
+          () => setSaveStatus("idle"),
+          1500,
+        );
+      } catch (err) {
+        if (requestId !== pendingRequestId.current) return;
+        updateUserLocally({ preferences: previous });
+        setSaveStatus("error");
+        setSaveError(
+          err instanceof Error ? err.message : "Failed to save preferences.",
+        );
+      }
+    },
+    [user, updateUserLocally],
+  );
+
+  if (isLoading || !user) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-muted">
+        <p className="text-muted-foreground">Loading...</p>
+      </div>
+    );
+  }
+
+  const prefs = user.preferences;
+  const pushPermission =
+    typeof window !== "undefined" && "Notification" in window
+      ? Notification.permission
+      : "default";
+
+  return (
+    <>
+      <Head>
+        <title>Settings - Aura</title>
+      </Head>
+      <div className="min-h-screen bg-muted px-4 py-12">
+        <div className="max-w-2xl mx-auto space-y-6">
+          <header className="flex items-center justify-between gap-3">
+            <div>
+              <h1 className="text-2xl font-bold">Settings</h1>
+              <p className="text-sm text-muted-foreground">
+                Theme and notification preferences for your account.
+              </p>
+            </div>
+            <SaveIndicator status={saveStatus} />
+          </header>
+
+          {saveError && (
+            <Alert variant="destructive" data-testid="settings-error">
+              <AlertDescription>{saveError}</AlertDescription>
+            </Alert>
+          )}
+
+          <Card data-testid="settings-appearance">
+            <CardHeader>
+              <CardTitle>Appearance</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <Label className="text-sm font-medium">Theme</Label>
+                <p className="text-xs text-muted-foreground mb-2">
+                  Pick a theme or follow your operating system.
+                </p>
+                <div
+                  className="grid grid-cols-3 gap-2"
+                  role="radiogroup"
+                  aria-label="Theme"
+                >
+                  {THEME_OPTIONS.map(({ value, label, Icon }) => {
+                    const selected = prefs.theme === value;
+                    return (
+                      <button
+                        key={value}
+                        type="button"
+                        role="radio"
+                        aria-checked={selected}
+                        onClick={() => persist({ theme: value })}
+                        className={cn(
+                          "flex flex-col items-center gap-1 rounded-md border px-3 py-3 text-sm transition-colors",
+                          selected
+                            ? "border-primary bg-primary/10 text-foreground"
+                            : "border-input hover:bg-accent",
+                        )}
+                        data-testid={`settings-theme-${value}`}
+                      >
+                        <Icon className="h-4 w-4" />
+                        <span>{label}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card data-testid="settings-notifications">
+            <CardHeader>
+              <CardTitle>Notifications</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <ToggleRow
+                id="email-toggle"
+                label="Email notifications"
+                description="Receive task reminders via email."
+                checked={prefs.emailNotificationsEnabled}
+                onChange={(checked) =>
+                  persist({ emailNotificationsEnabled: checked })
+                }
+                testId="settings-email-toggle"
+              />
+
+              <Separator />
+
+              <div className="space-y-2">
+                <ToggleRow
+                  id="push-toggle"
+                  label="Push notifications"
+                  description="Send browser push notifications when reminders fire."
+                  checked={prefs.pushNotificationsEnabled}
+                  onChange={(checked) =>
+                    persist({ pushNotificationsEnabled: checked })
+                  }
+                  testId="settings-push-toggle"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Browser permission:{" "}
+                  <span className="font-medium" data-testid="push-permission">
+                    {pushPermission}
+                  </span>
+                  . Push delivery isn’t wired up yet — your preference is
+                  saved and will take effect once browser push lands.
+                </p>
+              </div>
+
+              <Separator />
+
+              <div>
+                <Label className="text-sm font-medium">Frequency</Label>
+                <p className="text-xs text-muted-foreground mb-2">
+                  How often you’d like reminder emails grouped.
+                </p>
+                <div
+                  className="space-y-2"
+                  role="radiogroup"
+                  aria-label="Notification frequency"
+                >
+                  {FREQUENCY_OPTIONS.map(({ value, label, description }) => {
+                    const selected = prefs.notificationFrequency === value;
+                    return (
+                      <button
+                        key={value}
+                        type="button"
+                        role="radio"
+                        aria-checked={selected}
+                        onClick={() =>
+                          persist({ notificationFrequency: value })
+                        }
+                        className={cn(
+                          "w-full text-left rounded-md border px-3 py-2 text-sm transition-colors",
+                          selected
+                            ? "border-primary bg-primary/10"
+                            : "border-input hover:bg-accent",
+                        )}
+                        data-testid={`settings-frequency-${value}`}
+                      >
+                        <div className="font-medium">{label}</div>
+                        <div className="text-xs text-muted-foreground">
+                          {description}
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <p className="text-xs text-muted-foreground text-center">
+            Changes save automatically.
+          </p>
+        </div>
+      </div>
+    </>
+  );
+};
+
+interface ToggleRowProps {
+  id: string;
+  label: string;
+  description: string;
+  checked: boolean;
+  onChange: (next: boolean) => void;
+  testId: string;
+}
+
+const ToggleRow = ({
+  id,
+  label,
+  description,
+  checked,
+  onChange,
+  testId,
+}: ToggleRowProps) => (
+  <div className="flex items-start justify-between gap-4">
+    <div className="flex-1 min-w-0">
+      <Label htmlFor={id} className="text-sm font-medium cursor-pointer">
+        {label}
+      </Label>
+      <p className="text-xs text-muted-foreground">{description}</p>
+    </div>
+    <input
+      id={id}
+      type="checkbox"
+      role="switch"
+      checked={checked}
+      onChange={(e) => onChange(e.target.checked)}
+      className="mt-1 h-4 w-4 cursor-pointer"
+      data-testid={testId}
+    />
+  </div>
+);
+
+interface SaveIndicatorProps {
+  status: SaveStatus;
+}
+
+// Tiny passive status pill — appears for the saving/saved transitions and
+// hides when idle, so the page doesn't grow a permanent "Saved ✓" sticker.
+const SaveIndicator = ({ status }: SaveIndicatorProps) => {
+  if (status === "idle" || status === "error") return null;
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      type="button"
+      disabled
+      className="pointer-events-none gap-1.5"
+      data-testid={`settings-save-${status}`}
+    >
+      {status === "saving" ? (
+        <>
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          Saving…
+        </>
+      ) : (
+        <>
+          <Check className="h-3.5 w-3.5" />
+          Saved
+        </>
+      )}
+    </Button>
+  );
+};
+
+export default Settings;


### PR DESCRIPTION
## Summary

A new `/settings` page where users pick their theme (Light / Dark / System) and configure notification delivery. Foundation for the deferred work from #82 — the toggles persist now, the channels (#100, #101, #102) light up later.

### Backend
- Nullable `User.preferences` JSON column with canonical defaults (`{theme:"system", emailNotificationsEnabled:true, pushNotificationsEnabled:false, notificationFrequency:"realtime"}`). The getter merges defaults in so older rows don't need backfilling and partial PATCHes are clean.
- `UserPreferencesController` exposes `GET` + `PATCH /me/preferences`. Lives outside the generic User Patch operation so the allowed-keys + enum-values validation stays tight without spreading serializer groups across the entity. Unknown keys → 422; bad enum values → 422; non-object body → 400.
- `/api/me` inlines `preferences` so the PWA can apply the saved theme on first paint.

### Frontend
- `/settings` route with **Appearance** and **Notifications** cards. Theme picker is a 3-button radio; notification toggles use inline switches; frequency is a stacked radio. Each control saves optimistically with rollback on server reject.
- A small "Saving… / Saved" pill in the page header during the transition; no permanent "Saved ✓" sticker.
- `AuthContext.User` gains `preferences`, and a `useEffect` applies `preferences.theme` via `next-themes` whenever the profile changes — so the user's saved theme follows them across devices instead of being pinned to localStorage on this browser.
- "Settings" link added to the account menu sheet.

Closes #85.

### Deliberately out of scope (follow-ups)
- **Web Push** opt-in actually delivers nothing yet — toggle stores the preference; service worker + VAPID land in [#100](https://github.com/roboparker/Aura/issues/100).
- **Email-on-reminder** plumbing in [#101](https://github.com/roboparker/Aura/issues/101).
- **Hourly / daily digest** batching in [#102](https://github.com/roboparker/Aura/issues/102).

## Test plan
- [ ] `cd api && bin/phpunit tests/Api/UserPreferencesTest.php` — 11 cases: defaults, partial update, multi-key update, persistence, unknown key, bad enums, non-bool toggle, non-object body, `/api/me` inline.
- [ ] `cd e2e && npx playwright test settings.spec.js` — covers default values, theme switch + persistence after reload, `<html class="dark">` reflection, account-menu link.
- [ ] On `/settings`: switch theme → page restyles immediately; reload → still applied. Toggle email off → reload → still off. Pick "Daily digest" → reload → still selected.
- [ ] On a second browser, sign in with the same user → the theme picked on browser A is applied automatically.