### PR TITLE
feat(tasks): inline comments per task (post / edit / delete, markdown)

### DIFF
--- a/api/migrations/Version20260503190000.php
+++ b/api/migrations/Version20260503190000.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds the comment table for per-task discussion (see #90). Authored by a
+ * user against a task; both FKs cascade-delete so removing a task or user
+ * sweeps their comments along. The (task_id, created_at) composite index
+ * keeps the chronological listing query a single index scan.
+ */
+final class Version20260503190000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add comment table for task comments.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE comment (
+                id UUID NOT NULL,
+                task_id UUID NOT NULL,
+                author_id UUID NOT NULL,
+                body TEXT NOT NULL,
+                created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                updated_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL,
+                PRIMARY KEY(id)
+            )
+        SQL);
+        $this->addSql('CREATE INDEX IDX_9474526C8DB60186 ON comment (task_id)');
+        $this->addSql('CREATE INDEX IDX_9474526CF675F31B ON comment (author_id)');
+        $this->addSql('CREATE INDEX idx_comment_task_created ON comment (task_id, created_at)');
+        $this->addSql('ALTER TABLE comment ADD CONSTRAINT FK_9474526C8DB60186 FOREIGN KEY (task_id) REFERENCES task (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE comment ADD CONSTRAINT FK_9474526CF675F31B FOREIGN KEY (author_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE comment DROP CONSTRAINT FK_9474526C8DB60186');
+        $this->addSql('ALTER TABLE comment DROP CONSTRAINT FK_9474526CF675F31B');
+        $this->addSql('DROP TABLE comment');
+    }
+}

--- a/api/src/Doctrine/CommentAccessExtension.php
+++ b/api/src/Doctrine/CommentAccessExtension.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Doctrine;
+
+use ApiPlatform\Doctrine\Orm\Extension\QueryCollectionExtensionInterface;
+use ApiPlatform\Doctrine\Orm\Extension\QueryItemExtensionInterface;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+use App\Entity\Comment;
+use App\Entity\User;
+use Doctrine\ORM\QueryBuilder;
+use Symfony\Bundle\SecurityBundle\Security;
+
+/**
+ * Filters Comment queries to those whose parent task the current user can
+ * read — mirrors TaskOwnerExtension by joining through `comment.task` and
+ * accepting either task ownership or project membership. Applied to both
+ * collection and item queries so cross-task lookups return 404 instead of
+ * leaking the row's existence.
+ */
+final class CommentAccessExtension implements QueryCollectionExtensionInterface, QueryItemExtensionInterface
+{
+    public function __construct(private Security $security)
+    {
+    }
+
+    public function applyToCollection(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        ?Operation $operation = null,
+        array $context = [],
+    ): void {
+        $this->applyFilter($queryBuilder, $resourceClass);
+    }
+
+    public function applyToItem(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        array $identifiers,
+        ?Operation $operation = null,
+        array $context = [],
+    ): void {
+        $this->applyFilter($queryBuilder, $resourceClass);
+    }
+
+    private function applyFilter(QueryBuilder $queryBuilder, string $resourceClass): void
+    {
+        if (Comment::class !== $resourceClass) {
+            return;
+        }
+
+        if ($this->security->isGranted('ROLE_ADMIN')) {
+            return;
+        }
+
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            return;
+        }
+
+        $rootAlias = $queryBuilder->getRootAliases()[0];
+        $queryBuilder
+            ->innerJoin(sprintf('%s.task', $rootAlias), 'ca_task')
+            ->leftJoin('ca_task.project', 'ca_project')
+            ->leftJoin('ca_project.members', 'ca_member', 'WITH', 'ca_member = :currentUser')
+            ->andWhere('ca_task.owner = :currentUser OR ca_member IS NOT NULL')
+            ->setParameter('currentUser', $user);
+    }
+}

--- a/api/src/Entity/Comment.php
+++ b/api/src/Entity/Comment.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Doctrine\Orm\Filter\OrderFilter;
+use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
+use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use App\Repository\CommentRepository;
+use App\State\CommentAuthorProcessor;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Comment on a task. Read access mirrors the parent task — anyone who can
+ * see the task (owner, project member, admin) can see its comments. Write
+ * access is narrower: any reader can post; only the comment author can
+ * edit; the author OR the task owner OR an admin can delete (so a project
+ * lead can clean up after a teammate without needing to escalate).
+ *
+ * Threading is intentionally flat in v1 — see #105 for follow-up.
+ */
+#[ApiResource(
+    operations: [
+        new GetCollection(
+            security: "is_granted('ROLE_USER')",
+        ),
+        new Post(
+            security: "is_granted('ROLE_USER')",
+            securityPostDenormalize: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getTask().getOwner() == user or (object.getTask().getProject() !== null and object.getTask().getProject().getMembers().contains(user)))",
+            processor: CommentAuthorProcessor::class,
+        ),
+        new Get(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getTask().getOwner() == user or (object.getTask().getProject() !== null and object.getTask().getProject().getMembers().contains(user)))",
+        ),
+        new Patch(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getAuthor() == user)",
+        ),
+        new Delete(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getAuthor() == user or object.getTask().getOwner() == user)",
+        ),
+    ],
+    normalizationContext: ['groups' => ['comment:read']],
+    denormalizationContext: ['groups' => ['comment:write']],
+    order: ['createdAt' => 'ASC'],
+)]
+#[ApiFilter(SearchFilter::class, properties: ['task' => 'exact'])]
+#[ApiFilter(OrderFilter::class, properties: ['createdAt'], arguments: ['orderParameterName' => 'order'])]
+#[ORM\Entity(repositoryClass: CommentRepository::class)]
+#[ORM\Table(name: 'comment')]
+#[ORM\Index(columns: ['task_id', 'created_at'], name: 'idx_comment_task_created')]
+#[ORM\HasLifecycleCallbacks]
+class Comment
+{
+    public const MAX_BODY_LENGTH = 10_000;
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
+    #[Groups(['comment:read'])]
+    private ?Uuid $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Task::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    #[Assert\NotNull(message: 'Task is required.')]
+    #[Groups(['comment:read', 'comment:write'])]
+    private ?Task $task = null;
+
+    /**
+     * Author is set server-side by CommentAuthorProcessor on POST; the
+     * setter exists so PATCH can no-op the field, but the serializer
+     * group keeps it read-only over the wire.
+     */
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    #[Groups(['comment:read'])]
+    private ?User $author = null;
+
+    #[ORM\Column(type: 'text')]
+    #[Assert\NotBlank(message: 'Comment body is required.')]
+    #[Assert\Length(
+        max: self::MAX_BODY_LENGTH,
+        maxMessage: 'Comment cannot be longer than {{ limit }} characters.',
+    )]
+    #[Groups(['comment:read', 'comment:write'])]
+    private string $body = '';
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    #[Groups(['comment:read'])]
+    private \DateTimeImmutable $createdAt;
+
+    /**
+     * Bumped automatically on PATCH via the lifecycle hook; lets the PWA
+     * render an "(edited)" affordance without diffing payloads.
+     */
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    #[Groups(['comment:read'])]
+    private ?\DateTimeImmutable $updatedAt = null;
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    #[ORM\PreUpdate]
+    public function onPreUpdate(): void
+    {
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTask(): ?Task
+    {
+        return $this->task;
+    }
+
+    public function setTask(?Task $task): static
+    {
+        $this->task = $task;
+        return $this;
+    }
+
+    public function getAuthor(): ?User
+    {
+        return $this->author;
+    }
+
+    public function setAuthor(?User $author): static
+    {
+        $this->author = $author;
+        return $this;
+    }
+
+    public function getBody(): string
+    {
+        return $this->body;
+    }
+
+    public function setBody(string $body): static
+    {
+        $this->body = $body;
+        return $this;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): ?\DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+}

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -44,7 +44,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column(type: 'uuid', unique: true)]
     #[ORM\GeneratedValue(strategy: 'CUSTOM')]
     #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
-    #[Groups(['user:read', 'project:read', 'group:read', 'task:read'])]
+    #[Groups(['user:read', 'project:read', 'group:read', 'task:read', 'comment:read'])]
     private ?Uuid $id = null;
 
     // Settable on signup (`user:create`), but not on PATCH — changes
@@ -52,7 +52,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column(length: 180, unique: true)]
     #[Assert\NotBlank]
     #[Assert\Email]
-    #[Groups(['user:read', 'user:create', 'project:read', 'group:read', 'task:read'])]
+    #[Groups(['user:read', 'user:create', 'project:read', 'group:read', 'task:read', 'comment:read'])]
     private string $email = '';
 
     #[ORM\Column]
@@ -79,18 +79,18 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column(length: 100)]
     #[Assert\NotBlank(message: 'Given name is required.')]
     #[Assert\Length(max: 100)]
-    #[Groups(['user:read', 'user:write', 'project:read', 'group:read', 'task:read'])]
+    #[Groups(['user:read', 'user:write', 'project:read', 'group:read', 'task:read', 'comment:read'])]
     private string $givenName = '';
 
     #[ORM\Column(length: 100)]
     #[Assert\NotBlank(message: 'Family name is required.')]
     #[Assert\Length(max: 100)]
-    #[Groups(['user:read', 'user:write', 'project:read', 'group:read', 'task:read'])]
+    #[Groups(['user:read', 'user:write', 'project:read', 'group:read', 'task:read', 'comment:read'])]
     private string $familyName = '';
 
     #[ORM\Column(length: 100, nullable: true)]
     #[Assert\Length(max: 100)]
-    #[Groups(['user:read', 'user:write', 'project:read', 'group:read', 'task:read'])]
+    #[Groups(['user:read', 'user:write', 'project:read', 'group:read', 'task:read', 'comment:read'])]
     private ?string $nickname = null;
 
     /**
@@ -104,7 +104,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         choices: AvatarColorService::PALETTE,
         message: 'Pick a color from the available palette.',
     )]
-    #[Groups(['user:read', 'user:write', 'project:read', 'group:read', 'task:read'])]
+    #[Groups(['user:read', 'user:write', 'project:read', 'group:read', 'task:read', 'comment:read'])]
     private string $personalizedColor = AvatarColorService::PALETTE[0];
 
     #[ORM\ManyToOne(targetEntity: MediaObject::class)]
@@ -263,7 +263,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
      *
      * @return array<string, string>|null
      */
-    #[Groups(['user:read', 'project:read', 'group:read', 'task:read'])]
+    #[Groups(['user:read', 'project:read', 'group:read', 'task:read', 'comment:read'])]
     public function getAvatarUrls(): ?array
     {
         return $this->avatar?->getVariantUrls();

--- a/api/src/Repository/CommentRepository.php
+++ b/api/src/Repository/CommentRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Comment;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Comment>
+ */
+class CommentRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Comment::class);
+    }
+}

--- a/api/src/State/CommentAuthorProcessor.php
+++ b/api/src/State/CommentAuthorProcessor.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\Entity\Comment;
+use App\Entity\User;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+
+/**
+ * Stamps the comment with the currently authenticated user before persisting.
+ * Author is never trusted from the request payload — same pattern as
+ * TaskOwnerProcessor.
+ *
+ * @implements ProcessorInterface<Comment, Comment>
+ */
+final class CommentAuthorProcessor implements ProcessorInterface
+{
+    /**
+     * @param ProcessorInterface<Comment, Comment> $persistProcessor
+     */
+    public function __construct(
+        #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
+        private ProcessorInterface $persistProcessor,
+        private Security $security,
+    ) {
+    }
+
+    /**
+     * @param Comment $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Comment
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new UnauthorizedHttpException('Bearer', 'You must be authenticated to comment.');
+        }
+
+        $data->setAuthor($user);
+
+        return $this->persistProcessor->process($data, $operation, $uriVariables, $context);
+    }
+}

--- a/api/tests/Api/CommentTest.php
+++ b/api/tests/Api/CommentTest.php
@@ -1,0 +1,396 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\Comment;
+use App\Entity\Project;
+use App\Entity\Task;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+class CommentTest extends ApiTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $this->entityManager = $kernel->getContainer()
+            ->get('doctrine')
+            ->getManager();
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Comment')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testListRequiresAuth(): void
+    {
+        static::createClient()->request('GET', '/comments');
+        $this->assertResponseStatusCodeSame(401);
+    }
+
+    public function testCreateCommentOnOwnTask(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->createTask($alice, 'Pick a domain');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/comments', [
+            'json' => [
+                'task' => '/tasks/' . $task->getId(),
+                'body' => 'Started looking at registrars.',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertJsonContains([
+            '@type' => 'Comment',
+            'body' => 'Started looking at registrars.',
+        ]);
+
+        // Author was stamped server-side.
+        $reloaded = $this->entityManager->getRepository(Comment::class)
+            ->findOneBy(['body' => 'Started looking at registrars.']);
+        $this->assertNotNull($reloaded);
+        $this->assertTrue($alice->getId()->equals($reloaded->getAuthor()?->getId()));
+    }
+
+    public function testCreateRejectsClientSuppliedAuthor(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $task = $this->createTask($alice, 'Task');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/comments', [
+            'json' => [
+                'task' => '/tasks/' . $task->getId(),
+                'body' => 'Pretending to be Bob.',
+                'author' => '/users/' . $bob->getId(),
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+        $reloaded = $this->entityManager->getRepository(Comment::class)
+            ->findOneBy(['body' => 'Pretending to be Bob.']);
+        $this->assertTrue($alice->getId()->equals($reloaded->getAuthor()?->getId()));
+    }
+
+    public function testCannotCommentOnOtherUsersPersonalTask(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $bobsTask = $this->createTask($bob, "Bob's secret");
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/comments', [
+            'json' => [
+                'task' => '/tasks/' . $bobsTask->getId(),
+                'body' => 'Sneaky.',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        // TaskOwnerExtension hides Bob's task from Alice during IRI
+        // resolution, so denormalization fails before securityPostDenormalize
+        // even runs. 400 is the right shape (the IRI looks malformed from
+        // Alice's perspective); the security check never fires because
+        // there's no entity to check against.
+        $this->assertResponseStatusCodeSame(400);
+
+        // No comment was persisted on Bob's task either way.
+        $this->entityManager->clear();
+        $this->assertSame(
+            0,
+            (int) $this->entityManager->createQuery(
+                'SELECT COUNT(c) FROM App\Entity\Comment c WHERE c.task = :task',
+            )->setParameter('task', $bobsTask)->getSingleScalarResult(),
+        );
+    }
+
+    public function testProjectMemberCanCommentOnProjectTask(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $project = $this->createSharedProject($alice, [$alice, $bob], 'Team');
+        $task = $this->createTaskInProject($alice, $project, 'Plan launch');
+
+        $client = static::createClient();
+        $client->loginUser($bob);
+        $client->request('POST', '/comments', [
+            'json' => [
+                'task' => '/tasks/' . $task->getId(),
+                'body' => 'Drafting the announcement.',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+    }
+
+    public function testListFiltersToReadableTasks(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $aliceTask = $this->createTask($alice, 'Alice work');
+        $bobsTask = $this->createTask($bob, 'Bob work');
+
+        $this->seedComment($alice, $aliceTask, 'My note.');
+        $this->seedComment($bob, $bobsTask, 'Bob note.');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/comments');
+
+        $this->assertResponseIsSuccessful();
+        $bodies = array_map(
+            fn ($c) => $c['body'],
+            $client->getResponse()->toArray()['member'] ?? [],
+        );
+        $this->assertSame(['My note.'], $bodies);
+    }
+
+    public function testListByTaskReturnsChronological(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->createTask($alice, 'Task');
+
+        $first = $this->seedComment($alice, $task, 'First');
+        $first->getId(); // touch
+        // Use direct setters so the test isn't sleeping for ordering.
+        $second = new Comment();
+        $second->setTask($task);
+        $second->setAuthor($alice);
+        $second->setBody('Second');
+        $reflection = new \ReflectionClass($second);
+        $createdAt = $reflection->getProperty('createdAt');
+        $createdAt->setValue($second, $first->getCreatedAt()->modify('+1 minute'));
+        $this->entityManager->persist($second);
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/comments?task=/tasks/' . $task->getId());
+
+        $this->assertResponseIsSuccessful();
+        $bodies = array_map(
+            fn ($c) => $c['body'],
+            $client->getResponse()->toArray()['member'] ?? [],
+        );
+        $this->assertSame(['First', 'Second'], $bodies);
+    }
+
+    public function testEditOwnComment(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->createTask($alice, 'Task');
+        $comment = $this->seedComment($alice, $task, 'Original');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/comments/' . $comment->getId(), [
+            'json' => ['body' => 'Edited'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->entityManager->clear();
+        $reloaded = $this->entityManager->getRepository(Comment::class)->find($comment->getId());
+        $this->assertSame('Edited', $reloaded->getBody());
+        $this->assertNotNull($reloaded->getUpdatedAt(), 'updatedAt should be stamped on edit.');
+    }
+
+    public function testCannotEditAnotherUsersComment(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $project = $this->createSharedProject($alice, [$alice, $bob], 'Team');
+        $task = $this->createTaskInProject($alice, $project, 'Task');
+        $bobsComment = $this->seedComment($bob, $task, 'Bob said');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/comments/' . $bobsComment->getId(), [
+            'json' => ['body' => 'Alice editing!'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testAuthorCanDeleteOwnComment(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->createTask($alice, 'Task');
+        $comment = $this->seedComment($alice, $task, 'Mine');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('DELETE', '/comments/' . $comment->getId());
+
+        $this->assertResponseStatusCodeSame(204);
+    }
+
+    public function testTaskOwnerCanDeleteAnyCommentOnTheirTask(): void
+    {
+        // Project lead sweeps up after a teammate — owner of the task
+        // should be allowed to remove a comment they didn't author.
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $project = $this->createSharedProject($alice, [$alice, $bob], 'Team');
+        $task = $this->createTaskInProject($alice, $project, 'Task');
+        $bobsComment = $this->seedComment($bob, $task, 'Off-topic');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('DELETE', '/comments/' . $bobsComment->getId());
+
+        $this->assertResponseStatusCodeSame(204);
+    }
+
+    public function testProjectMemberWhoIsntOwnerCannotDeleteOthersComment(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $project = $this->createSharedProject($alice, [$alice, $bob], 'Team');
+        $task = $this->createTaskInProject($alice, $project, 'Task');
+        $aliceComment = $this->seedComment($alice, $task, 'Owner note');
+
+        $client = static::createClient();
+        $client->loginUser($bob);
+        $client->request('DELETE', '/comments/' . $aliceComment->getId());
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testCannotReadCommentOnInaccessibleTask(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $bobsTask = $this->createTask($bob, "Bob's task");
+        $bobsComment = $this->seedComment($bob, $bobsTask, 'Private');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/comments/' . $bobsComment->getId());
+
+        // Extension scopes the query, so cross-task lookups return 404.
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testEmptyBodyRejected(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->createTask($alice, 'Task');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/comments', [
+            'json' => [
+                'task' => '/tasks/' . $task->getId(),
+                'body' => '',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testOversizedBodyRejected(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->createTask($alice, 'Task');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/comments', [
+            'json' => [
+                'task' => '/tasks/' . $task->getId(),
+                'body' => str_repeat('x', Comment::MAX_BODY_LENGTH + 1),
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    private function seedComment(User $author, Task $task, string $body): Comment
+    {
+        $c = new Comment();
+        $c->setAuthor($author);
+        $c->setTask($task);
+        $c->setBody($body);
+        $this->entityManager->persist($c);
+        $this->entityManager->flush();
+        return $c;
+    }
+
+    private function createTask(User $owner, string $title): Task
+    {
+        $task = new Task();
+        $task->setOwner($owner);
+        $task->setTitle($title);
+        $this->entityManager->persist($task);
+        $this->entityManager->flush();
+        return $task;
+    }
+
+    private function createTaskInProject(User $owner, Project $project, string $title): Task
+    {
+        $task = new Task();
+        $task->setOwner($owner);
+        $task->setProject($project);
+        $task->setTitle($title);
+        $this->entityManager->persist($task);
+        $this->entityManager->flush();
+        return $task;
+    }
+
+    /**
+     * @param User[] $members
+     */
+    private function createSharedProject(User $owner, array $members, string $title): Project
+    {
+        $project = new Project();
+        $project->setOwner($owner);
+        $project->setTitle($title);
+        foreach ($members as $member) {
+            $project->addMember($member);
+        }
+        $this->entityManager->persist($project);
+        $this->entityManager->flush();
+        return $project;
+    }
+
+    /**
+     * @param string[] $roles
+     */
+    private function createUser(string $email, array $roles = ['ROLE_USER']): User
+    {
+        $container = static::getContainer();
+        /** @var UserPasswordHasherInterface $hasher */
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles($roles);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'password123'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/e2e/tests/comments.spec.js
+++ b/e2e/tests/comments.spec.js
@@ -1,0 +1,164 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+const {
+  BASE_URL,
+  uniqueEmail: shared,
+  registerAndSignIn,
+  createTaskInline,
+  fillDescription,
+} = require("./helpers");
+
+const uniqueEmail = () => shared("comments");
+
+test.describe("Task comments", () => {
+  test("user can post, edit, and delete a comment on their own task", async ({
+    page,
+  }) => {
+    await registerAndSignIn(page, uniqueEmail());
+    // Auto-accept the delete confirmation later in the test.
+    page.on("dialog", (dialog) => dialog.accept());
+
+    await page.goto(`${BASE_URL}/tasks`);
+    const title = `Plan launch ${Date.now()}`;
+    await createTaskInline(page, title);
+
+    const item = page.locator('[data-testid="task-item"]', { hasText: title });
+    await expect(item).toBeVisible();
+
+    // Toggle the comments panel for this task.
+    await item.locator('[data-testid="task-comments-toggle"]').click();
+    const panel = item.locator('[data-testid="comments-panel"]');
+    await expect(panel).toBeVisible();
+    await expect(panel.locator("text=No comments yet")).toBeVisible();
+
+    // Post a comment by typing into the BlockNote editor and clicking Post.
+    await fillDescription(page, panel, "First note about the launch.", {
+      ariaLabelPrefix: "Comment",
+    });
+    const submit = panel.locator('[data-testid="comment-submit"]');
+    await submit.scrollIntoViewIfNeeded();
+    await submit.click();
+
+    const comment = panel.locator('[data-testid="comment-item"]').first();
+    await expect(comment).toContainText("First note about the launch.");
+
+    // Toggle count is reflected on the toggle pill now.
+    await expect(
+      item.locator('[data-testid="task-comments-toggle"]'),
+    ).toContainText("Comments (1)");
+
+    // Edit the comment.
+    await comment.locator('[data-testid="comment-edit"]').click();
+    await fillDescription(page, comment, "Edited launch note.", {
+      ariaLabelPrefix: "Edit comment",
+    });
+    await comment.locator('[data-testid="comment-edit-save"]').click();
+    await expect(comment).toContainText("Edited launch note.");
+    await expect(comment).toContainText("edited");
+
+    // Delete it.
+    await comment.locator('[data-testid="comment-delete"]').click();
+    await expect(panel.locator('[data-testid="comment-item"]')).toHaveCount(0);
+    await expect(
+      item.locator('[data-testid="task-comments-toggle"]'),
+    ).toContainText("Comment");
+  });
+
+  test("comments survive a reload", async ({ page }) => {
+    await registerAndSignIn(page, uniqueEmail());
+    await page.goto(`${BASE_URL}/tasks`);
+    const title = `Persist note ${Date.now()}`;
+    await createTaskInline(page, title);
+
+    const item = page.locator('[data-testid="task-item"]', { hasText: title });
+    await item.locator('[data-testid="task-comments-toggle"]').click();
+    const panel = item.locator('[data-testid="comments-panel"]');
+    await fillDescription(page, panel, "Survives reload.", {
+      ariaLabelPrefix: "Comment",
+    });
+    await panel.locator('[data-testid="comment-submit"]').click();
+    await expect(
+      panel.locator('[data-testid="comment-item"]'),
+    ).toContainText("Survives reload.");
+
+    await page.reload();
+    const reopenedItem = page.locator('[data-testid="task-item"]', {
+      hasText: title,
+    });
+    await reopenedItem.locator('[data-testid="task-comments-toggle"]').click();
+    await expect(
+      reopenedItem
+        .locator('[data-testid="comments-panel"]')
+        .locator('[data-testid="comment-item"]'),
+    ).toContainText("Survives reload.");
+  });
+
+  test("non-author cannot see edit affordance", async ({ browser }) => {
+    // Alice owns a project task; Bob is a member who comments. Alice opens
+    // the panel and should see her own delete option (task owner) but no
+    // edit pencil on Bob's comment.
+    const aliceEmail = uniqueEmail();
+    const bobEmail = uniqueEmail();
+
+    const aliceCtx = await browser.newContext({ ignoreHTTPSErrors: true });
+    const alice = await aliceCtx.newPage();
+    await registerAndSignIn(alice, aliceEmail);
+    // Alice creates a project + task via API to isolate from inline UI.
+    const projectRes = await alice.request.post(`${BASE_URL}/projects`, {
+      headers: { "Content-Type": "application/ld+json" },
+      data: { title: `Shared ${Date.now()}` },
+    });
+    expect(projectRes.ok()).toBeTruthy();
+    const project = await projectRes.json();
+
+    // Bob signs up — needs to exist in the DB before Alice can add him by email.
+    const bobCtx = await browser.newContext({ ignoreHTTPSErrors: true });
+    const bob = await bobCtx.newPage();
+    await registerAndSignIn(bob, bobEmail);
+
+    // Alice adds Bob to the project (the endpoint takes email, not user id).
+    const addRes = await alice.request.post(
+      `${BASE_URL}${project["@id"]}/members`,
+      {
+        headers: { "Content-Type": "application/json" },
+        data: { email: bobEmail },
+      },
+    );
+    expect(addRes.ok()).toBeTruthy();
+
+    // Alice creates a task on the project.
+    const taskRes = await alice.request.post(`${BASE_URL}/tasks`, {
+      headers: { "Content-Type": "application/ld+json" },
+      data: { title: `Team task ${Date.now()}`, project: project["@id"] },
+    });
+    expect(taskRes.ok()).toBeTruthy();
+    const task = await taskRes.json();
+
+    // Bob posts a comment via API.
+    const commentRes = await bob.request.post(`${BASE_URL}/comments`, {
+      headers: { "Content-Type": "application/ld+json" },
+      data: { task: task["@id"], body: "Bob's note." },
+    });
+    expect(commentRes.ok()).toBeTruthy();
+
+    // Alice loads the page and expands comments.
+    await alice.goto(`${BASE_URL}/tasks`);
+    const aliceItem = alice.locator('[data-testid="task-item"]', {
+      hasText: task.title,
+    });
+    await aliceItem.locator('[data-testid="task-comments-toggle"]').click();
+    const aliceComment = aliceItem.locator('[data-testid="comment-item"]');
+    await expect(aliceComment).toContainText("Bob's note.");
+    // No edit pencil — Alice is not the author.
+    await expect(
+      aliceComment.locator('[data-testid="comment-edit"]'),
+    ).toHaveCount(0);
+    // But Alice IS the task owner, so she sees the delete option.
+    await expect(
+      aliceComment.locator('[data-testid="comment-delete"]'),
+    ).toBeVisible();
+
+    await aliceCtx.close();
+    await bobCtx.close();
+  });
+});

--- a/e2e/tests/helpers.js
+++ b/e2e/tests/helpers.js
@@ -22,21 +22,24 @@ async function registerAndSignIn(page, email, password = "password123", options 
 }
 
 /**
- * Type into the BlockNote description editor. The editor is a contenteditable
- * ProseMirror instance wrapped in our MarkdownEditor component, which exposes
- * an `aria-label` starting with "Description" (e.g. "Description",
- * "Description for new task", or `Description for "task title"`). Playwright's
- * `.fill()` is brittle on block editors, so we click into the editable and
- * use keyboard.type.
+ * Type into a BlockNote editor — used for both task descriptions and task
+ * comments. The editor is a contenteditable ProseMirror instance wrapped
+ * in our MarkdownEditor component, which exposes an `aria-label` set by the
+ * caller (e.g. "Description", `Description for "task title"`,
+ * `Comment on "task title"`, "Edit comment"). Playwright's `.fill()` is
+ * brittle on block editors, so we click into the editable and use
+ * keyboard.type.
  *
  * @param {import('@playwright/test').Page} page
  * @param {import('@playwright/test').Locator | undefined} scope optional scope (e.g. a specific edit form)
  * @param {string} text
+ * @param {{ ariaLabelPrefix?: string }} [options] aria-label prefix to disambiguate when multiple editors exist in scope; defaults to "Description"
  */
-async function fillDescription(page, scope, text) {
+async function fillDescription(page, scope, text, options = {}) {
+  const { ariaLabelPrefix = "Description" } = options;
   const root = scope ?? page;
   const editor = root
-    .locator('[aria-label^="Description"] [contenteditable="true"]')
+    .locator(`[aria-label^="${ariaLabelPrefix}"] [contenteditable="true"]`)
     .first();
   await editor.click();
   // Clear any existing content (edit mode pre-populates the block editor).

--- a/pwa/components/tasks/CommentsPanel.tsx
+++ b/pwa/components/tasks/CommentsPanel.tsx
@@ -1,0 +1,292 @@
+import { useEffect, useState } from "react";
+import { Pencil, Trash2 } from "lucide-react";
+import { displayName } from "@/lib/userDisplay";
+import MarkdownEditor from "@/components/editor/MarkdownEditor";
+import MarkdownView from "@/components/editor/MarkdownView";
+import UserAvatar, { type AvatarUser } from "@/components/user/UserAvatar";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+
+export interface Comment {
+  "@id": string;
+  id: string;
+  body: string;
+  // The API serializes Comment.author as the embedded user shape so we can
+  // render the avatar without a second fetch per comment.
+  author: AvatarUser & { "@id": string; id: string };
+  createdAt: string;
+  updatedAt: string | null;
+}
+
+interface CommentsPanelProps {
+  taskTitle: string;
+  /** Already-loaded comments for this task. Sorted oldest-first by the API. */
+  comments: Comment[];
+  /** True while the parent is awaiting the initial comments fetch. */
+  isLoading: boolean;
+  /** Author check uses this — null means an admin-viewing-someone-else case
+   *  where edit/delete should still work via the server's auth rules. */
+  currentUserIri: string | null;
+  /** Set when the current user is the owner of this task; widens delete
+   *  rights for the same reason the server does. */
+  isTaskOwner: boolean;
+  onCreate: (body: string) => Promise<void>;
+  onEdit: (comment: Comment, body: string) => Promise<void>;
+  onDelete: (comment: Comment) => Promise<void>;
+}
+
+const RELATIVE = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+
+const formatRelative = (iso: string): string => {
+  const ts = new Date(iso).getTime();
+  if (Number.isNaN(ts)) return "";
+  const diffSec = Math.round((ts - Date.now()) / 1000);
+  const abs = Math.abs(diffSec);
+  if (abs < 60) return RELATIVE.format(diffSec, "second");
+  if (abs < 3600) return RELATIVE.format(Math.round(diffSec / 60), "minute");
+  if (abs < 86400) return RELATIVE.format(Math.round(diffSec / 3600), "hour");
+  if (abs < 2592000) return RELATIVE.format(Math.round(diffSec / 86400), "day");
+  if (abs < 31536000) return RELATIVE.format(Math.round(diffSec / 2592000), "month");
+  return RELATIVE.format(Math.round(diffSec / 31536000), "year");
+};
+
+const CommentsPanel = ({
+  taskTitle,
+  comments,
+  isLoading,
+  currentUserIri,
+  isTaskOwner,
+  onCreate,
+  onEdit,
+  onDelete,
+}: CommentsPanelProps) => {
+  const [draft, setDraft] = useState("");
+  const [draftKey, setDraftKey] = useState(0);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async () => {
+    const trimmed = draft.trim();
+    if (!trimmed) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onCreate(draft);
+      setDraft("");
+      // Bump the editor key so BlockNote remounts with empty content.
+      setDraftKey((k) => k + 1);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to post comment.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3" data-testid="comments-panel">
+      {error && (
+        <Alert variant="destructive" data-testid="comments-error">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {isLoading ? (
+        <p className="text-xs text-muted-foreground">Loading comments…</p>
+      ) : comments.length === 0 ? (
+        <p className="text-xs text-muted-foreground italic">
+          No comments yet — start the discussion.
+        </p>
+      ) : (
+        <ul className="space-y-3">
+          {comments.map((comment) => (
+            <CommentRow
+              key={comment["@id"]}
+              comment={comment}
+              canEdit={
+                currentUserIri !== null && currentUserIri === comment.author["@id"]
+              }
+              canDelete={
+                currentUserIri !== null &&
+                (currentUserIri === comment.author["@id"] || isTaskOwner)
+              }
+              onEdit={(body) => onEdit(comment, body)}
+              onDelete={() => onDelete(comment)}
+            />
+          ))}
+        </ul>
+      )}
+
+      <div
+        className="space-y-2"
+        // Ctrl/Cmd+Enter submits — keydown bubbles out of BlockNote since
+        // it doesn't intercept the modifier+Enter combo for its own use.
+        onKeyDown={(e) => {
+          if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+            e.preventDefault();
+            void submit();
+          }
+        }}
+      >
+        <MarkdownEditor
+          key={draftKey}
+          ariaLabel={`Comment on "${taskTitle}"`}
+          value={draft}
+          onChange={setDraft}
+        />
+        <div className="flex items-center justify-between gap-2">
+          <p className="text-xs text-muted-foreground">
+            Markdown supported. <kbd>⌘</kbd>/<kbd>Ctrl</kbd>+<kbd>Enter</kbd>{" "}
+            to post.
+          </p>
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => void submit()}
+            disabled={submitting || draft.trim().length === 0}
+            data-testid="comment-submit"
+          >
+            {submitting ? "Posting…" : "Post comment"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+interface CommentRowProps {
+  comment: Comment;
+  canEdit: boolean;
+  canDelete: boolean;
+  onEdit: (body: string) => Promise<void>;
+  onDelete: () => Promise<void>;
+}
+
+const CommentRow = ({
+  comment,
+  canEdit,
+  canDelete,
+  onEdit,
+  onDelete,
+}: CommentRowProps) => {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(comment.body);
+  const [editorKey, setEditorKey] = useState(0);
+  const [savingEdit, setSavingEdit] = useState(false);
+
+  useEffect(() => {
+    if (!editing) setDraft(comment.body);
+  }, [comment.body, editing]);
+
+  const startEdit = () => {
+    setDraft(comment.body);
+    setEditorKey((k) => k + 1);
+    setEditing(true);
+  };
+
+  const cancelEdit = () => {
+    setDraft(comment.body);
+    setEditing(false);
+  };
+
+  const saveEdit = async () => {
+    const next = draft.trim();
+    if (!next) return;
+    if (next === comment.body) {
+      setEditing(false);
+      return;
+    }
+    setSavingEdit(true);
+    try {
+      await onEdit(draft);
+      setEditing(false);
+    } finally {
+      setSavingEdit(false);
+    }
+  };
+
+  const requestDelete = async () => {
+    if (!window.confirm("Delete this comment?")) return;
+    await onDelete();
+  };
+
+  return (
+    <li className="flex gap-3" data-testid="comment-item">
+      <UserAvatar user={comment.author} size="sm" />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <span className="font-medium text-foreground">
+            {displayName(comment.author)}
+          </span>
+          <span title={new Date(comment.createdAt).toLocaleString()}>
+            {formatRelative(comment.createdAt)}
+          </span>
+          {comment.updatedAt && (
+            <span title={new Date(comment.updatedAt).toLocaleString()}>
+              · edited
+            </span>
+          )}
+          <div className="ml-auto flex items-center gap-1">
+            {canEdit && !editing && (
+              <button
+                type="button"
+                onClick={startEdit}
+                aria-label="Edit comment"
+                className="text-muted-foreground hover:text-foreground p-0.5"
+                data-testid="comment-edit"
+              >
+                <Pencil className="h-3.5 w-3.5" />
+              </button>
+            )}
+            {canDelete && !editing && (
+              <button
+                type="button"
+                onClick={requestDelete}
+                aria-label="Delete comment"
+                className="text-destructive hover:text-destructive/80 p-0.5"
+                data-testid="comment-delete"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </button>
+            )}
+          </div>
+        </div>
+        {editing ? (
+          <div className="space-y-2 mt-1">
+            <MarkdownEditor
+              key={editorKey}
+              ariaLabel="Edit comment"
+              value={draft}
+              onChange={setDraft}
+            />
+            <div className="flex gap-2">
+              <Button
+                type="button"
+                size="sm"
+                onClick={() => void saveEdit()}
+                disabled={savingEdit || draft.trim().length === 0}
+                data-testid="comment-edit-save"
+              >
+                Save
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                onClick={cancelEdit}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <MarkdownView
+            source={comment.body}
+            className="text-sm mt-1"
+          />
+        )}
+      </div>
+    </li>
+  );
+};
+
+export default CommentsPanel;

--- a/pwa/pages/tasks.tsx
+++ b/pwa/pages/tasks.tsx
@@ -9,6 +9,7 @@ import {
   Bell,
   Filter,
   GripVertical,
+  MessageSquare,
   Repeat,
   Trash2,
   X,
@@ -38,6 +39,9 @@ import AssigneesCombobox, {
   type AssigneeOption,
 } from "@/components/tasks/AssigneesCombobox";
 import TagsCombobox from "@/components/tasks/TagsCombobox";
+import CommentsPanel, {
+  type Comment,
+} from "@/components/tasks/CommentsPanel";
 import UserAvatar from "@/components/user/UserAvatar";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -100,6 +104,10 @@ interface Task {
   createdOn: string;
   completedOn: string | null;
   dueDate: string | null;
+  // Embedded user shape under `task:read` (the User entity exposes its
+  // basic fields in that group). Used here only to widen comment
+  // delete-rights for the task owner without an extra fetch.
+  owner: { "@id": string };
   recurrenceRule: RecurrenceRule | null;
   reminders: ReminderOffset[] | null;
   position: number;
@@ -564,6 +572,9 @@ interface TaskRowProps {
   allTags: Tag[];
   assignableUsers: AssigneeOption[];
   reorderable: boolean;
+  currentUserIri: string | null;
+  comments: Comment[] | undefined;
+  commentsLoading: boolean;
   onToggle: (task: Task) => void;
   onDelete: (task: Task) => void;
   onTagsChange: (task: Task, nextTagIris: string[]) => Promise<void>;
@@ -577,6 +588,12 @@ interface TaskRowProps {
   ) => Promise<void>;
   onAssigneesChange: (task: Task, nextIris: string[]) => Promise<void>;
   onAssigneeAvatarClick: (assignee: AssigneeOption) => void;
+  /** Lazy-load trigger: parent fetches `/comments?task=…` the first time
+   *  this fires for a task. */
+  onLoadComments: (task: Task) => Promise<void>;
+  onCreateComment: (task: Task, body: string) => Promise<void>;
+  onEditComment: (comment: Comment, body: string) => Promise<void>;
+  onDeleteComment: (comment: Comment) => Promise<void>;
 }
 
 const TaskRow = ({
@@ -584,6 +601,9 @@ const TaskRow = ({
   allTags,
   assignableUsers,
   reorderable,
+  currentUserIri,
+  comments,
+  commentsLoading,
   onToggle,
   onDelete,
   onTagsChange,
@@ -594,6 +614,10 @@ const TaskRow = ({
   onRemindersChange,
   onAssigneesChange,
   onAssigneeAvatarClick,
+  onLoadComments,
+  onCreateComment,
+  onEditComment,
+  onDeleteComment,
 }: TaskRowProps) => {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: task["@id"],
@@ -605,6 +629,32 @@ const TaskRow = ({
     transition,
     opacity: isDragging ? 0.5 : 1,
   };
+
+  // --- Comments expansion -----------------------------------------------
+  // Comments are fetched lazily — the load fires the first time the user
+  // expands the section, then the parent caches the result so subsequent
+  // toggles are free.
+  const [commentsExpanded, setCommentsExpanded] = useState(false);
+  const commentCount = comments?.length;
+  // Used only to decide whether to render the trash icon on a comment the
+  // current user didn't author. The server is the source of truth — a
+  // wrong-positive here just yields a 403 on the actual DELETE.
+  const isLikelyTaskOwner =
+    currentUserIri !== null && task.owner["@id"] === currentUserIri;
+  const toggleComments = () => {
+    setCommentsExpanded((open) => !open);
+  };
+
+  // Trigger the lazy fetch *after* commit so we don't call setState on the
+  // parent during a child render (React would warn and bail).
+  useEffect(() => {
+    if (commentsExpanded && comments === undefined) {
+      void onLoadComments(task);
+    }
+    // `onLoadComments` is memoized in the parent on its dependencies; this
+    // effect re-runs only on the values we actually care about.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [commentsExpanded, comments]);
 
   // --- Inline title editing ---------------------------------------------
   const [editingTitle, setEditingTitle] = useState(false);
@@ -833,8 +883,46 @@ const TaskRow = ({
               Add description
             </button>
           )}
+          <button
+            type="button"
+            onClick={toggleComments}
+            aria-expanded={commentsExpanded}
+            aria-label={`${commentsExpanded ? "Hide" : "Show"} comments for "${task.title}"`}
+            className="mt-2 inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground rounded-sm"
+            data-testid="task-comments-toggle"
+          >
+            <MessageSquare className="h-3.5 w-3.5" />
+            <span>
+              {commentCount === undefined
+                ? "Comments"
+                : commentCount === 0
+                  ? "Comment"
+                  : `Comments (${commentCount})`}
+            </span>
+          </button>
         </TableCell>
       </TableRow>
+      {commentsExpanded && (
+        <TableRow
+          className="hover:bg-transparent"
+          data-testid="task-comments-row"
+        >
+          <TableCell className="w-8" aria-hidden="true" />
+          <TableCell className="w-10" aria-hidden="true" />
+          <TableCell colSpan={5} className="pl-0 pr-4 pt-0 pb-4">
+            <CommentsPanel
+              taskTitle={task.title}
+              comments={comments ?? []}
+              isLoading={commentsLoading && comments === undefined}
+              currentUserIri={currentUserIri}
+              isTaskOwner={isLikelyTaskOwner}
+              onCreate={(body) => onCreateComment(task, body)}
+              onEdit={(comment, body) => onEditComment(comment, body)}
+              onDelete={(comment) => onDeleteComment(comment)}
+            />
+          </TableCell>
+        </TableRow>
+      )}
     </tbody>
   );
 };
@@ -1113,6 +1201,15 @@ const Tasks = () => {
     isMyTasksPage ? "me" : "all",
   );
   const [overdueOnly, setOverdueOnly] = useState(false);
+  // Lazy-loaded comments per task IRI. Undefined entry = not yet fetched;
+  // empty array = fetched and there are none. The TaskRow uses the
+  // distinction to show "Comments" vs "Comments (0)" before the first load.
+  const [commentsByTask, setCommentsByTask] = useState<
+    Record<string, Comment[] | undefined>
+  >({});
+  const [loadingCommentsFor, setLoadingCommentsFor] = useState<Set<string>>(
+    () => new Set(),
+  );
 
   const sensors = useSensors(
     // Require an 8px drag before activating so a quick click on the grip
@@ -1498,6 +1595,125 @@ const Tasks = () => {
     }
   };
 
+  const handleLoadComments = useCallback(
+    async (task: Task) => {
+      const taskIri = task["@id"];
+      // Already loaded or in flight — bail out.
+      if (commentsByTask[taskIri] !== undefined) return;
+      if (loadingCommentsFor.has(taskIri)) return;
+      setLoadingCommentsFor((prev) => {
+        const next = new Set(prev);
+        next.add(taskIri);
+        return next;
+      });
+      try {
+        const res = await fetch(
+          `${ENTRYPOINT}/comments?task=${encodeURIComponent(taskIri)}&itemsPerPage=200`,
+          {
+            credentials: "include",
+            headers: { Accept: "application/ld+json" },
+          },
+        );
+        if (!res.ok) throw new Error("Failed to load comments.");
+        const data: { member?: Comment[]; "hydra:member"?: Comment[] } =
+          await res.json();
+        const list = data.member ?? data["hydra:member"] ?? [];
+        setCommentsByTask((prev) => ({ ...prev, [taskIri]: list }));
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load comments.");
+      } finally {
+        setLoadingCommentsFor((prev) => {
+          const next = new Set(prev);
+          next.delete(taskIri);
+          return next;
+        });
+      }
+    },
+    [commentsByTask, loadingCommentsFor],
+  );
+
+  const handleCreateComment = useCallback(
+    async (task: Task, body: string) => {
+      const trimmed = body.trim();
+      if (!trimmed) return;
+      const res = await fetch(`${ENTRYPOINT}/comments`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/ld+json" },
+        body: JSON.stringify({ task: task["@id"], body }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(
+          data["hydra:description"] || data.detail || "Failed to post comment.",
+        );
+      }
+      const created: Comment = await res.json();
+      setCommentsByTask((prev) => ({
+        ...prev,
+        [task["@id"]]: [...(prev[task["@id"]] ?? []), created],
+      }));
+    },
+    [],
+  );
+
+  const handleEditComment = useCallback(
+    async (comment: Comment, body: string) => {
+      const res = await fetch(`${ENTRYPOINT}${comment["@id"]}`, {
+        method: "PATCH",
+        credentials: "include",
+        headers: { "Content-Type": "application/merge-patch+json" },
+        body: JSON.stringify({ body }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(
+          data["hydra:description"] || data.detail || "Failed to update comment.",
+        );
+      }
+      const updated: Comment = await res.json();
+      // Comment doesn't carry its task IRI on the wire (`task` is the bare
+      // IRI string serialized at write time, but the read response from
+      // PATCH inlines the embedded task). Either way, walk every loaded
+      // task list and replace the matching comment.
+      setCommentsByTask((prev) => {
+        const next: typeof prev = {};
+        for (const [taskIri, list] of Object.entries(prev)) {
+          if (!list) {
+            next[taskIri] = list;
+            continue;
+          }
+          next[taskIri] = list.map((c) =>
+            c["@id"] === comment["@id"] ? { ...c, ...updated } : c,
+          );
+        }
+        return next;
+      });
+    },
+    [],
+  );
+
+  const handleDeleteComment = useCallback(async (comment: Comment) => {
+    const res = await fetch(`${ENTRYPOINT}${comment["@id"]}`, {
+      method: "DELETE",
+      credentials: "include",
+    });
+    if (!res.ok) {
+      throw new Error("Failed to delete comment.");
+    }
+    setCommentsByTask((prev) => {
+      const next: typeof prev = {};
+      for (const [taskIri, list] of Object.entries(prev)) {
+        if (!list) {
+          next[taskIri] = list;
+          continue;
+        }
+        next[taskIri] = list.filter((c) => c["@id"] !== comment["@id"]);
+      }
+      return next;
+    });
+  }, []);
+
   const handleDragEnd = async (event: DragEndEvent) => {
     const { active, over } = event;
     if (!over || active.id === over.id) return;
@@ -1817,6 +2033,9 @@ const Tasks = () => {
                           allTags={allTags}
                           assignableUsers={assignableForTask(task)}
                           reorderable={reorderable}
+                          currentUserIri={currentUserIri}
+                          comments={commentsByTask[task["@id"]]}
+                          commentsLoading={loadingCommentsFor.has(task["@id"])}
                           onToggle={handleToggle}
                           onDelete={handleDelete}
                           onTagsChange={handleTagsChange}
@@ -1829,6 +2048,10 @@ const Tasks = () => {
                           onAssigneeAvatarClick={(assignee) =>
                             setAssigneeFilter(assignee["@id"])
                           }
+                          onLoadComments={handleLoadComments}
+                          onCreateComment={handleCreateComment}
+                          onEditComment={handleEditComment}
+                          onDeleteComment={handleDeleteComment}
                         />
                       ))}
                     </Table>


### PR DESCRIPTION
## Summary

Per-task comments threaded into the existing tasks UI. Each task row gains a "Comments (N)" toggle below the description; expanding it surfaces a markdown composer + the comment list.

### Backend
- `Comment` entity (body, author, task, createdAt, updatedAt) with API Platform CRUD.
- **Read access** mirrors the parent task — anyone who can see the task can see its comments. **Write access** is narrower:
  - any task-reader can POST,
  - only the comment author can PATCH,
  - the author OR the task owner OR an admin can DELETE (so a project lead can clean up after a teammate without escalating).
- `CommentAuthorProcessor` stamps `author` from the security context on POST so it can't be spoofed.
- `CommentAccessExtension` scopes Comment queries to comments on tasks the current user can read; cross-task lookups return 404 instead of leaking row existence.
- `updatedAt` bumped via `#[ORM\PreUpdate]` so the PWA can render an "(edited)" affordance without diffing payloads.
- `comment:read` group added to `User.{id, email, givenName, familyName, nickname, personalizedColor, avatarUrls}` so the comment author embeds inline (saves a round-trip per row to render the avatar).

### Frontend
- New `CommentsPanel` component renders the inline thread: avatar + display name + relative timestamp + markdown body. Reuses `MarkdownEditor` (BlockNote) for composer + edits and `MarkdownView` for the read view — no new editor surface to learn.
- Comments lazy-load on first expand and are cached per task IRI in the parent so subsequent toggles are free.
- **Cmd/Ctrl+Enter** posts; the trash icon shows for the author and the task owner (server is the source of truth on the actual rule).

Closes #90.

### Deliberately out of scope (follow-ups)
- **Threaded replies** ([#105](https://github.com/roboparker/Aura/issues/105)) — current panel is flat. Adds `parentComment` + the depth-3 nesting from the original ticket.
- **@mention autocomplete + notifications** ([#106](https://github.com/roboparker/Aura/issues/106)) — wires into the existing `Notification` entity from #82.
- **Live updates via Mercure** ([#107](https://github.com/roboparker/Aura/issues/107)) — collaborator's posts appear without a reload.

## Test plan
- [ ] `cd api && bin/phpunit tests/Api/CommentTest.php` — 15 cases cover auth, author stamping, project-member access, list scoping, edit-by-author-only, delete by author or task owner, body validation.
- [ ] `cd api && bin/phpunit` — full suite still green (TaskTest 54/54, NotificationTest 9/9, UserPreferencesTest 11/11 verified locally).
- [ ] `docker compose exec php php bin/console doctrine:migrations:migrate` runs cleanly; `doctrine:schema:validate` reports in-sync.
- [ ] `cd e2e && npx playwright test comments.spec.js` — 3 scenarios: post→edit→delete; persistence after reload; non-author of someone else's comment doesn't see the edit pencil but task-owner does see delete.
- [ ] On `/tasks`: click "Comment" under any task → panel expands, composer appears. Type a comment, click Post → row appears with avatar + relative time. Edit pencil appears on own comment; trash on own comment + on others' if you own the task.