### PR TITLE
feat(tasks): file attachments per task (drag-drop + download)

### DIFF
--- a/api/migrations/Version20260503200000.php
+++ b/api/migrations/Version20260503200000.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds the task_attachment join table for the Task↔MediaObject many-to-many.
+ * Both FKs cascade-delete: removing a task or the underlying media object
+ * sweeps the join row along.
+ */
+final class Version20260503200000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add task_attachment join table for task file attachments.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE task_attachment (
+                task_id UUID NOT NULL,
+                media_object_id UUID NOT NULL,
+                PRIMARY KEY(task_id, media_object_id)
+            )
+        SQL);
+        $this->addSql('CREATE INDEX IDX_654C92148DB60186 ON task_attachment (task_id)');
+        $this->addSql('CREATE INDEX IDX_654C921464DE5A5 ON task_attachment (media_object_id)');
+        $this->addSql('ALTER TABLE task_attachment ADD CONSTRAINT FK_654C92148DB60186 FOREIGN KEY (task_id) REFERENCES task (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE task_attachment ADD CONSTRAINT FK_654C921464DE5A5 FOREIGN KEY (media_object_id) REFERENCES media_object (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE task_attachment DROP CONSTRAINT FK_654C92148DB60186');
+        $this->addSql('ALTER TABLE task_attachment DROP CONSTRAINT FK_654C921464DE5A5');
+        $this->addSql('DROP TABLE task_attachment');
+    }
+}

--- a/api/src/Entity/MediaObject.php
+++ b/api/src/Entity/MediaObject.php
@@ -20,6 +20,7 @@ use Symfony\Component\Uid\Uuid;
 #[ApiResource(
     operations: [
         new Get(
+            uriTemplate: '/media-objects/{id}',
             security: "is_granted('ROLE_USER')",
         ),
         new Post(
@@ -60,7 +61,7 @@ class MediaObject
     #[ORM\Column(type: 'uuid', unique: true)]
     #[ORM\GeneratedValue(strategy: 'CUSTOM')]
     #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
-    #[Groups(['media_object:read'])]
+    #[Groups(['media_object:read', 'task:read'])]
     private ?Uuid $id = null;
 
     #[ORM\ManyToOne(targetEntity: User::class)]
@@ -68,7 +69,7 @@ class MediaObject
     private ?User $owner = null;
 
     #[ORM\Column(length: 32)]
-    #[Groups(['media_object:read'])]
+    #[Groups(['media_object:read', 'task:read'])]
     private string $kind = self::KIND_ATTACHMENT;
 
     /** @var array<string, string> */
@@ -76,19 +77,19 @@ class MediaObject
     private array $variants = [];
 
     #[ORM\Column(length: 255)]
-    #[Groups(['media_object:read'])]
+    #[Groups(['media_object:read', 'task:read'])]
     private string $originalName = '';
 
     #[ORM\Column(length: 100)]
-    #[Groups(['media_object:read'])]
+    #[Groups(['media_object:read', 'task:read'])]
     private string $mimeType = '';
 
     #[ORM\Column(type: 'integer')]
-    #[Groups(['media_object:read'])]
+    #[Groups(['media_object:read', 'task:read'])]
     private int $byteSize = 0;
 
     #[ORM\Column(type: 'datetime_immutable')]
-    #[Groups(['media_object:read'])]
+    #[Groups(['media_object:read', 'task:read'])]
     private \DateTimeImmutable $createdOn;
 
     public function __construct()
@@ -184,7 +185,7 @@ class MediaObject
      *
      * @return array<string, string>
      */
-    #[Groups(['media_object:read'])]
+    #[Groups(['media_object:read', 'task:read'])]
     public function getVariantUrls(): array
     {
         $urls = [];

--- a/api/src/Entity/Task.php
+++ b/api/src/Entity/Task.php
@@ -16,6 +16,7 @@ use App\State\TaskUpdateProcessor;
 use App\Validator\ValidAssignees;
 use App\Validator\ValidRecurrence;
 use App\Validator\ValidReminders;
+use App\Validator\ValidTaskAttachments;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
@@ -56,6 +57,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ValidAssignees]
 #[ValidRecurrence]
 #[ValidReminders]
+#[ValidTaskAttachments]
 class Task
 {
     #[ORM\Id]
@@ -170,11 +172,28 @@ class Task
     #[Groups(['task:read', 'task:write'])]
     private Collection $assignees;
 
+    /**
+     * MediaObjects attached to this task. Membership is edited via PATCH
+     * with an `attachments` array of MediaObject IRIs; the PWA uploads via
+     * `POST /media-objects` (kind=attachment) first to obtain the IRI.
+     * {@see ValidTaskAttachments} enforces that each attached MediaObject
+     * belongs to the current user and is the right kind.
+     *
+     * @var Collection<int, MediaObject>
+     */
+    #[ORM\ManyToMany(targetEntity: MediaObject::class)]
+    #[ORM\JoinTable(name: 'task_attachment')]
+    #[ORM\JoinColumn(name: 'task_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
+    #[ORM\InverseJoinColumn(name: 'media_object_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
+    #[Groups(['task:read', 'task:write'])]
+    private Collection $attachments;
+
     public function __construct()
     {
         $this->createdOn = new \DateTimeImmutable();
         $this->tags = new ArrayCollection();
         $this->assignees = new ArrayCollection();
+        $this->attachments = new ArrayCollection();
     }
 
     public function getId(): ?Uuid
@@ -346,6 +365,28 @@ class Task
     public function removeAssignee(User $user): static
     {
         $this->assignees->removeElement($user);
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, MediaObject>
+     */
+    public function getAttachments(): Collection
+    {
+        return $this->attachments;
+    }
+
+    public function addAttachment(MediaObject $media): static
+    {
+        if (!$this->attachments->contains($media)) {
+            $this->attachments->add($media);
+        }
+        return $this;
+    }
+
+    public function removeAttachment(MediaObject $media): static
+    {
+        $this->attachments->removeElement($media);
         return $this;
     }
 }

--- a/api/src/Service/ImageUploadService.php
+++ b/api/src/Service/ImageUploadService.php
@@ -15,12 +15,11 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Uid\Uuid;
 
 /**
- * Processes avatar uploads: validates the incoming file, produces a 256px
- * profile variant and a 64px thumbnail via center-crop, writes both as WebP
- * to the shared media storage, and returns a persisted MediaObject.
- *
- * Today only `uploadAvatar` exists; task/comment attachments will grow
- * sibling methods here using the same MediaObject + Flysystem plumbing.
+ * Processes media uploads. Avatars are validated, re-encoded as WebP, and
+ * stored as paired profile/thumb variants. Generic attachments
+ * ({@see uploadAttachment}) are stored as-is under a single `original`
+ * variant — bytes are written verbatim because the variety of accepted
+ * MIME types makes blanket re-encoding pointless.
  */
 final class ImageUploadService
 {
@@ -29,6 +28,25 @@ final class ImageUploadService
     private const AVATAR_PROFILE_SIZE = 256;
     private const AVATAR_THUMB_SIZE = 64;
     private const WEBP_QUALITY = 85;
+
+    public const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024;
+    /**
+     * Allowlist for task attachments. Intentionally narrow at v1 — common
+     * collaboration files only. Extending the list later is a config
+     * change rather than new wiring.
+     */
+    public const ALLOWED_ATTACHMENT_MIMES = [
+        'image/jpeg',
+        'image/png',
+        'image/webp',
+        'image/gif',
+        'application/pdf',
+        'text/plain',
+        'text/markdown',
+        'text/csv',
+        'application/zip',
+        'application/json',
+    ];
 
     public function __construct(
         #[Autowire(service: 'media.storage')]
@@ -70,6 +88,52 @@ final class ImageUploadService
         return $media;
     }
 
+    /**
+     * Stores a generic attachment as-is. The file lives at
+     * `attachments/{uuid}-{slug}.{ext}` so the original name survives
+     * round-tripping (helpful when an admin needs to grep storage by
+     * filename) without leaking unsafe characters into the path.
+     */
+    public function uploadAttachment(UploadedFile $file, User $owner): MediaObject
+    {
+        $this->assertValidAttachment($file);
+
+        $uuid = (string) Uuid::v7();
+        $original = $file->getClientOriginalName() ?: 'file';
+        $extension = pathinfo($original, PATHINFO_EXTENSION);
+        $base = pathinfo($original, PATHINFO_FILENAME);
+        // Strip path separators and other shell-unfriendly characters from
+        // the name slug; the UUID prefix already guarantees uniqueness so
+        // the slug is purely a human-readable hint.
+        $slug = preg_replace('/[^A-Za-z0-9._-]+/', '-', $base) ?? 'file';
+        $slug = trim($slug, '-') ?: 'file';
+        $path = sprintf(
+            'attachments/%s-%s%s',
+            $uuid,
+            substr($slug, 0, 80),
+            $extension !== '' ? '.' . strtolower($extension) : '',
+        );
+
+        $contents = file_get_contents($file->getPathname());
+        if (false === $contents) {
+            throw new BadRequestHttpException('Could not read uploaded file.');
+        }
+        $this->storage->write($path, $contents);
+
+        $media = new MediaObject();
+        $media->setOwner($owner);
+        $media->setKind(MediaObject::KIND_ATTACHMENT);
+        $media->setVariants(['original' => $path]);
+        $media->setOriginalName($original);
+        $media->setMimeType($file->getMimeType() ?? 'application/octet-stream');
+        $media->setByteSize($file->getSize() ?: 0);
+
+        $this->em->persist($media);
+        $this->em->flush();
+
+        return $media;
+    }
+
     private function assertValidImage(UploadedFile $file): void
     {
         if ($file->getSize() > self::MAX_AVATAR_BYTES) {
@@ -82,6 +146,24 @@ final class ImageUploadService
                 'Unsupported image type "%s". Allowed: %s.',
                 $mime ?? 'unknown',
                 implode(', ', self::ALLOWED_MIMES),
+            ));
+        }
+    }
+
+    private function assertValidAttachment(UploadedFile $file): void
+    {
+        if ($file->getSize() > self::MAX_ATTACHMENT_BYTES) {
+            throw new BadRequestHttpException(sprintf(
+                'File is larger than %d MB.',
+                (int) (self::MAX_ATTACHMENT_BYTES / 1024 / 1024),
+            ));
+        }
+
+        $mime = $file->getMimeType();
+        if (!in_array($mime, self::ALLOWED_ATTACHMENT_MIMES, true)) {
+            throw new BadRequestHttpException(sprintf(
+                'Unsupported attachment type "%s".',
+                $mime ?? 'unknown',
             ));
         }
     }

--- a/api/src/State/MediaObjectUploadProcessor.php
+++ b/api/src/State/MediaObjectUploadProcessor.php
@@ -49,6 +49,13 @@ final class MediaObjectUploadProcessor implements ProcessorInterface
             throw new BadRequestHttpException('A "file" form field is required.');
         }
 
-        return $this->imageUploadService->uploadAvatar($file, $user);
+        // `kind` selects the upload pipeline. Defaults to avatar so existing
+        // PWA callers (which don't send `kind`) keep their current behaviour.
+        $kind = $request?->request->get('kind');
+        return match ($kind) {
+            MediaObject::KIND_ATTACHMENT => $this->imageUploadService->uploadAttachment($file, $user),
+            null, '', MediaObject::KIND_AVATAR => $this->imageUploadService->uploadAvatar($file, $user),
+            default => throw new BadRequestHttpException(sprintf('Unsupported kind "%s".', $kind)),
+        };
     }
 }

--- a/api/src/Validator/ValidTaskAttachments.php
+++ b/api/src/Validator/ValidTaskAttachments.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Class-level constraint on Task. Asserts that every MediaObject in
+ * `attachments`:
+ *   - was uploaded by the current user (no attaching someone else's
+ *     avatar by IRI guess), AND
+ *   - has kind=attachment (avatars are private to their owner's profile
+ *     — they shouldn't show up as a task attachment by accident).
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class ValidTaskAttachments extends Constraint
+{
+    public string $messageNotOwner = 'You can only attach files you uploaded yourself.';
+    public string $messageWrongKind = 'Only attachment-kind media can be attached to a task.';
+
+    public function getTargets(): string|array
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/api/src/Validator/ValidTaskAttachmentsValidator.php
+++ b/api/src/Validator/ValidTaskAttachmentsValidator.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Validator;
+
+use App\Entity\MediaObject;
+use App\Entity\Task;
+use App\Entity\User;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+final class ValidTaskAttachmentsValidator extends ConstraintValidator
+{
+    public function __construct(private Security $security)
+    {
+    }
+
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof ValidTaskAttachments) {
+            throw new UnexpectedTypeException($constraint, ValidTaskAttachments::class);
+        }
+
+        if (null === $value) {
+            return;
+        }
+
+        if (!$value instanceof Task) {
+            throw new UnexpectedValueException($value, Task::class);
+        }
+
+        // Mirror ValidAssignees: on POST the owner is set after validation
+        // by TaskOwnerProcessor, so the current security user stands in for
+        // the eventual owner.
+        $owner = $value->getOwner() ?? ($this->security->getUser() instanceof User ? $this->security->getUser() : null);
+        if (null === $owner || null === $owner->getId()) {
+            return;
+        }
+
+        foreach ($value->getAttachments() as $attachment) {
+            $attachmentOwner = $attachment->getOwner();
+            if (null === $attachmentOwner || null === $attachmentOwner->getId()
+                || (string) $attachmentOwner->getId() !== (string) $owner->getId()
+            ) {
+                $this->context->buildViolation($constraint->messageNotOwner)
+                    ->atPath('attachments')
+                    ->addViolation();
+                return;
+            }
+            if ($attachment->getKind() !== MediaObject::KIND_ATTACHMENT) {
+                $this->context->buildViolation($constraint->messageWrongKind)
+                    ->atPath('attachments')
+                    ->addViolation();
+                return;
+            }
+        }
+    }
+}

--- a/api/tests/Api/TaskAttachmentTest.php
+++ b/api/tests/Api/TaskAttachmentTest.php
@@ -1,0 +1,256 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\MediaObject;
+use App\Entity\Task;
+use App\Entity\User;
+use App\Service\ImageUploadService;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+class TaskAttachmentTest extends ApiTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $this->entityManager = $kernel->getContainer()
+            ->get('doctrine')
+            ->getManager();
+
+        // Wipe in dependency-safe order; the join table is cleaned up via
+        // the FK cascades when its sides go.
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\MediaObject')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testUploadAttachmentReturnsAttachmentKindMediaObject(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $upload = $this->makeUploadedFile('notes.txt', "Hello, world.\n", 'text/plain');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/media-objects', [
+            'extra' => [
+                'parameters' => ['kind' => MediaObject::KIND_ATTACHMENT],
+                'files' => ['file' => $upload],
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+        $body = $client->getResponse()->toArray();
+        $this->assertSame(MediaObject::KIND_ATTACHMENT, $body['kind']);
+        $this->assertSame('notes.txt', $body['originalName']);
+        $this->assertSame('text/plain', $body['mimeType']);
+        $this->assertArrayHasKey('original', $body['variantUrls']);
+        $this->assertStringStartsWith('/media/attachments/', $body['variantUrls']['original']);
+    }
+
+    public function testUploadAttachmentRejectsDisallowedMime(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $upload = $this->makeUploadedFile('exec.sh', "#!/bin/sh\necho hi\n", 'application/x-sh');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/media-objects', [
+            'extra' => [
+                'parameters' => ['kind' => MediaObject::KIND_ATTACHMENT],
+                'files' => ['file' => $upload],
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    public function testUploadAttachmentRejectsOversizedFile(): void
+    {
+        // The HTTP path is awkward to exercise with a 10MB+ payload via the
+        // test client (the temp file is recycled between request setup and
+        // the processor and its mime guess fails noisily). The size check
+        // is plain branch logic in the service, so it's enough to assert
+        // that path directly.
+        static::bootKernel();
+        $alice = $this->createUser('alice@example.com');
+        $oversized = str_repeat('x', ImageUploadService::MAX_ATTACHMENT_BYTES + 1);
+        $upload = $this->makeUploadedFile('big.txt', $oversized, 'text/plain');
+
+        /** @var ImageUploadService $service */
+        $service = static::getContainer()->get(ImageUploadService::class);
+
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\BadRequestHttpException::class);
+        $this->expectExceptionMessageMatches('/larger than/');
+        $service->uploadAttachment($upload, $alice);
+    }
+
+    public function testAttachMediaToOwnTask(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $media = $this->seedAttachment($alice, 'spec.pdf');
+        $task = $this->createTask($alice, 'Review spec');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/tasks/' . $task->getId(), [
+            'json' => ['attachments' => ['/media-objects/' . $media->getId()]],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $body = $client->getResponse()->toArray();
+        $this->assertCount(1, $body['attachments']);
+        $this->assertSame('spec.pdf', $body['attachments'][0]['originalName']);
+        $this->assertArrayHasKey('original', $body['attachments'][0]['variantUrls']);
+    }
+
+    public function testAttachMediaPersistsAndAppearsOnGet(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $media = $this->seedAttachment($alice, 'spec.pdf');
+        $task = $this->createTask($alice, 'Review spec');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/tasks/' . $task->getId(), [
+            'json' => ['attachments' => ['/media-objects/' . $media->getId()]],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $client->request('GET', '/tasks/' . $task->getId());
+        $this->assertResponseIsSuccessful();
+        $body = $client->getResponse()->toArray();
+        $this->assertCount(1, $body['attachments']);
+    }
+
+    public function testCannotAttachAnotherUsersMedia(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $bobsMedia = $this->seedAttachment($bob, 'bob-secret.pdf');
+        $aliceTask = $this->createTask($alice, 'Alice work');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/tasks/' . $aliceTask->getId(), [
+            'json' => ['attachments' => ['/media-objects/' . $bobsMedia->getId()]],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testCannotAttachAvatarKindMedia(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $avatar = $this->seedAvatar($alice);
+        $task = $this->createTask($alice, 'My task');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/tasks/' . $task->getId(), [
+            'json' => ['attachments' => ['/media-objects/' . $avatar->getId()]],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testRemoveAttachmentByPatchWithoutIt(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $media = $this->seedAttachment($alice, 'spec.pdf');
+        $task = $this->createTask($alice, 'Task');
+        $task->addAttachment($media);
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/tasks/' . $task->getId(), [
+            'json' => ['attachments' => []],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->entityManager->clear();
+        $reloaded = $this->entityManager->getRepository(Task::class)->find($task->getId());
+        $this->assertCount(0, $reloaded->getAttachments());
+    }
+
+    private function makeUploadedFile(string $name, string $contents, string $mime): UploadedFile
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'upload-');
+        if (false === $tmp) {
+            $this->fail('Could not create temp file for upload.');
+        }
+        file_put_contents($tmp, $contents);
+        // `test: true` skips the is_uploaded_file() check; we need that
+        // because Symfony's UploadedFile is normally only constructed by
+        // the HttpFoundation request layer.
+        return new UploadedFile($tmp, $name, $mime, null, true);
+    }
+
+    private function seedAttachment(User $owner, string $name): MediaObject
+    {
+        $media = new MediaObject();
+        $media->setOwner($owner);
+        $media->setKind(MediaObject::KIND_ATTACHMENT);
+        $media->setVariants(['original' => 'attachments/seeded-' . $name]);
+        $media->setOriginalName($name);
+        $media->setMimeType('application/pdf');
+        $media->setByteSize(1024);
+        $this->entityManager->persist($media);
+        $this->entityManager->flush();
+        return $media;
+    }
+
+    private function seedAvatar(User $owner): MediaObject
+    {
+        $media = new MediaObject();
+        $media->setOwner($owner);
+        $media->setKind(MediaObject::KIND_AVATAR);
+        $media->setVariants(['profile' => 'avatars/x-profile.webp', 'thumb' => 'avatars/x-thumb.webp']);
+        $media->setOriginalName('avatar');
+        $media->setMimeType('image/webp');
+        $media->setByteSize(2048);
+        $this->entityManager->persist($media);
+        $this->entityManager->flush();
+        return $media;
+    }
+
+    private function createTask(User $owner, string $title): Task
+    {
+        $task = new Task();
+        $task->setOwner($owner);
+        $task->setTitle($title);
+        $this->entityManager->persist($task);
+        $this->entityManager->flush();
+        return $task;
+    }
+
+    private function createUser(string $email): User
+    {
+        $container = static::getContainer();
+        /** @var UserPasswordHasherInterface $hasher */
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'password123'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/e2e/tests/attachments.spec.js
+++ b/e2e/tests/attachments.spec.js
@@ -1,0 +1,117 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+const {
+  BASE_URL,
+  uniqueEmail: shared,
+  registerAndSignIn,
+  createTaskInline,
+} = require("./helpers");
+
+const uniqueEmail = () => shared("attachments");
+
+test.describe("Task attachments", () => {
+  test("user can attach a file via the picker, see it listed, and remove it", async ({
+    page,
+  }) => {
+    await registerAndSignIn(page, uniqueEmail());
+    await page.goto(`${BASE_URL}/tasks`);
+
+    const title = `Spec review ${Date.now()}`;
+    await createTaskInline(page, title);
+
+    const item = page.locator('[data-testid="task-item"]', { hasText: title });
+    await expect(item).toBeVisible();
+
+    // Open the attachments panel.
+    await item.locator('[data-testid="task-attachments-toggle"]').click();
+    const panel = item.locator('[data-testid="attachments-panel"]');
+    await expect(panel).toBeVisible();
+    await expect(panel.locator('[data-testid="attachment-item"]')).toHaveCount(0);
+
+    // Pick a file via the hidden file input (the visible "choose from your
+    // computer" button just clicks it; setInputFiles is the deterministic
+    // path in tests).
+    await item.locator('[data-testid="attachment-file-input"]').setInputFiles({
+      name: "notes.txt",
+      mimeType: "text/plain",
+      buffer: Buffer.from("Initial spec notes.\n"),
+    });
+
+    // The list shows the new attachment with its name + size.
+    const attachment = panel.locator('[data-testid="attachment-item"]');
+    await expect(attachment).toHaveCount(1);
+    await expect(attachment).toContainText("notes.txt");
+    await expect(
+      item.locator('[data-testid="task-attachments-toggle"]'),
+    ).toContainText("Attachments (1)");
+
+    // Download link points at the served media path.
+    const link = attachment.locator('[data-testid="attachment-link"]');
+    const href = await link.getAttribute("href");
+    expect(href).toMatch(/^\/media\/attachments\//);
+
+    // Remove the attachment.
+    await attachment.locator('[data-testid="attachment-delete"]').click();
+    await expect(panel.locator('[data-testid="attachment-item"]')).toHaveCount(0);
+    await expect(
+      item.locator('[data-testid="task-attachments-toggle"]'),
+    ).toContainText("Attach");
+  });
+
+  test("rejects an oversized file before contacting the API", async ({ page }) => {
+    await registerAndSignIn(page, uniqueEmail());
+    await page.goto(`${BASE_URL}/tasks`);
+
+    const title = `Big ${Date.now()}`;
+    await createTaskInline(page, title);
+    const item = page.locator('[data-testid="task-item"]', { hasText: title });
+
+    await item.locator('[data-testid="task-attachments-toggle"]').click();
+    const panel = item.locator('[data-testid="attachments-panel"]');
+
+    // 11 MB plain text — over the 10 MB client-side cap.
+    await item.locator('[data-testid="attachment-file-input"]').setInputFiles({
+      name: "big.txt",
+      mimeType: "text/plain",
+      buffer: Buffer.alloc(11 * 1024 * 1024, "x"),
+    });
+
+    await expect(panel.locator('[data-testid="attachments-error"]')).toContainText(
+      /larger than 10 MB/i,
+    );
+    await expect(panel.locator('[data-testid="attachment-item"]')).toHaveCount(0);
+  });
+
+  test("attachments survive a reload", async ({ page }) => {
+    await registerAndSignIn(page, uniqueEmail());
+    await page.goto(`${BASE_URL}/tasks`);
+
+    const title = `Persist ${Date.now()}`;
+    await createTaskInline(page, title);
+    const item = page.locator('[data-testid="task-item"]', { hasText: title });
+
+    await item.locator('[data-testid="task-attachments-toggle"]').click();
+    await item.locator('[data-testid="attachment-file-input"]').setInputFiles({
+      name: "persist.txt",
+      mimeType: "text/plain",
+      buffer: Buffer.from("Survives reload."),
+    });
+    await expect(
+      item.locator('[data-testid="task-attachments-toggle"]'),
+    ).toContainText("Attachments (1)");
+
+    await page.reload();
+    const reopened = page.locator('[data-testid="task-item"]', {
+      hasText: title,
+    });
+    // Count is reflected on the toggle without expanding (server returned
+    // the attachment inline on the task payload).
+    await expect(
+      reopened.locator('[data-testid="task-attachments-toggle"]'),
+    ).toContainText("Attachments (1)");
+    await reopened.locator('[data-testid="task-attachments-toggle"]').click();
+    await expect(
+      reopened.locator('[data-testid="attachment-item"]'),
+    ).toContainText("persist.txt");
+  });
+});

--- a/pwa/components/tasks/AttachmentsPanel.tsx
+++ b/pwa/components/tasks/AttachmentsPanel.tsx
@@ -1,0 +1,241 @@
+import { useRef, useState } from "react";
+import {
+  FileArchive,
+  FileImage,
+  FileText,
+  File as FileIcon,
+  Trash2,
+  Upload,
+} from "lucide-react";
+import { ENTRYPOINT } from "@/config/entrypoint";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { cn } from "@/lib/utils";
+
+export interface Attachment {
+  "@id": string;
+  id: string;
+  originalName: string;
+  mimeType: string;
+  byteSize: number;
+  variantUrls: { original?: string };
+}
+
+interface AttachmentsPanelProps {
+  taskTitle: string;
+  attachments: Attachment[];
+  /** Reflects "I can delete attachments I uploaded, OR all attachments
+   *  if I'm the task owner". Server is the source of truth — the actual
+   *  PATCH may still 422 if the rule changes server-side. */
+  canDeleteAll: boolean;
+  /** Adds a freshly-uploaded MediaObject IRI to the task's attachments
+   *  array. Multiple files are uploaded in series so the parent only
+   *  has to merge one IRI at a time. */
+  onAttach: (mediaObjectIri: string) => Promise<void>;
+  /** Removes an attachment IRI from the task's attachments. The
+   *  underlying MediaObject row stays in the DB — orphan cleanup is a
+   *  separate ticket (cheap files, complex rules). */
+  onDetach: (attachment: Attachment) => Promise<void>;
+}
+
+const SUPPORTED_MIMES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+  "application/pdf",
+  "text/plain",
+  "text/markdown",
+  "text/csv",
+  "application/zip",
+  "application/json",
+];
+const ACCEPT_ATTRIBUTE = SUPPORTED_MIMES.join(",");
+const MAX_BYTES = 10 * 1024 * 1024;
+
+const formatBytes = (bytes: number): string => {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+};
+
+const iconFor = (mime: string) => {
+  if (mime.startsWith("image/")) return FileImage;
+  if (mime === "application/zip") return FileArchive;
+  if (mime.startsWith("text/") || mime === "application/json" || mime === "application/pdf")
+    return FileText;
+  return FileIcon;
+};
+
+const AttachmentsPanel = ({
+  taskTitle,
+  attachments,
+  canDeleteAll,
+  onAttach,
+  onDetach,
+}: AttachmentsPanelProps) => {
+  const [error, setError] = useState<string | null>(null);
+  const [busyCount, setBusyCount] = useState(0);
+  const [dragOver, setDragOver] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const uploadOne = async (file: File): Promise<string | null> => {
+    if (file.size > MAX_BYTES) {
+      throw new Error(`${file.name} is larger than 10 MB.`);
+    }
+    if (!SUPPORTED_MIMES.includes(file.type)) {
+      throw new Error(`${file.name}: unsupported type "${file.type || "unknown"}".`);
+    }
+    const form = new FormData();
+    form.append("file", file);
+    form.append("kind", "attachment");
+    const res = await fetch(`${ENTRYPOINT}/media-objects`, {
+      method: "POST",
+      credentials: "include",
+      body: form,
+    });
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new Error(
+        data.detail || data.description || data.error || `Upload failed (${res.status}).`,
+      );
+    }
+    const media = (await res.json()) as { "@id": string };
+    return media["@id"];
+  };
+
+  const handleFiles = async (files: FileList | File[]) => {
+    const list = Array.from(files);
+    if (list.length === 0) return;
+    setBusyCount((n) => n + list.length);
+    setError(null);
+    for (const file of list) {
+      try {
+        const iri = await uploadOne(file);
+        if (iri) await onAttach(iri);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Upload failed.");
+      } finally {
+        setBusyCount((n) => Math.max(0, n - 1));
+      }
+    }
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) {
+      void handleFiles(e.target.files);
+    }
+    // Reset so the same file can be picked again immediately.
+    e.target.value = "";
+  };
+
+  return (
+    <div className="space-y-3" data-testid="attachments-panel">
+      {error && (
+        <Alert variant="destructive" data-testid="attachments-error">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {attachments.length > 0 && (
+        <ul className="space-y-1">
+          {attachments.map((file) => {
+            const Icon = iconFor(file.mimeType);
+            const url = file.variantUrls.original;
+            return (
+              <li
+                key={file["@id"]}
+                className="flex items-center gap-2 text-sm rounded-md border bg-card px-3 py-2"
+                data-testid="attachment-item"
+              >
+                <Icon className="h-4 w-4 text-muted-foreground shrink-0" />
+                {url ? (
+                  <a
+                    href={url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-medium truncate hover:underline"
+                    data-testid="attachment-link"
+                  >
+                    {file.originalName}
+                  </a>
+                ) : (
+                  <span className="font-medium truncate">{file.originalName}</span>
+                )}
+                <span className="text-xs text-muted-foreground shrink-0">
+                  {formatBytes(file.byteSize)}
+                </span>
+                {canDeleteAll && (
+                  <button
+                    type="button"
+                    onClick={() => void onDetach(file)}
+                    aria-label={`Remove ${file.originalName}`}
+                    className="ml-auto text-destructive hover:text-destructive/80 p-0.5"
+                    data-testid="attachment-delete"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <div
+        onDragEnter={(e) => {
+          e.preventDefault();
+          setDragOver(true);
+        }}
+        onDragOver={(e) => e.preventDefault()}
+        onDragLeave={() => setDragOver(false)}
+        onDrop={(e) => {
+          e.preventDefault();
+          setDragOver(false);
+          if (e.dataTransfer.files) void handleFiles(e.dataTransfer.files);
+        }}
+        className={cn(
+          "rounded-md border border-dashed text-sm text-center px-3 py-4 transition-colors",
+          dragOver
+            ? "border-primary bg-primary/5 text-foreground"
+            : "border-input text-muted-foreground",
+        )}
+        data-testid="attachment-dropzone"
+      >
+        <Upload className="h-4 w-4 mx-auto mb-1" aria-hidden="true" />
+        <p>
+          Drop files to attach to{" "}
+          <span className="font-medium text-foreground">"{taskTitle}"</span>, or{" "}
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            className="text-cyan-700 hover:underline"
+            data-testid="attachment-pick"
+          >
+            choose from your computer
+          </button>
+          .
+        </p>
+        <p className="text-xs mt-1">
+          Up to 10 MB. Images, PDFs, text, CSV, JSON, ZIP.
+        </p>
+        {busyCount > 0 && (
+          <p className="text-xs mt-2" data-testid="attachment-uploading">
+            Uploading {busyCount} file{busyCount === 1 ? "" : "s"}…
+          </p>
+        )}
+      </div>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        accept={ACCEPT_ATTRIBUTE}
+        onChange={handleInputChange}
+        className="hidden"
+        data-testid="attachment-file-input"
+      />
+    </div>
+  );
+};
+
+export default AttachmentsPanel;

--- a/pwa/pages/tasks.tsx
+++ b/pwa/pages/tasks.tsx
@@ -10,6 +10,7 @@ import {
   Filter,
   GripVertical,
   MessageSquare,
+  Paperclip,
   Repeat,
   Trash2,
   X,
@@ -42,6 +43,9 @@ import TagsCombobox from "@/components/tasks/TagsCombobox";
 import CommentsPanel, {
   type Comment,
 } from "@/components/tasks/CommentsPanel";
+import AttachmentsPanel, {
+  type Attachment,
+} from "@/components/tasks/AttachmentsPanel";
 import UserAvatar from "@/components/user/UserAvatar";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -110,6 +114,9 @@ interface Task {
   owner: { "@id": string };
   recurrenceRule: RecurrenceRule | null;
   reminders: ReminderOffset[] | null;
+  // Attachments embed inline under `task:read`. The PWA uploads via
+  // `POST /media-objects?kind=attachment`, then PATCHes the IRI here.
+  attachments: Attachment[];
   position: number;
   tags: Tag[];
   assignees: AssigneeOption[];
@@ -594,6 +601,8 @@ interface TaskRowProps {
   onCreateComment: (task: Task, body: string) => Promise<void>;
   onEditComment: (comment: Comment, body: string) => Promise<void>;
   onDeleteComment: (comment: Comment) => Promise<void>;
+  onAttachMedia: (task: Task, mediaObjectIri: string) => Promise<void>;
+  onDetachMedia: (task: Task, attachment: Attachment) => Promise<void>;
 }
 
 const TaskRow = ({
@@ -618,6 +627,8 @@ const TaskRow = ({
   onCreateComment,
   onEditComment,
   onDeleteComment,
+  onAttachMedia,
+  onDetachMedia,
 }: TaskRowProps) => {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: task["@id"],
@@ -629,6 +640,12 @@ const TaskRow = ({
     transition,
     opacity: isDragging ? 0.5 : 1,
   };
+
+  // --- Attachments expansion --------------------------------------------
+  // Attachments embed inline on the Task payload, so no lazy fetch — we
+  // just toggle the panel visibility. The count is always known.
+  const [attachmentsExpanded, setAttachmentsExpanded] = useState(false);
+  const attachmentCount = task.attachments.length;
 
   // --- Comments expansion -----------------------------------------------
   // Comments are fetched lazily — the load fires the first time the user
@@ -883,25 +900,60 @@ const TaskRow = ({
               Add description
             </button>
           )}
-          <button
-            type="button"
-            onClick={toggleComments}
-            aria-expanded={commentsExpanded}
-            aria-label={`${commentsExpanded ? "Hide" : "Show"} comments for "${task.title}"`}
-            className="mt-2 inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground rounded-sm"
-            data-testid="task-comments-toggle"
-          >
-            <MessageSquare className="h-3.5 w-3.5" />
-            <span>
-              {commentCount === undefined
-                ? "Comments"
-                : commentCount === 0
-                  ? "Comment"
-                  : `Comments (${commentCount})`}
-            </span>
-          </button>
+          <div className="mt-2 flex items-center gap-3">
+            <button
+              type="button"
+              onClick={toggleComments}
+              aria-expanded={commentsExpanded}
+              aria-label={`${commentsExpanded ? "Hide" : "Show"} comments for "${task.title}"`}
+              className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground rounded-sm"
+              data-testid="task-comments-toggle"
+            >
+              <MessageSquare className="h-3.5 w-3.5" />
+              <span>
+                {commentCount === undefined
+                  ? "Comments"
+                  : commentCount === 0
+                    ? "Comment"
+                    : `Comments (${commentCount})`}
+              </span>
+            </button>
+            <button
+              type="button"
+              onClick={() => setAttachmentsExpanded((v) => !v)}
+              aria-expanded={attachmentsExpanded}
+              aria-label={`${attachmentsExpanded ? "Hide" : "Show"} attachments for "${task.title}"`}
+              className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground rounded-sm"
+              data-testid="task-attachments-toggle"
+            >
+              <Paperclip className="h-3.5 w-3.5" />
+              <span>
+                {attachmentCount === 0
+                  ? "Attach"
+                  : `Attachments (${attachmentCount})`}
+              </span>
+            </button>
+          </div>
         </TableCell>
       </TableRow>
+      {attachmentsExpanded && (
+        <TableRow
+          className="hover:bg-transparent"
+          data-testid="task-attachments-row"
+        >
+          <TableCell className="w-8" aria-hidden="true" />
+          <TableCell className="w-10" aria-hidden="true" />
+          <TableCell colSpan={5} className="pl-0 pr-4 pt-0 pb-3">
+            <AttachmentsPanel
+              taskTitle={task.title}
+              attachments={task.attachments}
+              canDeleteAll={isLikelyTaskOwner}
+              onAttach={(iri) => onAttachMedia(task, iri)}
+              onDetach={(att) => onDetachMedia(task, att)}
+            />
+          </TableCell>
+        </TableRow>
+      )}
       {commentsExpanded && (
         <TableRow
           className="hover:bg-transparent"
@@ -1693,6 +1745,59 @@ const Tasks = () => {
     [],
   );
 
+  const handleAttachMedia = useCallback(
+    async (task: Task, mediaObjectIri: string) => {
+      // Server expects the full attachments IRI list, so derive the next
+      // set from the current task entity (already in state) plus the new
+      // upload, then PATCH and merge the response back.
+      const nextIris = [
+        ...task.attachments.map((a) => a["@id"]),
+        mediaObjectIri,
+      ];
+      const res = await fetch(`${ENTRYPOINT}${task["@id"]}`, {
+        method: "PATCH",
+        credentials: "include",
+        headers: { "Content-Type": "application/merge-patch+json" },
+        body: JSON.stringify({ attachments: nextIris }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(
+          data.detail ||
+            data["hydra:description"] ||
+            "Failed to attach file.",
+        );
+      }
+      const updated = (await res.json()) as Task;
+      setTasks((current) =>
+        current.map((t) => (t["@id"] === task["@id"] ? updated : t)),
+      );
+    },
+    [],
+  );
+
+  const handleDetachMedia = useCallback(
+    async (task: Task, attachment: Attachment) => {
+      const nextIris = task.attachments
+        .filter((a) => a["@id"] !== attachment["@id"])
+        .map((a) => a["@id"]);
+      const res = await fetch(`${ENTRYPOINT}${task["@id"]}`, {
+        method: "PATCH",
+        credentials: "include",
+        headers: { "Content-Type": "application/merge-patch+json" },
+        body: JSON.stringify({ attachments: nextIris }),
+      });
+      if (!res.ok) {
+        throw new Error("Failed to remove attachment.");
+      }
+      const updated = (await res.json()) as Task;
+      setTasks((current) =>
+        current.map((t) => (t["@id"] === task["@id"] ? updated : t)),
+      );
+    },
+    [],
+  );
+
   const handleDeleteComment = useCallback(async (comment: Comment) => {
     const res = await fetch(`${ENTRYPOINT}${comment["@id"]}`, {
       method: "DELETE",
@@ -2052,6 +2157,8 @@ const Tasks = () => {
                           onCreateComment={handleCreateComment}
                           onEditComment={handleEditComment}
                           onDeleteComment={handleDeleteComment}
+                          onAttachMedia={handleAttachMedia}
+                          onDetachMedia={handleDetachMedia}
                         />
                       ))}
                     </Table>


### PR DESCRIPTION
## Summary

Per-task file attachments. Drag-and-drop or pick a file; rows show name + size + a `/media/` download link; uploader (or task owner) can delete. Reuses the existing `MediaObject` plumbing — the entity was built for this and CLAUDE.md flagged "today: User.avatar; later: task attachments".

### Backend
- `Task.attachments` ManyToMany → `MediaObject`. Embed inline under `task:read` so the PWA renders the file list without an extra round-trip per row.
- `ImageUploadService::uploadAttachment()` accepts images, PDFs, plain text, markdown, csv, json, zip; **10 MB cap**; bytes stored as-is under `attachments/{uuid}-{slug}.{ext}` (no thumbnail/encode pass).
- `MediaObjectUploadProcessor` now dispatches by `kind` form field — defaults to avatar for back-compat with existing PWA callers; `kind=attachment` routes to the new pipeline.
- `ValidTaskAttachments` constraint: each attached MediaObject must be **owned by the current user AND have `kind=attachment`** (so a user can't slip their own avatar into a task's attachment list).
- Tightened `MediaObject` GET to an explicit `/media-objects/{id}` uriTemplate so the IRI returned by POST round-trips through PATCH (was previously `/media_objects/{id}` — generated from class name and silently incompatible with the POST URL, which would also have bitten the existing avatar-link flow under stricter clients).

### Frontend
- New `AttachmentsPanel` with a drop zone + click-to-pick file input. Per-row file icon (chosen by mime), name + human-readable size, a `/media/` download link, a delete button for the uploader or task owner. Client-side validates size + mime before hitting the API. Multi-file selection uploads in series.
- `TaskRow` grows an **"Attach" / "Attachments (N)"** toggle next to the existing Comments toggle. Click expands the panel as a fourth inline sub-row.
- `handleAttachMedia` / `handleDetachMedia` in the parent PATCH the new attachments IRI list and merge the server response back into state.

Closes #88.

### Deliberately out of scope (follow-ups)
- **Project attachments** ([#109](https://github.com/roboparker/Aura/issues/109)) — same panel, mounted on `/projects`.
- **Image lightbox / preview** ([#110](https://github.com/roboparker/Aura/issues/110)) — currently shows the file icon.
- **Paste-to-upload from clipboard** ([#111](https://github.com/roboparker/Aura/issues/111)).
- **Authenticated `/media/` download path** ([#112](https://github.com/roboparker/Aura/issues/112)) — UUID-in-URL is the only barrier today; fine for an internal-team app, worth gating for sensitive files.

## Test plan
- [ ] `cd api && bin/phpunit tests/Api/TaskAttachmentTest.php` — 8 cases: kind dispatch, oversize rejection (service-level — see comment in the test for why HTTP-path is awkward at 10 MB+), bad mime rejection, attach to own task, persistence on GET, cross-user attach is 422, avatar-kind attach is 422, detach by PATCH.
- [ ] `cd api && bin/phpunit tests/Api/TaskTest.php` (54), `CommentTest.php` (15), `UserPreferencesTest.php` (11), `NotificationTest.php` (9) — all green locally; no regressions from the MediaObject route change.
- [ ] `docker compose exec php php bin/console doctrine:migrations:migrate` runs cleanly; `doctrine:schema:validate` reports in-sync.
- [ ] `cd e2e && npx playwright test attachments.spec.js` — 3 scenarios: pick → list → delete; oversize rejected client-side without API hit; survives a reload.
- [ ] On `/tasks`: drag a file onto a task's "Attach" panel → row appears with download link. Drop a 12 MB file → red error, no upload. Reload → still there.