### PR TITLE
feat(pwa): /dev/components living docs for shared components

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ npx playwright test
 - Use Tailwind CSS for styling. Reference design tokens via the shadcn variables (`bg-background`, `text-muted-foreground`, `border-input`, `text-destructive`, etc.) where possible. shadcn tokens use the canonical neutral baseColor (no brand override yet); brand cyan still lives in raw utilities (`bg-cyan-700`, `text-cyan-700`) on the navbar and link elements.
 - Forms backed by Formik should use `FormikField` from `pwa/components/ui/formik-field.tsx` rather than hand-rolled `<Field>` + `<label>` + `<ErrorMessage>` blocks.
 - Long-form description fields use `MarkdownEditor` for input and `MarkdownView` for rendering (both from `pwa/components/editor/`). Content is stored as markdown in the API's `TEXT` columns.
+- **Developer component docs**: every reusable component in `pwa/components/ui/` and the shared pieces under `pwa/components/{editor,user,common}/` has a documentation page at `pwa/pages/dev/components/<slug>.tsx`, indexed by `pwa/components/dev/registry.ts`. When you add a new reusable component, rename one, change a prop's public shape, or add a new variant, update the matching docs page (live example + source snippet via the `<CodeBlock />` helper) and the registry entry in the same PR. The index lives at `/dev/components`.
 
 ### E2E Tests
 - Shared helpers (auth + markdown editor) live in `e2e/tests/helpers.js` — prefer them over duplicating `registerAndSignIn` per spec.

--- a/pwa/components/dev/CodeBlock.tsx
+++ b/pwa/components/dev/CodeBlock.tsx
@@ -1,0 +1,60 @@
+import { useState } from "react";
+import { Highlight, themes, type Language } from "prism-react-renderer";
+import { useTheme } from "next-themes";
+import { Check, Copy } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type CodeBlockProps = {
+  code: string;
+  language?: Language;
+  className?: string;
+};
+
+const CodeBlock = ({ code, language = "tsx", className }: CodeBlockProps) => {
+  const { resolvedTheme } = useTheme();
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(code);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1500);
+  };
+
+  // `themes` is from prism-react-renderer; pick palette to match active mode.
+  const prismTheme = resolvedTheme === "dark" ? themes.vsDark : themes.github;
+
+  return (
+    <div className={cn("group relative overflow-hidden rounded-md border border-input bg-muted/30", className)}>
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label="Copy code"
+        className="absolute right-2 top-2 z-10 inline-flex h-7 w-7 items-center justify-center rounded-sm border border-input bg-background/80 text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100"
+      >
+        {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+      </button>
+      <Highlight code={code.trim()} language={language} theme={prismTheme}>
+        {({ className: hlClass, style, tokens, getLineProps, getTokenProps }) => (
+          <pre
+            className={cn(hlClass, "overflow-x-auto p-4 text-xs leading-relaxed")}
+            style={style}
+          >
+            {tokens.map((line, i) => {
+              const lineProps = getLineProps({ line });
+              return (
+                <div key={i} {...lineProps}>
+                  {line.map((token, key) => {
+                    const tokenProps = getTokenProps({ token });
+                    return <span key={key} {...tokenProps} />;
+                  })}
+                </div>
+              );
+            })}
+          </pre>
+        )}
+      </Highlight>
+    </div>
+  );
+};
+
+export default CodeBlock;

--- a/pwa/components/dev/ComponentDoc.tsx
+++ b/pwa/components/dev/ComponentDoc.tsx
@@ -1,0 +1,61 @@
+import Head from "next/head";
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { ArrowLeft } from "lucide-react";
+import { Separator } from "@/components/ui/separator";
+import CodeBlock from "./CodeBlock";
+
+type Example = {
+  title?: string;
+  description?: string;
+  code: string;
+  preview: ReactNode;
+};
+
+type ComponentDocProps = {
+  name: string;
+  description: string;
+  importPath: string;
+  examples: Example[];
+};
+
+const ComponentDoc = ({ name, description, importPath, examples }: ComponentDocProps) => (
+  <>
+    <Head>
+      <title>{`${name} · Dev Components`}</title>
+    </Head>
+    <main className="mx-auto max-w-4xl px-6 py-10">
+      <Link
+        href="/dev/components"
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft className="h-3.5 w-3.5" />
+        All components
+      </Link>
+      <header className="mt-4 mb-8">
+        <h1 className="text-3xl font-semibold tracking-tight">{name}</h1>
+        <p className="mt-2 text-muted-foreground">{description}</p>
+        <code className="mt-3 inline-block rounded-sm bg-muted px-2 py-1 font-mono text-xs">
+          {importPath}
+        </code>
+      </header>
+      <Separator className="mb-8" />
+      <div className="space-y-10">
+        {examples.map((example, i) => (
+          <section key={i}>
+            {example.title && <h2 className="mb-1 text-lg font-medium">{example.title}</h2>}
+            {example.description && (
+              <p className="mb-4 text-sm text-muted-foreground">{example.description}</p>
+            )}
+            <div className="rounded-md border border-input bg-background p-6">
+              {example.preview}
+            </div>
+            <CodeBlock className="mt-3" code={example.code} />
+          </section>
+        ))}
+      </div>
+    </main>
+  </>
+);
+
+export default ComponentDoc;

--- a/pwa/components/dev/registry.ts
+++ b/pwa/components/dev/registry.ts
@@ -1,0 +1,35 @@
+export type RegistryEntry = {
+  slug: string;
+  name: string;
+  category: "Primitive" | "Form" | "Overlay" | "Data" | "Editor" | "User" | "Theme";
+  description: string;
+};
+
+// Single source of truth for the /dev/components index. Keep this list in
+// sync with the per-slug pages under pages/dev/components/.
+export const componentRegistry: RegistryEntry[] = [
+  { slug: "alert", name: "Alert", category: "Primitive", description: "Inline message panel for notices and errors." },
+  { slug: "badge", name: "Badge", category: "Primitive", description: "Small label for statuses and counts." },
+  { slug: "button", name: "Button", category: "Primitive", description: "Variants, sizes, and icon-only buttons." },
+  { slug: "calendar", name: "Calendar", category: "Form", description: "Date picker built on react-day-picker." },
+  { slug: "card", name: "Card", category: "Primitive", description: "Surface container with header, content, and footer slots." },
+  { slug: "checkbox", name: "Checkbox", category: "Form", description: "Boolean input with controlled and indeterminate states." },
+  { slug: "combobox", name: "Combobox", category: "Form", description: "Searchable select with multi-value chips." },
+  { slug: "command", name: "Command", category: "Overlay", description: "Command palette built on cmdk." },
+  { slug: "dialog", name: "Dialog", category: "Overlay", description: "Modal dialog with title, body, and actions." },
+  { slug: "dropdown-menu", name: "Dropdown Menu", category: "Overlay", description: "Anchored menu with items, separators, and submenus." },
+  { slug: "formik-field", name: "FormikField", category: "Form", description: "Formik-aware label + input + error wrapper." },
+  { slug: "input", name: "Input", category: "Form", description: "Single-line text input." },
+  { slug: "input-group", name: "InputGroup", category: "Form", description: "Compose an input with leading/trailing addons." },
+  { slug: "label", name: "Label", category: "Form", description: "Accessible label associated to a form control." },
+  { slug: "popover", name: "Popover", category: "Overlay", description: "Floating content anchored to a trigger." },
+  { slug: "separator", name: "Separator", category: "Primitive", description: "Horizontal or vertical divider." },
+  { slug: "sheet", name: "Sheet", category: "Overlay", description: "Side-anchored drawer." },
+  { slug: "table", name: "Table", category: "Data", description: "Styled HTML table primitives." },
+  { slug: "tabs", name: "Tabs", category: "Primitive", description: "Tab list + panels." },
+  { slug: "textarea", name: "Textarea", category: "Form", description: "Multi-line text input." },
+  { slug: "markdown-editor", name: "MarkdownEditor", category: "Editor", description: "BlockNote-backed WYSIWYG markdown editor." },
+  { slug: "markdown-view", name: "MarkdownView", category: "Editor", description: "Read-only markdown renderer." },
+  { slug: "user-avatar", name: "UserAvatar", category: "User", description: "Avatar with image fallback to personalized initials." },
+  { slug: "theme-toggle", name: "ThemeToggle", category: "Theme", description: "Dark/light/system theme switcher." },
+];

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -36,6 +36,7 @@
     "next": "^16.2.4",
     "next-themes": "^0.4.6",
     "postcss": "^8.5.13",
+    "prism-react-renderer": "^2.4.1",
     "radix-ui": "^1.4.3",
     "react": "^19.2.5",
     "react-day-picker": "^9.14.0",

--- a/pwa/pages/dev/components/alert.tsx
+++ b/pwa/pages/dev/components/alert.tsx
@@ -1,0 +1,46 @@
+import { Terminal, AlertCircle } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const AlertPage = () => (
+  <ComponentDoc
+    name="Alert"
+    description="Inline message panel for notices and errors. Composed from Alert, AlertTitle, and AlertDescription."
+    importPath={`import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";`}
+    examples={[
+      {
+        title: "Default",
+        code: `<Alert>
+  <Terminal className="h-4 w-4" />
+  <AlertTitle>Heads up!</AlertTitle>
+  <AlertDescription>You can save changes with ⌘+S at any time.</AlertDescription>
+</Alert>`,
+        preview: (
+          <Alert>
+            <Terminal className="h-4 w-4" />
+            <AlertTitle>Heads up!</AlertTitle>
+            <AlertDescription>You can save changes with ⌘+S at any time.</AlertDescription>
+          </Alert>
+        ),
+      },
+      {
+        title: "Destructive",
+        description: "Use for errors and irreversible warnings.",
+        code: `<Alert variant="destructive">
+  <AlertCircle className="h-4 w-4" />
+  <AlertTitle>Could not save</AlertTitle>
+  <AlertDescription>The server returned a 500. Please retry.</AlertDescription>
+</Alert>`,
+        preview: (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Could not save</AlertTitle>
+            <AlertDescription>The server returned a 500. Please retry.</AlertDescription>
+          </Alert>
+        ),
+      },
+    ]}
+  />
+);
+
+export default AlertPage;

--- a/pwa/pages/dev/components/badge.tsx
+++ b/pwa/pages/dev/components/badge.tsx
@@ -1,0 +1,29 @@
+import { Badge } from "@/components/ui/badge";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const BadgePage = () => (
+  <ComponentDoc
+    name="Badge"
+    description="Small label for statuses, counts, and metadata."
+    importPath={`import { Badge } from "@/components/ui/badge";`}
+    examples={[
+      {
+        title: "Variants",
+        code: `<Badge>Default</Badge>
+<Badge variant="secondary">Secondary</Badge>
+<Badge variant="destructive">Destructive</Badge>
+<Badge variant="outline">Outline</Badge>`,
+        preview: (
+          <div className="flex flex-wrap gap-2">
+            <Badge>Default</Badge>
+            <Badge variant="secondary">Secondary</Badge>
+            <Badge variant="destructive">Destructive</Badge>
+            <Badge variant="outline">Outline</Badge>
+          </div>
+        ),
+      },
+    ]}
+  />
+);
+
+export default BadgePage;

--- a/pwa/pages/dev/components/button.tsx
+++ b/pwa/pages/dev/components/button.tsx
@@ -1,0 +1,54 @@
+import { Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const ButtonPage = () => (
+  <ComponentDoc
+    name="Button"
+    description="Variants and sizes built on class-variance-authority. Pass `asChild` to render the styles on an inner element (e.g. <Link>)."
+    importPath={`import { Button } from "@/components/ui/button";`}
+    examples={[
+      {
+        title: "Variants",
+        code: `<Button>Default</Button>
+<Button variant="secondary">Secondary</Button>
+<Button variant="outline">Outline</Button>
+<Button variant="ghost">Ghost</Button>
+<Button variant="destructive">Destructive</Button>
+<Button variant="link">Link</Button>`,
+        preview: (
+          <div className="flex flex-wrap gap-2">
+            <Button>Default</Button>
+            <Button variant="secondary">Secondary</Button>
+            <Button variant="outline">Outline</Button>
+            <Button variant="ghost">Ghost</Button>
+            <Button variant="destructive">Destructive</Button>
+            <Button variant="link">Link</Button>
+          </div>
+        ),
+      },
+      {
+        title: "Sizes",
+        code: `<Button size="sm">Small</Button>
+<Button>Default</Button>
+<Button size="lg">Large</Button>
+<Button size="icon" aria-label="Add"><Plus /></Button>`,
+        preview: (
+          <div className="flex flex-wrap items-center gap-2">
+            <Button size="sm">Small</Button>
+            <Button>Default</Button>
+            <Button size="lg">Large</Button>
+            <Button size="icon" aria-label="Add"><Plus /></Button>
+          </div>
+        ),
+      },
+      {
+        title: "Disabled",
+        code: `<Button disabled>Saving…</Button>`,
+        preview: <Button disabled>Saving…</Button>,
+      },
+    ]}
+  />
+);
+
+export default ButtonPage;

--- a/pwa/pages/dev/components/calendar.tsx
+++ b/pwa/pages/dev/components/calendar.tsx
@@ -1,0 +1,27 @@
+import { useState } from "react";
+import { Calendar } from "@/components/ui/calendar";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const SingleDate = () => {
+  const [date, setDate] = useState<Date | undefined>(new Date());
+  return <Calendar mode="single" selected={date} onSelect={setDate} />;
+};
+
+const CalendarPage = () => (
+  <ComponentDoc
+    name="Calendar"
+    description="Date picker built on react-day-picker. Most consumers pair this with Popover to make a date input."
+    importPath={`import { Calendar } from "@/components/ui/calendar";`}
+    examples={[
+      {
+        title: "Single date",
+        code: `const [date, setDate] = useState<Date | undefined>(new Date());
+
+<Calendar mode="single" selected={date} onSelect={setDate} />`,
+        preview: <SingleDate />,
+      },
+    ]}
+  />
+);
+
+export default CalendarPage;

--- a/pwa/pages/dev/components/card.tsx
+++ b/pwa/pages/dev/components/card.tsx
@@ -1,0 +1,55 @@
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const CardPage = () => (
+  <ComponentDoc
+    name="Card"
+    description="Surface container with optional header, content, and footer slots."
+    importPath={`import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from "@/components/ui/card";`}
+    examples={[
+      {
+        title: "With header, content, and footer",
+        code: `<Card className="max-w-sm">
+  <CardHeader>
+    <CardTitle>Project moonshot</CardTitle>
+    <CardDescription>Q3 launch readiness</CardDescription>
+  </CardHeader>
+  <CardContent>
+    <p className="text-sm text-muted-foreground">
+      Track tasks, owners, and timelines from one place.
+    </p>
+  </CardContent>
+  <CardFooter className="justify-end">
+    <Button size="sm">Open</Button>
+  </CardFooter>
+</Card>`,
+        preview: (
+          <Card className="max-w-sm">
+            <CardHeader>
+              <CardTitle>Project moonshot</CardTitle>
+              <CardDescription>Q3 launch readiness</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">
+                Track tasks, owners, and timelines from one place.
+              </p>
+            </CardContent>
+            <CardFooter className="justify-end">
+              <Button size="sm">Open</Button>
+            </CardFooter>
+          </Card>
+        ),
+      },
+    ]}
+  />
+);
+
+export default CardPage;

--- a/pwa/pages/dev/components/checkbox.tsx
+++ b/pwa/pages/dev/components/checkbox.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const Controlled = () => {
+  const [checked, setChecked] = useState(true);
+  return (
+    <div className="flex items-center gap-2">
+      <Checkbox id="subscribe" checked={checked} onCheckedChange={(v) => setChecked(Boolean(v))} />
+      <Label htmlFor="subscribe">Email me about updates</Label>
+    </div>
+  );
+};
+
+const CheckboxPage = () => (
+  <ComponentDoc
+    name="Checkbox"
+    description="Boolean input built on @radix-ui/react-checkbox. Pair with a Label using shared `id`/`htmlFor`."
+    importPath={`import { Checkbox } from "@/components/ui/checkbox";`}
+    examples={[
+      {
+        title: "Controlled",
+        code: `const [checked, setChecked] = useState(true);
+
+<div className="flex items-center gap-2">
+  <Checkbox
+    id="subscribe"
+    checked={checked}
+    onCheckedChange={(v) => setChecked(Boolean(v))}
+  />
+  <Label htmlFor="subscribe">Email me about updates</Label>
+</div>`,
+        preview: <Controlled />,
+      },
+      {
+        title: "Disabled",
+        code: `<Checkbox disabled />`,
+        preview: <Checkbox disabled />,
+      },
+    ]}
+  />
+);
+
+export default CheckboxPage;

--- a/pwa/pages/dev/components/combobox.tsx
+++ b/pwa/pages/dev/components/combobox.tsx
@@ -1,0 +1,81 @@
+import { useState } from "react";
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+} from "@/components/ui/combobox";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const fruits = [
+  { id: "apple", label: "Apple" },
+  { id: "banana", label: "Banana" },
+  { id: "cherry", label: "Cherry" },
+  { id: "date", label: "Date" },
+];
+
+type Fruit = (typeof fruits)[number];
+
+const SingleSelect = () => {
+  const [value, setValue] = useState<Fruit | null>(null);
+  return (
+    <Combobox<Fruit, false>
+      items={fruits}
+      value={value}
+      onValueChange={setValue}
+      itemToStringLabel={(f) => f.label}
+      itemToStringValue={(f) => f.id}
+    >
+      <ComboboxInput placeholder="Pick a fruit…" />
+      <ComboboxContent>
+        <ComboboxEmpty>No matches.</ComboboxEmpty>
+        <ComboboxList>
+          {(fruit: Fruit) => (
+            <ComboboxItem key={fruit.id} value={fruit}>
+              {fruit.label}
+            </ComboboxItem>
+          )}
+        </ComboboxList>
+      </ComboboxContent>
+    </Combobox>
+  );
+};
+
+const ComboboxPage = () => (
+  <ComponentDoc
+    name="Combobox"
+    description="Searchable select built on @base-ui/react. Pass `multiple` for chip-style multi-select. See pwa/components/tasks/TagsCombobox.tsx for a real-world chips example."
+    importPath={`import { Combobox, ComboboxInput, ComboboxContent, ComboboxList, ComboboxItem, ComboboxEmpty } from "@/components/ui/combobox";`}
+    examples={[
+      {
+        title: "Single-select",
+        code: `const [value, setValue] = useState<Fruit | null>(null);
+
+<Combobox<Fruit, false>
+  items={fruits}
+  value={value}
+  onValueChange={setValue}
+  itemToStringLabel={(f) => f.label}
+  itemToStringValue={(f) => f.id}
+>
+  <ComboboxInput placeholder="Pick a fruit…" />
+  <ComboboxContent>
+    <ComboboxEmpty>No matches.</ComboboxEmpty>
+    <ComboboxList>
+      {(fruit: Fruit) => (
+        <ComboboxItem key={fruit.id} value={fruit}>
+          {fruit.label}
+        </ComboboxItem>
+      )}
+    </ComboboxList>
+  </ComboboxContent>
+</Combobox>`,
+        preview: <SingleSelect />,
+      },
+    ]}
+  />
+);
+
+export default ComboboxPage;

--- a/pwa/pages/dev/components/command.tsx
+++ b/pwa/pages/dev/components/command.tsx
@@ -1,0 +1,58 @@
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+  CommandShortcut,
+} from "@/components/ui/command";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const CommandPage = () => (
+  <ComponentDoc
+    name="Command"
+    description="Command palette built on cmdk. Wrap with Dialog (or use CommandDialog) to make it modal."
+    importPath={`import { Command, CommandInput, CommandList, CommandEmpty, CommandGroup, CommandItem, CommandSeparator, CommandShortcut } from "@/components/ui/command";`}
+    examples={[
+      {
+        title: "Inline palette",
+        code: `<Command className="rounded-lg border shadow-sm">
+  <CommandInput placeholder="Type a command…" />
+  <CommandList>
+    <CommandEmpty>No results.</CommandEmpty>
+    <CommandGroup heading="Suggestions">
+      <CommandItem>New task <CommandShortcut>⌘N</CommandShortcut></CommandItem>
+      <CommandItem>Search projects</CommandItem>
+    </CommandGroup>
+    <CommandSeparator />
+    <CommandGroup heading="Settings">
+      <CommandItem>Profile</CommandItem>
+      <CommandItem>Preferences</CommandItem>
+    </CommandGroup>
+  </CommandList>
+</Command>`,
+        preview: (
+          <Command className="w-full max-w-md rounded-lg border shadow-sm">
+            <CommandInput placeholder="Type a command…" />
+            <CommandList>
+              <CommandEmpty>No results.</CommandEmpty>
+              <CommandGroup heading="Suggestions">
+                <CommandItem>New task <CommandShortcut>⌘N</CommandShortcut></CommandItem>
+                <CommandItem>Search projects</CommandItem>
+              </CommandGroup>
+              <CommandSeparator />
+              <CommandGroup heading="Settings">
+                <CommandItem>Profile</CommandItem>
+                <CommandItem>Preferences</CommandItem>
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        ),
+      },
+    ]}
+  />
+);
+
+export default CommandPage;

--- a/pwa/pages/dev/components/dialog.tsx
+++ b/pwa/pages/dev/components/dialog.tsx
@@ -1,0 +1,67 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const DialogPage = () => (
+  <ComponentDoc
+    name="Dialog"
+    description="Modal dialog built on radix-ui. Use Sheet for side-anchored panels."
+    importPath={`import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter, DialogClose } from "@/components/ui/dialog";`}
+    examples={[
+      {
+        title: "Confirm action",
+        code: `<Dialog>
+  <DialogTrigger asChild>
+    <Button variant="outline">Delete project</Button>
+  </DialogTrigger>
+  <DialogContent>
+    <DialogHeader>
+      <DialogTitle>Delete this project?</DialogTitle>
+      <DialogDescription>
+        This permanently removes the project and all its tasks.
+      </DialogDescription>
+    </DialogHeader>
+    <DialogFooter>
+      <DialogClose asChild>
+        <Button variant="outline">Cancel</Button>
+      </DialogClose>
+      <Button variant="destructive">Delete</Button>
+    </DialogFooter>
+  </DialogContent>
+</Dialog>`,
+        preview: (
+          <Dialog>
+            <DialogTrigger asChild>
+              <Button variant="outline">Delete project</Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Delete this project?</DialogTitle>
+                <DialogDescription>
+                  This permanently removes the project and all its tasks.
+                </DialogDescription>
+              </DialogHeader>
+              <DialogFooter>
+                <DialogClose asChild>
+                  <Button variant="outline">Cancel</Button>
+                </DialogClose>
+                <Button variant="destructive">Delete</Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        ),
+      },
+    ]}
+  />
+);
+
+export default DialogPage;

--- a/pwa/pages/dev/components/dropdown-menu.tsx
+++ b/pwa/pages/dev/components/dropdown-menu.tsx
@@ -1,0 +1,54 @@
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const DropdownMenuPage = () => (
+  <ComponentDoc
+    name="Dropdown Menu"
+    description="Anchored menu with items, separators, shortcuts, checkbox/radio items, and submenus. Built on @radix-ui/react-dropdown-menu."
+    importPath={`import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuShortcut } from "@/components/ui/dropdown-menu";`}
+    examples={[
+      {
+        title: "Account menu",
+        code: `<DropdownMenu>
+  <DropdownMenuTrigger asChild>
+    <Button variant="outline">Account</Button>
+  </DropdownMenuTrigger>
+  <DropdownMenuContent align="start">
+    <DropdownMenuLabel>My account</DropdownMenuLabel>
+    <DropdownMenuSeparator />
+    <DropdownMenuItem>Profile <DropdownMenuShortcut>⌘P</DropdownMenuShortcut></DropdownMenuItem>
+    <DropdownMenuItem>Settings <DropdownMenuShortcut>⌘,</DropdownMenuShortcut></DropdownMenuItem>
+    <DropdownMenuSeparator />
+    <DropdownMenuItem>Sign out</DropdownMenuItem>
+  </DropdownMenuContent>
+</DropdownMenu>`,
+        preview: (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline">Account</Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start">
+              <DropdownMenuLabel>My account</DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem>Profile <DropdownMenuShortcut>⌘P</DropdownMenuShortcut></DropdownMenuItem>
+              <DropdownMenuItem>Settings <DropdownMenuShortcut>⌘,</DropdownMenuShortcut></DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem>Sign out</DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ),
+      },
+    ]}
+  />
+);
+
+export default DropdownMenuPage;

--- a/pwa/pages/dev/components/formik-field.tsx
+++ b/pwa/pages/dev/components/formik-field.tsx
@@ -1,0 +1,63 @@
+import { Formik, Form } from "formik";
+import { FormikField } from "@/components/ui/formik-field";
+import { Button } from "@/components/ui/button";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const Demo = () => (
+  <Formik
+    initialValues={{ email: "", password: "" }}
+    validate={(values) => {
+      const errors: Record<string, string> = {};
+      if (!values.email) errors.email = "Required";
+      else if (!/^.+@.+\..+$/.test(values.email)) errors.email = "Invalid email";
+      if (values.password && values.password.length < 8) errors.password = "Must be at least 8 characters";
+      return errors;
+    }}
+    onSubmit={() => {
+      // no-op for the docs preview
+    }}
+  >
+    <Form className="space-y-4">
+      <FormikField name="email" label="Email" type="email" placeholder="you@example.com" />
+      <FormikField
+        name="password"
+        label="Password"
+        type="password"
+        description="At least 8 characters."
+      />
+      <Button type="submit">Sign in</Button>
+    </Form>
+  </Formik>
+);
+
+const FormikFieldPage = () => (
+  <ComponentDoc
+    name="FormikField"
+    description="Formik-aware wrapper that ties Label, Input, an optional description, and ErrorMessage together. Default for Formik-backed forms — don't hand-roll <Field> + <label> + <ErrorMessage> blocks."
+    importPath={`import { FormikField } from "@/components/ui/formik-field";`}
+    examples={[
+      {
+        title: "Sign-in form",
+        code: `<Formik
+  initialValues={{ email: "", password: "" }}
+  validate={(values) => { /* ... */ }}
+  onSubmit={(values) => api.signin(values)}
+>
+  <Form className="space-y-4">
+    <FormikField name="email" label="Email" type="email" placeholder="you@example.com" />
+    <FormikField
+      name="password"
+      label="Password"
+      type="password"
+      description="At least 8 characters."
+    />
+    <Button type="submit">Sign in</Button>
+  </Form>
+</Formik>`,
+        preview: <div className="w-full max-w-sm"><Demo /></div>,
+      },
+    ]}
+  />
+);
+
+export default FormikFieldPage;

--- a/pwa/pages/dev/components/index.tsx
+++ b/pwa/pages/dev/components/index.tsx
@@ -1,0 +1,58 @@
+import Head from "next/head";
+import Link from "next/link";
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { componentRegistry } from "@/components/dev/registry";
+
+const categories = [
+  "Primitive",
+  "Form",
+  "Overlay",
+  "Data",
+  "Editor",
+  "User",
+  "Theme",
+] as const;
+
+const ComponentsIndex = () => (
+  <>
+    <Head>
+      <title>Components · Dev</title>
+    </Head>
+    <main className="mx-auto max-w-5xl px-6 py-10">
+      <header className="mb-8">
+        <h1 className="text-3xl font-semibold tracking-tight">Component library</h1>
+        <p className="mt-2 max-w-2xl text-muted-foreground">
+          Living documentation for every reusable component in the PWA. Each page shows live
+          examples alongside the source you can copy into your own code.
+        </p>
+      </header>
+      {categories.map((category) => {
+        const entries = componentRegistry.filter((c) => c.category === category);
+        if (entries.length === 0) return null;
+        return (
+          <section key={category} className="mb-10">
+            <div className="mb-3 flex items-baseline gap-3">
+              <h2 className="text-xl font-medium">{category}</h2>
+              <Badge variant="secondary">{entries.length}</Badge>
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {entries.map((entry) => (
+                <Link key={entry.slug} href={`/dev/components/${entry.slug}`}>
+                  <Card className="h-full transition-colors hover:border-foreground/40">
+                    <CardHeader>
+                      <CardTitle className="text-base">{entry.name}</CardTitle>
+                      <CardDescription>{entry.description}</CardDescription>
+                    </CardHeader>
+                  </Card>
+                </Link>
+              ))}
+            </div>
+          </section>
+        );
+      })}
+    </main>
+  </>
+);
+
+export default ComponentsIndex;

--- a/pwa/pages/dev/components/input-group.tsx
+++ b/pwa/pages/dev/components/input-group.tsx
@@ -1,0 +1,64 @@
+import { Search, AtSign } from "lucide-react";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+  InputGroupText,
+} from "@/components/ui/input-group";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const InputGroupPage = () => (
+  <ComponentDoc
+    name="InputGroup"
+    description="Compose an input with leading/trailing addons (icons, text, buttons). Used internally by Combobox."
+    importPath={`import { InputGroup, InputGroupAddon, InputGroupInput, InputGroupText, InputGroupButton, InputGroupTextarea } from "@/components/ui/input-group";`}
+    examples={[
+      {
+        title: "Leading icon",
+        code: `<InputGroup>
+  <InputGroupAddon align="inline-start">
+    <Search />
+  </InputGroupAddon>
+  <InputGroupInput placeholder="Search tasks…" />
+</InputGroup>`,
+        preview: (
+          <div className="w-full max-w-sm">
+            <InputGroup>
+              <InputGroupAddon align="inline-start">
+                <Search />
+              </InputGroupAddon>
+              <InputGroupInput placeholder="Search tasks…" />
+            </InputGroup>
+          </div>
+        ),
+      },
+      {
+        title: "Trailing text addon",
+        code: `<InputGroup>
+  <InputGroupAddon align="inline-start">
+    <AtSign />
+  </InputGroupAddon>
+  <InputGroupInput placeholder="username" />
+  <InputGroupAddon align="inline-end">
+    <InputGroupText>@aura.dev</InputGroupText>
+  </InputGroupAddon>
+</InputGroup>`,
+        preview: (
+          <div className="w-full max-w-sm">
+            <InputGroup>
+              <InputGroupAddon align="inline-start">
+                <AtSign />
+              </InputGroupAddon>
+              <InputGroupInput placeholder="username" />
+              <InputGroupAddon align="inline-end">
+                <InputGroupText>@aura.dev</InputGroupText>
+              </InputGroupAddon>
+            </InputGroup>
+          </div>
+        ),
+      },
+    ]}
+  />
+);
+
+export default InputGroupPage;

--- a/pwa/pages/dev/components/input.tsx
+++ b/pwa/pages/dev/components/input.tsx
@@ -1,0 +1,38 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const InputPage = () => (
+  <ComponentDoc
+    name="Input"
+    description="Single-line text input. Forwards refs and accepts every native <input> attribute."
+    importPath={`import { Input } from "@/components/ui/input";`}
+    examples={[
+      {
+        title: "Default",
+        code: `<Input placeholder="Type something…" />`,
+        preview: <Input placeholder="Type something…" className="max-w-sm" />,
+      },
+      {
+        title: "With label",
+        code: `<div className="space-y-1.5">
+  <Label htmlFor="username">Username</Label>
+  <Input id="username" placeholder="ada-lovelace" />
+</div>`,
+        preview: (
+          <div className="w-72 space-y-1.5">
+            <Label htmlFor="username">Username</Label>
+            <Input id="username" placeholder="ada-lovelace" />
+          </div>
+        ),
+      },
+      {
+        title: "Disabled",
+        code: `<Input disabled value="Locked" />`,
+        preview: <Input disabled defaultValue="Locked" className="max-w-sm" />,
+      },
+    ]}
+  />
+);
+
+export default InputPage;

--- a/pwa/pages/dev/components/label.tsx
+++ b/pwa/pages/dev/components/label.tsx
@@ -1,0 +1,28 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const LabelPage = () => (
+  <ComponentDoc
+    name="Label"
+    description="Accessible label associated to a form control via `htmlFor`. Built on @radix-ui/react-label."
+    importPath={`import { Label } from "@/components/ui/label";`}
+    examples={[
+      {
+        title: "Paired with an input",
+        code: `<div className="space-y-1.5">
+  <Label htmlFor="email">Email</Label>
+  <Input id="email" type="email" placeholder="you@example.com" />
+</div>`,
+        preview: (
+          <div className="w-72 space-y-1.5">
+            <Label htmlFor="email">Email</Label>
+            <Input id="email" type="email" placeholder="you@example.com" />
+          </div>
+        ),
+      },
+    ]}
+  />
+);
+
+export default LabelPage;

--- a/pwa/pages/dev/components/markdown-editor.tsx
+++ b/pwa/pages/dev/components/markdown-editor.tsx
@@ -1,0 +1,31 @@
+import { useState } from "react";
+import MarkdownEditor from "@/components/editor/MarkdownEditor";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const Demo = () => {
+  const [value, setValue] = useState("# Hello\n\nType **markdown** here. Drag-and-drop, slash commands, and inline formatting all work.");
+  return <MarkdownEditor value={value} onChange={setValue} ariaLabel="Demo editor" />;
+};
+
+const MarkdownEditorPage = () => (
+  <ComponentDoc
+    name="MarkdownEditor"
+    description="BlockNote-backed WYSIWYG editor that reads and writes markdown. Lazy-loaded on the client because BlockNote touches the DOM at import time."
+    importPath={`import MarkdownEditor from "@/components/editor/MarkdownEditor";`}
+    examples={[
+      {
+        title: "Controlled value",
+        code: `const [value, setValue] = useState("# Hello\\n\\nType markdown here.");
+
+<MarkdownEditor
+  value={value}
+  onChange={setValue}
+  ariaLabel="Project description"
+/>`,
+        preview: <div className="w-full"><Demo /></div>,
+      },
+    ]}
+  />
+);
+
+export default MarkdownEditorPage;

--- a/pwa/pages/dev/components/markdown-view.tsx
+++ b/pwa/pages/dev/components/markdown-view.tsx
@@ -1,0 +1,33 @@
+import MarkdownView from "@/components/editor/MarkdownView";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const SAMPLE = `# Project moonshot
+
+A short summary of the **goal**, with a [link](https://example.com) and a list:
+
+- Tasks
+- Owners
+- Deadlines
+
+> Quote a stakeholder for context.
+
+\`\`\`ts
+const ready = true;
+\`\`\``;
+
+const MarkdownViewPage = () => (
+  <ComponentDoc
+    name="MarkdownView"
+    description="Read-only markdown renderer (react-markdown + remark-gfm). Paired with MarkdownEditor for the same content. Raw HTML is escaped."
+    importPath={`import MarkdownView from "@/components/editor/MarkdownView";`}
+    examples={[
+      {
+        title: "Render stored markdown",
+        code: `<MarkdownView source={project.description} />`,
+        preview: <MarkdownView source={SAMPLE} />,
+      },
+    ]}
+  />
+);
+
+export default MarkdownViewPage;

--- a/pwa/pages/dev/components/popover.tsx
+++ b/pwa/pages/dev/components/popover.tsx
@@ -1,0 +1,49 @@
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const PopoverPage = () => (
+  <ComponentDoc
+    name="Popover"
+    description="Floating panel anchored to a trigger. Built on radix-ui. Reach for Dialog when the panel is modal."
+    importPath={`import { Popover, PopoverTrigger, PopoverContent, PopoverHeader, PopoverTitle, PopoverDescription } from "@/components/ui/popover";`}
+    examples={[
+      {
+        title: "Anchored info panel",
+        code: `<Popover>
+  <PopoverTrigger asChild>
+    <Button variant="outline">Show details</Button>
+  </PopoverTrigger>
+  <PopoverContent align="start">
+    <PopoverHeader>
+      <PopoverTitle>Project moonshot</PopoverTitle>
+      <PopoverDescription>Owned by ada-lovelace.</PopoverDescription>
+    </PopoverHeader>
+  </PopoverContent>
+</Popover>`,
+        preview: (
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button variant="outline">Show details</Button>
+            </PopoverTrigger>
+            <PopoverContent align="start">
+              <PopoverHeader>
+                <PopoverTitle>Project moonshot</PopoverTitle>
+                <PopoverDescription>Owned by ada-lovelace.</PopoverDescription>
+              </PopoverHeader>
+            </PopoverContent>
+          </Popover>
+        ),
+      },
+    ]}
+  />
+);
+
+export default PopoverPage;

--- a/pwa/pages/dev/components/separator.tsx
+++ b/pwa/pages/dev/components/separator.tsx
@@ -1,0 +1,48 @@
+import { Separator } from "@/components/ui/separator";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const SeparatorPage = () => (
+  <ComponentDoc
+    name="Separator"
+    description="Horizontal or vertical divider built on @radix-ui/react-separator."
+    importPath={`import { Separator } from "@/components/ui/separator";`}
+    examples={[
+      {
+        title: "Horizontal",
+        code: `<div>
+  <p className="text-sm">Section A</p>
+  <Separator className="my-3" />
+  <p className="text-sm">Section B</p>
+</div>`,
+        preview: (
+          <div>
+            <p className="text-sm">Section A</p>
+            <Separator className="my-3" />
+            <p className="text-sm">Section B</p>
+          </div>
+        ),
+      },
+      {
+        title: "Vertical",
+        code: `<div className="flex h-6 items-center gap-3 text-sm">
+  <span>Inbox</span>
+  <Separator orientation="vertical" />
+  <span>Drafts</span>
+  <Separator orientation="vertical" />
+  <span>Sent</span>
+</div>`,
+        preview: (
+          <div className="flex h-6 items-center gap-3 text-sm">
+            <span>Inbox</span>
+            <Separator orientation="vertical" />
+            <span>Drafts</span>
+            <Separator orientation="vertical" />
+            <span>Sent</span>
+          </div>
+        ),
+      },
+    ]}
+  />
+);
+
+export default SeparatorPage;

--- a/pwa/pages/dev/components/sheet.tsx
+++ b/pwa/pages/dev/components/sheet.tsx
@@ -1,0 +1,49 @@
+import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const SheetPage = () => (
+  <ComponentDoc
+    name="Sheet"
+    description="Side-anchored drawer built on radix-ui Dialog. Pick `side` to anchor it to right, left, top, or bottom."
+    importPath={`import { Sheet, SheetTrigger, SheetContent, SheetHeader, SheetTitle, SheetDescription } from "@/components/ui/sheet";`}
+    examples={[
+      {
+        title: "Right drawer",
+        code: `<Sheet>
+  <SheetTrigger asChild>
+    <Button variant="outline">Open settings</Button>
+  </SheetTrigger>
+  <SheetContent side="right">
+    <SheetHeader>
+      <SheetTitle>Settings</SheetTitle>
+      <SheetDescription>Personal preferences sync across devices.</SheetDescription>
+    </SheetHeader>
+  </SheetContent>
+</Sheet>`,
+        preview: (
+          <Sheet>
+            <SheetTrigger asChild>
+              <Button variant="outline">Open settings</Button>
+            </SheetTrigger>
+            <SheetContent side="right">
+              <SheetHeader>
+                <SheetTitle>Settings</SheetTitle>
+                <SheetDescription>Personal preferences sync across devices.</SheetDescription>
+              </SheetHeader>
+            </SheetContent>
+          </Sheet>
+        ),
+      },
+    ]}
+  />
+);
+
+export default SheetPage;

--- a/pwa/pages/dev/components/table.tsx
+++ b/pwa/pages/dev/components/table.tsx
@@ -1,0 +1,75 @@
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const rows = [
+  { id: "T-101", title: "Polish onboarding", owner: "ada", status: "Open" },
+  { id: "T-102", title: "Fix avatar fallback", owner: "lin", status: "Done" },
+  { id: "T-103", title: "Audit Mercure topics", owner: "ren", status: "Open" },
+];
+
+const TablePage = () => (
+  <ComponentDoc
+    name="Table"
+    description="Styled wrappers for the native HTML table primitives."
+    importPath={`import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell, TableCaption } from "@/components/ui/table";`}
+    examples={[
+      {
+        title: "Basic data table",
+        code: `<Table>
+  <TableCaption>Open and recently closed tasks.</TableCaption>
+  <TableHeader>
+    <TableRow>
+      <TableHead>ID</TableHead>
+      <TableHead>Title</TableHead>
+      <TableHead>Owner</TableHead>
+      <TableHead>Status</TableHead>
+    </TableRow>
+  </TableHeader>
+  <TableBody>
+    {rows.map((row) => (
+      <TableRow key={row.id}>
+        <TableCell>{row.id}</TableCell>
+        <TableCell>{row.title}</TableCell>
+        <TableCell>{row.owner}</TableCell>
+        <TableCell>{row.status}</TableCell>
+      </TableRow>
+    ))}
+  </TableBody>
+</Table>`,
+        preview: (
+          <Table>
+            <TableCaption>Open and recently closed tasks.</TableCaption>
+            <TableHeader>
+              <TableRow>
+                <TableHead>ID</TableHead>
+                <TableHead>Title</TableHead>
+                <TableHead>Owner</TableHead>
+                <TableHead>Status</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map((row) => (
+                <TableRow key={row.id}>
+                  <TableCell>{row.id}</TableCell>
+                  <TableCell>{row.title}</TableCell>
+                  <TableCell>{row.owner}</TableCell>
+                  <TableCell>{row.status}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        ),
+      },
+    ]}
+  />
+);
+
+export default TablePage;

--- a/pwa/pages/dev/components/tabs.tsx
+++ b/pwa/pages/dev/components/tabs.tsx
@@ -1,0 +1,64 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const TabsPage = () => (
+  <ComponentDoc
+    name="Tabs"
+    description={`Tab list and panels. Pass variant="line" to TabsList for an underline style. Set orientation on Tabs to flip vertical.`}
+    importPath={`import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";`}
+    examples={[
+      {
+        title: "Default",
+        code: `<Tabs defaultValue="overview">
+  <TabsList>
+    <TabsTrigger value="overview">Overview</TabsTrigger>
+    <TabsTrigger value="activity">Activity</TabsTrigger>
+    <TabsTrigger value="settings">Settings</TabsTrigger>
+  </TabsList>
+  <TabsContent value="overview">High-level summary.</TabsContent>
+  <TabsContent value="activity">Recent events.</TabsContent>
+  <TabsContent value="settings">Configuration.</TabsContent>
+</Tabs>`,
+        preview: (
+          <Tabs defaultValue="overview" className="w-full max-w-md">
+            <TabsList>
+              <TabsTrigger value="overview">Overview</TabsTrigger>
+              <TabsTrigger value="activity">Activity</TabsTrigger>
+              <TabsTrigger value="settings">Settings</TabsTrigger>
+            </TabsList>
+            <TabsContent value="overview">High-level summary.</TabsContent>
+            <TabsContent value="activity">Recent events.</TabsContent>
+            <TabsContent value="settings">Configuration.</TabsContent>
+          </Tabs>
+        ),
+      },
+      {
+        title: "Underline variant",
+        code: `<Tabs defaultValue="all">
+  <TabsList variant="line">
+    <TabsTrigger value="all">All</TabsTrigger>
+    <TabsTrigger value="open">Open</TabsTrigger>
+    <TabsTrigger value="done">Done</TabsTrigger>
+  </TabsList>
+  <TabsContent value="all">Everything.</TabsContent>
+  <TabsContent value="open">In flight.</TabsContent>
+  <TabsContent value="done">Completed.</TabsContent>
+</Tabs>`,
+        preview: (
+          <Tabs defaultValue="all" className="w-full max-w-md">
+            <TabsList variant="line">
+              <TabsTrigger value="all">All</TabsTrigger>
+              <TabsTrigger value="open">Open</TabsTrigger>
+              <TabsTrigger value="done">Done</TabsTrigger>
+            </TabsList>
+            <TabsContent value="all">Everything.</TabsContent>
+            <TabsContent value="open">In flight.</TabsContent>
+            <TabsContent value="done">Completed.</TabsContent>
+          </Tabs>
+        ),
+      },
+    ]}
+  />
+);
+
+export default TabsPage;

--- a/pwa/pages/dev/components/textarea.tsx
+++ b/pwa/pages/dev/components/textarea.tsx
@@ -1,0 +1,28 @@
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const TextareaPage = () => (
+  <ComponentDoc
+    name="Textarea"
+    description="Multi-line text input. Use MarkdownEditor when the content is long-form prose."
+    importPath={`import { Textarea } from "@/components/ui/textarea";`}
+    examples={[
+      {
+        title: "With label",
+        code: `<div className="space-y-1.5">
+  <Label htmlFor="bio">Bio</Label>
+  <Textarea id="bio" placeholder="A short paragraph about you…" rows={4} />
+</div>`,
+        preview: (
+          <div className="w-full max-w-md space-y-1.5">
+            <Label htmlFor="bio">Bio</Label>
+            <Textarea id="bio" placeholder="A short paragraph about you…" rows={4} />
+          </div>
+        ),
+      },
+    ]}
+  />
+);
+
+export default TextareaPage;

--- a/pwa/pages/dev/components/theme-toggle.tsx
+++ b/pwa/pages/dev/components/theme-toggle.tsx
@@ -1,0 +1,19 @@
+import ThemeToggle from "@/components/common/ThemeToggle";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const ThemeTogglePage = () => (
+  <ComponentDoc
+    name="ThemeToggle"
+    description="Sun/moon button that flips between light and dark via next-themes. Mounted in the navbar; safe to drop anywhere inside a ThemeProvider."
+    importPath={`import ThemeToggle from "@/components/common/ThemeToggle";`}
+    examples={[
+      {
+        title: "Default",
+        code: `<ThemeToggle />`,
+        preview: <ThemeToggle />,
+      },
+    ]}
+  />
+);
+
+export default ThemeTogglePage;

--- a/pwa/pages/dev/components/user-avatar.tsx
+++ b/pwa/pages/dev/components/user-avatar.tsx
@@ -1,0 +1,46 @@
+import UserAvatar from "@/components/user/UserAvatar";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const ada = {
+  username: "ada-lovelace",
+  firstName: "Ada",
+  lastName: "Lovelace",
+  personalizedColor: "#0e7490",
+};
+
+const lin = {
+  username: "lin-mei",
+  firstName: "Lin",
+  lastName: "Mei",
+  personalizedColor: "#9333ea",
+};
+
+const UserAvatarPage = () => (
+  <ComponentDoc
+    name="UserAvatar"
+    description="Renders the uploaded image when present, otherwise white initials on the user's `personalizedColor` (a contrast-safe palette picked at signup). Sizes: sm (32px), md (40px), lg (96px)."
+    importPath={`import UserAvatar from "@/components/user/UserAvatar";`}
+    examples={[
+      {
+        title: "Initials fallback (no avatarUrls)",
+        code: `<UserAvatar
+  user={{
+    username: "ada-lovelace",
+    firstName: "Ada",
+    lastName: "Lovelace",
+    personalizedColor: "#0e7490",
+  }}
+/>`,
+        preview: (
+          <div className="flex items-center gap-4">
+            <UserAvatar user={ada} size="sm" />
+            <UserAvatar user={ada} size="md" />
+            <UserAvatar user={lin} size="lg" />
+          </div>
+        ),
+      },
+    ]}
+  />
+);
+
+export default UserAvatarPage;

--- a/pwa/pnpm-lock.yaml
+++ b/pwa/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       postcss:
         specifier: ^8.5.13
         version: 8.5.13
+      prism-react-renderer:
+        specifier: ^2.4.1
+        version: 2.4.1(react@19.2.5)
       radix-ui:
         specifier: ^1.4.3
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -1786,6 +1789,9 @@ packages:
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
 
+  '@types/prismjs@1.26.6':
+    resolution: {integrity: sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==}
+
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
@@ -3413,6 +3419,11 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prism-react-renderer@2.4.1:
+    resolution: {integrity: sha512-ey8Ls/+Di31eqzUxC46h8MksNuGx/n0AAC8uKpwFau4RPDYLuE3EXTp8N8G2vX2N7UC/+IXeNUnlWBGGcAG+Ig==}
+    peerDependencies:
+      react: '>=16.0.0'
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -5982,6 +5993,8 @@ snapshots:
 
   '@types/parse-json@4.0.2': {}
 
+  '@types/prismjs@1.26.6': {}
+
   '@types/prop-types@15.7.15': {}
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
@@ -8024,6 +8037,12 @@ snapshots:
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
+
+  prism-react-renderer@2.4.1(react@19.2.5):
+    dependencies:
+      '@types/prismjs': 1.26.6
+      clsx: 2.1.1
+      react: 19.2.5
 
   prop-types@15.8.1:
     dependencies:


### PR DESCRIPTION
## Description

Adds `/dev/components` — a developer-only docs route that showcases every reusable PWA component with a live example and a syntax-highlighted source snippet.

Closes #114.

### What's in here
- `pwa/components/dev/CodeBlock.tsx` — Prism wrapper (`prism-react-renderer`) with copy-to-clipboard and theme-aware (vsDark / github) palette via `next-themes`.
- `pwa/components/dev/ComponentDoc.tsx` — shared per-page layout (header, import path, examples).
- `pwa/components/dev/registry.ts` — single source of truth for the `/dev/components` index.
- `pwa/pages/dev/components/index.tsx` — index grouped by category.
- `pwa/pages/dev/components/<slug>.tsx` — one page per component (24 total).

### Components covered
**`ui/` primitives (20):** alert, badge, button, calendar, card, checkbox, combobox, command, dialog, dropdown-menu, formik-field, input, input-group, label, popover, separator, sheet, table, tabs, textarea.

**Shared (4):** markdown-editor, markdown-view, user-avatar, theme-toggle.

### Why prism-react-renderer
Pure-JS Prism wrapped as React: no CSS imports, themes are JS objects, SSR + client just work. Smaller than Shiki and more idiomatic than Highlight.js for this use case.

### Keeping it current
Adds a Code-Conventions bullet to `CLAUDE.md` so future PRs that add/rename a reusable component (or change its public prop shape) update the matching `/dev/components/<slug>` page and `registry.ts` entry in the same PR.

## Type of Change

- [x] New feature
- [x] Documentation

## Component

- [x] PWA (Next.js)
- [x] Documentation

## How Has This Been Tested?

- `pnpm lint` clean (only a pre-existing warning in `components/ui/combobox.tsx` unrelated to this change).
- `pnpm build` passes — all 25 dev routes (`/dev/components` + 24 component pages) compile and statically prerender.
- Manual sanity check planned by reviewers via `pnpm dev` → `http://localhost:3000/dev/components`.

## Checklist

- [x] Code follows project conventions (shadcn primitives, `@/*` alias, design tokens).
- [x] Lint and build pass locally.
- [x] Documentation updated (`CLAUDE.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)