### PR TITLE
feat(tasks): overdue task count badge in the navbar (#103)

### DIFF
--- a/api/src/Entity/Task.php
+++ b/api/src/Entity/Task.php
@@ -5,6 +5,7 @@ namespace App\Entity;
 use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\Metadata\ApiFilter;
 use ApiPlatform\Metadata\ApiResource;
+use App\Filter\OverdueFilter;
 use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
@@ -27,6 +28,11 @@ use Symfony\Component\Validator\Constraints as Assert;
     operations: [
         new GetCollection(
             security: "is_granted('ROLE_USER')",
+            // The navbar badge polls `?overdue=true&itemsPerPage=1` so it can
+            // read just `totalItems` and skip downloading task bodies. Without
+            // client-controlled pagination the per-page size is fixed at the
+            // 30-item default and the savings disappear.
+            paginationClientItemsPerPage: true,
         ),
         new Post(
             security: "is_granted('ROLE_USER')",
@@ -48,6 +54,7 @@ use Symfony\Component\Validator\Constraints as Assert;
     order: ['position' => 'ASC', 'createdOn' => 'DESC'],
 )]
 #[ApiFilter(SearchFilter::class, properties: ['project' => 'exact', 'assignees' => 'exact'])]
+#[ApiFilter(OverdueFilter::class)]
 #[ORM\Entity(repositoryClass: TaskRepository::class)]
 #[ORM\Table(name: 'task')]
 #[ORM\Index(columns: ['owner_id'], name: 'idx_task_owner')]

--- a/api/src/Filter/OverdueFilter.php
+++ b/api/src/Filter/OverdueFilter.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Filter;
+
+use ApiPlatform\Doctrine\Orm\Filter\AbstractFilter;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+use App\Entity\Task;
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * Boolean filter for `Task` collections: `?overdue=true` narrows the result to
+ * incomplete tasks whose `dueDate` is strictly in the past. Used by the navbar
+ * badge so the chrome can pull only `totalItems` (`itemsPerPage=1`) without
+ * walking the whole list client-side.
+ *
+ * `?overdue=false` is intentionally a no-op rather than its inverse; "not
+ * overdue" mixes "completed", "future-due", and "no due date" which are rarely
+ * a single useful set in product UI. Other values are ignored.
+ */
+final class OverdueFilter extends AbstractFilter
+{
+    public const PARAMETER = 'overdue';
+
+    protected function filterProperty(
+        string $property,
+        $value,
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        ?Operation $operation = null,
+        array $context = [],
+    ): void {
+        if (self::PARAMETER !== $property || Task::class !== $resourceClass) {
+            return;
+        }
+
+        if (!$this->isTruthy($value)) {
+            return;
+        }
+
+        $rootAlias = $queryBuilder->getRootAliases()[0];
+        $nowParam = $queryNameGenerator->generateParameterName('overdueNow');
+
+        $queryBuilder
+            ->andWhere(sprintf('%s.dueDate < :%s', $rootAlias, $nowParam))
+            ->andWhere(sprintf('%s.completedOn IS NULL', $rootAlias))
+            ->setParameter($nowParam, new \DateTimeImmutable());
+    }
+
+    public function getDescription(string $resourceClass): array
+    {
+        if (Task::class !== $resourceClass) {
+            return [];
+        }
+
+        return [
+            self::PARAMETER => [
+                'property' => self::PARAMETER,
+                'type' => 'bool',
+                'required' => false,
+                'description' => 'When true, restricts the collection to overdue tasks (incomplete with a past due date).',
+                'openapi' => [
+                    'example' => true,
+                    'allowEmptyValue' => false,
+                ],
+            ],
+        ];
+    }
+
+    private function isTruthy(mixed $value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_string($value)) {
+            return in_array(strtolower($value), ['1', 'true', 'yes', 'on'], true);
+        }
+
+        if (is_int($value)) {
+            return 1 === $value;
+        }
+
+        return false;
+    }
+}

--- a/api/tests/Api/TaskTest.php
+++ b/api/tests/Api/TaskTest.php
@@ -1030,6 +1030,94 @@ class TaskTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(404);
     }
 
+    public function testOverdueFilterReturnsOnlyIncompletePastDueTasks(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        // 1. overdue (past due, incomplete)
+        $overdue = $this->createTask($alice, 'Overdue task');
+        $overdue->setDueDate(new \DateTimeImmutable('-2 days'));
+        // 2. due in the future — must NOT match
+        $future = $this->createTask($alice, 'Future task');
+        $future->setDueDate(new \DateTimeImmutable('+2 days'));
+        // 3. past due BUT completed — must NOT match
+        $done = $this->createTask($alice, 'Past but done');
+        $done->setDueDate(new \DateTimeImmutable('-2 days'));
+        $done->setCompletedOn(new \DateTimeImmutable('-1 day'));
+        // 4. no due date — must NOT match
+        $this->createTask($alice, 'No due date');
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/tasks?overdue=true');
+
+        $this->assertResponseIsSuccessful();
+        $body = $client->getResponse()->toArray();
+        $this->assertSame(1, $body['totalItems']);
+        $this->assertSame('Overdue task', $body['member'][0]['title']);
+    }
+
+    public function testOverdueFilterCountOnlyMode(): void
+    {
+        // The navbar polls with `itemsPerPage=1` and reads `totalItems` to
+        // avoid pulling the full collection just for the badge count. Lock in
+        // that contract.
+        $alice = $this->createUser('alice@example.com');
+
+        for ($i = 0; $i < 3; ++$i) {
+            $task = $this->createTask($alice, "Late {$i}");
+            $task->setDueDate(new \DateTimeImmutable('-1 day'));
+        }
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/tasks?overdue=true&itemsPerPage=1');
+
+        $this->assertResponseIsSuccessful();
+        $body = $client->getResponse()->toArray();
+        $this->assertSame(3, $body['totalItems']);
+        $this->assertCount(1, $body['member']);
+    }
+
+    public function testOverdueFilterFalseIsNoOp(): void
+    {
+        // `overdue=false` is intentionally not the inverse — tasks with no due
+        // date and tasks due in the future are very different things. Treat it
+        // as "no filter" so the parameter has a single useful interpretation.
+        $alice = $this->createUser('alice@example.com');
+        $past = $this->createTask($alice, 'Past');
+        $past->setDueDate(new \DateTimeImmutable('-1 day'));
+        $this->createTask($alice, 'No due date');
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/tasks?overdue=false');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains(['totalItems' => 2]);
+    }
+
+    public function testOverdueFilterRespectsAccessControl(): void
+    {
+        // Bob's overdue task must not show up in Alice's overdue count even
+        // though TaskOwnerExtension is a separate concern — defense-in-depth.
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $bobOverdue = $this->createTask($bob, "Bob's overdue");
+        $bobOverdue->setDueDate(new \DateTimeImmutable('-3 days'));
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/tasks?overdue=true');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains(['totalItems' => 0]);
+    }
+
     public function testAssignableUsersIncludesSelf(): void
     {
         $alice = $this->createUser('alice@example.com');

--- a/e2e/tests/navbar-overdue-badge.spec.js
+++ b/e2e/tests/navbar-overdue-badge.spec.js
@@ -1,0 +1,63 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+const {
+  BASE_URL,
+  uniqueEmail: shared,
+  registerAndSignIn,
+} = require("./helpers");
+
+const uniqueEmail = () => shared("nav-overdue");
+
+test.describe("Navbar overdue badge", () => {
+  test("hidden when there are no overdue tasks", async ({ page }) => {
+    await registerAndSignIn(page, uniqueEmail());
+    // The badge polls /tasks?overdue=true on mount; with a fresh user there
+    // is nothing overdue so the chip stays unrendered.
+    await expect(
+      page.locator('[data-testid="navbar-overdue-badge"]'),
+    ).toHaveCount(0);
+  });
+
+  test("appears with the overdue count and links to the tasks page", async ({
+    page,
+  }) => {
+    await registerAndSignIn(page, uniqueEmail());
+
+    // Seed two overdue tasks via the API so the badge has something to count.
+    // The page itself doesn't matter — the badge is part of the navbar and
+    // shows on every authenticated route.
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    yesterday.setHours(0, 0, 0, 0);
+
+    for (let i = 0; i < 2; i += 1) {
+      const createRes = await page.request.post(`${BASE_URL}/tasks`, {
+        headers: { "Content-Type": "application/ld+json" },
+        data: { title: `Late ${i} ${Date.now()}` },
+      });
+      expect(createRes.ok()).toBeTruthy();
+      const created = await createRes.json();
+      const patchRes = await page.request.patch(
+        `${BASE_URL}${created["@id"]}`,
+        {
+          headers: { "Content-Type": "application/merge-patch+json" },
+          data: { dueDate: yesterday.toISOString() },
+        },
+      );
+      expect(patchRes.ok()).toBeTruthy();
+    }
+
+    // A reload fires the badge fetch immediately rather than waiting on the
+    // 30s poll interval.
+    await page.reload();
+
+    const badge = page.locator('[data-testid="navbar-overdue-badge"]');
+    await expect(badge).toBeVisible();
+    await expect(
+      page.locator('[data-testid="navbar-overdue-count"]'),
+    ).toHaveText("2");
+
+    await badge.click();
+    await expect(page).toHaveURL(/\/tasks$/);
+  });
+});

--- a/pwa/components/common/Navbar.tsx
+++ b/pwa/components/common/Navbar.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
 import NotificationBell from "@/components/notifications/NotificationBell";
+import OverdueBadge from "@/components/tasks/OverdueBadge";
 import ThemeToggle from "./ThemeToggle";
 
 const NAV_LINKS = [
@@ -63,6 +64,7 @@ const Navbar = () => {
         <div className="flex items-center gap-1">
           {isAuthenticated && user ? (
             <Sheet>
+              <OverdueBadge enabled={isAuthenticated} />
               <NotificationBell enabled={isAuthenticated} />
               <ThemeToggle />
               <SheetTrigger asChild>

--- a/pwa/components/tasks/OverdueBadge.tsx
+++ b/pwa/components/tasks/OverdueBadge.tsx
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { AlertTriangle } from "lucide-react";
+import { ENTRYPOINT } from "@/config/entrypoint";
+import { cn } from "@/lib/utils";
+
+const POLL_INTERVAL_MS = 30_000;
+
+interface OverdueBadgeProps {
+  /** Hides the badge and pauses polling when the user isn't logged in, so we
+   *  don't spam 401s on the public landing page. Mirrors NotificationBell. */
+  enabled: boolean;
+}
+
+interface OverdueCollection {
+  totalItems?: number;
+}
+
+const OverdueBadge = ({ enabled }: OverdueBadgeProps) => {
+  const [count, setCount] = useState(0);
+
+  const fetchCount = useCallback(async () => {
+    if (!enabled) return;
+    try {
+      const res = await fetch(
+        // itemsPerPage=1 keeps the response tiny — we only read totalItems.
+        // The server-side overdue filter does the date math so the chrome
+        // doesn't have to enumerate the user's tasks just to compute a badge.
+        `${ENTRYPOINT}/tasks?overdue=true&itemsPerPage=1`,
+        {
+          credentials: "include",
+          headers: { Accept: "application/ld+json" },
+        },
+      );
+      if (!res.ok) return;
+      const data: OverdueCollection = await res.json();
+      setCount(typeof data.totalItems === "number" ? data.totalItems : 0);
+    } catch {
+      // Polling is a chrome convenience — stay silent on failure and let the
+      // next tick recover.
+    }
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled) {
+      setCount(0);
+      return;
+    }
+    fetchCount();
+    const id = window.setInterval(fetchCount, POLL_INTERVAL_MS);
+    return () => window.clearInterval(id);
+  }, [enabled, fetchCount]);
+
+  // Refresh when the tab regains focus so a long idle doesn't leave a stale
+  // count sitting in the navbar.
+  useEffect(() => {
+    if (!enabled) return;
+    const onVisible = () => {
+      if (document.visibilityState === "visible") fetchCount();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => document.removeEventListener("visibilitychange", onVisible);
+  }, [enabled, fetchCount]);
+
+  if (!enabled || count <= 0) return null;
+
+  const countLabel = count > 9 ? "9+" : String(count);
+  const ariaLabel = `${count} overdue task${count === 1 ? "" : "s"}`;
+
+  return (
+    <Link
+      href="/tasks"
+      aria-label={ariaLabel}
+      title={ariaLabel}
+      data-testid="navbar-overdue-badge"
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold",
+        "bg-destructive text-destructive-foreground no-underline",
+        "hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+      )}
+    >
+      <AlertTriangle className="h-3 w-3" aria-hidden="true" />
+      <span data-testid="navbar-overdue-count">{countLabel}</span>
+    </Link>
+  );
+};
+
+export default OverdueBadge;


### PR DESCRIPTION
## Summary
- New `OverdueFilter` (`?overdue=true`) on `GET /tasks` plus client-controlled `itemsPerPage`, so the chrome can poll for `totalItems` without paying for task bodies.
- New `OverdueBadge` in the navbar — small destructive pill next to the bell with the overdue count (capped at `9+`); hidden when zero. Polls every 30s and on tab focus, mirroring `NotificationBell`. Clicking it lands on `/tasks` where the existing overdue filter chip lives.
- 4 new phpunit cases for the filter (correctness, count-only mode, `false` no-op, access scoping) + a Playwright spec for the badge zero-state and visible-with-count flow.

Closes #103.

## Test plan
- [x] `cd api && APP_ENV=test php bin/phpunit tests/Api/TaskTest.php` — 58 tests pass (54 prior + 4 new overdue).
- [x] Full suite: `php -d memory_limit=512M bin/phpunit` → 199 tests, 483 assertions, all green.
- [x] `cd pwa && pnpm lint` — clean (only the pre-existing combobox warning).
- [ ] `cd e2e && npx playwright test navbar-overdue-badge` — exercised in CI; couldn't run locally (no host node).
- [ ] Manual: log in, navigate around — badge stays hidden with no overdue tasks.
- [ ] Manual: PATCH a task's `dueDate` to yesterday → reload → badge shows `1`. Add another → badge shows `2`. Mark one complete → drops to `1`. Complete the last → badge disappears.
- [ ] Manual: click the badge → lands on `/tasks` with the existing overdue chip ready to filter the list.