### PR TITLE
feat(tasks): image lightbox for task attachments

### DIFF
--- a/e2e/tests/attachments-lightbox.spec.js
+++ b/e2e/tests/attachments-lightbox.spec.js
@@ -1,0 +1,155 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+const {
+  BASE_URL,
+  uniqueEmail: shared,
+  registerAndSignIn,
+  createTaskInline,
+} = require("./helpers");
+
+const uniqueEmail = () => shared("attach-lightbox");
+
+// Smallest valid PNGs (1x1) — server validates the upload by sniffing the
+// MIME, so a real image header is required even though the bytes are tiny.
+const tinyPng = (color) => {
+  // Two pre-built 1x1 PNGs so two distinct attachments produce different
+  // image objects (helps reasoning about the lightbox cycling between them).
+  if (color === "red") {
+    return Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+      "base64",
+    );
+  }
+  return Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
+    "base64",
+  );
+};
+
+test.describe("Image attachment lightbox", () => {
+  test("image attachments render a thumbnail and open in a lightbox", async ({
+    page,
+  }) => {
+    await registerAndSignIn(page, uniqueEmail());
+    await page.goto(`${BASE_URL}/tasks`);
+
+    const title = `Lightbox ${Date.now()}`;
+    await createTaskInline(page, title);
+    const item = page.locator('[data-testid="task-item"]', { hasText: title });
+
+    await item.locator('[data-testid="task-attachments-toggle"]').click();
+    const panel = item.locator('[data-testid="attachments-panel"]');
+
+    await item.locator('[data-testid="attachment-file-input"]').setInputFiles({
+      name: "shot.png",
+      mimeType: "image/png",
+      buffer: tinyPng("red"),
+    });
+
+    const attachment = panel.locator('[data-testid="attachment-item"]');
+    await expect(attachment).toHaveCount(1);
+    // Image rows expose a thumbnail button and no <a> link.
+    await expect(
+      attachment.locator('[data-testid="attachment-thumbnail"]'),
+    ).toBeVisible();
+
+    // Click the thumbnail → lightbox opens.
+    await attachment.locator('[data-testid="attachment-thumbnail"]').click();
+    const lightbox = page.locator('[data-testid="attachment-lightbox"]');
+    await expect(lightbox).toBeVisible();
+    await expect(
+      lightbox.locator('[data-testid="attachment-lightbox-image"]'),
+    ).toHaveAttribute("alt", "shot.png");
+
+    // Esc closes.
+    await page.keyboard.press("Escape");
+    await expect(lightbox).toBeHidden();
+  });
+
+  test("arrow keys cycle through image attachments on the same task", async ({
+    page,
+  }) => {
+    await registerAndSignIn(page, uniqueEmail());
+    await page.goto(`${BASE_URL}/tasks`);
+
+    const title = `Lightbox cycle ${Date.now()}`;
+    await createTaskInline(page, title);
+    const item = page.locator('[data-testid="task-item"]', { hasText: title });
+
+    await item.locator('[data-testid="task-attachments-toggle"]').click();
+    const panel = item.locator('[data-testid="attachments-panel"]');
+    const fileInput = item.locator('[data-testid="attachment-file-input"]');
+
+    await fileInput.setInputFiles({
+      name: "first.png",
+      mimeType: "image/png",
+      buffer: tinyPng("red"),
+    });
+    await expect(panel.locator('[data-testid="attachment-item"]')).toHaveCount(
+      1,
+    );
+    await fileInput.setInputFiles({
+      name: "second.png",
+      mimeType: "image/png",
+      buffer: tinyPng("blue"),
+    });
+    await expect(panel.locator('[data-testid="attachment-item"]')).toHaveCount(
+      2,
+    );
+
+    // Open lightbox on the first image.
+    await panel
+      .locator('[data-testid="attachment-thumbnail"]')
+      .first()
+      .click();
+    const lightboxImg = page.locator(
+      '[data-testid="attachment-lightbox-image"]',
+    );
+    await expect(lightboxImg).toHaveAttribute("alt", "first.png");
+
+    // Arrow-right cycles to the next image.
+    await page.keyboard.press("ArrowRight");
+    await expect(lightboxImg).toHaveAttribute("alt", "second.png");
+
+    // Arrow-right wraps back to the first.
+    await page.keyboard.press("ArrowRight");
+    await expect(lightboxImg).toHaveAttribute("alt", "first.png");
+
+    // Arrow-left wraps to the last.
+    await page.keyboard.press("ArrowLeft");
+    await expect(lightboxImg).toHaveAttribute("alt", "second.png");
+
+    await page.keyboard.press("Escape");
+    await expect(
+      page.locator('[data-testid="attachment-lightbox"]'),
+    ).toBeHidden();
+  });
+
+  test("non-image attachments still render with a download link", async ({
+    page,
+  }) => {
+    await registerAndSignIn(page, uniqueEmail());
+    await page.goto(`${BASE_URL}/tasks`);
+
+    const title = `Mixed ${Date.now()}`;
+    await createTaskInline(page, title);
+    const item = page.locator('[data-testid="task-item"]', { hasText: title });
+
+    await item.locator('[data-testid="task-attachments-toggle"]').click();
+    await item.locator('[data-testid="attachment-file-input"]').setInputFiles({
+      name: "notes.txt",
+      mimeType: "text/plain",
+      buffer: Buffer.from("Plaintext attachment.\n"),
+    });
+    const panel = item.locator('[data-testid="attachments-panel"]');
+    const attachment = panel.locator('[data-testid="attachment-item"]').first();
+    // Non-image rows have an <a href> link, no thumbnail button.
+    await expect(
+      attachment.locator('[data-testid="attachment-thumbnail"]'),
+    ).toHaveCount(0);
+    const link = attachment.locator('[data-testid="attachment-link"]');
+    const tag = await link.evaluate((el) => el.tagName.toLowerCase());
+    expect(tag).toBe("a");
+    expect(await link.getAttribute("href")).toMatch(/^\/media\/attachments\//);
+  });
+});

--- a/pwa/components/tasks/AttachmentsPanel.tsx
+++ b/pwa/components/tasks/AttachmentsPanel.tsx
@@ -1,11 +1,13 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
+  ChevronLeft,
+  ChevronRight,
   FileArchive,
-  FileImage,
   FileText,
   File as FileIcon,
   Trash2,
   Upload,
+  X,
 } from "lucide-react";
 import { ENTRYPOINT } from "@/config/entrypoint";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -59,12 +61,13 @@ const formatBytes = (bytes: number): string => {
 };
 
 const iconFor = (mime: string) => {
-  if (mime.startsWith("image/")) return FileImage;
   if (mime === "application/zip") return FileArchive;
   if (mime.startsWith("text/") || mime === "application/json" || mime === "application/pdf")
     return FileText;
   return FileIcon;
 };
+
+const isImage = (mime: string) => mime.startsWith("image/");
 
 const AttachmentsPanel = ({
   taskTitle,
@@ -77,6 +80,33 @@ const AttachmentsPanel = ({
   const [busyCount, setBusyCount] = useState(0);
   const [dragOver, setDragOver] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  // Index into `imageAttachments` (computed below) of the image currently
+  // shown in the lightbox; null = closed. We store the index rather than the
+  // attachment itself so arrow-key cycling stays in sync if the upstream
+  // attachments list mutates while open.
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+  const imageAttachments = attachments.filter((a) => isImage(a.mimeType));
+
+  useEffect(() => {
+    if (lightboxIndex === null) return;
+    if (imageAttachments.length === 0) {
+      setLightboxIndex(null);
+      return;
+    }
+    const total = imageAttachments.length;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setLightboxIndex(null);
+      } else if (e.key === "ArrowRight") {
+        setLightboxIndex((i) => (i === null ? null : (i + 1) % total));
+      } else if (e.key === "ArrowLeft") {
+        setLightboxIndex((i) => (i === null ? null : (i - 1 + total) % total));
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [lightboxIndex, imageAttachments.length]);
 
   const uploadOne = async (file: File): Promise<string | null> => {
     if (file.size > MAX_BYTES) {
@@ -139,8 +169,63 @@ const AttachmentsPanel = ({
       {attachments.length > 0 && (
         <ul className="space-y-1">
           {attachments.map((file) => {
-            const Icon = iconFor(file.mimeType);
             const url = file.variantUrls.original;
+            if (isImage(file.mimeType)) {
+              const imageIndex = imageAttachments.indexOf(file);
+              return (
+                <li
+                  key={file["@id"]}
+                  className="flex items-center gap-2 text-sm rounded-md border bg-card px-3 py-2"
+                  data-testid="attachment-item"
+                  data-attachment-kind="image"
+                >
+                  {url ? (
+                    <button
+                      type="button"
+                      onClick={() => setLightboxIndex(imageIndex)}
+                      className="shrink-0 rounded overflow-hidden border bg-muted focus:outline-none focus:ring-2 focus:ring-ring"
+                      aria-label={`Preview ${file.originalName}`}
+                      data-testid="attachment-thumbnail"
+                    >
+                      <img
+                        src={url}
+                        alt=""
+                        className="h-10 w-10 object-cover"
+                      />
+                    </button>
+                  ) : (
+                    <span className="h-10 w-10 shrink-0 rounded border bg-muted" />
+                  )}
+                  {url ? (
+                    <button
+                      type="button"
+                      onClick={() => setLightboxIndex(imageIndex)}
+                      className="font-medium truncate hover:underline text-left"
+                      data-testid="attachment-link"
+                    >
+                      {file.originalName}
+                    </button>
+                  ) : (
+                    <span className="font-medium truncate">{file.originalName}</span>
+                  )}
+                  <span className="text-xs text-muted-foreground shrink-0">
+                    {formatBytes(file.byteSize)}
+                  </span>
+                  {canDeleteAll && (
+                    <button
+                      type="button"
+                      onClick={() => void onDetach(file)}
+                      aria-label={`Remove ${file.originalName}`}
+                      className="ml-auto text-destructive hover:text-destructive/80 p-0.5"
+                      data-testid="attachment-delete"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  )}
+                </li>
+              );
+            }
+            const Icon = iconFor(file.mimeType);
             return (
               <li
                 key={file["@id"]}
@@ -179,6 +264,71 @@ const AttachmentsPanel = ({
             );
           })}
         </ul>
+      )}
+
+      {lightboxIndex !== null && imageAttachments[lightboxIndex] && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label={`Preview: ${imageAttachments[lightboxIndex].originalName}`}
+          onClick={() => setLightboxIndex(null)}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/85 p-4"
+          data-testid="attachment-lightbox"
+        >
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              setLightboxIndex(null);
+            }}
+            aria-label="Close preview"
+            className="absolute top-4 right-4 rounded-full bg-black/40 p-2 text-white hover:bg-black/60"
+            data-testid="attachment-lightbox-close"
+          >
+            <X className="h-5 w-5" />
+          </button>
+          {imageAttachments.length > 1 && (
+            <>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  const total = imageAttachments.length;
+                  setLightboxIndex((i) =>
+                    i === null ? null : (i - 1 + total) % total,
+                  );
+                }}
+                aria-label="Previous image"
+                className="absolute left-4 top-1/2 -translate-y-1/2 rounded-full bg-black/40 p-2 text-white hover:bg-black/60"
+                data-testid="attachment-lightbox-prev"
+              >
+                <ChevronLeft className="h-6 w-6" />
+              </button>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  const total = imageAttachments.length;
+                  setLightboxIndex((i) =>
+                    i === null ? null : (i + 1) % total,
+                  );
+                }}
+                aria-label="Next image"
+                className="absolute right-4 top-1/2 -translate-y-1/2 rounded-full bg-black/40 p-2 text-white hover:bg-black/60"
+                data-testid="attachment-lightbox-next"
+              >
+                <ChevronRight className="h-6 w-6" />
+              </button>
+            </>
+          )}
+          <img
+            src={imageAttachments[lightboxIndex].variantUrls.original}
+            alt={imageAttachments[lightboxIndex].originalName}
+            onClick={(e) => e.stopPropagation()}
+            className="max-h-[90vh] max-w-[90vw] object-contain"
+            data-testid="attachment-lightbox-image"
+          />
+        </div>
       )}
 
       <div


### PR DESCRIPTION
Closes #110.

## Summary

- Image attachments (`mimeType.startsWith("image/")`) now render a 40px square thumbnail next to the filename instead of the generic file icon.
- Clicking the thumbnail or filename opens a fullscreen lightbox at native size (capped to 90vh / 90vw).
- Inside the lightbox: ArrowRight / ArrowLeft cycle through the task's other image attachments (wrapping at the ends), Esc closes, clicking the backdrop closes, dedicated close / prev / next buttons are also rendered.
- Non-image attachments keep the existing icon row + `<a href="/media/...">` download link.

## Test plan

- [x] New `e2e/tests/attachments-lightbox.spec.js` covers thumbnail rendering, opening the lightbox, arrow-key cycling (forward + backward + wrap), Esc-to-close, and the non-image row regression.
- [ ] Existing `attachments.spec.js` still green (it only uses `text/plain`, which goes through the unchanged non-image branch).
- [ ] Manually attach a screenshot to a task → thumbnail visible → click → lightbox opens → arrow keys cycle → Esc closes.