### PR TITLE
feat(tasks): paste-to-upload image attachments

### DIFF
--- a/e2e/tests/attachments-paste.spec.js
+++ b/e2e/tests/attachments-paste.spec.js
@@ -1,0 +1,141 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+const {
+  BASE_URL,
+  uniqueEmail: shared,
+  registerAndSignIn,
+  createTaskInline,
+} = require("./helpers");
+
+const uniqueEmail = () => shared("attach-paste");
+
+// Smallest valid 1x1 PNG.
+const TINY_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+/**
+ * Synthesise a paste event carrying a real PNG file payload, then dispatch
+ * it on the focused element. Playwright doesn't expose a "real" clipboard
+ * with file items, so we build the DataTransfer in-page from a base64 PNG
+ * and let the React handler treat it like a native paste.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {string} testid data-testid of the element to dispatch on
+ * @param {{ pngBase64: string, mimeType: string, filename?: string }} opts
+ */
+async function dispatchImagePaste(page, testid, opts) {
+  await page.evaluate(
+    ({ testid, pngBase64, mimeType, filename }) => {
+      const target = document.querySelector(`[data-testid="${testid}"]`);
+      if (!(target instanceof HTMLElement)) {
+        throw new Error(`Target [data-testid="${testid}"] not found`);
+      }
+      const bytes = Uint8Array.from(atob(pngBase64), (c) => c.charCodeAt(0));
+      const file = new File([bytes], filename || "image.png", {
+        type: mimeType,
+      });
+      const dt = new DataTransfer();
+      dt.items.add(file);
+      const event = new ClipboardEvent("paste", {
+        bubbles: true,
+        cancelable: true,
+        clipboardData: dt,
+      });
+      target.dispatchEvent(event);
+    },
+    { testid, pngBase64: opts.pngBase64, mimeType: opts.mimeType, filename: opts.filename },
+  );
+}
+
+test.describe("Paste-to-upload image attachments", () => {
+  test("pasting an image into the description editor uploads it as an attachment", async ({
+    page,
+  }) => {
+    await registerAndSignIn(page, uniqueEmail());
+    await page.goto(`${BASE_URL}/tasks`);
+
+    const title = `Paste ${Date.now()}`;
+    await createTaskInline(page, title);
+    const item = page.locator('[data-testid="task-item"]', { hasText: title });
+
+    // Open the description editor so its DOM exists in the row.
+    await item.locator('[data-testid="task-description-add"]').click();
+
+    // Dispatch a synthesized paste at the row level — the React handler is
+    // attached to the <tbody>, so events anywhere inside the row bubble up.
+    await dispatchImagePaste(page, "task-item", {
+      pngBase64: TINY_PNG_BASE64,
+      mimeType: "image/png",
+      filename: "screenshot.png",
+    });
+
+    // The attachments panel auto-opens on paste, and the upload appears.
+    const panel = item.locator('[data-testid="attachments-panel"]');
+    await expect(panel).toBeVisible();
+    await expect(panel.locator('[data-testid="attachment-item"]')).toHaveCount(1);
+    await expect(
+      item.locator('[data-testid="task-attachments-toggle"]'),
+    ).toContainText("Attachments (1)");
+  });
+
+  test("pasting plain text does not upload anything", async ({ page }) => {
+    await registerAndSignIn(page, uniqueEmail());
+    await page.goto(`${BASE_URL}/tasks`);
+
+    const title = `Paste-text ${Date.now()}`;
+    await createTaskInline(page, title);
+    const item = page.locator('[data-testid="task-item"]', { hasText: title });
+
+    // Open the attachments panel so we can assert the count stays at 0.
+    await item.locator('[data-testid="task-attachments-toggle"]').click();
+    const panel = item.locator('[data-testid="attachments-panel"]');
+    await expect(panel.locator('[data-testid="attachment-item"]')).toHaveCount(0);
+
+    // Dispatch a paste with text only (no file items).
+    await page.evaluate(() => {
+      const target = document.querySelector('[data-testid="task-item"]');
+      if (!(target instanceof HTMLElement)) throw new Error("no row");
+      const dt = new DataTransfer();
+      dt.setData("text/plain", "Just some text.");
+      const event = new ClipboardEvent("paste", {
+        bubbles: true,
+        cancelable: true,
+        clipboardData: dt,
+      });
+      target.dispatchEvent(event);
+    });
+
+    // No upload, no attachment row.
+    await expect(panel.locator('[data-testid="attachment-item"]')).toHaveCount(0);
+    await expect(
+      item.locator('[data-testid="task-attachments-toggle"]'),
+    ).toContainText("Attach");
+  });
+
+  test("pasting an image with no filename uses a synthesised name", async ({
+    page,
+  }) => {
+    await registerAndSignIn(page, uniqueEmail());
+    await page.goto(`${BASE_URL}/tasks`);
+
+    const title = `Paste-noname ${Date.now()}`;
+    await createTaskInline(page, title);
+    const item = page.locator('[data-testid="task-item"]', { hasText: title });
+
+    // Native screenshot tools commonly hand the browser a File whose name is
+    // the literal "image.png" placeholder — our handler treats that as
+    // "no name" and synthesises a timestamped filename instead.
+    await dispatchImagePaste(page, "task-item", {
+      pngBase64: TINY_PNG_BASE64,
+      mimeType: "image/png",
+      filename: "image.png",
+    });
+
+    const panel = item.locator('[data-testid="attachments-panel"]');
+    await expect(panel.locator('[data-testid="attachment-item"]')).toHaveCount(1);
+    // Filename starts with the synthesized "pasted-" prefix.
+    await expect(
+      panel.locator('[data-testid="attachment-item"]').first(),
+    ).toContainText(/pasted-\d{4}-\d{2}-\d{2}/);
+  });
+});

--- a/pwa/components/tasks/AttachmentsPanel.tsx
+++ b/pwa/components/tasks/AttachmentsPanel.tsx
@@ -9,8 +9,11 @@ import {
   Upload,
   X,
 } from "lucide-react";
-import { ENTRYPOINT } from "@/config/entrypoint";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  ATTACHMENT_SUPPORTED_MIMES,
+  uploadAttachmentFile,
+} from "@/lib/attachments";
 import { cn } from "@/lib/utils";
 
 export interface Attachment {
@@ -39,20 +42,7 @@ interface AttachmentsPanelProps {
   onDetach: (attachment: Attachment) => Promise<void>;
 }
 
-const SUPPORTED_MIMES = [
-  "image/jpeg",
-  "image/png",
-  "image/webp",
-  "image/gif",
-  "application/pdf",
-  "text/plain",
-  "text/markdown",
-  "text/csv",
-  "application/zip",
-  "application/json",
-];
-const ACCEPT_ATTRIBUTE = SUPPORTED_MIMES.join(",");
-const MAX_BYTES = 10 * 1024 * 1024;
+const ACCEPT_ATTRIBUTE = ATTACHMENT_SUPPORTED_MIMES.join(",");
 
 const formatBytes = (bytes: number): string => {
   if (bytes < 1024) return `${bytes} B`;
@@ -108,31 +98,6 @@ const AttachmentsPanel = ({
     return () => window.removeEventListener("keydown", handler);
   }, [lightboxIndex, imageAttachments.length]);
 
-  const uploadOne = async (file: File): Promise<string | null> => {
-    if (file.size > MAX_BYTES) {
-      throw new Error(`${file.name} is larger than 10 MB.`);
-    }
-    if (!SUPPORTED_MIMES.includes(file.type)) {
-      throw new Error(`${file.name}: unsupported type "${file.type || "unknown"}".`);
-    }
-    const form = new FormData();
-    form.append("file", file);
-    form.append("kind", "attachment");
-    const res = await fetch(`${ENTRYPOINT}/media-objects`, {
-      method: "POST",
-      credentials: "include",
-      body: form,
-    });
-    if (!res.ok) {
-      const data = await res.json().catch(() => ({}));
-      throw new Error(
-        data.detail || data.description || data.error || `Upload failed (${res.status}).`,
-      );
-    }
-    const media = (await res.json()) as { "@id": string };
-    return media["@id"];
-  };
-
   const handleFiles = async (files: FileList | File[]) => {
     const list = Array.from(files);
     if (list.length === 0) return;
@@ -140,8 +105,8 @@ const AttachmentsPanel = ({
     setError(null);
     for (const file of list) {
       try {
-        const iri = await uploadOne(file);
-        if (iri) await onAttach(iri);
+        const iri = await uploadAttachmentFile(file);
+        await onAttach(iri);
       } catch (err) {
         setError(err instanceof Error ? err.message : "Upload failed.");
       } finally {

--- a/pwa/lib/attachments.ts
+++ b/pwa/lib/attachments.ts
@@ -1,0 +1,69 @@
+import { ENTRYPOINT } from "@/config/entrypoint";
+
+export const ATTACHMENT_SUPPORTED_MIMES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+  "application/pdf",
+  "text/plain",
+  "text/markdown",
+  "text/csv",
+  "application/zip",
+  "application/json",
+];
+
+export const ATTACHMENT_MAX_BYTES = 10 * 1024 * 1024;
+
+/**
+ * Uploads a single file as a task attachment via `POST /media-objects`
+ * (kind=attachment) and returns the resulting MediaObject IRI. Throws an
+ * Error with a user-facing message on validation or server failure.
+ *
+ * Shared between the attachments panel (file picker / drag-drop) and the
+ * task-row paste handler so client-side validation stays in one place.
+ */
+export async function uploadAttachmentFile(file: File): Promise<string> {
+  if (file.size > ATTACHMENT_MAX_BYTES) {
+    throw new Error(`${file.name} is larger than 10 MB.`);
+  }
+  if (!ATTACHMENT_SUPPORTED_MIMES.includes(file.type)) {
+    throw new Error(
+      `${file.name}: unsupported type "${file.type || "unknown"}".`,
+    );
+  }
+  const form = new FormData();
+  form.append("file", file);
+  form.append("kind", "attachment");
+  const res = await fetch(`${ENTRYPOINT}/media-objects`, {
+    method: "POST",
+    credentials: "include",
+    body: form,
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(
+      data.detail ||
+        data.description ||
+        data.error ||
+        `Upload failed (${res.status}).`,
+    );
+  }
+  const media = (await res.json()) as { "@id": string };
+  return media["@id"];
+}
+
+/**
+ * Synthesises a filename for clipboard images that arrive without one
+ * (e.g. native screenshot tools). Format: `pasted-YYYY-MM-DDTHH-MM-SS.<ext>`
+ * — colons in the ISO timestamp are replaced so the name is safe across
+ * filesystems.
+ */
+export function synthesizePastedImageName(mimeType: string): string {
+  const ext = mimeType.split("/")[1] || "png";
+  const stamp = new Date()
+    .toISOString()
+    .replace(/[:.]/g, "-")
+    .replace(/Z$/, "");
+  return `pasted-${stamp}.${ext}`;
+}

--- a/pwa/pages/tasks.tsx
+++ b/pwa/pages/tasks.tsx
@@ -34,6 +34,10 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import { useAuth } from "@/contexts/AuthContext";
 import { ENTRYPOINT } from "@/config/entrypoint";
+import {
+  synthesizePastedImageName,
+  uploadAttachmentFile,
+} from "@/lib/attachments";
 import { signinHrefForCurrent } from "@/lib/authRedirect";
 import MarkdownEditor from "@/components/editor/MarkdownEditor";
 import AssigneesCombobox, {
@@ -645,7 +649,47 @@ const TaskRow = ({
   // Attachments embed inline on the Task payload, so no lazy fetch — we
   // just toggle the panel visibility. The count is always known.
   const [attachmentsExpanded, setAttachmentsExpanded] = useState(false);
+  const [pasteError, setPasteError] = useState<string | null>(null);
   const attachmentCount = task.attachments.length;
+
+  // Paste-to-upload: when the user pastes an image while focused inside this
+  // task row (description editor, comment composer, etc.), upload it as an
+  // attachment instead of letting the editor try to render the bytes inline.
+  // Text and other non-image clipboard payloads pass through untouched.
+  const handleTaskPaste = async (e: React.ClipboardEvent<HTMLElement>) => {
+    const items = e.clipboardData?.items;
+    if (!items) return;
+    const imageFiles: File[] = [];
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      if (item.kind === "file" && item.type.startsWith("image/")) {
+        const f = item.getAsFile();
+        if (f) imageFiles.push(f);
+      }
+    }
+    if (imageFiles.length === 0) return;
+    e.preventDefault();
+    setAttachmentsExpanded(true);
+    setPasteError(null);
+    for (const original of imageFiles) {
+      // Browsers usually return clipboard images as `File` with a name like
+      // "image.png" and a real type, but native screenshot tools sometimes
+      // hand us empty/bogus names. Re-wrap with a synthesised name so the
+      // server-side filename slug is meaningful.
+      const named =
+        original.name && original.name !== "image.png"
+          ? original
+          : new File([original], synthesizePastedImageName(original.type), {
+              type: original.type,
+            });
+      try {
+        const iri = await uploadAttachmentFile(named);
+        await onAttachMedia(task, iri);
+      } catch (err) {
+        setPasteError(err instanceof Error ? err.message : "Paste upload failed.");
+      }
+    }
+  };
 
   // --- Comments expansion -----------------------------------------------
   // Comments are fetched lazily — the load fires the first time the user
@@ -739,7 +783,12 @@ const TaskRow = ({
   // a `group/task` so hovering either row paints the bg on both, making the
   // pair feel like one card.
   return (
-    <tbody ref={setNodeRef} style={style} data-testid="task-item">
+    <tbody
+      ref={setNodeRef}
+      style={style}
+      data-testid="task-item"
+      onPaste={handleTaskPaste}
+    >
       <TableRow className="border-b-0 hover:bg-transparent">
         <TableCell className="w-8 align-top">
           <button
@@ -944,6 +993,15 @@ const TaskRow = ({
           <TableCell className="w-8" aria-hidden="true" />
           <TableCell className="w-10" aria-hidden="true" />
           <TableCell colSpan={5} className="pl-0 pr-4 pt-0 pb-3">
+            {pasteError && (
+              <Alert
+                variant="destructive"
+                className="mb-2"
+                data-testid="task-paste-error"
+              >
+                <AlertDescription>{pasteError}</AlertDescription>
+              </Alert>
+            )}
             <AttachmentsPanel
               taskTitle={task.title}
               attachments={task.attachments}


### PR DESCRIPTION
Closes #111.

## Summary

- Pasting an image while focused inside a task row (description editor, comment composer, anywhere in the `<tbody>`) uploads it as a task attachment via `POST /media-objects?kind=attachment`.
- The attachments panel auto-expands on a successful image paste so the user sees the new file appear.
- Plain text and other non-image clipboard payloads pass through untouched (no `preventDefault`, the editor receives them normally).
- Clipboard images that arrive with no name (or the generic `image.png` placeholder native screenshot tools tend to emit) are re-wrapped with a synthesised `pasted-{ISO timestamp}.png` filename so the server-side slug is meaningful.
- Extracted `uploadAttachmentFile` and the supported-MIME list into `pwa/lib/attachments.ts` so the panel's file-picker / drag-drop and the new paste handler share a single client-side validation pass.

## Test plan

- [x] New `e2e/tests/attachments-paste.spec.js` covers: image paste → upload + panel auto-opens, text paste → no upload, image paste with placeholder filename → synthesised name.
- [ ] Existing `attachments.spec.js` (file picker) still green — same upload helper, just relocated.
- [ ] Manually paste a screenshot into a task description → attachment row appears, screenshot is downloadable from the served `/media/...` URL.
- [ ] Pasting plain text into the description editor still inserts text normally.