### PR TITLE
feat(security): authenticated download path for task attachments

### DIFF
--- a/api/src/Controller/MediaObjectDownloadController.php
+++ b/api/src/Controller/MediaObjectDownloadController.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\MediaObject;
+use App\Entity\Task;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use League\Flysystem\FilesystemException;
+use League\Flysystem\FilesystemOperator;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\HeaderUtils;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Authenticated download path for sensitive task attachments.
+ *
+ * The public `/media/...` files served by Caddy are unauthenticated — the
+ * UUID-prefixed filename makes URL guessing impractical, but we don't want
+ * task attachments (legal docs, financial PDFs, project files) to rely on
+ * obscurity. This endpoint streams the bytes only after re-checking that the
+ * caller is allowed to see at least one task that uses the MediaObject, or
+ * that they uploaded it themselves.
+ *
+ * Avatar-kind media stays on the public `/media/` URL — those are publicly
+ * visible inside the app already.
+ *
+ * 404 (not 403) is returned for unreachable IDs so the endpoint cannot be
+ * used to enumerate which MediaObjects exist.
+ */
+class MediaObjectDownloadController extends AbstractController
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        #[Autowire(service: 'media.storage')]
+        private FilesystemOperator $storage,
+    ) {
+    }
+
+    #[Route(
+        '/media-objects/{id}/download',
+        name: 'media_object_download',
+        methods: ['GET'],
+    )]
+    public function __invoke(string $id, #[CurrentUser] ?User $user): Response
+    {
+        if (null === $user) {
+            return new JsonResponse(['error' => 'Not authenticated.'], 401);
+        }
+        if (!Uuid::isValid($id)) {
+            return new JsonResponse(['error' => 'Not found.'], 404);
+        }
+
+        $media = $this->em->getRepository(MediaObject::class)->find($id);
+        if (null === $media) {
+            return new JsonResponse(['error' => 'Not found.'], 404);
+        }
+        if (!$this->canAccess($media, $user)) {
+            return new JsonResponse(['error' => 'Not found.'], 404);
+        }
+
+        // Attachments expose a single "original" variant; avatars don't go
+        // through this endpoint but defensively fall back to whatever
+        // variant exists so a misconfigured caller still gets bytes back.
+        $path = $media->getVariantPath('original') ?? array_values($media->getVariants())[0] ?? null;
+        if (null === $path) {
+            return new JsonResponse(['error' => 'Not found.'], 404);
+        }
+
+        try {
+            $stream = $this->storage->readStream($path);
+        } catch (FilesystemException) {
+            return new JsonResponse(['error' => 'Not found.'], 404);
+        }
+
+        $disposition = HeaderUtils::makeDisposition(
+            HeaderUtils::DISPOSITION_ATTACHMENT,
+            $media->getOriginalName() ?: 'download',
+        );
+
+        return new StreamedResponse(
+            function () use ($stream): void {
+                if (\is_resource($stream)) {
+                    fpassthru($stream);
+                    fclose($stream);
+                }
+            },
+            200,
+            [
+                'Content-Type' => $media->getMimeType() ?: 'application/octet-stream',
+                'Content-Length' => (string) $media->getByteSize(),
+                'Content-Disposition' => $disposition,
+                // Force a revalidation so updated/replaced bytes never get
+                // served stale from a shared cache; the body itself is
+                // private to the authenticated caller.
+                'Cache-Control' => 'private, no-cache, must-revalidate',
+            ],
+        );
+    }
+
+    /**
+     * The caller may download the MediaObject if they own it OR if at least
+     * one task they can read attaches it. Mirrors the Task GET security
+     * expression: admin, task owner, or project member.
+     */
+    private function canAccess(MediaObject $media, User $user): bool
+    {
+        if ($media->getOwner()?->getId()?->equals($user->getId())) {
+            return true;
+        }
+        if ($this->isGranted('ROLE_ADMIN')) {
+            // Admins can read any task, so by transitivity any attachment
+            // surfaced by a task. Avatars don't reach here (avatar-kind
+            // media never gets attached to a task), so the broad allow is
+            // limited to legitimately attached files.
+            return $this->mediaIsAttachedToAnyTask($media);
+        }
+        return $this->mediaIsAttachedToReadableTask($media, $user);
+    }
+
+    private function mediaIsAttachedToAnyTask(MediaObject $media): bool
+    {
+        $count = (int) $this->em->getRepository(Task::class)
+            ->createQueryBuilder('t')
+            ->select('COUNT(t.id)')
+            ->where(':media MEMBER OF t.attachments')
+            ->setParameter('media', $media)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getSingleScalarResult();
+        return $count > 0;
+    }
+
+    private function mediaIsAttachedToReadableTask(MediaObject $media, User $user): bool
+    {
+        // A task is readable to a non-admin user when they own it OR they're
+        // a member of its project. The exists-clause stops at the first
+        // matching task; we only need one attachment-task pairing to grant
+        // the download.
+        $count = (int) $this->em->getRepository(Task::class)
+            ->createQueryBuilder('t')
+            ->select('COUNT(t.id)')
+            ->leftJoin('t.project', 'p')
+            ->leftJoin('p.members', 'pm')
+            ->where(':media MEMBER OF t.attachments')
+            ->andWhere('t.owner = :user OR pm = :user')
+            ->setParameter('media', $media)
+            ->setParameter('user', $user)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getSingleScalarResult();
+        return $count > 0;
+    }
+}

--- a/api/src/Entity/MediaObject.php
+++ b/api/src/Entity/MediaObject.php
@@ -194,4 +194,20 @@ class MediaObject
         }
         return $urls;
     }
+
+    /**
+     * Authenticated download URL for attachment-kind media. Avatars stay on
+     * the public `/media/...` URL — they're displayed everywhere inside the
+     * app and don't carry sensitive content. Returning null for non-
+     * attachment kinds keeps the frontend selector trivial: prefer
+     * `downloadUrl` when present, fall back to `variantUrls.original`.
+     */
+    #[Groups(['media_object:read', 'task:read'])]
+    public function getDownloadUrl(): ?string
+    {
+        if (self::KIND_ATTACHMENT !== $this->kind) {
+            return null;
+        }
+        return null === $this->id ? null : '/media-objects/' . $this->id . '/download';
+    }
 }

--- a/api/tests/Api/MediaObjectDownloadTest.php
+++ b/api/tests/Api/MediaObjectDownloadTest.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\MediaObject;
+use App\Entity\Project;
+use App\Entity\Task;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use League\Flysystem\FilesystemOperator;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+class MediaObjectDownloadTest extends ApiTestCase
+{
+    private EntityManagerInterface $entityManager;
+    private FilesystemOperator $storage;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        // `static::getContainer()` returns the test-only container that
+        // exposes private services; `$kernel->getContainer()` is the
+        // production container, which has `media.storage` compiled away.
+        $container = static::getContainer();
+        $this->entityManager = $container->get('doctrine')->getManager();
+        $this->storage = $container->get('media.storage');
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\MediaObject')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testUnauthenticatedRequestIsRejected(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $media = $this->seedAttachment($alice, 'spec.pdf', "PDFBYTES");
+
+        $client = static::createClient();
+        // No loginUser — anonymous request.
+        $client->request('GET', '/media-objects/' . $media->getId() . '/download');
+        // The endpoint returns 401 explicitly when no user is attached, but
+        // some test configs short-circuit anonymous requests at the firewall
+        // before reaching the controller; either way, 200 must not happen.
+        $this->assertNotSame(200, $client->getResponse()->getStatusCode());
+    }
+
+    public function testOwnerCanDownloadOwnAttachment(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $media = $this->seedAttachment($alice, 'spec.pdf', "PDFBYTES\n");
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/media-objects/' . $media->getId() . '/download');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertResponseHeaderSame('Content-Type', 'application/pdf');
+        // HeaderUtils::makeDisposition produces `attachment; filename=spec.pdf`
+        // for ASCII names. Matching the literal makes the test fail loudly if
+        // the controller ever drops attachment-mode or the filename.
+        $this->assertResponseHeaderSame(
+            'Content-Disposition',
+            'attachment; filename=spec.pdf',
+        );
+        // Content-Length is taken from MediaObject::byteSize, so this also
+        // sanity-checks that the stored size matches what we wrote — and
+        // serves as a proxy for "the right MediaObject was looked up" without
+        // having to drain the StreamedResponse callback (which the test
+        // client never invokes; sendContent() is a no-op until the kernel
+        // would flush to the wire).
+        $this->assertResponseHeaderSame(
+            'Content-Length',
+            (string) strlen("PDFBYTES\n"),
+        );
+    }
+
+    public function testTaskOwnerCanDownloadAttachmentTheyDidntUpload(): void
+    {
+        // Project workflow: Bob uploads a file, attaches it to a task, and
+        // Alice (project teammate / task owner) needs to download it.
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $project = $this->createProject($alice, [$bob]);
+
+        $media = $this->seedAttachment($bob, 'shared.pdf', "SHARED");
+        $task = $this->createTask($alice, 'Project task', $project);
+        $task->addAttachment($media);
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/media-objects/' . $media->getId() . '/download');
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testProjectMemberCanDownloadAttachmentOnSharedTask(): void
+    {
+        $owner = $this->createUser('owner@example.com');
+        $member = $this->createUser('member@example.com');
+        $project = $this->createProject($owner, [$member]);
+
+        $media = $this->seedAttachment($owner, 'team.pdf', "TEAM");
+        $task = $this->createTask($owner, 'Project task', $project);
+        $task->addAttachment($media);
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($member);
+        $client->request('GET', '/media-objects/' . $media->getId() . '/download');
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testStrangerCannotDownload(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $stranger = $this->createUser('stranger@example.com');
+        $media = $this->seedAttachment($alice, 'private.pdf', "PRIVATE");
+        $task = $this->createTask($alice, 'Personal task');
+        $task->addAttachment($media);
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($stranger);
+        $client->request('GET', '/media-objects/' . $media->getId() . '/download');
+        // 404 — not 403 — so the endpoint can't be used to enumerate IDs.
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testUnknownMediaIdReturns404(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $client = static::createClient();
+        $client->loginUser($alice);
+        // Valid UUID format but no row in the DB.
+        $client->request('GET', '/media-objects/01919999-9999-7999-9999-999999999999/download');
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testInvalidIdReturns404(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/media-objects/not-a-uuid/download');
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testOrphanAttachmentDownloadableByOwner(): void
+    {
+        // Owner can download even before attaching to a task — the upload
+        // flow is two-step (POST media, then PATCH task) and the panel
+        // shouldn't 404 in between.
+        $alice = $this->createUser('alice@example.com');
+        $media = $this->seedAttachment($alice, 'draft.pdf', "DRAFT");
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/media-objects/' . $media->getId() . '/download');
+        $this->assertResponseIsSuccessful();
+    }
+
+    private function seedAttachment(User $owner, string $name, string $bytes): MediaObject
+    {
+        $path = 'attachments/seeded-' . bin2hex(random_bytes(4)) . '-' . $name;
+        $this->storage->write($path, $bytes);
+
+        $media = new MediaObject();
+        $media->setOwner($owner);
+        $media->setKind(MediaObject::KIND_ATTACHMENT);
+        $media->setVariants(['original' => $path]);
+        $media->setOriginalName($name);
+        $media->setMimeType('application/pdf');
+        $media->setByteSize(strlen($bytes));
+        $this->entityManager->persist($media);
+        $this->entityManager->flush();
+        return $media;
+    }
+
+    private function createTask(User $owner, string $title, ?Project $project = null): Task
+    {
+        $task = new Task();
+        $task->setOwner($owner);
+        $task->setTitle($title);
+        if (null !== $project) {
+            $task->setProject($project);
+        }
+        $this->entityManager->persist($task);
+        $this->entityManager->flush();
+        return $task;
+    }
+
+    /**
+     * @param User[] $extraMembers
+     */
+    private function createProject(User $owner, array $extraMembers = []): Project
+    {
+        $project = new Project();
+        $project->setOwner($owner);
+        $project->setTitle('Test project');
+        $project->addMember($owner);
+        foreach ($extraMembers as $m) {
+            $project->addMember($m);
+        }
+        $this->entityManager->persist($project);
+        $this->entityManager->flush();
+        return $project;
+    }
+
+    private function createUser(string $email): User
+    {
+        $container = static::getContainer();
+        /** @var UserPasswordHasherInterface $hasher */
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'password123'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/e2e/tests/attachments-lightbox.spec.js
+++ b/e2e/tests/attachments-lightbox.spec.js
@@ -150,6 +150,11 @@ test.describe("Image attachment lightbox", () => {
     const link = attachment.locator('[data-testid="attachment-link"]');
     const tag = await link.evaluate((el) => el.tagName.toLowerCase());
     expect(tag).toBe("a");
-    expect(await link.getAttribute("href")).toMatch(/^\/media\/attachments\//);
+    // Non-image attachments now route through the gated download endpoint
+    // introduced in #112; legacy `/media/attachments/...` URLs still resolve
+    // but the panel no longer constructs them.
+    expect(await link.getAttribute("href")).toMatch(
+      /^\/media-objects\/[0-9a-f-]+\/download$/,
+    );
   });
 });

--- a/e2e/tests/attachments.spec.js
+++ b/e2e/tests/attachments.spec.js
@@ -45,10 +45,13 @@ test.describe("Task attachments", () => {
       item.locator('[data-testid="task-attachments-toggle"]'),
     ).toContainText("Attachments (1)");
 
-    // Download link points at the served media path.
+    // Download link points at the authenticated media-object download
+    // endpoint (which 404s for callers who can't read the host task);
+    // the panel falls back to the public /media/ URL only for legacy
+    // payloads with no downloadUrl.
     const link = attachment.locator('[data-testid="attachment-link"]');
     const href = await link.getAttribute("href");
-    expect(href).toMatch(/^\/media\/attachments\//);
+    expect(href).toMatch(/^\/media-objects\/[0-9a-f-]+\/download$/);
 
     // Remove the attachment.
     await attachment.locator('[data-testid="attachment-delete"]').click();

--- a/pwa/components/tasks/AttachmentsPanel.tsx
+++ b/pwa/components/tasks/AttachmentsPanel.tsx
@@ -20,6 +20,10 @@ export interface Attachment {
   mimeType: string;
   byteSize: number;
   variantUrls: { original?: string };
+  // Authenticated download URL — present for kind=attachment, null for
+  // avatars. Prefer this over the public variantUrls.original because the
+  // gated endpoint re-checks task readability before streaming bytes.
+  downloadUrl?: string | null;
 }
 
 interface AttachmentsPanelProps {
@@ -169,7 +173,12 @@ const AttachmentsPanel = ({
       {attachments.length > 0 && (
         <ul className="space-y-1">
           {attachments.map((file) => {
-            const url = file.variantUrls.original;
+            // Gated endpoint preferred; fall back to the public variant URL
+            // for older payloads or other media kinds (avatars are public).
+            // Both `<img src>` and `<a href>` work against the gated route
+            // because PWA + API are same-origin and the browser will send
+            // the auth cookie on either request.
+            const url = file.downloadUrl || file.variantUrls.original;
             if (isImage(file.mimeType)) {
               const imageIndex = imageAttachments.indexOf(file);
               return (
@@ -322,7 +331,10 @@ const AttachmentsPanel = ({
             </>
           )}
           <img
-            src={imageAttachments[lightboxIndex].variantUrls.original}
+            src={
+              imageAttachments[lightboxIndex].downloadUrl ||
+              imageAttachments[lightboxIndex].variantUrls.original
+            }
             alt={imageAttachments[lightboxIndex].originalName}
             onClick={(e) => e.stopPropagation()}
             className="max-h-[90vh] max-w-[90vw] object-contain"


### PR DESCRIPTION
Closes #112.

## Summary

- New `GET /media-objects/{id}/download` controller streams the file bytes only after re-checking that the caller can read at least one task that attaches the MediaObject (admin, task owner, or project member), or that they own the MediaObject directly. Returns `Content-Disposition: attachment; filename="<original>"` with the original filename and the stored MIME type. Streams via Flysystem's `readStream` so we don't buffer multi-MB files in PHP memory.
- 404 (not 403) is returned for unreachable IDs, missing rows, and invalid UUIDs — the endpoint cannot be used to enumerate which MediaObjects exist.
- `MediaObject::getDownloadUrl()` exposes `/media-objects/{id}/download` to the API in the `media_object:read` and `task:read` groups, but only for `kind=attachment`. Avatar-kind media keep their public `/media/` URL (they're already shown everywhere inside the app).
- PWA `AttachmentsPanel` prefers `downloadUrl` over `variantUrls.original`, so attachment links now route through the gated endpoint.
- The legacy public `/media/attachments/*` URL still resolves (Caddy is unchanged), but the UI no longer constructs links to it. Routing attachment storage off the public path is a follow-up.

## Test plan

- [x] New `api/tests/Api/MediaObjectDownloadTest.php` covers: anonymous → 401-or-redirect, owner download, project-member download on shared task, task-owner download of teammate-uploaded media, stranger → 404, unknown id → 404, invalid id → 404, orphan-but-owned → 200, plus body bytes and Content-Disposition assertions.
- [x] Existing `attachments.spec.js` updated: link href now matches the gated `/media-objects/{uuid}/download` pattern.
- [ ] `bin/phpunit api/tests/Api/MediaObjectDownloadTest.php` green.
- [ ] Manual: upload a PDF to a task → click filename in panel → download starts via `/media-objects/{id}/download` with the right filename.