### PR TITLE
feat(comments): live updates via Mercure (closes #107)

### DIFF
--- a/api/config/reference.php
+++ b/api/config/reference.php
@@ -1003,8 +1003,8 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * }
  * @psalm-type MercureConfig = array{
  *     hubs?: array<string, array{ // Default: []
- *         url?: scalar|Param|null, // URL of the hub's publish endpoint
- *         public_url?: scalar|Param|null, // URL of the hub's public endpoint // Default: null
+ *         url?: scalar|Param|null, // URL of the hub's publish endpoint // Default: null
+ *         public_url?: scalar|Param|null, // URL of the hub's public endpoint
  *         jwt?: string|array{ // JSON Web Token configuration.
  *             value?: scalar|Param|null, // JSON Web Token to use to publish to this hub.
  *             provider?: scalar|Param|null, // The ID of a service to call to provide the JSON Web Token.

--- a/api/src/Controller/TaskCommentsMercureTokenController.php
+++ b/api/src/Controller/TaskCommentsMercureTokenController.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\Task;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Mercure\Authorization;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Hands the PWA a `mercureAuthorization` cookie scoped to the comments
+ * topic for a single task. The cookie is signed by the same secret the
+ * publisher uses, so the Mercure hub treats the bearer as authorised to
+ * subscribe to `/tasks/{id}/comments` — and only that topic.
+ *
+ * Auth mirrors the Task GET security expression (admin / task owner /
+ * project member). 404 (not 403) is returned for unreachable IDs so the
+ * endpoint can't be used to enumerate task IDs.
+ */
+class TaskCommentsMercureTokenController extends AbstractController
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private Authorization $authorization,
+    ) {
+    }
+
+    #[Route(
+        '/tasks/{id}/comments/mercure-token',
+        name: 'task_comments_mercure_token',
+        methods: ['GET'],
+    )]
+    public function __invoke(string $id, Request $request, #[CurrentUser] ?User $user): Response
+    {
+        if (null === $user) {
+            return new JsonResponse(['error' => 'Not authenticated.'], 401);
+        }
+        if (!Uuid::isValid($id)) {
+            return new JsonResponse(['error' => 'Not found.'], 404);
+        }
+
+        $task = $this->em->getRepository(Task::class)->find($id);
+        if (null === $task) {
+            return new JsonResponse(['error' => 'Not found.'], 404);
+        }
+        if (!$this->canRead($task, $user)) {
+            return new JsonResponse(['error' => 'Not found.'], 404);
+        }
+
+        $topic = '/tasks/' . $task->getId() . '/comments';
+        // Authorization::setCookie stages a Set-Cookie on the request
+        // attributes; the Mercure event listener flushes it onto the
+        // response just before send. The cookie is path-scoped to the
+        // hub URL, so the browser only sends it back when opening an
+        // EventSource against /.well-known/mercure.
+        $this->authorization->setCookie($request, [$topic]);
+
+        return new JsonResponse(['topic' => $topic]);
+    }
+
+    private function canRead(Task $task, User $user): bool
+    {
+        if ($this->isGranted('ROLE_ADMIN')) {
+            return true;
+        }
+        if ($task->getOwner()?->getId()?->equals($user->getId())) {
+            return true;
+        }
+        $project = $task->getProject();
+        if (null === $project) {
+            return false;
+        }
+        foreach ($project->getMembers() as $member) {
+            if ($member->getId()?->equals($user->getId())) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/api/src/Entity/Comment.php
+++ b/api/src/Entity/Comment.php
@@ -13,6 +13,8 @@ use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
 use App\Repository\CommentRepository;
 use App\State\CommentAuthorProcessor;
+use App\State\CommentDeleteProcessor;
+use App\State\CommentUpdateProcessor;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Uid\Uuid;
@@ -42,9 +44,11 @@ use Symfony\Component\Validator\Constraints as Assert;
         ),
         new Patch(
             security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getAuthor() == user)",
+            processor: CommentUpdateProcessor::class,
         ),
         new Delete(
             security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getAuthor() == user or object.getTask().getOwner() == user)",
+            processor: CommentDeleteProcessor::class,
         ),
     ],
     normalizationContext: ['groups' => ['comment:read']],

--- a/api/src/Service/CommentMercurePublisher.php
+++ b/api/src/Service/CommentMercurePublisher.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Comment;
+use App\Entity\Task;
+use Symfony\Component\Mercure\HubInterface;
+use Symfony\Component\Mercure\Update;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Publishes comment lifecycle events on the parent task's Mercure topic so
+ * collaborators see each other's posts without reloading. The topic is the
+ * task's path with `/comments` appended (e.g. `/tasks/abc-123/comments`),
+ * which matches what the subscribe-token endpoint authorizes.
+ *
+ * Updates are published with `private=true` — only subscribers whose JWT
+ * lists the topic in its `subscribe` claim will receive them. The
+ * `TaskCommentsMercureTokenController` is the only place that mints those
+ * JWTs, and it re-uses the Task GET security expression, so no one
+ * downstream of this service can subscribe without proving they can read
+ * the parent task.
+ */
+final class CommentMercurePublisher
+{
+    public function __construct(
+        private HubInterface $hub,
+        private NormalizerInterface $normalizer,
+    ) {
+    }
+
+    public function publishCreated(Comment $comment): void
+    {
+        $this->publish('create', $comment, $this->serializeComment($comment));
+    }
+
+    public function publishUpdated(Comment $comment): void
+    {
+        $this->publish('update', $comment, $this->serializeComment($comment));
+    }
+
+    /**
+     * Delete is special: by the time a subscriber would want to fetch the
+     * comment it's already gone, so we send just the IRI + parent task IRI.
+     * The frontend uses the IRI to drop the row from local state.
+     */
+    public function publishDeleted(Comment $comment): void
+    {
+        $task = $comment->getTask();
+        if (null === $task || null === $task->getId() || null === $comment->getId()) {
+            return;
+        }
+        $payload = [
+            'type' => 'delete',
+            'id' => '/comments/' . $comment->getId(),
+            'task' => '/tasks/' . $task->getId(),
+        ];
+        $this->dispatch($task, $payload);
+    }
+
+    /**
+     * @param array<string, mixed> $serialized
+     */
+    private function publish(string $type, Comment $comment, array $serialized): void
+    {
+        $task = $comment->getTask();
+        if (null === $task || null === $task->getId()) {
+            return;
+        }
+        $this->dispatch($task, [
+            'type' => $type,
+            'comment' => $serialized,
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function dispatch(Task $task, array $payload): void
+    {
+        $topic = '/tasks/' . $task->getId() . '/comments';
+        $this->hub->publish(new Update($topic, json_encode($payload, \JSON_THROW_ON_ERROR), true));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serializeComment(Comment $comment): array
+    {
+        /** @var array<string, mixed> $data */
+        $data = $this->normalizer->normalize($comment, 'jsonld', ['groups' => ['comment:read']]);
+        return $data;
+    }
+}

--- a/api/src/State/CommentDeleteProcessor.php
+++ b/api/src/State/CommentDeleteProcessor.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\Entity\Comment;
+use App\Service\CommentMercurePublisher;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Wraps the default ORM remove processor on `DELETE /comments/{id}`.
+ * The publish has to happen *before* the SQL delete so the entity still
+ * has its id and parent task — after `process()` returns the in-memory
+ * object's id is gone and the doctrine listener has already detached it.
+ *
+ * @implements ProcessorInterface<Comment, void|Comment>
+ */
+final class CommentDeleteProcessor implements ProcessorInterface
+{
+    /**
+     * @param ProcessorInterface<Comment, void|Comment> $removeProcessor
+     */
+    public function __construct(
+        #[Autowire(service: 'api_platform.doctrine.orm.state.remove_processor')]
+        private ProcessorInterface $removeProcessor,
+        private CommentMercurePublisher $publisher,
+    ) {
+    }
+
+    /**
+     * @param Comment $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): mixed
+    {
+        // Snapshot first; the remove processor wipes the in-memory id.
+        $this->publisher->publishDeleted($data);
+        return $this->removeProcessor->process($data, $operation, $uriVariables, $context);
+    }
+}

--- a/api/src/State/CommentUpdateProcessor.php
+++ b/api/src/State/CommentUpdateProcessor.php
@@ -5,21 +5,17 @@ namespace App\State;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\Entity\Comment;
-use App\Entity\User;
 use App\Service\CommentMercurePublisher;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 /**
- * Stamps the comment with the currently authenticated user before persisting,
- * then notifies Mercure subscribers of the new comment so collaborators see
- * it without reloading. Author is never trusted from the request payload —
- * same pattern as TaskOwnerProcessor.
+ * Wraps the default ORM persist processor on `PATCH /comments/{id}` so we
+ * can publish the edit to Mercure subscribers after the row has been
+ * flushed. Same pattern as TaskUpdateProcessor.
  *
  * @implements ProcessorInterface<Comment, Comment>
  */
-final class CommentAuthorProcessor implements ProcessorInterface
+final class CommentUpdateProcessor implements ProcessorInterface
 {
     /**
      * @param ProcessorInterface<Comment, Comment> $persistProcessor
@@ -27,7 +23,6 @@ final class CommentAuthorProcessor implements ProcessorInterface
     public function __construct(
         #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
         private ProcessorInterface $persistProcessor,
-        private Security $security,
         private CommentMercurePublisher $publisher,
     ) {
     }
@@ -37,16 +32,8 @@ final class CommentAuthorProcessor implements ProcessorInterface
      */
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Comment
     {
-        $user = $this->security->getUser();
-        if (!$user instanceof User) {
-            throw new UnauthorizedHttpException('Bearer', 'You must be authenticated to comment.');
-        }
-
-        $data->setAuthor($user);
-
         $result = $this->persistProcessor->process($data, $operation, $uriVariables, $context);
-        $this->publisher->publishCreated($result);
-
+        $this->publisher->publishUpdated($result);
         return $result;
     }
 }

--- a/api/tests/Api/TaskCommentsMercureTokenTest.php
+++ b/api/tests/Api/TaskCommentsMercureTokenTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\Project;
+use App\Entity\Task;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+class TaskCommentsMercureTokenTest extends ApiTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $container = static::getContainer();
+        $this->entityManager = $container->get('doctrine')->getManager();
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Comment')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testUnauthenticatedRequestRejected(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->createTask($alice, 'Personal task');
+
+        $client = static::createClient();
+        $client->request('GET', '/tasks/' . $task->getId() . '/comments/mercure-token');
+        $this->assertNotSame(200, $client->getResponse()->getStatusCode());
+    }
+
+    public function testTaskOwnerGetsTokenAndCookie(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->createTask($alice, 'Personal task');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/tasks/' . $task->getId() . '/comments/mercure-token');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains([
+            'topic' => '/tasks/' . $task->getId() . '/comments',
+        ]);
+
+        // The mercureAuthorization cookie is set on the response by the
+        // Symfony Mercure listener after the controller stages it. The
+        // ApiPlatform test Response wrapper hides headers/cookies, so we
+        // unwrap to the underlying HttpFoundation response.
+        $cookies = $client->getResponse()->getKernelResponse()->headers->getCookies();
+        $names = array_map(static fn ($c) => $c->getName(), $cookies);
+        $this->assertContains('mercureAuthorization', $names, 'Subscriber cookie must be set on the response.');
+    }
+
+    public function testProjectMemberGetsToken(): void
+    {
+        $owner = $this->createUser('owner@example.com');
+        $member = $this->createUser('member@example.com');
+        $project = $this->createSharedProject($owner, [$owner, $member]);
+        $task = $this->createTaskInProject($owner, $project, 'Project task');
+
+        $client = static::createClient();
+        $client->loginUser($member);
+        $client->request('GET', '/tasks/' . $task->getId() . '/comments/mercure-token');
+
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testStrangerCannotGetToken(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $stranger = $this->createUser('stranger@example.com');
+        $task = $this->createTask($alice, 'Private task');
+
+        $client = static::createClient();
+        $client->loginUser($stranger);
+        $client->request('GET', '/tasks/' . $task->getId() . '/comments/mercure-token');
+
+        // 404 (not 403) — same enumeration-resistance rule the Task GET uses.
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testUnknownTaskReturns404(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/tasks/0193ffff-9999-7999-8999-999999999999/comments/mercure-token');
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testInvalidUuidReturns404(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/tasks/not-a-uuid/comments/mercure-token');
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    private function createTask(User $owner, string $title, ?Project $project = null): Task
+    {
+        $task = new Task();
+        $task->setOwner($owner);
+        $task->setTitle($title);
+        if (null !== $project) {
+            $task->setProject($project);
+        }
+        $this->entityManager->persist($task);
+        $this->entityManager->flush();
+        return $task;
+    }
+
+    private function createTaskInProject(User $owner, Project $project, string $title): Task
+    {
+        return $this->createTask($owner, $title, $project);
+    }
+
+    /**
+     * @param User[] $members
+     */
+    private function createSharedProject(User $owner, array $members): Project
+    {
+        $project = new Project();
+        $project->setOwner($owner);
+        $project->setTitle('Shared');
+        foreach ($members as $m) {
+            $project->addMember($m);
+        }
+        $this->entityManager->persist($project);
+        $this->entityManager->flush();
+        return $project;
+    }
+
+    private function createUser(string $email): User
+    {
+        $container = static::getContainer();
+        /** @var UserPasswordHasherInterface $hasher */
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'password123'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+        return $user;
+    }
+}

--- a/api/tests/Service/CommentMercurePublisherTest.php
+++ b/api/tests/Service/CommentMercurePublisherTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Entity\Comment;
+use App\Entity\Task;
+use App\Entity\User;
+use App\Service\CommentMercurePublisher;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mercure\HubInterface;
+use Symfony\Component\Mercure\Update;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Unit tests for the publisher. The hub is replaced with an in-memory
+ * recorder; we don't go through ApiPlatform here because the goal is to
+ * pin the topic format and payload shape so subscribers can rely on them.
+ */
+class CommentMercurePublisherTest extends TestCase
+{
+    public function testPublishCreatedSendsCommentPayloadOnTaskTopic(): void
+    {
+        [$publisher, $hub] = $this->makePublisher();
+
+        $publisher->publishCreated($this->makeComment(
+            taskId: '0193aaaa-0001-7000-8000-000000000001',
+            commentId: '0193bbbb-0001-7000-8000-000000000001',
+            body: 'Looks good.',
+        ));
+
+        $this->assertCount(1, $hub->updates);
+        $update = $hub->updates[0];
+        $this->assertSame('/tasks/0193aaaa-0001-7000-8000-000000000001/comments', $update->getTopics()[0]);
+        $this->assertTrue($update->isPrivate(), 'Updates must be private so unauthorised subscribers cannot read them.');
+
+        $payload = json_decode($update->getData(), true, 512, \JSON_THROW_ON_ERROR);
+        $this->assertSame('create', $payload['type']);
+        $this->assertSame('Looks good.', $payload['comment']['body']);
+        $this->assertSame('/comments/0193bbbb-0001-7000-8000-000000000001', $payload['comment']['@id']);
+    }
+
+    public function testPublishUpdatedUsesUpdateType(): void
+    {
+        [$publisher, $hub] = $this->makePublisher();
+
+        $publisher->publishUpdated($this->makeComment(
+            taskId: '0193aaaa-0001-7000-8000-000000000002',
+            commentId: '0193bbbb-0001-7000-8000-000000000002',
+            body: 'Edited.',
+        ));
+
+        $payload = json_decode($hub->updates[0]->getData(), true, 512, \JSON_THROW_ON_ERROR);
+        $this->assertSame('update', $payload['type']);
+        $this->assertSame('Edited.', $payload['comment']['body']);
+    }
+
+    public function testPublishDeletedSendsLeanIriPayload(): void
+    {
+        [$publisher, $hub] = $this->makePublisher();
+
+        $publisher->publishDeleted($this->makeComment(
+            taskId: '0193aaaa-0001-7000-8000-000000000003',
+            commentId: '0193bbbb-0001-7000-8000-000000000003',
+            body: 'Stale comment.',
+        ));
+
+        $update = $hub->updates[0];
+        $this->assertSame(
+            '/tasks/0193aaaa-0001-7000-8000-000000000003/comments',
+            $update->getTopics()[0],
+        );
+        $payload = json_decode($update->getData(), true, 512, \JSON_THROW_ON_ERROR);
+        $this->assertSame([
+            'type' => 'delete',
+            'id' => '/comments/0193bbbb-0001-7000-8000-000000000003',
+            'task' => '/tasks/0193aaaa-0001-7000-8000-000000000003',
+        ], $payload);
+    }
+
+    public function testPublishCreatedNoOpWhenTaskMissing(): void
+    {
+        // Defensive guard for entities that somehow lose their task
+        // reference between persist and publish — we'd rather skip the
+        // event than throw and 500 the API call.
+        [$publisher, $hub] = $this->makePublisher();
+        $comment = new Comment();
+        $publisher->publishCreated($comment);
+        $this->assertCount(0, $hub->updates);
+    }
+
+    /**
+     * @return array{0: CommentMercurePublisher, 1: object{updates: array<int, Update>}}
+     */
+    private function makePublisher(): array
+    {
+        $hub = new class implements HubInterface {
+            /** @var array<int, Update> */
+            public array $updates = [];
+
+            public function publish(Update $update): string
+            {
+                $this->updates[] = $update;
+                return 'id-' . count($this->updates);
+            }
+
+            public function getUrl(): string { return 'http://test'; }
+            public function getPublicUrl(): string { return 'http://test'; }
+            public function getProvider(): \Symfony\Component\Mercure\Jwt\TokenProviderInterface { throw new \LogicException(); }
+            public function getFactory(): ?\Symfony\Component\Mercure\Jwt\TokenFactoryInterface { return null; }
+        };
+
+        $normalizer = $this->createMock(NormalizerInterface::class);
+        $normalizer->method('normalize')->willReturnCallback(
+            // Inline serialiser keeps the test independent of the API
+            // Platform serializer setup; the important assertion is that
+            // the publisher routes data through whatever NormalizerInterface
+            // it gets — the actual JSON-LD shape is exercised by the
+            // existing CommentTest cases.
+            static function (Comment $c): array {
+                return [
+                    '@id' => '/comments/' . $c->getId(),
+                    '@type' => 'Comment',
+                    'id' => (string) $c->getId(),
+                    'body' => $c->getBody(),
+                ];
+            },
+        );
+
+        return [new CommentMercurePublisher($hub, $normalizer), $hub];
+    }
+
+    private function makeComment(string $taskId, string $commentId, string $body): Comment
+    {
+        $owner = new User();
+        $this->setEntityId($owner, '0193cccc-0001-7000-8000-000000000001');
+
+        $task = new Task();
+        $task->setOwner($owner);
+        $task->setTitle('Parent task');
+        $this->setEntityId($task, $taskId);
+
+        $comment = new Comment();
+        $comment->setTask($task);
+        $comment->setAuthor($owner);
+        $comment->setBody($body);
+        $this->setEntityId($comment, $commentId);
+
+        return $comment;
+    }
+
+    private function setEntityId(object $entity, string $uuid): void
+    {
+        $reflection = new \ReflectionClass($entity);
+        $idProperty = $reflection->getProperty('id');
+        $idProperty->setAccessible(true);
+        $idProperty->setValue($entity, Uuid::fromString($uuid));
+    }
+}

--- a/pwa/lib/useCommentLiveUpdates.ts
+++ b/pwa/lib/useCommentLiveUpdates.ts
@@ -1,0 +1,77 @@
+import { useEffect } from "react";
+import { ENTRYPOINT } from "@/config/entrypoint";
+
+/**
+ * Mercure subscription for a single task's comments topic.
+ *
+ * Lifecycle: when `enabled` becomes true, hit the API for a subscriber
+ * cookie scoped to `/tasks/{id}/comments`, then open an EventSource on
+ * the Mercure hub. On every message, parse the JSON envelope and
+ * forward it to `onEvent`. Closes the EventSource on cleanup so leaving
+ * the panel collapsed doesn't keep a connection open per task.
+ *
+ * The hub URL is derived from the entrypoint — same-origin in dev /
+ * prod (Caddy/FrankenPHP), so the EventSource picks up the
+ * `mercureAuthorization` cookie automatically (path-scoped to
+ * `/.well-known/mercure`).
+ */
+export type CommentLiveEvent =
+  | { type: "create" | "update"; comment: { "@id": string; [key: string]: unknown } }
+  | { type: "delete"; id: string; task: string };
+
+export const useCommentLiveUpdates = (
+  taskId: string | null,
+  enabled: boolean,
+  onEvent: (event: CommentLiveEvent) => void,
+): void => {
+  useEffect(() => {
+    if (!enabled || !taskId) return;
+    let cancelled = false;
+    let source: EventSource | null = null;
+
+    const open = async () => {
+      try {
+        // The token endpoint sets the mercureAuthorization cookie scoped
+        // to the topic; this fetch carries the session cookie via
+        // credentials: 'include' and writes back the subscriber cookie.
+        const tokenRes = await fetch(
+          `${ENTRYPOINT}/tasks/${encodeURIComponent(taskId)}/comments/mercure-token`,
+          { credentials: "include" },
+        );
+        if (!tokenRes.ok) return;
+        const { topic } = (await tokenRes.json()) as { topic: string };
+        if (cancelled || !topic) return;
+
+        // Mercure hub URL — same-origin via Caddy on /.well-known/mercure.
+        // Using a relative path keeps env-handling out of the client.
+        const url = new URL("/.well-known/mercure", window.location.origin);
+        url.searchParams.append("topic", topic);
+
+        source = new EventSource(url.toString(), { withCredentials: true });
+        source.onmessage = (event) => {
+          try {
+            const parsed = JSON.parse(event.data) as CommentLiveEvent;
+            onEvent(parsed);
+          } catch {
+            // Malformed payload — drop silently rather than crash the panel.
+          }
+        };
+      } catch {
+        // Network error or auth failure: live updates simply don't kick
+        // in for this session. Stale state until the user reloads is
+        // a tolerable degradation.
+      }
+    };
+
+    void open();
+
+    return () => {
+      cancelled = true;
+      source?.close();
+    };
+    // `onEvent` intentionally excluded — the caller's setter is stable
+    // (memoized) and re-binding on every parent render would tear down
+    // the SSE connection on every keystroke elsewhere on the page.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [taskId, enabled]);
+};

--- a/pwa/pages/tasks.tsx
+++ b/pwa/pages/tasks.tsx
@@ -39,6 +39,10 @@ import {
   uploadAttachmentFile,
 } from "@/lib/attachments";
 import { signinHrefForCurrent } from "@/lib/authRedirect";
+import {
+  useCommentLiveUpdates,
+  type CommentLiveEvent,
+} from "@/lib/useCommentLiveUpdates";
 import MarkdownEditor from "@/components/editor/MarkdownEditor";
 import AssigneesCombobox, {
   type AssigneeOption,
@@ -607,6 +611,9 @@ interface TaskRowProps {
   onDeleteComment: (comment: Comment) => Promise<void>;
   onAttachMedia: (task: Task, mediaObjectIri: string) => Promise<void>;
   onDetachMedia: (task: Task, attachment: Attachment) => Promise<void>;
+  /** Forwarded to useCommentLiveUpdates: parent merges deltas published
+   *  by Mercure into commentsByTask state. */
+  onCommentLiveEvent: (taskIri: string, event: CommentLiveEvent) => void;
 }
 
 const TaskRow = ({
@@ -633,6 +640,7 @@ const TaskRow = ({
   onDeleteComment,
   onAttachMedia,
   onDetachMedia,
+  onCommentLiveEvent,
 }: TaskRowProps) => {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: task["@id"],
@@ -716,6 +724,13 @@ const TaskRow = ({
     // effect re-runs only on the values we actually care about.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [commentsExpanded, comments]);
+
+  // Subscribe to live comment updates only while the panel is open.
+  // Closes the EventSource on collapse so we don't leave a connection
+  // open per task in the list.
+  useCommentLiveUpdates(commentsExpanded ? task.id : null, commentsExpanded, (event) => {
+    onCommentLiveEvent(task["@id"], event);
+  });
 
   // --- Inline title editing ---------------------------------------------
   const [editingTitle, setEditingTitle] = useState(false);
@@ -1856,6 +1871,41 @@ const Tasks = () => {
     [],
   );
 
+  const handleCommentLiveEvent = useCallback(
+    (taskIri: string, event: CommentLiveEvent) => {
+      // Live deltas merge into the parent's commentsByTask cache. We
+      // dedupe on @id so the event from the user's own POST doesn't
+      // double-insert when the optimistic local push and the Mercure
+      // echo race each other.
+      setCommentsByTask((prev) => {
+        const list = prev[taskIri];
+        if (!list) {
+          // Panel hasn't loaded comments yet — nothing to merge into.
+          // The lazy fetch will pick up the new comment when expanded.
+          return prev;
+        }
+        if (event.type === "delete") {
+          return {
+            ...prev,
+            [taskIri]: list.filter((c) => c["@id"] !== event.id),
+          };
+        }
+        const incoming = event.comment as unknown as Comment;
+        const idx = list.findIndex((c) => c["@id"] === incoming["@id"]);
+        if (event.type === "create") {
+          if (idx !== -1) return prev;
+          return { ...prev, [taskIri]: [...list, incoming] };
+        }
+        // update
+        if (idx === -1) return prev;
+        const next = list.slice();
+        next[idx] = incoming;
+        return { ...prev, [taskIri]: next };
+      });
+    },
+    [],
+  );
+
   const handleDeleteComment = useCallback(async (comment: Comment) => {
     const res = await fetch(`${ENTRYPOINT}${comment["@id"]}`, {
       method: "DELETE",
@@ -2217,6 +2267,7 @@ const Tasks = () => {
                           onDeleteComment={handleDeleteComment}
                           onAttachMedia={handleAttachMedia}
                           onDetachMedia={handleDetachMedia}
+                          onCommentLiveEvent={handleCommentLiveEvent}
                         />
                       ))}
                     </Table>

--- a/pwa/pages/tasks.tsx
+++ b/pwa/pages/tasks.tsx
@@ -1774,10 +1774,19 @@ const Tasks = () => {
         );
       }
       const created: Comment = await res.json();
-      setCommentsByTask((prev) => ({
-        ...prev,
-        [task["@id"]]: [...(prev[task["@id"]] ?? []), created],
-      }));
+      setCommentsByTask((prev) => {
+        const existing = prev[task["@id"]] ?? [];
+        // The Mercure echo of this POST can race the response and
+        // get applied first by handleCommentLiveEvent. Dedup on @id
+        // so we don't end up with two copies of the same comment.
+        if (existing.some((c) => c["@id"] === created["@id"])) {
+          return prev;
+        }
+        return {
+          ...prev,
+          [task["@id"]]: [...existing, created],
+        };
+      });
     },
     [],
   );


### PR DESCRIPTION
## Summary
- Backend publishes Comment lifecycle events (create / update / delete) on the per-task Mercure topic `/tasks/{taskId}/comments`. Updates are sent with `private=true` so only authorised subscribers receive them.
- New `GET /tasks/{id}/comments/mercure-token` endpoint mints a `mercureAuthorization` cookie scoped to that single topic, only after re-checking Task readability (admin / task owner / project member); 404 (not 403) on unreachable IDs.
- Frontend `useCommentLiveUpdates` hook fetches the token, opens an `EventSource` on the same-origin Mercure hub, and merges deltas into the cached comment list. Subscription is bound to the panel being expanded and torn down on collapse/unmount, with `@id` dedup so the publisher's echo of the user's own POST doesn't double-insert.

## Test plan
- [x] `CommentMercurePublisherTest` (unit): pins topic format + payload shape for create / update / delete; defends the no-task no-op
- [x] `TaskCommentsMercureTokenTest` (functional): auth coverage — owner / project member / stranger (404) / unknown ID (404) / invalid UUID (404) / unauthenticated; asserts the subscriber cookie lands on the response
- [x] Full PHPUnit (225 tests) green
- [x] `pnpm tsc --noEmit` and `pnpm lint` clean

Closes #107