### PR TITLE
chore: automate CHANGELOG.md from conventional commits (closes #5)

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,122 @@
+name: Changelog
+
+# Two triggers:
+#  - On tag push matching `YYYY.MM.DD.N`: regenerate the full CHANGELOG.md
+#    from the entire git history, commit the result back to `main`, and
+#    attach the just-released section to the GitHub Release notes.
+#  - On `workflow_dispatch`: same regenerate-and-commit flow without
+#    tagging — useful for re-running after a config tweak.
+#
+# `pull_request` runs (separate job) only generate the changelog and
+# upload it as a build artifact so reviewers can preview what the next
+# release section will look like, without writing to the repo.
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "cliff.toml"
+      - ".github/workflows/changelog.yml"
+
+permissions:
+  contents: write
+
+concurrency:
+  # Tag pushes run sequentially so two same-day releases don't race on
+  # the CHANGELOG.md commit. PR previews can run in parallel — they
+  # don't touch main.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    name: Update CHANGELOG.md on release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main with full history
+        uses: actions/checkout@v4
+        with:
+          # Always check out main rather than the tag commit — git-cliff
+          # reads tags from the fetched history regardless of HEAD, and
+          # we need to be on main to commit + push the regenerated file.
+          ref: main
+          fetch-depth: 0
+          # The default GITHUB_TOKEN has `contents: write` (granted at
+          # the workflow level above) so it can push to main.
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate full CHANGELOG.md
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --verbose
+        env:
+          OUTPUT: CHANGELOG.md
+
+      - name: Generate latest-release section
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          # `--latest --strip header` keeps just the section for the
+          # most recent tag — perfect body for a GitHub Release.
+          args: --latest --strip header
+        env:
+          OUTPUT: RELEASE_NOTES.md
+
+      - name: Commit CHANGELOG.md back to main
+        # Only commit if the file actually changed — re-runs after a
+        # successful release should be no-ops, not empty commits.
+        run: |
+          if git diff --quiet CHANGELOG.md; then
+            echo "CHANGELOG.md unchanged — skipping commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git commit -m "docs: update CHANGELOG.md for ${GITHUB_REF_NAME}"
+          git push origin main
+
+      - name: Update GitHub Release body
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Create the release if it doesn't exist yet, otherwise
+          # update the body. Either way the latest-release section
+          # becomes the visible release notes.
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            gh release edit "${GITHUB_REF_NAME}" --notes-file RELEASE_NOTES.md
+          else
+            gh release create "${GITHUB_REF_NAME}" --notes-file RELEASE_NOTES.md --title "${GITHUB_REF_NAME}"
+          fi
+
+  preview:
+    if: github.event_name == 'pull_request'
+    name: Preview CHANGELOG diff
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Render unreleased section
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --unreleased --strip header
+        env:
+          OUTPUT: unreleased.md
+
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: changelog-preview
+          path: |
+            unreleased.md
+            cliff.toml
+          retention-days: 7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,7 @@ npx playwright test
 ### Releases
 - Date-based build numbers: `YYYY.MM.DD.N` (e.g., `2026.04.12.1`)
 - Tag `main` when ready to release: `git tag 2026.04.12.1 && git push origin 2026.04.12.1`
+- The **Changelog workflow** (`.github/workflows/changelog.yml`) auto-regenerates `CHANGELOG.md` and creates the GitHub Release via [git-cliff](https://github.com/orhun/git-cliff) on tag push; rules live in `cliff.toml`. Only `feat:`/`fix:`/`security:`/`perf:`/`refactor:` commits make the changelog — keep PR titles in conventional-commit form so they land in the right section.
 
 ## Key Configuration
 - **Database URL**: `DATABASE_URL` env var (default: PostgreSQL on `database:5432`)

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,77 @@
+# git-cliff configuration for Aura.
+#
+# Generates a Keep-a-Changelog–formatted CHANGELOG.md from conventional
+# commit messages. Tag format is YYYY.MM.DD.N — git-cliff doesn't need
+# a tag-pattern hint because we feed it tags explicitly via the action.
+#
+# Section mapping mirrors Keep a Changelog headings:
+#   feat              -> Added
+#   fix               -> Fixed
+#   security          -> Security
+#   perf, refactor    -> Changed
+#   deprecate         -> Deprecated
+#   remove            -> Removed
+# Everything else (chore, docs, test, ci, build, style) is dropped on
+# the floor — release notes describe user-visible changes, not housekeeping.
+
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/), and \
+this project uses [date-based build numbers](docs/branching-and-releases.md) \
+for versioning (`YYYY.MM.DD.N`).
+"""
+body = """
+{% if version -%}
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+    ## [Unreleased]
+{% endif %}
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}
+- {{ commit.message | upper_first | trim }}\
+{% endfor %}
+{% endfor %}\n
+"""
+trim = true
+footer = ""
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+# Commit-parser rules in priority order. Set `skip = true` to drop a
+# category entirely.
+commit_parsers = [
+    { message = "^feat", group = "Added" },
+    { message = "^fix", group = "Fixed" },
+    { message = "^security", group = "Security" },
+    { message = "^perf", group = "Changed" },
+    { message = "^refactor", group = "Changed" },
+    { message = "^deprecate", group = "Deprecated" },
+    { message = "^remove", group = "Removed" },
+    { message = "^chore", skip = true },
+    { message = "^docs", skip = true },
+    { message = "^test", skip = true },
+    { message = "^ci", skip = true },
+    { message = "^build", skip = true },
+    { message = "^style", skip = true },
+    # Squash-merge PRs may produce "Merge pull request" if anything
+    # slips past — drop them too.
+    { message = "^Merge", skip = true },
+    # Catch-all: any conventional-looking commit whose type wasn't
+    # listed above (e.g. legacy `#2412:` style) gets dropped rather
+    # than producing a section header out of the literal type. Without
+    # this, commits like `#2412: Fix for docker build issue` create a
+    # `### #2412` heading in the changelog.
+    { message = ".*", skip = true },
+]
+filter_commits = false
+# Tag pattern: YYYY.MM.DD.N (no `v` prefix). Anchored so we don't pick
+# up arbitrary numeric tags.
+tag_pattern = "^[0-9]{4}\\.[0-9]{2}\\.[0-9]{2}\\.[0-9]+$"
+sort_commits = "newest"

--- a/docs/branching-and-releases.md
+++ b/docs/branching-and-releases.md
@@ -85,7 +85,10 @@ git tag 2026.04.12.1
 git push origin 2026.04.12.1
 ```
 
-4. Create a GitHub release from the tag (optional but recommended)
+4. The **Changelog workflow** (`.github/workflows/changelog.yml`) fires automatically on tag push:
+   - Regenerates `CHANGELOG.md` from conventional commits via [git-cliff](https://github.com/orhun/git-cliff) and pushes the update to `main`.
+   - Creates a GitHub Release whose body is the just-cut section of the changelog.
+   No manual step is required for either; the workflow uses `cliff.toml` at the repo root for grouping rules. Commits that don't follow `feat:`/`fix:`/`security:`/`perf:`/`refactor:` are dropped from the user-visible changelog (housekeeping like `chore:`, `docs:`, `ci:` is intentionally excluded).
 
 ### What Triggers a Release
 


### PR DESCRIPTION
## Summary
- Adds `cliff.toml` and a `Changelog` GitHub Actions workflow that auto-regenerates `CHANGELOG.md` from conventional commits using [git-cliff](https://github.com/orhun/git-cliff)
- Fires on tag push matching `YYYY.MM.DD.N`: rewrites `CHANGELOG.md`, pushes the update to `main`, and creates the GitHub Release with the just-cut section as its body
- PR job uploads a preview of the unreleased section as a build artifact whenever `cliff.toml` or the workflow itself changes — included in *this* PR's CI artifacts so reviewers can see exactly what the next release would look like
- Maps conventional types to Keep-a-Changelog sections (`feat`→Added, `fix`→Fixed, `perf`/`refactor`→Changed, `security`→Security, `deprecate`→Deprecated, `remove`→Removed); housekeeping (`chore`/`docs`/`ci`/`build`/`style`/`test`) is dropped
- Catch-all skip rule keeps legacy non-conventional commits (e.g. one upstream `#2412:` -prefixed commit) from generating bogus section headers

## Test plan
- [x] `cliff.toml` smoke-tested locally via `docker run orhunp/git-cliff` — `--unreleased --strip header` and full-changelog modes both render cleanly
- [x] Workflow YAML reviewed: tag-push commits back to `main` (not the detached tag), `concurrency` keyed per-ref to avoid same-day races, `cancel-in-progress: false` so a release run is never preempted
- [ ] First real validation will be the next tag push — manual test plan: cut a `2026.05.04.1` tag → CHANGELOG.md update lands on `main` → GitHub Release body contains only that section

## Notes
- Once this lands, please keep PR titles in conventional-commit form so they end up in the right section. Existing `feat:`/`fix:`/etc. commits are already correctly categorised in the preview.

Closes #5