### PR TITLE
feat(comments): threaded replies on task comments (closes #105)

### DIFF
--- a/api/migrations/Version20260504020000.php
+++ b/api/migrations/Version20260504020000.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds parent_comment_id to comment for threaded replies (see #105). The FK
+ * cascades on delete so removing a parent drops its subtree in one shot;
+ * depth is bounded in the entity validator (Comment::MAX_DEPTH) so the
+ * cascade stays small.
+ */
+final class Version20260504020000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add parent_comment_id to comment for threaded replies.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE comment ADD parent_comment_id UUID DEFAULT NULL');
+        $this->addSql('ALTER TABLE comment ADD CONSTRAINT FK_9474526CBF2AF943 FOREIGN KEY (parent_comment_id) REFERENCES comment (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE INDEX idx_comment_parent ON comment (parent_comment_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE comment DROP CONSTRAINT FK_9474526CBF2AF943');
+        $this->addSql('DROP INDEX idx_comment_parent');
+        $this->addSql('ALTER TABLE comment DROP parent_comment_id');
+    }
+}

--- a/api/src/Entity/Comment.php
+++ b/api/src/Entity/Comment.php
@@ -5,6 +5,7 @@ namespace App\Entity;
 use ApiPlatform\Doctrine\Orm\Filter\OrderFilter;
 use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Get;
@@ -19,6 +20,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 /**
  * Comment on a task. Read access mirrors the parent task — anyone who can
@@ -27,7 +29,10 @@ use Symfony\Component\Validator\Constraints as Assert;
  * edit; the author OR the task owner OR an admin can delete (so a project
  * lead can clean up after a teammate without needing to escalate).
  *
- * Threading is intentionally flat in v1 — see #105 for follow-up.
+ * Replies are threaded via `parentComment`. Validation enforces that a
+ * reply's parent belongs to the same task and that the chain depth stays
+ * within {@see self::MAX_DEPTH}. Deleting a parent cascades to its subtree
+ * via the FK ON DELETE CASCADE.
  */
 #[ApiResource(
     operations: [
@@ -55,15 +60,24 @@ use Symfony\Component\Validator\Constraints as Assert;
     denormalizationContext: ['groups' => ['comment:write']],
     order: ['createdAt' => 'ASC'],
 )]
-#[ApiFilter(SearchFilter::class, properties: ['task' => 'exact'])]
+#[ApiFilter(SearchFilter::class, properties: ['task' => 'exact', 'parentComment' => 'exact'])]
 #[ApiFilter(OrderFilter::class, properties: ['createdAt'], arguments: ['orderParameterName' => 'order'])]
 #[ORM\Entity(repositoryClass: CommentRepository::class)]
 #[ORM\Table(name: 'comment')]
 #[ORM\Index(columns: ['task_id', 'created_at'], name: 'idx_comment_task_created')]
+#[ORM\Index(columns: ['parent_comment_id'], name: 'idx_comment_parent')]
 #[ORM\HasLifecycleCallbacks]
 class Comment
 {
     public const MAX_BODY_LENGTH = 10_000;
+
+    /**
+     * Maximum thread depth, counting the root comment as depth 1. A reply
+     * to the root is depth 2, a reply-to-a-reply is depth 3, and that's
+     * the cap — replying to a depth-3 comment is rejected. Matches the
+     * visual indent cap on the frontend.
+     */
+    public const MAX_DEPTH = 3;
 
     #[ORM\Id]
     #[ORM\Column(type: 'uuid', unique: true)]
@@ -97,6 +111,27 @@ class Comment
     #[Groups(['comment:read', 'comment:write'])]
     private string $body = '';
 
+    /**
+     * Self-referencing parent for threaded replies. Nullable for root
+     * comments. ON DELETE CASCADE means deleting a parent drops its
+     * subtree in one shot — depth is bounded so the cascade stays small.
+     *
+     * `readableLink: false` keeps the field serialized as a bare IRI on
+     * the read side; the default would inline the parent (and its parent,
+     * recursively) and quickly bloat the payload on a long thread.
+     */
+    #[ApiProperty(readableLink: false)]
+    #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'replies')]
+    #[ORM\JoinColumn(name: 'parent_comment_id', referencedColumnName: 'id', nullable: true, onDelete: 'CASCADE')]
+    #[Groups(['comment:read', 'comment:write'])]
+    private ?Comment $parentComment = null;
+
+    /**
+     * @var \Doctrine\Common\Collections\Collection<int, Comment>
+     */
+    #[ORM\OneToMany(mappedBy: 'parentComment', targetEntity: self::class)]
+    private \Doctrine\Common\Collections\Collection $replies;
+
     #[ORM\Column(type: 'datetime_immutable')]
     #[Groups(['comment:read'])]
     private \DateTimeImmutable $createdAt;
@@ -112,6 +147,7 @@ class Comment
     public function __construct()
     {
         $this->createdAt = new \DateTimeImmutable();
+        $this->replies = new \Doctrine\Common\Collections\ArrayCollection();
     }
 
     #[ORM\PreUpdate]
@@ -166,5 +202,67 @@ class Comment
     public function getUpdatedAt(): ?\DateTimeImmutable
     {
         return $this->updatedAt;
+    }
+
+    public function getParentComment(): ?Comment
+    {
+        return $this->parentComment;
+    }
+
+    public function setParentComment(?Comment $parentComment): static
+    {
+        $this->parentComment = $parentComment;
+        return $this;
+    }
+
+    /**
+     * Walks up the chain to compute this comment's depth (root = 1). Stops
+     * one past {@see self::MAX_DEPTH} so the validator can reject without
+     * looping forever if somebody manages to seed a cycle through the
+     * back door (e.g. fixtures).
+     */
+    public function getDepth(): int
+    {
+        $depth = 1;
+        $cursor = $this->parentComment;
+        while ($cursor !== null && $depth <= self::MAX_DEPTH + 1) {
+            $depth++;
+            $cursor = $cursor->getParentComment();
+        }
+        return $depth;
+    }
+
+    #[Assert\Callback]
+    public function validateParentComment(ExecutionContextInterface $context): void
+    {
+        $parent = $this->parentComment;
+        if ($parent === null) {
+            return;
+        }
+
+        if ($parent === $this) {
+            $context->buildViolation('A comment cannot reply to itself.')
+                ->atPath('parentComment')
+                ->addViolation();
+            return;
+        }
+
+        if ($this->task !== null
+            && $parent->getTask() !== null
+            && !$this->task->getId()?->equals($parent->getTask()->getId())
+        ) {
+            $context->buildViolation('Reply must be on the same task as its parent.')
+                ->atPath('parentComment')
+                ->addViolation();
+        }
+
+        if ($parent->getDepth() >= self::MAX_DEPTH) {
+            $context->buildViolation(sprintf(
+                'Replies cannot be nested more than %d levels deep.',
+                self::MAX_DEPTH,
+            ))
+                ->atPath('parentComment')
+                ->addViolation();
+        }
     }
 }

--- a/api/tests/Api/CommentTest.php
+++ b/api/tests/Api/CommentTest.php
@@ -305,6 +305,113 @@ class CommentTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(422);
     }
 
+    public function testReplyToCommentOnSameTaskSucceeds(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->createTask($alice, 'Task');
+        $root = $this->seedComment($alice, $task, 'Root');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/comments', [
+            'json' => [
+                'task' => '/tasks/' . $task->getId(),
+                'parentComment' => '/comments/' . $root->getId(),
+                'body' => 'A reply',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertJsonContains([
+            '@type' => 'Comment',
+            'body' => 'A reply',
+            'parentComment' => '/comments/' . $root->getId(),
+        ]);
+    }
+
+    public function testReplyParentMustBelongToSameTask(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $taskA = $this->createTask($alice, 'Task A');
+        $taskB = $this->createTask($alice, 'Task B');
+        $rootOnA = $this->seedComment($alice, $taskA, 'Root on A');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/comments', [
+            'json' => [
+                'task' => '/tasks/' . $taskB->getId(),
+                'parentComment' => '/comments/' . $rootOnA->getId(),
+                'body' => 'Wrong task',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testReplyDepthCapped(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->createTask($alice, 'Task');
+        $depth1 = $this->seedComment($alice, $task, 'd1');
+        $depth2 = $this->seedReply($alice, $task, $depth1, 'd2');
+        $depth3 = $this->seedReply($alice, $task, $depth2, 'd3');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/comments', [
+            'json' => [
+                'task' => '/tasks/' . $task->getId(),
+                'parentComment' => '/comments/' . $depth3->getId(),
+                'body' => 'too deep',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testDeletingParentCascadesToReplies(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->createTask($alice, 'Task');
+        $root = $this->seedComment($alice, $task, 'Root');
+        $reply = $this->seedReply($alice, $task, $root, 'reply');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('DELETE', '/comments/' . $root->getId());
+        $this->assertResponseStatusCodeSame(204);
+
+        $this->entityManager->clear();
+        $stillThere = $this->entityManager->getRepository(Comment::class)->find($reply->getId());
+        $this->assertNull($stillThere, 'Reply should be removed when its parent is deleted.');
+    }
+
+    public function testCanFilterCommentsByParent(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->createTask($alice, 'Task');
+        $root = $this->seedComment($alice, $task, 'Root');
+        $this->seedReply($alice, $task, $root, 'reply-1');
+        $this->seedReply($alice, $task, $root, 'reply-2');
+        $this->seedComment($alice, $task, 'Other root');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/comments?parentComment=/comments/' . $root->getId());
+
+        $this->assertResponseIsSuccessful();
+        $bodies = array_map(
+            fn ($c) => $c['body'],
+            $client->getResponse()->toArray()['member'] ?? [],
+        );
+        sort($bodies);
+        $this->assertSame(['reply-1', 'reply-2'], $bodies);
+    }
+
     public function testOversizedBodyRejected(): void
     {
         $alice = $this->createUser('alice@example.com');
@@ -328,6 +435,18 @@ class CommentTest extends ApiTestCase
         $c = new Comment();
         $c->setAuthor($author);
         $c->setTask($task);
+        $c->setBody($body);
+        $this->entityManager->persist($c);
+        $this->entityManager->flush();
+        return $c;
+    }
+
+    private function seedReply(User $author, Task $task, Comment $parent, string $body): Comment
+    {
+        $c = new Comment();
+        $c->setAuthor($author);
+        $c->setTask($task);
+        $c->setParentComment($parent);
         $c->setBody($body);
         $this->entityManager->persist($c);
         $this->entityManager->flush();

--- a/pwa/components/tasks/CommentsPanel.tsx
+++ b/pwa/components/tasks/CommentsPanel.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
-import { Pencil, Trash2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Pencil, Reply, Trash2 } from "lucide-react";
 import { displayName } from "@/lib/userDisplay";
 import MarkdownEditor from "@/components/editor/MarkdownEditor";
 import MarkdownView from "@/components/editor/MarkdownView";
@@ -14,9 +14,24 @@ export interface Comment {
   // The API serializes Comment.author as the embedded user shape so we can
   // render the avatar without a second fetch per comment.
   author: AvatarUser & { "@id": string; id: string };
+  // IRI of the parent comment when this is a threaded reply, null at root.
+  parentComment: string | null;
   createdAt: string;
   updatedAt: string | null;
 }
+
+/**
+ * Mirrors the server's `Comment::MAX_DEPTH`. Replies are blocked once a
+ * comment sits at this depth so the API stays in sync with the UI.
+ */
+const MAX_DEPTH = 3;
+
+/**
+ * How many sibling replies render expanded by default. Anything past this
+ * collapses behind a "Show N more replies" toggle, matching the spec on
+ * #105.
+ */
+const COLLAPSE_AFTER = 3;
 
 interface CommentsPanelProps {
   taskTitle: string;
@@ -30,7 +45,8 @@ interface CommentsPanelProps {
   /** Set when the current user is the owner of this task; widens delete
    *  rights for the same reason the server does. */
   isTaskOwner: boolean;
-  onCreate: (body: string) => Promise<void>;
+  /** `parentIri` is null for top-level posts and a comment IRI for replies. */
+  onCreate: (body: string, parentIri: string | null) => Promise<void>;
   onEdit: (comment: Comment, body: string) => Promise<void>;
   onDelete: (comment: Comment) => Promise<void>;
 }
@@ -50,6 +66,33 @@ const formatRelative = (iso: string): string => {
   return RELATIVE.format(Math.round(diffSec / 31536000), "year");
 };
 
+interface CommentNode {
+  comment: Comment;
+  children: CommentNode[];
+}
+
+/**
+ * Builds the tree from the flat list. Orphan replies (parent missing — can
+ * happen briefly while a Mercure delete event races a list reload) get
+ * promoted to roots so they don't disappear from the UI.
+ */
+const buildThreadTree = (comments: Comment[]): CommentNode[] => {
+  const nodes = new Map<string, CommentNode>();
+  for (const c of comments) {
+    nodes.set(c["@id"], { comment: c, children: [] });
+  }
+  const roots: CommentNode[] = [];
+  nodes.forEach((node) => {
+    const parentIri = node.comment.parentComment;
+    if (parentIri && nodes.has(parentIri)) {
+      nodes.get(parentIri)!.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  });
+  return roots;
+};
+
 const CommentsPanel = ({
   taskTitle,
   comments,
@@ -65,13 +108,15 @@ const CommentsPanel = ({
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const tree = useMemo(() => buildThreadTree(comments), [comments]);
+
   const submit = async () => {
     const trimmed = draft.trim();
     if (!trimmed) return;
     setSubmitting(true);
     setError(null);
     try {
-      await onCreate(draft);
+      await onCreate(draft, null);
       setDraft("");
       // Bump the editor key so BlockNote remounts with empty content.
       setDraftKey((k) => k + 1);
@@ -92,25 +137,22 @@ const CommentsPanel = ({
 
       {isLoading ? (
         <p className="text-xs text-muted-foreground">Loading comments…</p>
-      ) : comments.length === 0 ? (
+      ) : tree.length === 0 ? (
         <p className="text-xs text-muted-foreground italic">
           No comments yet — start the discussion.
         </p>
       ) : (
         <ul className="space-y-3">
-          {comments.map((comment) => (
-            <CommentRow
-              key={comment["@id"]}
-              comment={comment}
-              canEdit={
-                currentUserIri !== null && currentUserIri === comment.author["@id"]
-              }
-              canDelete={
-                currentUserIri !== null &&
-                (currentUserIri === comment.author["@id"] || isTaskOwner)
-              }
-              onEdit={(body) => onEdit(comment, body)}
-              onDelete={() => onDelete(comment)}
+          {tree.map((node) => (
+            <CommentBranch
+              key={node.comment["@id"]}
+              node={node}
+              depth={1}
+              currentUserIri={currentUserIri}
+              isTaskOwner={isTaskOwner}
+              onCreate={onCreate}
+              onEdit={onEdit}
+              onDelete={onDelete}
             />
           ))}
         </ul>
@@ -153,10 +195,96 @@ const CommentsPanel = ({
   );
 };
 
+interface CommentBranchProps {
+  node: CommentNode;
+  /** 1 for root comments, 2/3 for nested replies. Capped at MAX_DEPTH. */
+  depth: number;
+  currentUserIri: string | null;
+  isTaskOwner: boolean;
+  onCreate: (body: string, parentIri: string | null) => Promise<void>;
+  onEdit: (comment: Comment, body: string) => Promise<void>;
+  onDelete: (comment: Comment) => Promise<void>;
+}
+
+// Renders one comment plus its (recursively rendered) children. Indent
+// stops growing past MAX_DEPTH so the panel doesn't drift off the right
+// edge on long threads.
+const CommentBranch = ({
+  node,
+  depth,
+  currentUserIri,
+  isTaskOwner,
+  onCreate,
+  onEdit,
+  onDelete,
+}: CommentBranchProps) => {
+  const { comment, children } = node;
+  const [showAllReplies, setShowAllReplies] = useState(false);
+  const visibleChildren = showAllReplies
+    ? children
+    : children.slice(0, COLLAPSE_AFTER);
+  const hiddenCount = children.length - visibleChildren.length;
+  // Visual indent caps at MAX_DEPTH — anything deeper renders flush with
+  // its grandparent. The server-side validator stops new replies from
+  // ever creating one of those rows in the first place.
+  const childDepth = Math.min(depth + 1, MAX_DEPTH);
+
+  return (
+    <li data-testid="comment-item">
+      <CommentRow
+        comment={comment}
+        depth={depth}
+        canEdit={
+          currentUserIri !== null && currentUserIri === comment.author["@id"]
+        }
+        canDelete={
+          currentUserIri !== null &&
+          (currentUserIri === comment.author["@id"] || isTaskOwner)
+        }
+        canReply={depth < MAX_DEPTH}
+        onCreate={onCreate}
+        onEdit={(body) => onEdit(comment, body)}
+        onDelete={() => onDelete(comment)}
+      />
+      {children.length > 0 && (
+        <ul className="mt-3 space-y-3 border-l border-border pl-4 ml-4">
+          {visibleChildren.map((child) => (
+            <CommentBranch
+              key={child.comment["@id"]}
+              node={child}
+              depth={childDepth}
+              currentUserIri={currentUserIri}
+              isTaskOwner={isTaskOwner}
+              onCreate={onCreate}
+              onEdit={onEdit}
+              onDelete={onDelete}
+            />
+          ))}
+          {hiddenCount > 0 && (
+            <li>
+              <button
+                type="button"
+                onClick={() => setShowAllReplies(true)}
+                className="text-xs text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+                data-testid="comment-show-more-replies"
+              >
+                Show {hiddenCount} more {hiddenCount === 1 ? "reply" : "replies"}
+              </button>
+            </li>
+          )}
+        </ul>
+      )}
+    </li>
+  );
+};
+
 interface CommentRowProps {
   comment: Comment;
+  depth: number;
   canEdit: boolean;
   canDelete: boolean;
+  canReply: boolean;
+  onCreate: (body: string, parentIri: string | null) => Promise<void>;
   onEdit: (body: string) => Promise<void>;
   onDelete: () => Promise<void>;
 }
@@ -165,6 +293,8 @@ const CommentRow = ({
   comment,
   canEdit,
   canDelete,
+  canReply,
+  onCreate,
   onEdit,
   onDelete,
 }: CommentRowProps) => {
@@ -172,6 +302,12 @@ const CommentRow = ({
   const [draft, setDraft] = useState(comment.body);
   const [editorKey, setEditorKey] = useState(0);
   const [savingEdit, setSavingEdit] = useState(false);
+
+  const [replying, setReplying] = useState(false);
+  const [replyDraft, setReplyDraft] = useState("");
+  const [replyKey, setReplyKey] = useState(0);
+  const [postingReply, setPostingReply] = useState(false);
+  const [replyError, setReplyError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!editing) setDraft(comment.body);
@@ -209,8 +345,40 @@ const CommentRow = ({
     await onDelete();
   };
 
+  const startReply = () => {
+    setReplyDraft("");
+    setReplyKey((k) => k + 1);
+    setReplyError(null);
+    setReplying(true);
+  };
+
+  const cancelReply = () => {
+    setReplying(false);
+    setReplyDraft("");
+    setReplyError(null);
+  };
+
+  const submitReply = async () => {
+    const trimmed = replyDraft.trim();
+    if (!trimmed) return;
+    setPostingReply(true);
+    setReplyError(null);
+    try {
+      await onCreate(replyDraft, comment["@id"]);
+      setReplying(false);
+      setReplyDraft("");
+      setReplyKey((k) => k + 1);
+    } catch (err) {
+      setReplyError(
+        err instanceof Error ? err.message : "Failed to post reply.",
+      );
+    } finally {
+      setPostingReply(false);
+    }
+  };
+
   return (
-    <li className="flex gap-3" data-testid="comment-item">
+    <div className="flex gap-3">
       <UserAvatar user={comment.author} size="sm" />
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
@@ -226,6 +394,17 @@ const CommentRow = ({
             </span>
           )}
           <div className="ml-auto flex items-center gap-1">
+            {canReply && !editing && !replying && (
+              <button
+                type="button"
+                onClick={startReply}
+                aria-label="Reply to comment"
+                className="text-muted-foreground hover:text-foreground p-0.5"
+                data-testid="comment-reply"
+              >
+                <Reply className="h-3.5 w-3.5" />
+              </button>
+            )}
             {canEdit && !editing && (
               <button
                 type="button"
@@ -284,8 +463,50 @@ const CommentRow = ({
             className="text-sm mt-1"
           />
         )}
+        {replying && (
+          <div
+            className="space-y-2 mt-2"
+            onKeyDown={(e) => {
+              if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+                e.preventDefault();
+                void submitReply();
+              }
+            }}
+          >
+            {replyError && (
+              <Alert variant="destructive" data-testid="comment-reply-error">
+                <AlertDescription>{replyError}</AlertDescription>
+              </Alert>
+            )}
+            <MarkdownEditor
+              key={replyKey}
+              ariaLabel={`Reply to ${displayName(comment.author)}`}
+              value={replyDraft}
+              onChange={setReplyDraft}
+            />
+            <div className="flex gap-2">
+              <Button
+                type="button"
+                size="sm"
+                onClick={() => void submitReply()}
+                disabled={postingReply || replyDraft.trim().length === 0}
+                data-testid="comment-reply-submit"
+              >
+                {postingReply ? "Posting…" : "Reply"}
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                onClick={cancelReply}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        )}
       </div>
-    </li>
+    </div>
   );
 };
 

--- a/pwa/pages/tasks.tsx
+++ b/pwa/pages/tasks.tsx
@@ -554,6 +554,31 @@ const plainTextDescription = (markdown: string | null): string => {
     .trim();
 };
 
+// Removes a comment and every descendant whose `parentComment` chain
+// terminates at the deleted IRI. Used after a manual delete *and* when a
+// Mercure delete event arrives — the server cascade fires at the DB
+// level and only the top of the subtree is broadcast.
+const pruneSubtree = (list: Comment[], removedIri: string): Comment[] => {
+  const removed = new Set<string>([removedIri]);
+  // Comments arrive oldest-first; a single forward pass catches all
+  // descendants because a reply is always created after its parent.
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const c of list) {
+      if (
+        !removed.has(c["@id"]) &&
+        c.parentComment !== null &&
+        removed.has(c.parentComment)
+      ) {
+        removed.add(c["@id"]);
+        changed = true;
+      }
+    }
+  }
+  return list.filter((c) => !removed.has(c["@id"]));
+};
+
 interface SortableHeaderProps {
   label: string;
   sortKey: SortKey;
@@ -606,7 +631,11 @@ interface TaskRowProps {
   /** Lazy-load trigger: parent fetches `/comments?task=…` the first time
    *  this fires for a task. */
   onLoadComments: (task: Task) => Promise<void>;
-  onCreateComment: (task: Task, body: string) => Promise<void>;
+  onCreateComment: (
+    task: Task,
+    body: string,
+    parentIri?: string | null,
+  ) => Promise<void>;
   onEditComment: (comment: Comment, body: string) => Promise<void>;
   onDeleteComment: (comment: Comment) => Promise<void>;
   onAttachMedia: (task: Task, mediaObjectIri: string) => Promise<void>;
@@ -1041,7 +1070,9 @@ const TaskRow = ({
               isLoading={commentsLoading && comments === undefined}
               currentUserIri={currentUserIri}
               isTaskOwner={isLikelyTaskOwner}
-              onCreate={(body) => onCreateComment(task, body)}
+              onCreate={(body, parentIri) =>
+                onCreateComment(task, body, parentIri)
+              }
               onEdit={(comment, body) => onEditComment(comment, body)}
               onDelete={(comment) => onDeleteComment(comment)}
             />
@@ -1758,14 +1789,19 @@ const Tasks = () => {
   );
 
   const handleCreateComment = useCallback(
-    async (task: Task, body: string) => {
+    async (task: Task, body: string, parentIri: string | null = null) => {
       const trimmed = body.trim();
       if (!trimmed) return;
+      const payload: { task: string; body: string; parentComment?: string } = {
+        task: task["@id"],
+        body,
+      };
+      if (parentIri) payload.parentComment = parentIri;
       const res = await fetch(`${ENTRYPOINT}/comments`, {
         method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/ld+json" },
-        body: JSON.stringify({ task: task["@id"], body }),
+        body: JSON.stringify(payload),
       });
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
@@ -1896,7 +1932,7 @@ const Tasks = () => {
         if (event.type === "delete") {
           return {
             ...prev,
-            [taskIri]: list.filter((c) => c["@id"] !== event.id),
+            [taskIri]: pruneSubtree(list, event.id),
           };
         }
         const incoming = event.comment as unknown as Comment;
@@ -1923,6 +1959,9 @@ const Tasks = () => {
     if (!res.ok) {
       throw new Error("Failed to delete comment.");
     }
+    // Server CASCADE drops the reply subtree at the DB level but doesn't
+    // publish a Mercure delete per descendant — mirror that here so the
+    // UI doesn't keep showing orphaned replies until the next reload.
     setCommentsByTask((prev) => {
       const next: typeof prev = {};
       for (const [taskIri, list] of Object.entries(prev)) {
@@ -1930,7 +1969,7 @@ const Tasks = () => {
           next[taskIri] = list;
           continue;
         }
-        next[taskIri] = list.filter((c) => c["@id"] !== comment["@id"]);
+        next[taskIri] = pruneSubtree(list, comment["@id"]);
       }
       return next;
     });


### PR DESCRIPTION
## Summary
- Self-referencing `parentComment` relation on `Comment` with `ON DELETE CASCADE`; callback validator pins replies to the same task as their parent and caps depth at `Comment::MAX_DEPTH = 3`.
- New API serializer keeps `parentComment` as a bare IRI (`readableLink: false`) so a long thread doesn't recursively inline its ancestors.
- PWA `CommentsPanel` groups the flat comment list into a tree, indents nested replies (visual cap matches server depth), exposes a Reply button + inline composer per comment, and collapses sibling lists past three entries behind a "Show N more replies" toggle.
- Frontend mirrors the server cascade locally — when a parent is deleted (manually or via a Mercure echo) every descendant is pruned from local state, since the cascade fires at the DB level and isn't broadcast per row.

Closes #105.

## Test plan
- [x] `bin/phpunit tests/Api/CommentTest.php` — new cases cover happy-path replies, parent-on-different-task rejection, depth-3 reject, parent filter, and DB-level cascade on delete (236 tests across the API still green with `memory_limit=512M`).
- [x] `npx tsc --noEmit` and `pnpm lint` both clean (only pre-existing warnings).
- [ ] Manual: post a root comment, reply twice (3 levels), confirm Reply button disappears at depth 3 and the API rejects a hand-crafted depth-4 POST.