### PR TITLE
feat(notifications): email delivery for task reminders (closes #101)

### DIFF
--- a/api/src/Command/DispatchTaskRemindersCommand.php
+++ b/api/src/Command/DispatchTaskRemindersCommand.php
@@ -10,11 +10,15 @@ use App\Repository\TaskRepository;
 use App\Validator\ValidReminders;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
+use Symfony\Component\Mailer\MailerInterface;
 
 /**
  * Walks every active recurring or due-soon task and creates Notification
@@ -39,6 +43,11 @@ final class DispatchTaskRemindersCommand extends Command
         private TaskRepository $tasks,
         private NotificationRepository $notifications,
         private EntityManagerInterface $em,
+        private MailerInterface $mailer,
+        #[Autowire('%env(APP_FRONTEND_URL)%')]
+        private string $frontendUrl,
+        #[Autowire('%env(default::MAILER_FROM)%')]
+        private ?string $mailerFrom = null,
     ) {
         parent::__construct();
     }
@@ -47,6 +56,7 @@ final class DispatchTaskRemindersCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
         $now = new \DateTimeImmutable();
+        $emailsSent = 0;
 
         // We could narrow this by `dueDate >= now - 7 days` to bound the
         // scan, but for an MVP the dataset is small enough that the
@@ -101,13 +111,72 @@ final class DispatchTaskRemindersCommand extends Command
                         // notification still landed, just from the other
                         // worker.
                         $this->em->clear();
+                        continue;
+                    }
+
+                    if ($this->sendReminderEmail($recipient, $task, $offset, $io)) {
+                        ++$emailsSent;
                     }
                 }
             }
         }
 
-        $io->success(sprintf('Created %d notification(s).', $created));
+        $io->success(sprintf(
+            'Created %d notification(s); sent %d email(s).',
+            $created,
+            $emailsSent,
+        ));
         return Command::SUCCESS;
+    }
+
+    /**
+     * Sends the reminder email if the recipient's preferences allow it.
+     * Digest frequencies (hourly/daily) are explicitly skipped — that's
+     * #102's territory. Returns true when an email was actually handed to
+     * the mailer transport so the caller can keep an accurate count for
+     * the success summary.
+     */
+    private function sendReminderEmail(
+        User $recipient,
+        Task $task,
+        string $offset,
+        SymfonyStyle $io,
+    ): bool {
+        $prefs = $recipient->getPreferences();
+        if (false === ($prefs['emailNotificationsEnabled'] ?? true)) {
+            return false;
+        }
+        if ('realtime' !== ($prefs['notificationFrequency'] ?? 'realtime')) {
+            return false;
+        }
+
+        $email = (new TemplatedEmail())
+            ->from($this->mailerFrom ?: 'no-reply@aura.test')
+            ->to($recipient->getEmail())
+            ->subject(sprintf('Reminder: %s', $task->getTitle()))
+            ->htmlTemplate('emails/task_reminder.html.twig')
+            ->textTemplate('emails/task_reminder.txt.twig')
+            ->context([
+                'recipient' => $recipient,
+                'task' => $task,
+                'offsetLabel' => $this->humanOffset($offset),
+                'tasksUrl' => rtrim($this->frontendUrl, '/') . '/tasks',
+            ]);
+
+        try {
+            $this->mailer->send($email);
+            return true;
+        } catch (TransportExceptionInterface $e) {
+            // Don't blow up the whole dispatcher run if the mail server is
+            // momentarily unreachable — the in-app notification already
+            // landed, and the next cron pass will retry untouched users.
+            $io->warning(sprintf(
+                'Failed to send reminder email to %s: %s',
+                $recipient->getEmail(),
+                $e->getMessage(),
+            ));
+            return false;
+        }
     }
 
     /**
@@ -143,13 +212,22 @@ final class DispatchTaskRemindersCommand extends Command
 
     private function buildBody(Task $task, string $offset): string
     {
-        $human = match ($offset) {
+        $due = $task->getDueDate()?->format('M j, Y g:i a') ?? '';
+        return sprintf(
+            '"%s" is due in %s (%s).',
+            $task->getTitle(),
+            $this->humanOffset($offset),
+            $due,
+        );
+    }
+
+    private function humanOffset(string $offset): string
+    {
+        return match ($offset) {
             '15m' => '15 minutes',
             '1h' => '1 hour',
             '1d' => '1 day',
             default => $offset,
         };
-        $due = $task->getDueDate()?->format('M j, Y g:i a') ?? '';
-        return sprintf('"%s" is due in %s (%s).', $task->getTitle(), $human, $due);
     }
 }

--- a/api/templates/emails/task_reminder.html.twig
+++ b/api/templates/emails/task_reminder.html.twig
@@ -1,0 +1,19 @@
+{# @var task \App\Entity\Task #}
+{# @var recipient \App\Entity\User #}
+<p>Hi {{ recipient.givenName ?: recipient.email }},</p>
+
+<p>
+    This is a reminder that
+    <strong>&ldquo;{{ task.title }}&rdquo;</strong>
+    is due in {{ offsetLabel }}{% if task.dueDate %} (<time datetime="{{ task.dueDate|date('c') }}">{{ task.dueDate|date('M j, Y g:i a') }}</time>){% endif %}.
+</p>
+
+{% if task.recurrenceRule %}
+    <p>This task recurs on a schedule, so a fresh occurrence will be created once you mark this one complete.</p>
+{% endif %}
+
+<p>
+    <a href="{{ tasksUrl }}">Open Aura</a> to view or update the task.
+</p>
+
+<p>&mdash; Aura</p>

--- a/api/templates/emails/task_reminder.txt.twig
+++ b/api/templates/emails/task_reminder.txt.twig
@@ -1,0 +1,13 @@
+{# @var task \App\Entity\Task #}
+{# @var recipient \App\Entity\User #}
+Hi {{ recipient.givenName ?: recipient.email }},
+
+This is a reminder that "{{ task.title }}" is due in {{ offsetLabel }}{% if task.dueDate %} ({{ task.dueDate|date('M j, Y g:i a') }}){% endif %}.
+{% if task.recurrenceRule %}
+
+This task recurs on a schedule, so a fresh occurrence will be created once you mark this one complete.
+{% endif %}
+
+Open Aura to view or update the task: {{ tasksUrl }}
+
+— Aura

--- a/api/tests/Api/NotificationTest.php
+++ b/api/tests/Api/NotificationTest.php
@@ -202,6 +202,86 @@ class NotificationTest extends ApiTestCase
         $this->assertSame(['alice@example.com', 'bob@example.com'], $emails);
     }
 
+    public function testDispatcherSendsEmailForRealtimeRecipient(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $this->seedDueTask($alice, 'Standup');
+
+        $this->runDispatcher();
+
+        $this->assertEmailCount(1);
+        $message = $this->getMailerMessage(0);
+        $this->assertEmailHeaderSame($message, 'To', 'alice@example.com');
+        $this->assertEmailHeaderSame($message, 'Subject', 'Reminder: Standup');
+        $this->assertEmailHtmlBodyContains($message, 'Standup');
+        $this->assertEmailHtmlBodyContains($message, 'due in 1 hour');
+        $this->assertEmailTextBodyContains($message, 'due in 1 hour');
+    }
+
+    public function testDispatcherSkipsEmailWhenUserDisabledIt(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $alice->setPreferences(['emailNotificationsEnabled' => false]);
+        $this->entityManager->flush();
+        $this->seedDueTask($alice, 'Standup');
+
+        $this->runDispatcher();
+
+        // The in-app row should still land — only the email is suppressed.
+        $this->assertCount(
+            1,
+            $this->entityManager->getRepository(Notification::class)->findAll(),
+        );
+        $this->assertEmailCount(0);
+    }
+
+    public function testDispatcherSkipsEmailForDigestFrequencies(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $alice->setPreferences(['notificationFrequency' => 'hourly']);
+        $bob = $this->createUser('bob@example.com');
+        $bob->setPreferences(['notificationFrequency' => 'daily']);
+        $this->entityManager->flush();
+
+        $this->seedDueTask($alice, 'Alice task');
+        $this->seedDueTask($bob, 'Bob task');
+
+        $this->runDispatcher();
+
+        $this->assertCount(
+            2,
+            $this->entityManager->getRepository(Notification::class)->findAll(),
+        );
+        // Both users are on digest frequencies — #102 owns those, the
+        // realtime path here must stay quiet.
+        $this->assertEmailCount(0);
+    }
+
+    public function testDispatcherDoesNotResendEmailOnIdempotentRerun(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $this->seedDueTask($alice, 'Standup');
+
+        $this->runDispatcher();
+        $this->runDispatcher();
+
+        // Second run must skip the already-created notification AND the
+        // already-sent email so cron retries don't spam recipients.
+        $this->assertEmailCount(1);
+    }
+
+    private function seedDueTask(User $owner, string $title): Task
+    {
+        $task = new Task();
+        $task->setOwner($owner);
+        $task->setTitle($title);
+        $task->setDueDate((new \DateTimeImmutable())->modify('+30 minutes'));
+        $task->setReminders(['1h']);
+        $this->entityManager->persist($task);
+        $this->entityManager->flush();
+        return $task;
+    }
+
     private function runDispatcher(): int
     {
         $command = static::getContainer()->get(DispatchTaskRemindersCommand::class);


### PR DESCRIPTION
## Summary
- `DispatchTaskRemindersCommand` now sends a `TemplatedEmail` after persisting each in-app `Notification` row, gated by the recipient's preferences (`emailNotificationsEnabled=true` AND `notificationFrequency=realtime`). Digest frequencies are skipped here — #102 will own those.
- Templates: `api/templates/emails/task_reminder.{html,txt}.twig`, rendering task title, due date, recurrence note when applicable, and a `tasksUrl` deep link.
- Mailer transport errors are caught per-recipient and surfaced as warnings; the in-app row is already flushed by that point so an SMTP hiccup doesn't roll back notifications or abort the cron run.

Closes #101.

## Test plan
- [x] `bin/phpunit tests/Api/NotificationTest.php` — new cases cover sent-on-realtime, suppressed when `emailNotificationsEnabled=false`, suppressed for hourly/daily, and idempotent reruns don't resend.
- [x] Full API suite green (248 tests).
- [ ] Manual: in dev with Mailpit, create a task with `dueDate=now+30m` and `reminders=['1h']`, run `bin/console app:tasks:reminders:dispatch`, verify Mailpit received the email.