### PR TITLE
feat(notifications): hourly + daily digest dispatcher (closes #102)

### DIFF
--- a/api/migrations/Version20260504030000.php
+++ b/api/migrations/Version20260504030000.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds digested_at to notification so DispatchNotificationDigestCommand
+ * (see #102) can mark rows as already-shipped in a digest email and skip
+ * them on subsequent runs. Independent of read_at, which tracks user
+ * acknowledgment of the in-app row.
+ */
+final class Version20260504030000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add digested_at to notification for digest delivery tracking.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE notification ADD digested_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE notification DROP digested_at');
+    }
+}

--- a/api/src/Command/DispatchNotificationDigestCommand.php
+++ b/api/src/Command/DispatchNotificationDigestCommand.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\Notification;
+use App\Entity\User;
+use App\Repository\NotificationRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
+use Symfony\Component\Mailer\MailerInterface;
+
+/**
+ * Rolls up pending in-app notifications for users on the digest cadence
+ * (`hourly` or `daily`) and ships them as a single grouped email per run.
+ *
+ * Pairs with App\Command\DispatchTaskRemindersCommand: the realtime path
+ * there sends per-notification emails and explicitly skips users on a
+ * digest frequency, so this command owns their email delivery instead.
+ *
+ * Idempotency: rows that have already been included in a digest are
+ * stamped with `digestedAt`, so reruns inside the same window won't
+ * resend. Recommended cron cadence (also documented in deployment.md):
+ *   - `--period=hourly` at minute 55
+ *   - `--period=daily`  at 08:00 UTC
+ */
+#[AsCommand(
+    name: 'app:notifications:dispatch-digest',
+    description: 'Group pending notifications into a single digest email per recipient.',
+)]
+final class DispatchNotificationDigestCommand extends Command
+{
+    private const ALLOWED_PERIODS = ['hourly', 'daily'];
+
+    public function __construct(
+        private NotificationRepository $notifications,
+        private EntityManagerInterface $em,
+        private MailerInterface $mailer,
+        #[Autowire('%env(APP_FRONTEND_URL)%')]
+        private string $frontendUrl,
+        #[Autowire('%env(default::MAILER_FROM)%')]
+        private ?string $mailerFrom = null,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption(
+            'period',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Which digest cadence to send for: hourly or daily.',
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $period = (string) $input->getOption('period');
+        if (!in_array($period, self::ALLOWED_PERIODS, true)) {
+            $io->error(sprintf(
+                'Option --period must be one of: %s.',
+                implode(', ', self::ALLOWED_PERIODS),
+            ));
+            return Command::INVALID;
+        }
+
+        $now = new \DateTimeImmutable();
+        $emailsSent = 0;
+        $rowsDigested = 0;
+
+        foreach ($this->findUsersByFrequency($period) as $user) {
+            $prefs = $user->getPreferences();
+            // Honour the per-user opt-out even though they're on a digest
+            // frequency — the toggle is the master switch for any email
+            // delivery, regardless of cadence.
+            if (false === ($prefs['emailNotificationsEnabled'] ?? true)) {
+                continue;
+            }
+
+            $pending = $this->notifications->findPendingDigestForRecipient($user);
+            if ([] === $pending) {
+                continue;
+            }
+
+            if ($this->sendDigestEmail($user, $pending, $period, $io)) {
+                ++$emailsSent;
+            }
+
+            // Stamp regardless of mailer success — if the SMTP call fails
+            // we've already warned, and re-sending the same digest on the
+            // next cron run would just spam the recipient. The in-app
+            // notifications stay accessible through the bell either way.
+            foreach ($pending as $row) {
+                $row->setDigestedAt($now);
+                ++$rowsDigested;
+            }
+            $this->em->flush();
+        }
+
+        $io->success(sprintf(
+            'Sent %d %s digest(s) covering %d notification(s).',
+            $emailsSent,
+            $period,
+            $rowsDigested,
+        ));
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Returns every user whose `notificationFrequency` preference matches
+     * the requested period. We load all users and filter in PHP because
+     * preferences live in a JSON column without a generated index — fine
+     * for the current scale, and sidesteps Postgres-specific DQL.
+     *
+     * @return User[]
+     */
+    private function findUsersByFrequency(string $period): array
+    {
+        $all = $this->em->getRepository(User::class)->findAll();
+        return array_values(array_filter(
+            $all,
+            static fn (User $u) => ($u->getPreferences()['notificationFrequency'] ?? 'realtime') === $period,
+        ));
+    }
+
+    /**
+     * @param Notification[] $pending
+     */
+    private function sendDigestEmail(
+        User $recipient,
+        array $pending,
+        string $period,
+        SymfonyStyle $io,
+    ): bool {
+        $count = count($pending);
+        $subject = sprintf(
+            '%s digest: %d notification%s waiting',
+            ucfirst($period),
+            $count,
+            1 === $count ? '' : 's',
+        );
+
+        $email = (new TemplatedEmail())
+            ->from($this->mailerFrom ?: 'no-reply@aura.test')
+            ->to($recipient->getEmail())
+            ->subject($subject)
+            ->htmlTemplate('emails/notification_digest.html.twig')
+            ->textTemplate('emails/notification_digest.txt.twig')
+            ->context([
+                'recipient' => $recipient,
+                'notifications' => $pending,
+                'period' => $period,
+                'tasksUrl' => rtrim($this->frontendUrl, '/') . '/tasks',
+            ]);
+
+        try {
+            $this->mailer->send($email);
+            return true;
+        } catch (TransportExceptionInterface $e) {
+            $io->warning(sprintf(
+                'Failed to send %s digest to %s: %s',
+                $period,
+                $recipient->getEmail(),
+                $e->getMessage(),
+            ));
+            return false;
+        }
+    }
+}

--- a/api/src/Entity/Notification.php
+++ b/api/src/Entity/Notification.php
@@ -107,6 +107,17 @@ class Notification
     #[Groups(['notification:read'])]
     private \DateTimeImmutable $createdAt;
 
+    /**
+     * Stamped by App\Command\DispatchNotificationDigestCommand once a row
+     * has been included in a digest email so the next digest run skips it.
+     * Independent of {@see $readAt} — a digest can ship before the user
+     * opens the bell, and a user can read a notification without ever
+     * having received a digest (realtime path).
+     */
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    #[Groups(['notification:read'])]
+    private ?\DateTimeImmutable $digestedAt = null;
+
     public function __construct()
     {
         $this->createdAt = new \DateTimeImmutable();
@@ -207,5 +218,16 @@ class Notification
     public function getCreatedAt(): \DateTimeImmutable
     {
         return $this->createdAt;
+    }
+
+    public function getDigestedAt(): ?\DateTimeImmutable
+    {
+        return $this->digestedAt;
+    }
+
+    public function setDigestedAt(?\DateTimeImmutable $digestedAt): static
+    {
+        $this->digestedAt = $digestedAt;
+        return $this;
     }
 }

--- a/api/src/Repository/NotificationRepository.php
+++ b/api/src/Repository/NotificationRepository.php
@@ -32,4 +32,23 @@ class NotificationRepository extends ServiceEntityRepository
             'reminderOffset' => $offset,
         ]);
     }
+
+    /**
+     * Returns notifications for a recipient that have not yet been
+     * included in any digest email — what the digest dispatcher needs to
+     * roll up into the next outgoing message. Ordered oldest-first so
+     * the email reads chronologically.
+     *
+     * @return Notification[]
+     */
+    public function findPendingDigestForRecipient(User $recipient): array
+    {
+        return $this->createQueryBuilder('n')
+            ->andWhere('n.recipient = :recipient')
+            ->andWhere('n.digestedAt IS NULL')
+            ->setParameter('recipient', $recipient)
+            ->orderBy('n.createdAt', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/api/templates/emails/notification_digest.html.twig
+++ b/api/templates/emails/notification_digest.html.twig
@@ -1,0 +1,22 @@
+{# @var notifications App\Entity\Notification[] #}
+{# @var recipient \App\Entity\User #}
+<p>Hi {{ recipient.givenName ?: recipient.email }},</p>
+
+<p>
+    Here's your {{ period }} digest from Aura — {{ notifications|length }} notification{{ notifications|length == 1 ? '' : 's' }} since the last batch.
+</p>
+
+<ul>
+    {% for n in notifications %}
+        <li>
+            <strong>{{ n.title }}</strong>
+            {% if n.body %}<br>{{ n.body }}{% endif %}
+        </li>
+    {% endfor %}
+</ul>
+
+<p>
+    <a href="{{ tasksUrl }}">Open Aura</a> to review the details or change your notification frequency.
+</p>
+
+<p>&mdash; Aura</p>

--- a/api/templates/emails/notification_digest.txt.twig
+++ b/api/templates/emails/notification_digest.txt.twig
@@ -1,0 +1,15 @@
+{# @var notifications App\Entity\Notification[] #}
+{# @var recipient \App\Entity\User #}
+Hi {{ recipient.givenName ?: recipient.email }},
+
+Here's your {{ period }} digest from Aura — {{ notifications|length }} notification{{ notifications|length == 1 ? '' : 's' }} since the last batch.
+
+{% for n in notifications %}
+- {{ n.title }}{% if n.body %}
+    {{ n.body }}
+{% endif %}
+{% endfor %}
+
+Open Aura to review the details or change your notification frequency: {{ tasksUrl }}
+
+— Aura

--- a/api/tests/Api/NotificationTest.php
+++ b/api/tests/Api/NotificationTest.php
@@ -3,11 +3,13 @@
 namespace App\Tests\Api;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Command\DispatchNotificationDigestCommand;
 use App\Command\DispatchTaskRemindersCommand;
 use App\Entity\Notification;
 use App\Entity\Task;
 use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
@@ -282,11 +284,119 @@ class NotificationTest extends ApiTestCase
         return $task;
     }
 
+    public function testDigestGroupsPendingNotificationsForHourlyUser(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $alice->setPreferences(['notificationFrequency' => 'hourly']);
+        $this->entityManager->flush();
+        $this->seedNotification($alice, 'First');
+        $this->seedNotification($alice, 'Second');
+
+        $exit = $this->runDigest('hourly');
+        $this->assertSame(0, $exit);
+
+        // One email containing both items.
+        $this->assertEmailCount(1);
+        $msg = $this->getMailerMessage(0);
+        $this->assertEmailHeaderSame($msg, 'To', 'alice@example.com');
+        $this->assertEmailHeaderSame($msg, 'Subject', 'Hourly digest: 2 notifications waiting');
+        $this->assertEmailHtmlBodyContains($msg, 'First');
+        $this->assertEmailHtmlBodyContains($msg, 'Second');
+
+        // Both rows are stamped so the next run skips them.
+        $this->entityManager->clear();
+        foreach ($this->entityManager->getRepository(Notification::class)->findAll() as $row) {
+            $this->assertNotNull($row->getDigestedAt());
+        }
+    }
+
+    public function testDigestRerunDoesNotResendAlreadyShipped(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $alice->setPreferences(['notificationFrequency' => 'daily']);
+        $this->entityManager->flush();
+        $this->seedNotification($alice, 'Yesterday');
+
+        $this->runDigest('daily');
+        $this->runDigest('daily');
+
+        // Same notification, only one digest email — second run was a no-op.
+        $this->assertEmailCount(1);
+    }
+
+    public function testDigestSkipsRealtimeUsers(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $alice->setPreferences(['notificationFrequency' => 'realtime']);
+        $this->entityManager->flush();
+        $this->seedNotification($alice, 'Realtime row');
+
+        $this->runDigest('hourly');
+        $this->runDigest('daily');
+
+        $this->assertEmailCount(0);
+    }
+
+    public function testDigestRespectsEmailNotificationsDisabled(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $alice->setPreferences([
+            'notificationFrequency' => 'hourly',
+            'emailNotificationsEnabled' => false,
+        ]);
+        $this->entityManager->flush();
+        $this->seedNotification($alice, 'Pending');
+
+        $this->runDigest('hourly');
+
+        $this->assertEmailCount(0);
+        $this->entityManager->clear();
+        // Row stays "undigested" so toggling email back on later still
+        // gathers it into the next digest, rather than silently swallowing
+        // the user's pending notifications during the opt-out window.
+        $this->assertNull(
+            $this->entityManager->getRepository(Notification::class)
+                ->findOneBy(['title' => 'Pending'])
+                ?->getDigestedAt(),
+        );
+    }
+
+    public function testDigestRequiresValidPeriod(): void
+    {
+        $command = static::getContainer()->get(DispatchNotificationDigestCommand::class);
+        $tester = new CommandTester($command);
+        $this->assertSame(Command::INVALID, $tester->execute(['--period' => 'weekly']));
+    }
+
+    public function testDigestPeriodsDoNotPoachEachOthersUsers(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $alice->setPreferences(['notificationFrequency' => 'hourly']);
+        $bob = $this->createUser('bob@example.com');
+        $bob->setPreferences(['notificationFrequency' => 'daily']);
+        $this->entityManager->flush();
+        $this->seedNotification($alice, 'Alice item');
+        $this->seedNotification($bob, 'Bob item');
+
+        $this->runDigest('hourly');
+
+        $this->assertEmailCount(1);
+        $msg = $this->getMailerMessage(0);
+        $this->assertEmailHeaderSame($msg, 'To', 'alice@example.com');
+    }
+
     private function runDispatcher(): int
     {
         $command = static::getContainer()->get(DispatchTaskRemindersCommand::class);
         $tester = new CommandTester($command);
         return $tester->execute([]);
+    }
+
+    private function runDigest(string $period): int
+    {
+        $command = static::getContainer()->get(DispatchNotificationDigestCommand::class);
+        $tester = new CommandTester($command);
+        return $tester->execute(['--period' => $period]);
     }
 
     private function seedNotification(User $recipient, string $title): Notification

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -136,3 +136,15 @@ Use the `update-deps.sh` script to update all project dependencies:
 ```bash
 ./update-deps.sh
 ```
+
+## Scheduled background jobs
+
+Two console commands need to run on a cron in production:
+
+| Command | Recommended cadence | Purpose |
+| --- | --- | --- |
+| `bin/console app:tasks:reminders:dispatch` | Every 5 minutes | Creates in-app notifications for due task reminders and (for users on `notificationFrequency=realtime` with `emailNotificationsEnabled=true`) sends a per-reminder email. |
+| `bin/console app:notifications:dispatch-digest --period=hourly` | Hourly at minute 55 | Rolls up pending in-app notifications for users on `notificationFrequency=hourly` into a single grouped digest email. |
+| `bin/console app:notifications:dispatch-digest --period=daily` | Daily at 08:00 UTC | Same as above for users on `notificationFrequency=daily`. |
+
+The digest commands stamp each notification with `digestedAt` once shipped, so reruns within the same window are no-ops. The realtime path skips users whose frequency is `hourly` or `daily`, so the two paths never double-deliver.


### PR DESCRIPTION
## Summary
- New console command `app:notifications:dispatch-digest --period=hourly|daily` rolls up pending notifications for users on the matching `notificationFrequency` into a single grouped email per run.
- New nullable `digestedAt` column on `Notification` (migration `Version20260504030000`) marks shipped rows so reruns inside the same window are no-ops.
- Honors the `emailNotificationsEnabled` master toggle; rows for opted-out users stay undigested so a later opt-in still picks them up rather than swallowing pending state during the opt-out window.
- The realtime reminder path (#101) already skips non-realtime users, so this command and that one never double-deliver.
- Templates at `api/templates/emails/notification_digest.{html,txt}.twig`; recommended cron cadence (hourly at `:55`, daily at `08:00 UTC`) documented in `docs/deployment.md`.

Closes #102.

## Test plan
- [x] `bin/phpunit tests/Api/NotificationTest.php` — new cases cover grouped delivery, idempotent reruns, period isolation, realtime-user skip, opt-out preservation, and invalid `--period`.
- [x] Full API suite green (254 tests).
- [ ] Manual: in dev with Mailpit, set a user's `notificationFrequency=hourly`, seed two notifications, run `bin/console app:notifications:dispatch-digest --period=hourly`, confirm one digest email lists both items and a second run is silent.