### PR TITLE
feat(comments): @mention notifications + chip rendering (addresses #106)

### DIFF
--- a/api/migrations/Version20260504040000.php
+++ b/api/migrations/Version20260504040000.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds comment_id to notification (nullable, FK to comment with cascade
+ * delete) so @mention rows can deep-link back to the comment that
+ * triggered them. The (recipient, comment) unique constraint backs the
+ * idempotency check in CommentMentionService — editing a comment to
+ * keep an existing mention won't re-fire it.
+ */
+final class Version20260504040000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add comment_id to notification for @mention notifications.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE notification ADD comment_id UUID DEFAULT NULL');
+        $this->addSql('ALTER TABLE notification ADD CONSTRAINT FK_BF5476CAF8697D13 FOREIGN KEY (comment_id) REFERENCES comment (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE INDEX IDX_BF5476CAF8697D13 ON notification (comment_id)');
+        $this->addSql('CREATE UNIQUE INDEX uniq_comment_mention ON notification (recipient_id, comment_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX uniq_comment_mention');
+        $this->addSql('DROP INDEX IDX_BF5476CAF8697D13');
+        $this->addSql('ALTER TABLE notification DROP CONSTRAINT FK_BF5476CAF8697D13');
+        $this->addSql('ALTER TABLE notification DROP comment_id');
+    }
+}

--- a/api/src/Entity/Notification.php
+++ b/api/src/Entity/Notification.php
@@ -50,9 +50,14 @@ use Symfony\Component\Uid\Uuid;
     name: 'uniq_task_reminder',
     columns: ['recipient_id', 'task_id', 'reminder_offset'],
 )]
+#[ORM\UniqueConstraint(
+    name: 'uniq_comment_mention',
+    columns: ['recipient_id', 'comment_id'],
+)]
 class Notification
 {
     public const TYPE_TASK_REMINDER = 'task_reminder';
+    public const TYPE_TASK_MENTION = 'task_mention';
 
     #[ORM\Id]
     #[ORM\Column(type: 'uuid', unique: true)]
@@ -94,6 +99,19 @@ class Notification
      */
     #[ORM\Column(length: 16, nullable: true)]
     private ?string $reminderOffset = null;
+
+    /**
+     * Comment that triggered this notification — only set for
+     * `task_mention` rows. Together with `recipient` it forms a unique
+     * key so editing a comment can't re-fire mentions to the same user.
+     * The bare IRI is exposed under `notification:read` so the PWA can
+     * deep-link to the comment without an extra fetch.
+     */
+    #[\ApiPlatform\Metadata\ApiProperty(readableLink: false)]
+    #[ORM\ManyToOne(targetEntity: Comment::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'CASCADE')]
+    #[Groups(['notification:read'])]
+    private ?Comment $comment = null;
 
     /**
      * Set by NotificationUpdateProcessor when the user marks the row read.
@@ -228,6 +246,17 @@ class Notification
     public function setDigestedAt(?\DateTimeImmutable $digestedAt): static
     {
         $this->digestedAt = $digestedAt;
+        return $this;
+    }
+
+    public function getComment(): ?Comment
+    {
+        return $this->comment;
+    }
+
+    public function setComment(?Comment $comment): static
+    {
+        $this->comment = $comment;
         return $this;
     }
 }

--- a/api/src/Service/CommentMentionService.php
+++ b/api/src/Service/CommentMentionService.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Comment;
+use App\Entity\Notification;
+use App\Entity\User;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Parses `@mention` tokens out of a comment body and creates one
+ * `task_mention` Notification per resolved recipient. Tokens are
+ * resolved against the comment's task: project members + task owner.
+ * Mentions of users outside that set are ignored silently — the spec
+ * (#106) treats unknown handles as plain text rather than an error so
+ * users can write `@TODO` or `@anywhere` without provoking a 4xx.
+ *
+ * Idempotent on edit: the (recipient, comment) unique index plus the
+ * pre-flight existsForCommentRecipient check make sure adding a new
+ * mention to an existing comment notifies only the new recipient,
+ * never re-pings the previously mentioned ones.
+ */
+final class CommentMentionService
+{
+    /**
+     * Matches `@token` where token is a non-whitespace run that looks
+     * like an email local-part (ASCII alphanumerics, dot, underscore,
+     * dash, plus). Bounded by start-of-string or non-word so we don't
+     * mistake `email@host` inside prose for a mention.
+     */
+    private const MENTION_PATTERN = '/(?:^|\s)@([A-Za-z0-9._+-]+)/';
+
+    public function __construct(
+        private EntityManagerInterface $em,
+    ) {
+    }
+
+    /**
+     * Returns the deduplicated list of @mention tokens (without the @)
+     * found in the body, preserving first-seen order. Used by callers
+     * that want to render or display the list; the create path below
+     * uses the same parser internally.
+     *
+     * @return string[]
+     */
+    public function extractMentions(string $body): array
+    {
+        if (!preg_match_all(self::MENTION_PATTERN, $body, $matches)) {
+            return [];
+        }
+        $seen = [];
+        foreach ($matches[1] as $token) {
+            $key = strtolower($token);
+            if (!isset($seen[$key])) {
+                $seen[$key] = $token;
+            }
+        }
+        return array_values($seen);
+    }
+
+    /**
+     * Creates Notification rows for each mention in the comment's body
+     * that resolves to an authorized recipient (project member or task
+     * owner). Returns the count of rows created — 0 when every mention
+     * was either unknown, the comment author themselves (no self-pings),
+     * or already notified.
+     */
+    public function dispatchMentions(Comment $comment): int
+    {
+        $body = $comment->getBody();
+        $tokens = $this->extractMentions($body);
+        if ([] === $tokens) {
+            return 0;
+        }
+
+        $task = $comment->getTask();
+        $author = $comment->getAuthor();
+        if (null === $task || null === $author) {
+            return 0;
+        }
+
+        $candidates = $this->collectMentionableUsers($comment);
+        if ([] === $candidates) {
+            return 0;
+        }
+
+        $created = 0;
+        foreach ($tokens as $token) {
+            $user = $this->resolveToken($token, $candidates);
+            if (null === $user) {
+                continue;
+            }
+            // Suppress self-mentions — pinging yourself is just noise.
+            if ($author->getId()?->equals($user->getId())) {
+                continue;
+            }
+            if ($this->alreadyNotified($user, $comment)) {
+                continue;
+            }
+
+            $notification = new Notification();
+            $notification->setRecipient($user);
+            $notification->setTask($task);
+            $notification->setComment($comment);
+            $notification->setType(Notification::TYPE_TASK_MENTION);
+            $notification->setTitle(sprintf(
+                '%s mentioned you on "%s"',
+                $this->displayName($author),
+                $task->getTitle(),
+            ));
+            $notification->setBody($this->snippet($body));
+            $this->em->persist($notification);
+
+            try {
+                $this->em->flush();
+                ++$created;
+            } catch (UniqueConstraintViolationException) {
+                // Race with a concurrent edit on the same comment —
+                // the row landed via the other path. Recover the EM
+                // and continue with the remaining tokens.
+                $this->em->clear();
+            }
+        }
+
+        return $created;
+    }
+
+    /**
+     * Project members + task owner. Personal tasks (no project) yield
+     * just the owner — useful for self-mention suppression rather than
+     * notification, but the contract stays consistent.
+     *
+     * @return User[] Keyed by lowercase email-local-part for fast resolution.
+     */
+    private function collectMentionableUsers(Comment $comment): array
+    {
+        $task = $comment->getTask();
+        if (null === $task) {
+            return [];
+        }
+        $bag = [];
+        $owner = $task->getOwner();
+        if (null !== $owner) {
+            $bag[$this->localPart($owner)] = $owner;
+        }
+        $project = $task->getProject();
+        if (null !== $project) {
+            foreach ($project->getMembers() as $member) {
+                $bag[$this->localPart($member)] = $member;
+            }
+        }
+        return $bag;
+    }
+
+    /**
+     * @param array<string, User> $candidates
+     */
+    private function resolveToken(string $token, array $candidates): ?User
+    {
+        return $candidates[strtolower($token)] ?? null;
+    }
+
+    private function localPart(User $user): string
+    {
+        $email = strtolower($user->getEmail());
+        $at = strpos($email, '@');
+        return false === $at ? $email : substr($email, 0, $at);
+    }
+
+    private function alreadyNotified(User $recipient, Comment $comment): bool
+    {
+        return null !== $this->em->getRepository(Notification::class)->findOneBy([
+            'recipient' => $recipient,
+            'comment' => $comment,
+        ]);
+    }
+
+    private function displayName(User $user): string
+    {
+        $name = trim(($user->getGivenName() ?? '') . ' ' . ($user->getFamilyName() ?? ''));
+        return '' !== $name ? $name : $user->getEmail();
+    }
+
+    private function snippet(string $body): string
+    {
+        $clean = trim(preg_replace('/\s+/', ' ', $body) ?? '');
+        return mb_strlen($clean) > 200
+            ? mb_substr($clean, 0, 197) . '…'
+            : $clean;
+    }
+}

--- a/api/src/State/CommentAuthorProcessor.php
+++ b/api/src/State/CommentAuthorProcessor.php
@@ -6,6 +6,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\Entity\Comment;
 use App\Entity\User;
+use App\Service\CommentMentionService;
 use App\Service\CommentMercurePublisher;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -29,6 +30,7 @@ final class CommentAuthorProcessor implements ProcessorInterface
         private ProcessorInterface $persistProcessor,
         private Security $security,
         private CommentMercurePublisher $publisher,
+        private CommentMentionService $mentions,
     ) {
     }
 
@@ -45,6 +47,7 @@ final class CommentAuthorProcessor implements ProcessorInterface
         $data->setAuthor($user);
 
         $result = $this->persistProcessor->process($data, $operation, $uriVariables, $context);
+        $this->mentions->dispatchMentions($result);
         $this->publisher->publishCreated($result);
 
         return $result;

--- a/api/src/State/CommentUpdateProcessor.php
+++ b/api/src/State/CommentUpdateProcessor.php
@@ -5,6 +5,7 @@ namespace App\State;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\Entity\Comment;
+use App\Service\CommentMentionService;
 use App\Service\CommentMercurePublisher;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
@@ -24,6 +25,7 @@ final class CommentUpdateProcessor implements ProcessorInterface
         #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
         private ProcessorInterface $persistProcessor,
         private CommentMercurePublisher $publisher,
+        private CommentMentionService $mentions,
     ) {
     }
 
@@ -33,6 +35,10 @@ final class CommentUpdateProcessor implements ProcessorInterface
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Comment
     {
         $result = $this->persistProcessor->process($data, $operation, $uriVariables, $context);
+        // Edits can introduce new @mentions; the (recipient, comment)
+        // unique key + alreadyNotified short-circuit keep prior mentions
+        // from re-firing.
+        $this->mentions->dispatchMentions($result);
         $this->publisher->publishUpdated($result);
         return $result;
     }

--- a/api/tests/Api/CommentTest.php
+++ b/api/tests/Api/CommentTest.php
@@ -4,6 +4,7 @@ namespace App\Tests\Api;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use App\Entity\Comment;
+use App\Entity\Notification;
 use App\Entity\Project;
 use App\Entity\Task;
 use App\Entity\User;
@@ -21,6 +22,10 @@ class CommentTest extends ApiTestCase
             ->get('doctrine')
             ->getManager();
 
+        // Notifications hold FKs to both Comment and Task (mention rows
+        // and reminder rows respectively); wipe them first so the bulk
+        // entity deletes below don't trip on orphans.
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Notification')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Comment')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();
@@ -428,6 +433,181 @@ class CommentTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testMentionCreatesNotificationForProjectMember(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $project = $this->createSharedProject($alice, [$alice, $bob], 'Team');
+        $task = $this->createTaskInProject($alice, $project, 'Plan launch');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/comments', [
+            'json' => [
+                'task' => '/tasks/' . $task->getId(),
+                'body' => 'Heads up @bob — can you review?',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+
+        $this->entityManager->clear();
+        $rows = $this->entityManager->getRepository(Notification::class)->findAll();
+        $this->assertCount(1, $rows);
+        $this->assertSame(Notification::TYPE_TASK_MENTION, $rows[0]->getType());
+        $this->assertSame(
+            (string) $bob->getId(),
+            (string) $rows[0]->getRecipient()?->getId(),
+        );
+    }
+
+    public function testMentionOfNonMemberIsIgnored(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        // Charlie exists but isn't a member of the task's project.
+        $charlie = $this->createUser('charlie@example.com');
+        $project = $this->createSharedProject($alice, [$alice], 'Solo');
+        $task = $this->createTaskInProject($alice, $project, 'Task');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/comments', [
+            'json' => [
+                'task' => '/tasks/' . $task->getId(),
+                'body' => 'cc @charlie',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        // Comment itself still posts — unknown @ tokens are plain text,
+        // not validation errors.
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertNotNull($charlie->getId());
+
+        $this->entityManager->clear();
+        $this->assertCount(
+            0,
+            $this->entityManager->getRepository(Notification::class)->findAll(),
+        );
+    }
+
+    public function testMentionDoesNotNotifyAuthor(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createSharedProject($alice, [$alice], 'Solo');
+        $task = $this->createTaskInProject($alice, $project, 'Task');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/comments', [
+            'json' => [
+                'task' => '/tasks/' . $task->getId(),
+                'body' => 'Reminding @alice (me)',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+
+        $this->entityManager->clear();
+        $this->assertCount(
+            0,
+            $this->entityManager->getRepository(Notification::class)->findAll(),
+        );
+    }
+
+    public function testEditingCommentDoesNotResendExistingMention(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $project = $this->createSharedProject($alice, [$alice, $bob], 'Team');
+        $task = $this->createTaskInProject($alice, $project, 'Task');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/comments', [
+            'json' => [
+                'task' => '/tasks/' . $task->getId(),
+                'body' => 'Hey @bob',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+        $created = $client->getResponse()->toArray();
+
+        // Edit keeps the same mention — must NOT create a second notification.
+        $client->request('PATCH', $created['@id'], [
+            'json' => ['body' => 'Hey @bob (small typo fix)'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $this->entityManager->clear();
+        $this->assertCount(
+            1,
+            $this->entityManager->getRepository(Notification::class)->findAll(),
+        );
+    }
+
+    public function testEditingCommentToAddNewMentionFiresOnlyForNewRecipient(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $carol = $this->createUser('carol@example.com');
+        $project = $this->createSharedProject($alice, [$alice, $bob, $carol], 'Team');
+        $task = $this->createTaskInProject($alice, $project, 'Task');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/comments', [
+            'json' => [
+                'task' => '/tasks/' . $task->getId(),
+                'body' => 'Hey @bob',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $created = $client->getResponse()->toArray();
+
+        $client->request('PATCH', $created['@id'], [
+            'json' => ['body' => 'Hey @bob and @carol'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $this->entityManager->clear();
+        $rows = $this->entityManager->getRepository(Notification::class)->findAll();
+        $this->assertCount(2, $rows);
+        $emails = array_map(
+            fn (Notification $n) => $n->getRecipient()?->getEmail(),
+            $rows,
+        );
+        sort($emails);
+        $this->assertSame(['bob@example.com', 'carol@example.com'], $emails);
+    }
+
+    public function testDuplicateMentionsInOneCommentNotifyOnce(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $project = $this->createSharedProject($alice, [$alice, $bob], 'Team');
+        $task = $this->createTaskInProject($alice, $project, 'Task');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/comments', [
+            'json' => [
+                'task' => '/tasks/' . $task->getId(),
+                'body' => '@bob @BOB @bob — please look',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+
+        $this->entityManager->clear();
+        $this->assertCount(
+            1,
+            $this->entityManager->getRepository(Notification::class)->findAll(),
+        );
     }
 
     private function seedComment(User $author, Task $task, string $body): Comment

--- a/pwa/components/editor/MarkdownView.tsx
+++ b/pwa/components/editor/MarkdownView.tsx
@@ -1,20 +1,83 @@
+import { Fragment, type ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 interface MarkdownViewProps {
   source: string | null | undefined;
   className?: string;
+  /**
+   * When true, `@token` runs inside text nodes render as styled mention
+   * chips. Used in the comment view to highlight resolved mentions
+   * created by the server-side parser (#106). The same pattern as the
+   * server: alphanumerics + `._+-`, bounded by start-of-string or
+   * whitespace so plain emails (`foo@bar.com`) stay un-styled.
+   */
+  highlightMentions?: boolean;
 }
+
+const MENTION_PATTERN = /(^|\s)(@[A-Za-z0-9._+-]+)/g;
+
+const renderMentionsInText = (input: string): ReactNode => {
+  if (!input.includes("@")) return input;
+  const parts: ReactNode[] = [];
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+  // Reset and reuse a single regex instance so we don't depend on
+  // matchAll iteration support (the project's TS target is below es2015).
+  MENTION_PATTERN.lastIndex = 0;
+  while ((match = MENTION_PATTERN.exec(input)) !== null) {
+    const idx = match.index;
+    const lead = match[1] ?? "";
+    const mention = match[2] ?? "";
+    const start = idx + lead.length;
+    if (start > cursor) parts.push(input.slice(cursor, start));
+    parts.push(
+      <span
+        key={`m-${start}`}
+        className="inline-flex items-center rounded bg-cyan-50 px-1 text-cyan-700 dark:bg-cyan-950 dark:text-cyan-300"
+        data-testid="comment-mention"
+      >
+        {mention}
+      </span>,
+    );
+    cursor = start + mention.length;
+  }
+  if (cursor < input.length) parts.push(input.slice(cursor));
+  return (
+    <>
+      {parts.map((p, i) => (
+        <Fragment key={i}>{p}</Fragment>
+      ))}
+    </>
+  );
+};
 
 // Read-only renderer for stored markdown. react-markdown escapes raw HTML by
 // default (we don't enable rehype-raw), so user input can't inject script tags.
 // Styling lives in globals.css under `.markdown-view` since we don't ship the
 // tailwind-typography plugin.
-const MarkdownView = ({ source, className }: MarkdownViewProps) => {
+const MarkdownView = ({
+  source,
+  className,
+  highlightMentions,
+}: MarkdownViewProps) => {
   if (!source) return null;
+  // react-markdown delivers each text leaf as a string child; we walk
+  // it and replace @mention runs with styled spans. Block structure is
+  // preserved because only the leaf renderer is overridden.
+  const components = highlightMentions
+    ? {
+        text: ({ children }: { children?: ReactNode }) =>
+          typeof children === "string"
+            ? renderMentionsInText(children)
+            : children,
+      }
+    : undefined;
   return (
     <div className={`markdown-view ${className ?? ""}`}>
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{source}</ReactMarkdown>
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+        {source}
+      </ReactMarkdown>
     </div>
   );
 };

--- a/pwa/components/tasks/CommentsPanel.tsx
+++ b/pwa/components/tasks/CommentsPanel.tsx
@@ -461,6 +461,7 @@ const CommentRow = ({
           <MarkdownView
             source={comment.body}
             className="text-sm mt-1"
+            highlightMentions
           />
         )}
         {replying && (

--- a/pwa/pages/dev/components/markdown-view.tsx
+++ b/pwa/pages/dev/components/markdown-view.tsx
@@ -26,6 +26,16 @@ const MarkdownViewPage = () => (
         code: `<MarkdownView source={project.description} />`,
         preview: <MarkdownView source={SAMPLE} />,
       },
+      {
+        title: "Highlight @mention chips (comment view)",
+        code: `<MarkdownView source={comment.body} highlightMentions />`,
+        preview: (
+          <MarkdownView
+            source={"Heads up @bob — please look. cc @carol"}
+            highlightMentions
+          />
+        ),
+      },
     ]}
   />
 );


### PR DESCRIPTION
## Summary
- `CommentMentionService` parses `@username` tokens (username = email local-part) from comment bodies on POST and PATCH, resolves against project members + task owner, and creates one `task_mention` `Notification` per recipient with a `comment` deep-link.
- Mentions of users outside the project, the comment author themselves, and recipients already notified for the same comment are silently ignored — editing to add a new mention only pings the newcomer.
- Schema: nullable `comment_id` FK on `notification` (cascade delete) + unique `(recipient_id, comment_id)` index for dedupe (migration `Version20260504040000`).
- PWA: new `highlightMentions` prop on `MarkdownView` wraps `@token` runs in styled chips inside text leaves; comment read view opts in. Dev component doc updated with a chip example.
- **Out of scope**: BlockNote composer autocomplete on `@`. The user can still type `@username` by hand and the server resolves it; hooking BlockNote's suggestion menu warrants its own PR. Marking this PR as "addresses" rather than "closes" so the issue stays open for the autocomplete piece.

## Test plan
- [x] `bin/phpunit tests/Api/CommentTest.php` — 6 new mention cases (project-member resolution, non-member ignored, no self-ping, edit dedupes, edit-with-new-mention pings new recipient only, duplicates collapse).
- [x] Full API suite green (260 tests).
- [x] `npx tsc --noEmit` and `pnpm lint` clean (only pre-existing warnings).
- [ ] Manual: create a project task with another member, post `Hey @bob`, confirm bell badges Bob; edit comment to `Hey @bob and @carol`, confirm only Carol gets a fresh notification.