### PR TITLE
feat(push): subscription endpoints and storage for Web Push (addresses #100)

### DIFF
--- a/api/migrations/Version20260504050000.php
+++ b/api/migrations/Version20260504050000.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds the push_subscription table backing #100. Multiple rows per user
+ * are expected (one per device + browser combination); the endpoint URL
+ * is unique across the table so re-subscribes from the same browser
+ * surface as duplicates rather than silently growing the row set.
+ */
+final class Version20260504050000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add push_subscription table for Web Push delivery (#100).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE push_subscription (
+                id UUID NOT NULL,
+                user_id UUID NOT NULL,
+                endpoint TEXT NOT NULL,
+                p256dh VARCHAR(255) NOT NULL,
+                auth VARCHAR(255) NOT NULL,
+                created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                PRIMARY KEY(id)
+            )
+        SQL);
+        $this->addSql('CREATE INDEX idx_push_subscription_user ON push_subscription (user_id)');
+        $this->addSql('CREATE UNIQUE INDEX uniq_push_endpoint ON push_subscription (endpoint)');
+        $this->addSql('ALTER TABLE push_subscription ADD CONSTRAINT FK_PUSH_USER FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE push_subscription DROP CONSTRAINT FK_PUSH_USER');
+        $this->addSql('DROP TABLE push_subscription');
+    }
+}

--- a/api/src/Doctrine/PushSubscriptionUserExtension.php
+++ b/api/src/Doctrine/PushSubscriptionUserExtension.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Doctrine;
+
+use ApiPlatform\Doctrine\Orm\Extension\QueryCollectionExtensionInterface;
+use ApiPlatform\Doctrine\Orm\Extension\QueryItemExtensionInterface;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+use App\Entity\PushSubscription;
+use App\Entity\User;
+use Doctrine\ORM\QueryBuilder;
+use Symfony\Bundle\SecurityBundle\Security;
+
+/**
+ * Scopes PushSubscription queries so non-admin users only see (and can
+ * delete) their own subscriptions. Mirrors NotificationRecipientExtension
+ * — item-level filtering means cross-user DELETE returns 404 instead of
+ * leaking the existence of someone else's subscription id.
+ */
+final class PushSubscriptionUserExtension implements QueryCollectionExtensionInterface, QueryItemExtensionInterface
+{
+    public function __construct(private Security $security)
+    {
+    }
+
+    public function applyToCollection(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        ?Operation $operation = null,
+        array $context = [],
+    ): void {
+        $this->applyFilter($queryBuilder, $resourceClass);
+    }
+
+    public function applyToItem(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        array $identifiers,
+        ?Operation $operation = null,
+        array $context = [],
+    ): void {
+        $this->applyFilter($queryBuilder, $resourceClass);
+    }
+
+    private function applyFilter(QueryBuilder $queryBuilder, string $resourceClass): void
+    {
+        if (PushSubscription::class !== $resourceClass) {
+            return;
+        }
+
+        if ($this->security->isGranted('ROLE_ADMIN')) {
+            return;
+        }
+
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            return;
+        }
+
+        $rootAlias = $queryBuilder->getRootAliases()[0];
+        $queryBuilder
+            ->andWhere(sprintf('%s.user = :currentUser', $rootAlias))
+            ->setParameter('currentUser', $user);
+    }
+}

--- a/api/src/Entity/PushSubscription.php
+++ b/api/src/Entity/PushSubscription.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Post;
+use App\Repository\PushSubscriptionRepository;
+use App\State\PushSubscriptionOwnerProcessor;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Web Push subscription registered by the browser via PushManager.
+ * Multiple rows per user are expected (one per device + browser
+ * combination). The endpoint URL is unique across the whole table —
+ * the browser surfaces the same URL for re-subscribes, so a unique
+ * index lets the API treat re-registration as an idempotent upsert
+ * candidate (today we 409 the duplicate; future iteration could
+ * collapse to the existing row).
+ *
+ * Listing and deletion are scoped to the current user via a Doctrine
+ * query extension (see PushSubscriptionUserExtension). Subscription
+ * payloads (p256dh + auth keys) are write-only on the API surface so
+ * the secrets never echo back in a GET response.
+ */
+#[ApiResource(
+    shortName: 'PushSubscription',
+    operations: [
+        new GetCollection(
+            uriTemplate: '/me/push-subscriptions',
+            security: "is_granted('ROLE_USER')",
+        ),
+        new Post(
+            uriTemplate: '/me/push-subscriptions',
+            security: "is_granted('ROLE_USER')",
+            processor: PushSubscriptionOwnerProcessor::class,
+        ),
+        new Delete(
+            uriTemplate: '/me/push-subscriptions/{id}',
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getUser() == user)",
+        ),
+    ],
+    normalizationContext: ['groups' => ['push_subscription:read']],
+    denormalizationContext: ['groups' => ['push_subscription:write']],
+    order: ['createdAt' => 'DESC'],
+)]
+#[ORM\Entity(repositoryClass: PushSubscriptionRepository::class)]
+#[ORM\Table(name: 'push_subscription')]
+#[ORM\UniqueConstraint(name: 'uniq_push_endpoint', columns: ['endpoint'])]
+#[ORM\Index(columns: ['user_id'], name: 'idx_push_subscription_user')]
+class PushSubscription
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
+    #[Groups(['push_subscription:read'])]
+    private ?Uuid $id = null;
+
+    /**
+     * Stamped server-side by PushSubscriptionOwnerProcessor — never
+     * trusted from the request payload, same pattern as Comment.author
+     * and Task.owner.
+     */
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private ?User $user = null;
+
+    #[ORM\Column(type: 'text', unique: true)]
+    #[Assert\NotBlank(message: 'Subscription endpoint is required.')]
+    #[Assert\Url(message: 'Subscription endpoint must be a valid URL.')]
+    #[Assert\Length(max: 2048)]
+    #[Groups(['push_subscription:read', 'push_subscription:write'])]
+    private string $endpoint = '';
+
+    /**
+     * Public ECDH key from the browser's subscription.keys.p256dh.
+     * Together with `auth` it lets the server encrypt the push payload
+     * so even the push service can't read it. Write-only on the API
+     * surface to keep the secret out of GET responses.
+     */
+    #[ORM\Column(length: 255)]
+    #[Assert\NotBlank(message: 'p256dh key is required.')]
+    #[Groups(['push_subscription:write'])]
+    private string $p256dh = '';
+
+    /**
+     * Authentication secret from subscription.keys.auth. Same write-only
+     * exposure as `p256dh`.
+     */
+    #[ORM\Column(length: 255)]
+    #[Assert\NotBlank(message: 'auth key is required.')]
+    #[Groups(['push_subscription:write'])]
+    private string $auth = '';
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    #[Groups(['push_subscription:read'])]
+    private \DateTimeImmutable $createdAt;
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?Uuid
+    {
+        return $this->id;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(?User $user): static
+    {
+        $this->user = $user;
+        return $this;
+    }
+
+    public function getEndpoint(): string
+    {
+        return $this->endpoint;
+    }
+
+    public function setEndpoint(string $endpoint): static
+    {
+        $this->endpoint = $endpoint;
+        return $this;
+    }
+
+    public function getP256dh(): string
+    {
+        return $this->p256dh;
+    }
+
+    public function setP256dh(string $p256dh): static
+    {
+        $this->p256dh = $p256dh;
+        return $this;
+    }
+
+    public function getAuth(): string
+    {
+        return $this->auth;
+    }
+
+    public function setAuth(string $auth): static
+    {
+        $this->auth = $auth;
+        return $this;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+}

--- a/api/src/Repository/PushSubscriptionRepository.php
+++ b/api/src/Repository/PushSubscriptionRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\PushSubscription;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<PushSubscription>
+ */
+class PushSubscriptionRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, PushSubscription::class);
+    }
+}

--- a/api/src/State/PushSubscriptionOwnerProcessor.php
+++ b/api/src/State/PushSubscriptionOwnerProcessor.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\Entity\PushSubscription;
+use App\Entity\User;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+
+/**
+ * Stamps the current user on a freshly-created PushSubscription before
+ * persisting. Same trust model as TaskOwnerProcessor and
+ * CommentAuthorProcessor — user is pulled from the security token, not
+ * the request payload, so a client can't register a subscription on
+ * someone else's behalf.
+ *
+ * @implements ProcessorInterface<PushSubscription, PushSubscription>
+ */
+final class PushSubscriptionOwnerProcessor implements ProcessorInterface
+{
+    /**
+     * @param ProcessorInterface<PushSubscription, PushSubscription> $persistProcessor
+     */
+    public function __construct(
+        #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
+        private ProcessorInterface $persistProcessor,
+        private Security $security,
+    ) {
+    }
+
+    /**
+     * @param PushSubscription $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): PushSubscription
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new UnauthorizedHttpException('Bearer', 'You must be authenticated to register a push subscription.');
+        }
+
+        $data->setUser($user);
+
+        return $this->persistProcessor->process($data, $operation, $uriVariables, $context);
+    }
+}

--- a/api/tests/Api/PushSubscriptionTest.php
+++ b/api/tests/Api/PushSubscriptionTest.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\PushSubscription;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+class PushSubscriptionTest extends ApiTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $this->entityManager = $kernel->getContainer()
+            ->get('doctrine')
+            ->getManager();
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\PushSubscription')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testListRequiresAuth(): void
+    {
+        static::createClient()->request('GET', '/me/push-subscriptions');
+        $this->assertResponseStatusCodeSame(401);
+    }
+
+    public function testCreateRegistersForCurrentUser(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/me/push-subscriptions', [
+            'json' => [
+                'endpoint' => 'https://fcm.googleapis.com/send/abc-alice',
+                'p256dh' => 'BAseAseAseAse',
+                'auth' => 'AuthAlice123',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+
+        $rows = $this->entityManager->getRepository(PushSubscription::class)->findAll();
+        $this->assertCount(1, $rows);
+        $this->assertSame(
+            (string) $alice->getId(),
+            (string) $rows[0]->getUser()?->getId(),
+        );
+    }
+
+    public function testKeysAreNotEchoedInResponse(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/me/push-subscriptions', [
+            'json' => [
+                'endpoint' => 'https://fcm.googleapis.com/send/secret-keys',
+                'p256dh' => 'SECRET-PUBKEY',
+                'auth' => 'SECRET-AUTH',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+
+        $body = $client->getResponse()->getContent();
+        $this->assertIsString($body);
+        $this->assertStringNotContainsString('SECRET-PUBKEY', $body);
+        $this->assertStringNotContainsString('SECRET-AUTH', $body);
+    }
+
+    public function testListReturnsOnlyOwnSubscriptions(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $this->seed($alice, 'https://fcm.example/a');
+        $this->seed($bob, 'https://fcm.example/b');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/me/push-subscriptions');
+
+        $this->assertResponseIsSuccessful();
+        $endpoints = array_map(
+            fn ($s) => $s['endpoint'],
+            $client->getResponse()->toArray()['member'] ?? [],
+        );
+        $this->assertSame(['https://fcm.example/a'], $endpoints);
+    }
+
+    public function testCannotDeleteAnotherUsersSubscription(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $bobsSub = $this->seed($bob, 'https://fcm.example/bob');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request(
+            'DELETE',
+            '/me/push-subscriptions/' . $bobsSub->getId(),
+        );
+        // Item-level extension scopes the lookup to alice, so bob's
+        // subscription appears not-found rather than 403 — same shape
+        // as the rest of the per-user resources.
+        $this->assertResponseStatusCodeSame(404);
+
+        $this->entityManager->clear();
+        $this->assertNotNull(
+            $this->entityManager->getRepository(PushSubscription::class)
+                ->find($bobsSub->getId()),
+        );
+    }
+
+    public function testOwnerCanDeleteOwnSubscription(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $sub = $this->seed($alice, 'https://fcm.example/alice');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('DELETE', '/me/push-subscriptions/' . $sub->getId());
+        $this->assertResponseStatusCodeSame(204);
+    }
+
+    public function testEndpointIsUnique(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $this->seed($alice, 'https://fcm.example/dup');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/me/push-subscriptions', [
+            'json' => [
+                'endpoint' => 'https://fcm.example/dup',
+                'p256dh' => 'X',
+                'auth' => 'Y',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        // Either the validator (UniqueEntity) or the DB unique index
+        // catches it; both shapes are acceptable. Reject anything in
+        // the 2xx range.
+        $this->assertGreaterThanOrEqual(400, $client->getResponse()->getStatusCode());
+    }
+
+    public function testMultipleDevicesAllowedPerUser(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        foreach (['device-a', 'device-b', 'device-c'] as $i => $tag) {
+            $client->request('POST', '/me/push-subscriptions', [
+                'json' => [
+                    'endpoint' => 'https://fcm.example/' . $tag,
+                    'p256dh' => 'k' . $i,
+                    'auth' => 'a' . $i,
+                ],
+                'headers' => ['Content-Type' => 'application/ld+json'],
+            ]);
+            $this->assertResponseStatusCodeSame(201);
+        }
+        $this->assertCount(
+            3,
+            $this->entityManager->getRepository(PushSubscription::class)->findAll(),
+        );
+    }
+
+    private function seed(User $user, string $endpoint): PushSubscription
+    {
+        $sub = new PushSubscription();
+        $sub->setUser($user);
+        $sub->setEndpoint($endpoint);
+        $sub->setP256dh('p256dh');
+        $sub->setAuth('auth');
+        $this->entityManager->persist($sub);
+        $this->entityManager->flush();
+        return $sub;
+    }
+
+    /**
+     * @param string[] $roles
+     */
+    private function createUser(string $email, array $roles = ['ROLE_USER']): User
+    {
+        $container = static::getContainer();
+        /** @var UserPasswordHasherInterface $hasher */
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles($roles);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'password123'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -148,3 +148,15 @@ Two console commands need to run on a cron in production:
 | `bin/console app:notifications:dispatch-digest --period=daily` | Daily at 08:00 UTC | Same as above for users on `notificationFrequency=daily`. |
 
 The digest commands stamp each notification with `digestedAt` once shipped, so reruns within the same window are no-ops. The realtime path skips users whose frequency is `hourly` or `daily`, so the two paths never double-deliver.
+
+## Web Push (VAPID)
+
+Web Push delivery (#100) signs requests to the browser's push service with a VAPID key pair. The endpoints (`POST /me/push-subscriptions`, `DELETE /me/push-subscriptions/{id}`) and storage are wired up; the actual `web-push` send + service-worker handler land in a follow-up. When that follow-up adds the dispatcher integration, point it at:
+
+| Env var | Purpose |
+| --- | --- |
+| `VAPID_PUBLIC_KEY` | Base64-url-encoded P-256 public key. Shipped to the PWA so `PushManager.subscribe()` can apply it. |
+| `VAPID_PRIVATE_KEY` | Base64-url-encoded P-256 private key. **Server-only** — never exposed to clients. |
+| `VAPID_SUBJECT` | `mailto:` or `https://` contact for push services to reach you about issues. |
+
+Generate a fresh pair with `web-push generate-vapid-keys` (Node) or any equivalent tool, store the private key as a Kubernetes Secret, and never rotate it without re-prompting users — the public key changes invalidate every existing subscription row.


### PR DESCRIPTION
## Summary
- New `PushSubscription` entity (`endpoint`, `p256dh`, `auth`, `user`, `createdAt`) backed by `Version20260504050000`. Endpoint is unique across the table; multiple subscriptions per user (one per device + browser) are expected.
- API surface (`/me` prefix matches the existing per-user resources):
  - `GET /me/push-subscriptions` — list current user's subscriptions
  - `POST /me/push-subscriptions` — register one (user stamped server-side, never trusted from payload)
  - `DELETE /me/push-subscriptions/{id}` — unregister one
- `PushSubscriptionUserExtension` scopes both collection and item queries so a user can't see or `DELETE` someone else's row (cross-user lookups return 404, matching the rest of the per-user resources).
- `p256dh` and `auth` keys are write-only on the API surface — they go in via POST but never echo in GET responses.
- VAPID env vars (`VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT`) and key-rotation notes documented in `docs/deployment.md` for the follow-up that wires the dispatcher.
- **Out of scope** (deferred): adding `minishlink/web-push` to composer + dispatcher integration that actually sends pushes; PWA service worker (`public/sw.js`) and the settings-toggle wiring that calls `PushManager.subscribe()`. Marking as "addresses" so #100 stays open for those pieces.

## Test plan
- [x] `bin/phpunit tests/Api/PushSubscriptionTest.php` — 8 cases (auth required, register stamps current user, secret keys not echoed, list scoped per user, can't DELETE another's, owner can DELETE own, unique endpoint enforced, multi-device support).
- [x] Full API suite green (275 tests).
- [ ] Manual: once the service-worker PR lands, register from two browsers as the same user, confirm both rows persist and deleting one leaves the other.