### PR TITLE
feat(custom-fields): per-project field definitions with CRUD (addresses #84)

### DIFF
--- a/api/migrations/Version20260504060000.php
+++ b/api/migrations/Version20260504060000.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds custom_field_definition for per-project field schemas (#84).
+ * Values themselves land in a follow-up — this migration only sets up
+ * the definitions so the project-settings UI can be built first.
+ */
+final class Version20260504060000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add custom_field_definition table for per-project field schemas (#84).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE custom_field_definition (
+                id UUID NOT NULL,
+                project_id UUID NOT NULL,
+                name VARCHAR(80) NOT NULL,
+                type VARCHAR(16) NOT NULL,
+                options JSON DEFAULT NULL,
+                position INT NOT NULL DEFAULT 0,
+                required BOOLEAN NOT NULL DEFAULT FALSE,
+                created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                PRIMARY KEY(id)
+            )
+        SQL);
+        $this->addSql('CREATE INDEX idx_cfd_project_position ON custom_field_definition (project_id, position)');
+        $this->addSql('CREATE UNIQUE INDEX uniq_cfd_project_name ON custom_field_definition (project_id, name)');
+        $this->addSql('ALTER TABLE custom_field_definition ADD CONSTRAINT FK_CFD_PROJECT FOREIGN KEY (project_id) REFERENCES project (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE custom_field_definition DROP CONSTRAINT FK_CFD_PROJECT');
+        $this->addSql('DROP TABLE custom_field_definition');
+    }
+}

--- a/api/src/Doctrine/CustomFieldDefinitionAccessExtension.php
+++ b/api/src/Doctrine/CustomFieldDefinitionAccessExtension.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Doctrine;
+
+use ApiPlatform\Doctrine\Orm\Extension\QueryCollectionExtensionInterface;
+use ApiPlatform\Doctrine\Orm\Extension\QueryItemExtensionInterface;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+use App\Entity\CustomFieldDefinition;
+use App\Entity\User;
+use Doctrine\ORM\QueryBuilder;
+use Symfony\Bundle\SecurityBundle\Security;
+
+/**
+ * Scopes CustomFieldDefinition listings and item lookups to projects
+ * the current user belongs to. Mirrors CommentAccessExtension and the
+ * other per-project read scopes — non-member item GETs return 404
+ * rather than 403 so we don't leak existence.
+ */
+final class CustomFieldDefinitionAccessExtension implements
+    QueryCollectionExtensionInterface,
+    QueryItemExtensionInterface
+{
+    public function __construct(private Security $security)
+    {
+    }
+
+    public function applyToCollection(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        ?Operation $operation = null,
+        array $context = [],
+    ): void {
+        $this->applyFilter($queryBuilder, $resourceClass);
+    }
+
+    public function applyToItem(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        array $identifiers,
+        ?Operation $operation = null,
+        array $context = [],
+    ): void {
+        $this->applyFilter($queryBuilder, $resourceClass);
+    }
+
+    private function applyFilter(QueryBuilder $queryBuilder, string $resourceClass): void
+    {
+        if (CustomFieldDefinition::class !== $resourceClass) {
+            return;
+        }
+        if ($this->security->isGranted('ROLE_ADMIN')) {
+            return;
+        }
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            return;
+        }
+
+        $rootAlias = $queryBuilder->getRootAliases()[0];
+        $projectAlias = 'cfd_project';
+        $memberAlias = 'cfd_project_members';
+        $queryBuilder
+            ->innerJoin($rootAlias . '.project', $projectAlias)
+            ->innerJoin($projectAlias . '.members', $memberAlias)
+            ->andWhere($memberAlias . ' = :currentUser')
+            ->setParameter('currentUser', $user);
+    }
+}

--- a/api/src/Entity/CustomFieldDefinition.php
+++ b/api/src/Entity/CustomFieldDefinition.php
@@ -1,0 +1,267 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Doctrine\Orm\Filter\OrderFilter;
+use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
+use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use App\Repository\CustomFieldDefinitionRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+
+/**
+ * Per-project custom field definition (#84). Each project can declare
+ * its own set of fields that the eventual task UI will render
+ * dynamically; values themselves (CustomFieldValue) land in a follow-up
+ * — this PR ships only the definitions + CRUD so the project-settings
+ * UI can be built against a stable surface first.
+ *
+ * Read access mirrors the parent project (members + admins). Write
+ * access is owner-only — the field schema is structural and easy to
+ * disrupt for the rest of the project, so we keep mutation narrow
+ * even though every member can post tasks.
+ */
+#[ApiResource(
+    shortName: 'CustomFieldDefinition',
+    operations: [
+        new GetCollection(
+            security: "is_granted('ROLE_USER')",
+        ),
+        new Post(
+            security: "is_granted('ROLE_USER')",
+            securityPostDenormalize: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getProject() !== null and object.getProject().getOwner() == user)",
+        ),
+        new Get(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getProject().getMembers().contains(user))",
+        ),
+        new Patch(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getProject().getOwner() == user)",
+        ),
+        new Delete(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getProject().getOwner() == user)",
+        ),
+    ],
+    normalizationContext: ['groups' => ['custom_field_definition:read']],
+    denormalizationContext: ['groups' => ['custom_field_definition:write']],
+    order: ['position' => 'ASC', 'createdAt' => 'ASC'],
+)]
+#[ApiFilter(SearchFilter::class, properties: ['project' => 'exact'])]
+#[ApiFilter(OrderFilter::class, properties: ['position'], arguments: ['orderParameterName' => 'order'])]
+#[ORM\Entity(repositoryClass: CustomFieldDefinitionRepository::class)]
+#[ORM\Table(name: 'custom_field_definition')]
+#[ORM\Index(columns: ['project_id', 'position'], name: 'idx_cfd_project_position')]
+#[ORM\UniqueConstraint(name: 'uniq_cfd_project_name', columns: ['project_id', 'name'])]
+#[UniqueEntity(
+    fields: ['project', 'name'],
+    message: 'A field with this name already exists in the project.',
+)]
+class CustomFieldDefinition
+{
+    public const TYPE_TEXT = 'text';
+    public const TYPE_NUMBER = 'number';
+    public const TYPE_DATE = 'date';
+    public const TYPE_DROPDOWN = 'dropdown';
+    public const TYPE_CHECKBOX = 'checkbox';
+
+    public const ALLOWED_TYPES = [
+        self::TYPE_TEXT,
+        self::TYPE_NUMBER,
+        self::TYPE_DATE,
+        self::TYPE_DROPDOWN,
+        self::TYPE_CHECKBOX,
+    ];
+
+    public const MAX_NAME_LENGTH = 80;
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
+    #[Groups(['custom_field_definition:read'])]
+    private ?Uuid $id = null;
+
+    /**
+     * Bare IRI on the read side — same shape as Comment.parentComment.
+     * Embedding the whole project would balloon the list payload for a
+     * project with many members.
+     */
+    #[ApiProperty(readableLink: false)]
+    #[ORM\ManyToOne(targetEntity: Project::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    #[Assert\NotNull(message: 'Project is required.')]
+    #[Groups(['custom_field_definition:read', 'custom_field_definition:write'])]
+    private ?Project $project = null;
+
+    #[ORM\Column(length: self::MAX_NAME_LENGTH)]
+    #[Assert\NotBlank(message: 'Field name is required.')]
+    #[Assert\Length(
+        max: self::MAX_NAME_LENGTH,
+        maxMessage: 'Field name cannot be longer than {{ limit }} characters.',
+    )]
+    #[Groups(['custom_field_definition:read', 'custom_field_definition:write'])]
+    private string $name = '';
+
+    #[ORM\Column(length: 16)]
+    #[Assert\Choice(
+        choices: self::ALLOWED_TYPES,
+        message: 'Type must be one of: text, number, date, dropdown, checkbox.',
+    )]
+    #[Groups(['custom_field_definition:read', 'custom_field_definition:write'])]
+    private string $type = self::TYPE_TEXT;
+
+    /**
+     * Required only when type is `dropdown`. Stored as a JSON array of
+     * non-empty unique strings — the choices the picker presents.
+     *
+     * @var array<int, string>|null
+     */
+    #[ORM\Column(type: 'json', nullable: true)]
+    #[Groups(['custom_field_definition:read', 'custom_field_definition:write'])]
+    private ?array $options = null;
+
+    #[ORM\Column(type: 'integer', options: ['default' => 0])]
+    #[Assert\PositiveOrZero(message: 'Position cannot be negative.')]
+    #[Groups(['custom_field_definition:read', 'custom_field_definition:write'])]
+    private int $position = 0;
+
+    #[ORM\Column(type: 'boolean', options: ['default' => false])]
+    #[Groups(['custom_field_definition:read', 'custom_field_definition:write'])]
+    private bool $required = false;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    #[Groups(['custom_field_definition:read'])]
+    private \DateTimeImmutable $createdAt;
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?Uuid
+    {
+        return $this->id;
+    }
+
+    public function getProject(): ?Project
+    {
+        return $this->project;
+    }
+
+    public function setProject(?Project $project): static
+    {
+        $this->project = $project;
+        return $this;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): static
+    {
+        $this->name = trim($name);
+        return $this;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function setType(string $type): static
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+    /**
+     * @return array<int, string>|null
+     */
+    public function getOptions(): ?array
+    {
+        return $this->options;
+    }
+
+    /**
+     * @param array<int, string>|null $options
+     */
+    public function setOptions(?array $options): static
+    {
+        $this->options = $options;
+        return $this;
+    }
+
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function setPosition(int $position): static
+    {
+        $this->position = $position;
+        return $this;
+    }
+
+    public function isRequired(): bool
+    {
+        return $this->required;
+    }
+
+    public function setRequired(bool $required): static
+    {
+        $this->required = $required;
+        return $this;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * Cross-field validation: dropdown fields must declare at least one
+     * non-empty option; non-dropdown fields must not declare any. The
+     * Choice constraint above already handles the type allow-list, so
+     * we only police the `options` shape here.
+     */
+    #[Assert\Callback]
+    public function validateOptions(ExecutionContextInterface $context): void
+    {
+        if (self::TYPE_DROPDOWN === $this->type) {
+            $cleaned = array_values(array_filter(
+                array_map(static fn ($v) => is_string($v) ? trim($v) : '', $this->options ?? []),
+                static fn (string $v) => '' !== $v,
+            ));
+            if (count($cleaned) < 1) {
+                $context->buildViolation('Dropdown fields require at least one option.')
+                    ->atPath('options')
+                    ->addViolation();
+                return;
+            }
+            if (count($cleaned) !== count(array_unique($cleaned))) {
+                $context->buildViolation('Dropdown options must be unique.')
+                    ->atPath('options')
+                    ->addViolation();
+            }
+            return;
+        }
+
+        if (null !== $this->options && [] !== $this->options) {
+            $context->buildViolation('Only dropdown fields can declare options.')
+                ->atPath('options')
+                ->addViolation();
+        }
+    }
+}

--- a/api/src/Repository/CustomFieldDefinitionRepository.php
+++ b/api/src/Repository/CustomFieldDefinitionRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\CustomFieldDefinition;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<CustomFieldDefinition>
+ */
+class CustomFieldDefinitionRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, CustomFieldDefinition::class);
+    }
+}

--- a/api/tests/Api/CustomFieldDefinitionTest.php
+++ b/api/tests/Api/CustomFieldDefinitionTest.php
@@ -1,0 +1,284 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\CustomFieldDefinition;
+use App\Entity\Project;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+class CustomFieldDefinitionTest extends ApiTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $this->entityManager = $kernel->getContainer()
+            ->get('doctrine')
+            ->getManager();
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\CustomFieldDefinition')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testListRequiresAuth(): void
+    {
+        static::createClient()->request('GET', '/custom_field_definitions');
+        $this->assertResponseStatusCodeSame(401);
+    }
+
+    public function testOwnerCanCreateTextField(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/custom_field_definitions', [
+            'json' => [
+                'project' => '/projects/' . $project->getId(),
+                'name' => 'Severity',
+                'type' => 'text',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+    }
+
+    public function testNonOwnerMemberCannotCreate(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $project->addMember($bob);
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($bob);
+        $client->request('POST', '/custom_field_definitions', [
+            'json' => [
+                'project' => '/projects/' . $project->getId(),
+                'name' => 'Severity',
+                'type' => 'text',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testStrangerCannotEvenSeeProjectFields(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $field = $this->seedField($project, 'Severity', 'text');
+
+        $client = static::createClient();
+        $client->loginUser($bob);
+        $client->request('GET', '/custom_field_definitions/' . $field->getId());
+        // Cross-project lookups return 404 (extension scopes the query),
+        // matching the rest of the per-project resources.
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testListFiltersToProjectsTheUserBelongsTo(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $aliceProject = $this->createProject($alice, 'Alice');
+        $bobProject = $this->createProject($bob, 'Bob');
+        $this->seedField($aliceProject, 'A1', 'text');
+        $this->seedField($bobProject, 'B1', 'text');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/custom_field_definitions');
+        $this->assertResponseIsSuccessful();
+        $names = array_map(
+            fn ($c) => $c['name'],
+            $client->getResponse()->toArray()['member'] ?? [],
+        );
+        $this->assertSame(['A1'], $names);
+    }
+
+    public function testDropdownRequiresOptions(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/custom_field_definitions', [
+            'json' => [
+                'project' => '/projects/' . $project->getId(),
+                'name' => 'Priority',
+                'type' => 'dropdown',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testNonDropdownRejectsOptions(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/custom_field_definitions', [
+            'json' => [
+                'project' => '/projects/' . $project->getId(),
+                'name' => 'Severity',
+                'type' => 'text',
+                'options' => ['Low', 'High'],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testDropdownHappyPath(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/custom_field_definitions', [
+            'json' => [
+                'project' => '/projects/' . $project->getId(),
+                'name' => 'Priority',
+                'type' => 'dropdown',
+                'options' => ['Low', 'Medium', 'High'],
+                'required' => true,
+                'position' => 1,
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertJsonContains([
+            'name' => 'Priority',
+            'type' => 'dropdown',
+            'options' => ['Low', 'Medium', 'High'],
+            'required' => true,
+            'position' => 1,
+        ]);
+    }
+
+    public function testInvalidTypeRejected(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/custom_field_definitions', [
+            'json' => [
+                'project' => '/projects/' . $project->getId(),
+                'name' => 'Mystery',
+                'type' => 'mystery-shape',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testDuplicateNameInProjectRejected(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $this->seedField($project, 'Severity', 'text');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/custom_field_definitions', [
+            'json' => [
+                'project' => '/projects/' . $project->getId(),
+                'name' => 'Severity',
+                'type' => 'text',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        // Either 409 (Doctrine unique violation surfaced as Conflict) or
+        // 422 (validator-driven) — both signal the duplicate.
+        $this->assertGreaterThanOrEqual(400, $client->getResponse()->getStatusCode());
+        $this->assertLessThan(500, $client->getResponse()->getStatusCode());
+    }
+
+    public function testOwnerCanDelete(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $field = $this->seedField($project, 'Severity', 'text');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('DELETE', '/custom_field_definitions/' . $field->getId());
+        $this->assertResponseStatusCodeSame(204);
+    }
+
+    public function testMemberCannotDelete(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $project->addMember($bob);
+        $this->entityManager->flush();
+        $field = $this->seedField($project, 'Severity', 'text');
+
+        $client = static::createClient();
+        $client->loginUser($bob);
+        $client->request('DELETE', '/custom_field_definitions/' . $field->getId());
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    private function seedField(Project $project, string $name, string $type): CustomFieldDefinition
+    {
+        $field = new CustomFieldDefinition();
+        $field->setProject($project);
+        $field->setName($name);
+        $field->setType($type);
+        $this->entityManager->persist($field);
+        $this->entityManager->flush();
+        return $field;
+    }
+
+    private function createProject(User $owner, string $title): Project
+    {
+        $project = new Project();
+        $project->setOwner($owner);
+        $project->setTitle($title);
+        $project->addMember($owner);
+        $this->entityManager->persist($project);
+        $this->entityManager->flush();
+        return $project;
+    }
+
+    /**
+     * @param string[] $roles
+     */
+    private function createUser(string $email, array $roles = ['ROLE_USER']): User
+    {
+        $container = static::getContainer();
+        /** @var UserPasswordHasherInterface $hasher */
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles($roles);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'password123'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}


### PR DESCRIPTION
## Summary
- New `CustomFieldDefinition` entity (text, number, date, dropdown, checkbox types) scoped to a `Project`. Migration `Version20260504060000`.
- API Platform CRUD on `/custom_field_definitions` filterable by `?project=…`, ordered by `position` then `createdAt`.
- Read scoping: `CustomFieldDefinitionAccessExtension` joins to project members so non-member item lookups return 404 (matches `CommentAccessExtension` and `NotificationRecipientExtension` shape); write ops are owner-only.
- Cross-field validation: dropdown fields require ≥1 unique non-empty option; non-dropdown fields forbid options. `UniqueEntity(project, name)` returns a clean 422 instead of leaking the DB unique violation as a 500.
- **Out of scope**: `CustomFieldValue` (per-task storage), task POST/PATCH accepting custom values, task list filtering/sorting by custom values, frontend project-settings UI, dynamic field rendering on the task detail/list views. Those are follow-ups; marking this PR as "addresses" so #84 stays open until they land.

## Test plan
- [x] `bin/phpunit tests/Api/CustomFieldDefinitionTest.php` — 12 cases: auth, owner-can-create, member-can't-create, stranger 404, listing scoped to user's projects, dropdown requires options, non-dropdown rejects options, dropdown happy path, invalid type rejected, duplicate name rejected (clean 422), owner can delete, member cannot delete.
- [x] Full API suite green (287 tests).