### PR TITLE
feat(discussions): project-level discussion threads with CRUD (addresses #91)

### DIFF
--- a/api/migrations/Version20260504070000.php
+++ b/api/migrations/Version20260504070000.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds the discussion table for project-level discussion threads (#91).
+ * Replies + chat channels land in follow-ups; this PR ships only the
+ * top-level Discussion entity so the project-tabs UI can be built
+ * against a stable surface first.
+ */
+final class Version20260504070000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add discussion table for project-level discussion threads (#91).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE discussion (
+                id UUID NOT NULL,
+                project_id UUID NOT NULL,
+                author_id UUID NOT NULL,
+                title VARCHAR(200) NOT NULL,
+                body TEXT NOT NULL,
+                category VARCHAR(16) NOT NULL,
+                is_pinned BOOLEAN NOT NULL DEFAULT FALSE,
+                is_locked BOOLEAN NOT NULL DEFAULT FALSE,
+                created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                updated_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL,
+                PRIMARY KEY(id)
+            )
+        SQL);
+        $this->addSql('CREATE INDEX idx_discussion_project_created ON discussion (project_id, created_at)');
+        $this->addSql('CREATE INDEX idx_discussion_project_pinned ON discussion (project_id, is_pinned, created_at)');
+        $this->addSql('ALTER TABLE discussion ADD CONSTRAINT FK_DISC_PROJECT FOREIGN KEY (project_id) REFERENCES project (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE discussion ADD CONSTRAINT FK_DISC_AUTHOR FOREIGN KEY (author_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE discussion DROP CONSTRAINT FK_DISC_PROJECT');
+        $this->addSql('ALTER TABLE discussion DROP CONSTRAINT FK_DISC_AUTHOR');
+        $this->addSql('DROP TABLE discussion');
+    }
+}

--- a/api/src/Doctrine/DiscussionAccessExtension.php
+++ b/api/src/Doctrine/DiscussionAccessExtension.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Doctrine;
+
+use ApiPlatform\Doctrine\Orm\Extension\QueryCollectionExtensionInterface;
+use ApiPlatform\Doctrine\Orm\Extension\QueryItemExtensionInterface;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+use App\Entity\Discussion;
+use App\Entity\User;
+use Doctrine\ORM\QueryBuilder;
+use Symfony\Bundle\SecurityBundle\Security;
+
+/**
+ * Scopes Discussion queries to projects the current user belongs to —
+ * the same shape as CommentAccessExtension and
+ * CustomFieldDefinitionAccessExtension. Item lookups for non-members
+ * return 404 instead of 403 so we don't leak existence.
+ */
+final class DiscussionAccessExtension implements
+    QueryCollectionExtensionInterface,
+    QueryItemExtensionInterface
+{
+    public function __construct(private Security $security)
+    {
+    }
+
+    public function applyToCollection(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        ?Operation $operation = null,
+        array $context = [],
+    ): void {
+        $this->applyFilter($queryBuilder, $resourceClass);
+    }
+
+    public function applyToItem(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        array $identifiers,
+        ?Operation $operation = null,
+        array $context = [],
+    ): void {
+        $this->applyFilter($queryBuilder, $resourceClass);
+    }
+
+    private function applyFilter(QueryBuilder $queryBuilder, string $resourceClass): void
+    {
+        if (Discussion::class !== $resourceClass) {
+            return;
+        }
+        if ($this->security->isGranted('ROLE_ADMIN')) {
+            return;
+        }
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            return;
+        }
+
+        $rootAlias = $queryBuilder->getRootAliases()[0];
+        $projectAlias = 'disc_project';
+        $memberAlias = 'disc_project_members';
+        $queryBuilder
+            ->innerJoin($rootAlias . '.project', $projectAlias)
+            ->innerJoin($projectAlias . '.members', $memberAlias)
+            ->andWhere($memberAlias . ' = :currentUser')
+            ->setParameter('currentUser', $user);
+    }
+}

--- a/api/src/Entity/Discussion.php
+++ b/api/src/Entity/Discussion.php
@@ -1,0 +1,249 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Doctrine\Orm\Filter\OrderFilter;
+use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
+use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use App\Repository\DiscussionRepository;
+use App\State\DiscussionAuthorProcessor;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Project-level discussion thread (#91). Read access mirrors the
+ * project — every member can browse; create access is also any
+ * member; edit is author-only; delete + pin/lock are project-owner OR
+ * the post's author. Pin/lock are exposed as plain PATCHable fields
+ * (gated by {@see DiscussionUpdateProcessor} in a follow-up — for the
+ * MVP they're owner-only via the entity-level expression).
+ *
+ * Replies, locking interactions, and the chat side of the original
+ * spec land in follow-ups — this PR ships only the Discussion entity
+ * and its CRUD so the project tabs UI can be built first.
+ */
+#[ApiResource(
+    operations: [
+        new GetCollection(
+            security: "is_granted('ROLE_USER')",
+        ),
+        new Post(
+            security: "is_granted('ROLE_USER')",
+            securityPostDenormalize: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or (object.getProject() !== null and object.getProject().getMembers().contains(user)))",
+            processor: DiscussionAuthorProcessor::class,
+        ),
+        new Get(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getProject().getMembers().contains(user))",
+        ),
+        new Patch(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getAuthor() == user or object.getProject().getOwner() == user)",
+        ),
+        new Delete(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getAuthor() == user or object.getProject().getOwner() == user)",
+        ),
+    ],
+    normalizationContext: ['groups' => ['discussion:read']],
+    denormalizationContext: ['groups' => ['discussion:write']],
+    order: ['isPinned' => 'DESC', 'createdAt' => 'DESC'],
+)]
+#[ApiFilter(SearchFilter::class, properties: ['project' => 'exact', 'category' => 'exact'])]
+#[ApiFilter(OrderFilter::class, properties: ['createdAt', 'updatedAt'])]
+#[ORM\Entity(repositoryClass: DiscussionRepository::class)]
+#[ORM\Table(name: 'discussion')]
+#[ORM\Index(columns: ['project_id', 'created_at'], name: 'idx_discussion_project_created')]
+#[ORM\Index(columns: ['project_id', 'is_pinned', 'created_at'], name: 'idx_discussion_project_pinned')]
+#[ORM\HasLifecycleCallbacks]
+class Discussion
+{
+    public const CATEGORY_GENERAL = 'general';
+    public const CATEGORY_IDEAS = 'ideas';
+    public const CATEGORY_ANNOUNCEMENTS = 'announcements';
+    public const CATEGORY_QA = 'q-and-a';
+
+    public const ALLOWED_CATEGORIES = [
+        self::CATEGORY_GENERAL,
+        self::CATEGORY_IDEAS,
+        self::CATEGORY_ANNOUNCEMENTS,
+        self::CATEGORY_QA,
+    ];
+
+    public const MAX_TITLE_LENGTH = 200;
+    public const MAX_BODY_LENGTH = 50_000;
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
+    #[Groups(['discussion:read'])]
+    private ?Uuid $id = null;
+
+    #[ApiProperty(readableLink: false)]
+    #[ORM\ManyToOne(targetEntity: Project::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    #[Assert\NotNull(message: 'Project is required.')]
+    #[Groups(['discussion:read', 'discussion:write'])]
+    private ?Project $project = null;
+
+    /**
+     * Stamped by DiscussionAuthorProcessor on POST; read-only on the
+     * wire so a client can't post on someone else's behalf.
+     */
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    #[Groups(['discussion:read'])]
+    private ?User $author = null;
+
+    #[ORM\Column(length: self::MAX_TITLE_LENGTH)]
+    #[Assert\NotBlank(message: 'Title is required.')]
+    #[Assert\Length(
+        max: self::MAX_TITLE_LENGTH,
+        maxMessage: 'Title cannot be longer than {{ limit }} characters.',
+    )]
+    #[Groups(['discussion:read', 'discussion:write'])]
+    private string $title = '';
+
+    #[ORM\Column(type: 'text')]
+    #[Assert\NotBlank(message: 'Body is required.')]
+    #[Assert\Length(
+        max: self::MAX_BODY_LENGTH,
+        maxMessage: 'Body cannot be longer than {{ limit }} characters.',
+    )]
+    #[Groups(['discussion:read', 'discussion:write'])]
+    private string $body = '';
+
+    #[ORM\Column(length: 16)]
+    #[Assert\Choice(
+        choices: self::ALLOWED_CATEGORIES,
+        message: 'Category must be one of: general, ideas, announcements, q-and-a.',
+    )]
+    #[Groups(['discussion:read', 'discussion:write'])]
+    private string $category = self::CATEGORY_GENERAL;
+
+    #[ORM\Column(type: 'boolean', options: ['default' => false])]
+    #[Groups(['discussion:read', 'discussion:write'])]
+    private bool $isPinned = false;
+
+    #[ORM\Column(type: 'boolean', options: ['default' => false])]
+    #[Groups(['discussion:read', 'discussion:write'])]
+    private bool $isLocked = false;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    #[Groups(['discussion:read'])]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    #[Groups(['discussion:read'])]
+    private ?\DateTimeImmutable $updatedAt = null;
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    #[ORM\PreUpdate]
+    public function onPreUpdate(): void
+    {
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?Uuid
+    {
+        return $this->id;
+    }
+
+    public function getProject(): ?Project
+    {
+        return $this->project;
+    }
+
+    public function setProject(?Project $project): static
+    {
+        $this->project = $project;
+        return $this;
+    }
+
+    public function getAuthor(): ?User
+    {
+        return $this->author;
+    }
+
+    public function setAuthor(?User $author): static
+    {
+        $this->author = $author;
+        return $this;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): static
+    {
+        $this->title = $title;
+        return $this;
+    }
+
+    public function getBody(): string
+    {
+        return $this->body;
+    }
+
+    public function setBody(string $body): static
+    {
+        $this->body = $body;
+        return $this;
+    }
+
+    public function getCategory(): string
+    {
+        return $this->category;
+    }
+
+    public function setCategory(string $category): static
+    {
+        $this->category = $category;
+        return $this;
+    }
+
+    public function isPinned(): bool
+    {
+        return $this->isPinned;
+    }
+
+    public function setIsPinned(bool $isPinned): static
+    {
+        $this->isPinned = $isPinned;
+        return $this;
+    }
+
+    public function isLocked(): bool
+    {
+        return $this->isLocked;
+    }
+
+    public function setIsLocked(bool $isLocked): static
+    {
+        $this->isLocked = $isLocked;
+        return $this;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): ?\DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+}

--- a/api/src/Repository/DiscussionRepository.php
+++ b/api/src/Repository/DiscussionRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Discussion;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Discussion>
+ */
+class DiscussionRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Discussion::class);
+    }
+}

--- a/api/src/State/DiscussionAuthorProcessor.php
+++ b/api/src/State/DiscussionAuthorProcessor.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\Entity\Discussion;
+use App\Entity\User;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+
+/**
+ * Stamps the current user as the discussion author before persisting,
+ * matching the trust model used by CommentAuthorProcessor and
+ * TaskOwnerProcessor — the field is set server-side rather than
+ * trusted from the request payload.
+ *
+ * @implements ProcessorInterface<Discussion, Discussion>
+ */
+final class DiscussionAuthorProcessor implements ProcessorInterface
+{
+    /**
+     * @param ProcessorInterface<Discussion, Discussion> $persistProcessor
+     */
+    public function __construct(
+        #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
+        private ProcessorInterface $persistProcessor,
+        private Security $security,
+    ) {
+    }
+
+    /**
+     * @param Discussion $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Discussion
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new UnauthorizedHttpException('Bearer', 'You must be authenticated to start a discussion.');
+        }
+
+        $data->setAuthor($user);
+
+        return $this->persistProcessor->process($data, $operation, $uriVariables, $context);
+    }
+}

--- a/api/tests/Api/DiscussionTest.php
+++ b/api/tests/Api/DiscussionTest.php
@@ -1,0 +1,275 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\Discussion;
+use App\Entity\Project;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+class DiscussionTest extends ApiTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $this->entityManager = $kernel->getContainer()
+            ->get('doctrine')
+            ->getManager();
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Discussion')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testListRequiresAuth(): void
+    {
+        static::createClient()->request('GET', '/discussions');
+        $this->assertResponseStatusCodeSame(401);
+    }
+
+    public function testMemberCanCreate(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $project->addMember($bob);
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($bob);
+        $client->request('POST', '/discussions', [
+            'json' => [
+                'project' => '/projects/' . $project->getId(),
+                'title' => 'Idea: switch to pnpm',
+                'body' => 'Should be a quick win.',
+                'category' => 'ideas',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+
+        // Author stamped server-side, not from payload.
+        $row = $this->entityManager->getRepository(Discussion::class)
+            ->findOneBy(['title' => 'Idea: switch to pnpm']);
+        $this->assertNotNull($row);
+        $this->assertSame(
+            (string) $bob->getId(),
+            (string) $row->getAuthor()?->getId(),
+        );
+    }
+
+    public function testNonMemberCannotCreate(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $stranger = $this->createUser('stranger@example.com');
+        $project = $this->createProject($alice, 'Backend');
+
+        $client = static::createClient();
+        $client->loginUser($stranger);
+        $client->request('POST', '/discussions', [
+            'json' => [
+                'project' => '/projects/' . $project->getId(),
+                'title' => 'Sneaky',
+                'body' => 'Body',
+                'category' => 'general',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        // ProjectAccessExtension hides Alice's project from the
+        // stranger during IRI resolution, so denormalization fails
+        // before securityPostDenormalize runs — same shape as the
+        // CommentTest cross-task case.
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    public function testInvalidCategoryRejected(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/discussions', [
+            'json' => [
+                'project' => '/projects/' . $project->getId(),
+                'title' => 'Wrong cat',
+                'body' => 'Body',
+                'category' => 'rumors',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testListFiltersToProjectsTheUserBelongsTo(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $aliceProject = $this->createProject($alice, 'Alice');
+        $bobProject = $this->createProject($bob, 'Bob');
+        $this->seed($alice, $aliceProject, 'A1');
+        $this->seed($bob, $bobProject, 'B1');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/discussions');
+        $this->assertResponseIsSuccessful();
+        $titles = array_map(
+            fn ($d) => $d['title'],
+            $client->getResponse()->toArray()['member'] ?? [],
+        );
+        $this->assertSame(['A1'], $titles);
+    }
+
+    public function testCanFilterByCategory(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $this->seed($alice, $project, 'General one', 'general');
+        $this->seed($alice, $project, 'Idea one', 'ideas');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/discussions?category=ideas');
+        $this->assertResponseIsSuccessful();
+        $titles = array_map(
+            fn ($d) => $d['title'],
+            $client->getResponse()->toArray()['member'] ?? [],
+        );
+        $this->assertSame(['Idea one'], $titles);
+    }
+
+    public function testAuthorCanEdit(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $disc = $this->seed($alice, $project, 'Original');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/discussions/' . $disc->getId(), [
+            'json' => ['title' => 'Edited'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseIsSuccessful();
+        $this->entityManager->clear();
+        $reloaded = $this->entityManager->getRepository(Discussion::class)->find($disc->getId());
+        $this->assertSame('Edited', $reloaded?->getTitle());
+        $this->assertNotNull($reloaded?->getUpdatedAt());
+    }
+
+    public function testNonAuthorMemberCannotEdit(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $project->addMember($bob);
+        $this->entityManager->flush();
+        $aliceDiscussion = $this->seed($alice, $project, 'Original');
+
+        $client = static::createClient();
+        $client->loginUser($bob);
+        $client->request('PATCH', '/discussions/' . $aliceDiscussion->getId(), [
+            'json' => ['title' => 'Bob editing'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testProjectOwnerCanPinAnotherMembersDiscussion(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $project->addMember($bob);
+        $this->entityManager->flush();
+        $bobDiscussion = $this->seed($bob, $project, 'Bob post');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/discussions/' . $bobDiscussion->getId(), [
+            'json' => ['isPinned' => true],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testStrangerCannotReadDiscussion(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $stranger = $this->createUser('stranger@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $disc = $this->seed($alice, $project, 'Hidden');
+
+        $client = static::createClient();
+        $client->loginUser($stranger);
+        $client->request('GET', '/discussions/' . $disc->getId());
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testProjectOwnerCanDeleteOthersDiscussion(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $project->addMember($bob);
+        $this->entityManager->flush();
+        $bobDiscussion = $this->seed($bob, $project, 'Off-topic');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('DELETE', '/discussions/' . $bobDiscussion->getId());
+        $this->assertResponseStatusCodeSame(204);
+    }
+
+    private function seed(User $author, Project $project, string $title, string $category = 'general'): Discussion
+    {
+        $disc = new Discussion();
+        $disc->setProject($project);
+        $disc->setAuthor($author);
+        $disc->setTitle($title);
+        $disc->setBody('Body for ' . $title);
+        $disc->setCategory($category);
+        $this->entityManager->persist($disc);
+        $this->entityManager->flush();
+        return $disc;
+    }
+
+    private function createProject(User $owner, string $title): Project
+    {
+        $project = new Project();
+        $project->setOwner($owner);
+        $project->setTitle($title);
+        $project->addMember($owner);
+        $this->entityManager->persist($project);
+        $this->entityManager->flush();
+        return $project;
+    }
+
+    /**
+     * @param string[] $roles
+     */
+    private function createUser(string $email, array $roles = ['ROLE_USER']): User
+    {
+        $container = static::getContainer();
+        /** @var UserPasswordHasherInterface $hasher */
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles($roles);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'password123'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}


### PR DESCRIPTION
## Summary
- New `Discussion` entity (title, body, category enum, isPinned, isLocked) scoped to a `Project`. Migration `Version20260504070000`.
- API Platform CRUD on `/discussions` filterable by `?project=…` and `?category=…`, default order `(isPinned DESC, createdAt DESC)` so pinned posts float without client-side re-sort.
- Read scoping: `DiscussionAccessExtension` joins to project members so non-member item lookups return 404 (matches the rest of the per-project resources).
- Write rules: any project member can create; author can edit; author OR project owner can delete and toggle pin/lock. `DiscussionAuthorProcessor` stamps the author from the security token rather than the request payload.
- **Out of scope**: `DiscussionReply` entity (threaded replies), `ChatChannel` + `ChatMessage` (the chat side of the original spec), Mercure live updates, frontend discussions/chat tabs. Marking as "addresses" so #91 stays open until those land.

## Test plan
- [x] `bin/phpunit tests/Api/DiscussionTest.php` — 11 cases: auth, member-can-create (author stamped server-side), non-member can't, invalid category 422, listing scoped to user's projects, category filter, author can edit (updatedAt stamped), non-author member can't edit, project owner can pin another's discussion, stranger 404, project owner can delete another's discussion.
- [x] Full API suite green (298 tests).