### PR TITLE
feat(push): dispatch Web Push for task reminders (#100)

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -59,3 +59,14 @@ MAILER_DSN=null://null
 # postgresql+advisory://db_user:db_password@localhost/db_name
 LOCK_DSN=flock
 ###< symfony/lock ###
+
+###> minishlink/web-push (VAPID) ###
+# Web Push delivery from `app:tasks:reminders:dispatch`. Leaving any of
+# the three slots empty disables push send (the dispatcher logs a warning
+# and the in-app + email paths still run), so a fresh checkout doesn't
+# need to generate keys to keep the suite green. Override in .env.local
+# for staging/prod with a fresh pair from `web-push generate-vapid-keys`.
+VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+VAPID_SUBJECT=
+###< minishlink/web-push (VAPID) ###

--- a/api/composer.json
+++ b/api/composer.json
@@ -12,6 +12,7 @@
         "doctrine/orm": "^3.0",
         "intervention/image": "^4.0",
         "league/flysystem-bundle": "^3.3",
+        "minishlink/web-push": "^10.0",
         "nelmio/cors-bundle": "^2.2",
         "phpdocumentor/reflection-docblock": "^6.0",
         "phpstan/phpdoc-parser": "^2.0",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e833cbf2b1494b1a6abe9c94028b237c",
+    "content-hash": "d7b84d45bf77546e5ff80690ccfe9ebe",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -1159,6 +1159,65 @@
                 "source": "https://github.com/api-platform/validator/tree/v4.3.4"
             },
             "time": "2026-04-30T12:21:24+00:00"
+        },
+        {
+            "name": "brick/math",
+            "version": "0.17.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/brick/math.git",
+                "reference": "6aef71a9fbbd1ee7be0e313cd627f8e6f7125a5b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/brick/math/zipball/6aef71a9fbbd1ee7be0e313cd627f8e6f7125a5b",
+                "reference": "6aef71a9fbbd1ee7be0e313cd627f8e6f7125a5b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "2.1.22",
+                "phpunit/phpunit": "^11.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Brick\\Math\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Arbitrary-precision arithmetic library",
+            "keywords": [
+                "Arbitrary-precision",
+                "BigInteger",
+                "BigRational",
+                "arithmetic",
+                "bigdecimal",
+                "bignum",
+                "bignumber",
+                "brick",
+                "decimal",
+                "integer",
+                "math",
+                "mathematics",
+                "rational"
+            ],
+            "support": {
+                "issues": "https://github.com/brick/math/issues",
+                "source": "https://github.com/brick/math/tree/0.17.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/BenMorel",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-19T20:55:20+00:00"
         },
         {
             "name": "composer/semver",
@@ -2642,6 +2701,332 @@
             "time": "2025-12-13T19:37:35+00:00"
         },
         {
+            "name": "guzzlehttp/guzzle",
+            "version": "7.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/promises": "^2.3",
+                "guzzlehttp/psr7": "^2.8",
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-client": "^1.0",
+                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "ext-curl": "*",
+                "guzzle/client-integration-tests": "3.0.2",
+                "php-http/message-factory": "^1.1",
+                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "psr/log": "^1.1 || ^2.0 || ^3.0"
+            },
+            "suggest": {
+                "ext-curl": "Required for CURL handler support",
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Jeremy Lindblom",
+                    "email": "jeremeamia@gmail.com",
+                    "homepage": "https://github.com/jeremeamia"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "psr-18",
+                "psr-7",
+                "rest",
+                "web service"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/guzzle/issues",
+                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/guzzle",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-23T22:36:01+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
+                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/promises/issues",
+                "source": "https://github.com/guzzle/promises/tree/2.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/promises",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-22T14:34:08+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "2.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.1 || ^2.0",
+                "ralouphie/getallheaders": "^3.0"
+            },
+            "provide": {
+                "psr/http-factory-implementation": "1.0",
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "http-interop/http-factory-tests": "0.9.0",
+                "jshttp/mime-db": "1.54.0.1",
+                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+            },
+            "suggest": {
+                "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/psr7/issues",
+                "source": "https://github.com/guzzle/psr7/tree/2.9.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/psr7",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-10T16:41:02+00:00"
+        },
+        {
             "name": "intervention/gif",
             "version": "5.0.0",
             "source": {
@@ -3115,6 +3500,76 @@
                 }
             ],
             "time": "2024-09-21T08:32:55+00:00"
+        },
+        {
+            "name": "minishlink/web-push",
+            "version": "v10.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/web-push-libs/web-push-php.git",
+                "reference": "547695eb42b062517fc604c85d6f7bb8174d31b0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/web-push-libs/web-push-php/zipball/547695eb42b062517fc604c85d6f7bb8174d31b0",
+                "reference": "547695eb42b062517fc604c85d6f7bb8174d31b0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "ext-openssl": "*",
+                "guzzlehttp/guzzle": "^7.9.2",
+                "php": ">=8.2",
+                "spomky-labs/base64url": "^2.0.4",
+                "symfony/polyfill-php83": "^1.33",
+                "web-token/jwt-library": "^3.4.9|^4.0.6"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^v3.92.2",
+                "phpstan/phpstan": "^2.1.33",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^11.5.46|^12.5.2",
+                "symfony/polyfill-iconv": "^1.33"
+            },
+            "suggest": {
+                "ext-bcmath": "Optional for performance.",
+                "ext-gmp": "Optional for performance."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Minishlink\\WebPush\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Louis Lagrange",
+                    "email": "lagrange.louis@gmail.com",
+                    "homepage": "https://github.com/Minishlink"
+                }
+            ],
+            "description": "Web Push library for PHP",
+            "homepage": "https://github.com/web-push-libs/web-push-php",
+            "keywords": [
+                "Push API",
+                "WebPush",
+                "notifications",
+                "push",
+                "web"
+            ],
+            "support": {
+                "issues": "https://github.com/web-push-libs/web-push-php/issues",
+                "source": "https://github.com/web-push-libs/web-push-php/tree/v10.0.3"
+            },
+            "time": "2026-03-09T23:16:02+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -3777,6 +4232,166 @@
             "time": "2019-01-08T18:20:26+00:00"
         },
         {
+            "name": "psr/http-client",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client"
+            },
+            "time": "2023-09-23T14:17:50+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
             "name": "psr/link",
             "version": "2.0.1",
             "source": {
@@ -3881,6 +4496,50 @@
                 "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
             "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "support": {
+                "issues": "https://github.com/ralouphie/getallheaders/issues",
+                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
+            },
+            "time": "2019-03-08T08:55:37+00:00"
         },
         {
             "name": "runtime/frankenphp-symfony",
@@ -4105,6 +4764,71 @@
             "time": "2026-01-24T13:27:55+00:00"
         },
         {
+            "name": "spomky-labs/base64url",
+            "version": "v2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Spomky-Labs/base64url.git",
+                "reference": "7752ce931ec285da4ed1f4c5aa27e45e097be61d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Spomky-Labs/base64url/zipball/7752ce931ec285da4ed1f4c5aa27e45e097be61d",
+                "reference": "7752ce931ec285da4ed1f4c5aa27e45e097be61d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^0.11|^0.12",
+                "phpstan/phpstan-beberlei-assert": "^0.11|^0.12",
+                "phpstan/phpstan-deprecation-rules": "^0.11|^0.12",
+                "phpstan/phpstan-phpunit": "^0.11|^0.12",
+                "phpstan/phpstan-strict-rules": "^0.11|^0.12"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Base64Url\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Florent Morselli",
+                    "homepage": "https://github.com/Spomky-Labs/base64url/contributors"
+                }
+            ],
+            "description": "Base 64 URL Safe Encoding/Decoding PHP Library",
+            "homepage": "https://github.com/Spomky-Labs/base64url",
+            "keywords": [
+                "base64",
+                "rfc4648",
+                "safe",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/Spomky-Labs/base64url/issues",
+                "source": "https://github.com/Spomky-Labs/base64url/tree/v2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2020-11-03T09:10:25+00:00"
+        },
+        {
             "name": "spomky-labs/otphp",
             "version": "11.4.2",
             "source": {
@@ -4173,6 +4897,116 @@
                 }
             ],
             "time": "2026-01-23T10:53:01+00:00"
+        },
+        {
+            "name": "spomky-labs/pki-framework",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Spomky-Labs/pki-framework.git",
+                "reference": "aa576cbd07128075bef97ac2f8af9854e67513d8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Spomky-Labs/pki-framework/zipball/aa576cbd07128075bef97ac2f8af9854e67513d8",
+                "reference": "aa576cbd07128075bef97ac2f8af9854e67513d8",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "^0.10|^0.11|^0.12|^0.13|^0.14|^0.15|^0.16|^0.17",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "psr/clock": "^1.0"
+            },
+            "require-dev": {
+                "ekino/phpstan-banned-code": "^1.0|^2.0|^3.0",
+                "ext-gmp": "*",
+                "ext-openssl": "*",
+                "infection/infection": "^0.28|^0.29|^0.31|^0.32",
+                "php-parallel-lint/php-parallel-lint": "^1.3",
+                "phpstan/extension-installer": "^1.3|^2.0",
+                "phpstan/phpstan": "^1.8|^2.0",
+                "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
+                "phpstan/phpstan-phpunit": "^1.1|^2.0",
+                "phpstan/phpstan-strict-rules": "^1.3|^2.0",
+                "phpunit/phpunit": "^10.1|^11.0|^12.0|^13.0",
+                "rector/rector": "^1.0|^2.0",
+                "roave/security-advisories": "dev-latest",
+                "symfony/string": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0",
+                "symplify/easy-coding-standard": "^12.0|^13.0"
+            },
+            "suggest": {
+                "ext-bcmath": "For better performance (or GMP)",
+                "ext-gmp": "For better performance (or BCMath)",
+                "ext-openssl": "For OpenSSL based cyphering"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "SpomkyLabs\\Pki\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Joni Eskelinen",
+                    "email": "jonieske@gmail.com",
+                    "role": "Original developer"
+                },
+                {
+                    "name": "Florent Morselli",
+                    "email": "florent.morselli@spomky-labs.com",
+                    "role": "Spomky-Labs PKI Framework developer"
+                }
+            ],
+            "description": "A PHP framework for managing Public Key Infrastructures. It comprises X.509 public key certificates, attribute certificates, certification requests and certification path validation.",
+            "homepage": "https://github.com/spomky-labs/pki-framework",
+            "keywords": [
+                "DER",
+                "Private Key",
+                "ac",
+                "algorithm identifier",
+                "asn.1",
+                "asn1",
+                "attribute certificate",
+                "certificate",
+                "certification request",
+                "cryptography",
+                "csr",
+                "decrypt",
+                "ec",
+                "encrypt",
+                "pem",
+                "pkcs",
+                "public key",
+                "rsa",
+                "sign",
+                "signature",
+                "verify",
+                "x.509",
+                "x.690",
+                "x509",
+                "x690"
+            ],
+            "support": {
+                "issues": "https://github.com/Spomky-Labs/pki-framework/issues",
+                "source": "https://github.com/Spomky-Labs/pki-framework/tree/1.4.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-03-23T22:56:56+00:00"
         },
         {
             "name": "stof/doctrine-extensions-bundle",
@@ -9221,6 +10055,95 @@
             "time": "2026-03-17T21:31:11+00:00"
         },
         {
+            "name": "web-token/jwt-library",
+            "version": "4.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/web-token/jwt-library.git",
+                "reference": "e8ab00927a3856f3f0c8218226382cd6a58928a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/web-token/jwt-library/zipball/e8ab00927a3856f3f0c8218226382cd6a58928a1",
+                "reference": "e8ab00927a3856f3f0c8218226382cd6a58928a1",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "^0.12|^0.13|^0.14|^0.15|^0.16|^0.17",
+                "php": ">=8.2",
+                "psr/clock": "^1.0",
+                "spomky-labs/pki-framework": "^1.2.1"
+            },
+            "conflict": {
+                "spomky-labs/jose": "*"
+            },
+            "suggest": {
+                "ext-bcmath": "GMP or BCMath is highly recommended to improve the library performance",
+                "ext-gmp": "GMP or BCMath is highly recommended to improve the library performance",
+                "ext-openssl": "For key management (creation, optimization, etc.) and some algorithms (AES, RSA, ECDSA, etc.)",
+                "ext-sodium": "Sodium is required for OKP key creation, EdDSA signature algorithm and ECDH-ES key encryption with OKP keys",
+                "paragonie/sodium_compat": "Sodium is required for OKP key creation, EdDSA signature algorithm and ECDH-ES key encryption with OKP keys",
+                "spomky-labs/aes-key-wrap": "For all Key Wrapping algorithms (AxxxKW, AxxxGCMKW, PBES2-HSxxx+AyyyKW...)",
+                "symfony/console": "Needed to use console commands",
+                "symfony/http-client": "To enable JKU/X5U support."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Jose\\Component\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Florent Morselli",
+                    "homepage": "https://github.com/Spomky"
+                },
+                {
+                    "name": "All contributors",
+                    "homepage": "https://github.com/web-token/jwt-framework/contributors"
+                }
+            ],
+            "description": "JWT library",
+            "homepage": "https://github.com/web-token",
+            "keywords": [
+                "JOSE",
+                "JWE",
+                "JWK",
+                "JWKSet",
+                "JWS",
+                "Jot",
+                "RFC7515",
+                "RFC7516",
+                "RFC7517",
+                "RFC7518",
+                "RFC7519",
+                "RFC7520",
+                "bundle",
+                "jwa",
+                "jwt",
+                "symfony"
+            ],
+            "support": {
+                "issues": "https://github.com/web-token/jwt-library/issues",
+                "source": "https://github.com/web-token/jwt-library/tree/4.1.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-04-14T07:44:20+00:00"
+        },
+        {
             "name": "webmozart/assert",
             "version": "2.3.0",
             "source": {
@@ -10686,59 +11609,6 @@
                 "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
             },
             "time": "2025-12-06T11:56:16+00:00"
-        },
-        {
-            "name": "psr/http-message",
-            "version": "2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/http-message.git",
-                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
-                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Http\\Message\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for HTTP messages",
-            "homepage": "https://github.com/php-fig/http-message",
-            "keywords": [
-                "http",
-                "http-message",
-                "psr",
-                "psr-7",
-                "request",
-                "response"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/http-message/tree/2.0"
-            },
-            "time": "2023-04-04T09:54:51+00:00"
         },
         {
             "name": "react/cache",

--- a/api/config/services.yaml
+++ b/api/config/services.yaml
@@ -55,3 +55,14 @@ services:
     stof_doctrine_extensions.tool.actor_provider:
         class: App\Service\IriActorProvider
         arguments: ['@security.helper']
+
+    App\Push\PushSenderInterface: '@App\Push\WebPushSender'
+
+# In test the dispatcher must not open real sockets to FCM/Mozilla — alias
+# the interface to an in-memory recorder the test suite can inspect and
+# pre-arm with "expired" endpoints to exercise the prune-dead-rows path.
+when@test:
+    services:
+        App\Tests\Push\InMemoryPushSender:
+            public: true
+        App\Push\PushSenderInterface: '@App\Tests\Push\InMemoryPushSender'

--- a/api/src/Command/DispatchTaskRemindersCommand.php
+++ b/api/src/Command/DispatchTaskRemindersCommand.php
@@ -5,7 +5,10 @@ namespace App\Command;
 use App\Entity\Notification;
 use App\Entity\Task;
 use App\Entity\User;
+use App\Push\PushPayload;
+use App\Push\PushSenderInterface;
 use App\Repository\NotificationRepository;
+use App\Repository\PushSubscriptionRepository;
 use App\Repository\TaskRepository;
 use App\Validator\ValidReminders;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
@@ -42,6 +45,8 @@ final class DispatchTaskRemindersCommand extends Command
     public function __construct(
         private TaskRepository $tasks,
         private NotificationRepository $notifications,
+        private PushSubscriptionRepository $pushSubscriptions,
+        private PushSenderInterface $pushSender,
         private EntityManagerInterface $em,
         private MailerInterface $mailer,
         #[Autowire('%env(APP_FRONTEND_URL)%')]
@@ -57,6 +62,7 @@ final class DispatchTaskRemindersCommand extends Command
         $io = new SymfonyStyle($input, $output);
         $now = new \DateTimeImmutable();
         $emailsSent = 0;
+        $pushesSent = 0;
 
         // We could narrow this by `dueDate >= now - 7 days` to bound the
         // scan, but for an MVP the dataset is small enough that the
@@ -117,16 +123,66 @@ final class DispatchTaskRemindersCommand extends Command
                     if ($this->sendReminderEmail($recipient, $task, $offset, $io)) {
                         ++$emailsSent;
                     }
+
+                    $pushesSent += $this->sendReminderPush($recipient, $task, $offset);
                 }
             }
         }
 
         $io->success(sprintf(
-            'Created %d notification(s); sent %d email(s).',
+            'Created %d notification(s); sent %d email(s); delivered %d push(es).',
             $created,
             $emailsSent,
+            $pushesSent,
         ));
         return Command::SUCCESS;
+    }
+
+    /**
+     * Sends a Web Push for the reminder to every subscription the recipient
+     * has registered, gated on `pushNotificationsEnabled`. Subscriptions
+     * the browser's push service reports as expired (404/410) are pruned
+     * inline so the next dispatcher pass doesn't re-attempt them.
+     *
+     * Returns the count of pushes the transport accepted (i.e. pushes that
+     * actually left the box) so the caller can keep the success summary
+     * accurate.
+     */
+    private function sendReminderPush(User $recipient, Task $task, string $offset): int
+    {
+        $prefs = $recipient->getPreferences();
+        if (true !== ($prefs['pushNotificationsEnabled'] ?? false)) {
+            return 0;
+        }
+
+        $subscriptions = $this->pushSubscriptions->findActiveForUser($recipient);
+        if ([] === $subscriptions) {
+            return 0;
+        }
+
+        $payload = new PushPayload(
+            title: sprintf('Reminder: %s', $task->getTitle()),
+            body: $this->buildBody($task, $offset),
+            url: rtrim($this->frontendUrl, '/') . '/tasks/' . $task->getId(),
+            tag: 'task-reminder-' . $task->getId() . '-' . $offset,
+        );
+
+        $delivered = 0;
+        foreach ($subscriptions as $subscription) {
+            $result = $this->pushSender->send($subscription, $payload);
+            if ($result->subscriptionExpired) {
+                // Browser revoked or GC'd the registration. Prune the row
+                // so we don't keep retrying a dead endpoint forever.
+                $this->em->remove($subscription);
+                $this->em->flush();
+                continue;
+            }
+            if ($result->success) {
+                ++$delivered;
+            }
+        }
+
+        return $delivered;
     }
 
     /**

--- a/api/src/Push/PushPayload.php
+++ b/api/src/Push/PushPayload.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Push;
+
+/**
+ * Payload shape that the service-worker `push` event handler reads to build
+ * the `Notification` it shows to the user. Kept JSON-serialisable so the
+ * sender can hand it straight to minishlink/web-push as the encrypted body.
+ */
+final class PushPayload implements \JsonSerializable
+{
+    public function __construct(
+        public readonly string $title,
+        public readonly string $body,
+        public readonly ?string $url = null,
+        public readonly ?string $tag = null,
+    ) {
+    }
+
+    /**
+     * @return array<string, string|null>
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'title' => $this->title,
+            'body' => $this->body,
+            'url' => $this->url,
+            'tag' => $this->tag,
+        ];
+    }
+
+    public function toJson(): string
+    {
+        return json_encode($this, JSON_THROW_ON_ERROR);
+    }
+}

--- a/api/src/Push/PushSendResult.php
+++ b/api/src/Push/PushSendResult.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Push;
+
+/**
+ * Outcome of a single Web Push send. `subscriptionExpired` lets the caller
+ * prune the matching subscription row when the browser's push service
+ * returns 404/410, which is the standard signal that the user revoked the
+ * permission or the browser garbage-collected the registration.
+ */
+final class PushSendResult
+{
+    public function __construct(
+        public readonly bool $success,
+        public readonly bool $subscriptionExpired,
+        public readonly ?int $statusCode = null,
+        public readonly ?string $reason = null,
+    ) {
+    }
+}

--- a/api/src/Push/PushSenderInterface.php
+++ b/api/src/Push/PushSenderInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Push;
+
+use App\Entity\PushSubscription;
+
+/**
+ * Abstraction the dispatcher talks to. The prod implementation
+ * (`WebPushSender`) wraps minishlink/web-push; the test env aliases this
+ * to an in-memory recorder so the suite never opens a real socket.
+ */
+interface PushSenderInterface
+{
+    public function send(PushSubscription $subscription, PushPayload $payload): PushSendResult;
+}

--- a/api/src/Push/WebPushSender.php
+++ b/api/src/Push/WebPushSender.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Push;
+
+use App\Entity\PushSubscription as PushSubscriptionEntity;
+use Minishlink\WebPush\Subscription as WebPushSubscription;
+use Minishlink\WebPush\WebPush;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Real Web Push sender backed by minishlink/web-push. VAPID keys are
+ * pulled from env vars (see docs/deployment.md). When any of the three
+ * VAPID slots is empty the sender no-ops with a warning so a freshly
+ * checked-out dev environment doesn't crash the dispatcher cron — the
+ * in-app notifications still land, just no push leaves the box.
+ */
+final class WebPushSender implements PushSenderInterface
+{
+    public function __construct(
+        #[Autowire('%env(default::VAPID_PUBLIC_KEY)%')]
+        private readonly ?string $publicKey,
+        #[Autowire('%env(default::VAPID_PRIVATE_KEY)%')]
+        private readonly ?string $privateKey,
+        #[Autowire('%env(default::VAPID_SUBJECT)%')]
+        private readonly ?string $subject,
+        private readonly LoggerInterface $logger = new NullLogger(),
+    ) {
+    }
+
+    public function send(PushSubscriptionEntity $subscription, PushPayload $payload): PushSendResult
+    {
+        if (!$this->isConfigured()) {
+            $this->logger->warning('Web Push send skipped: VAPID keys are not configured.');
+            return new PushSendResult(false, false, null, 'VAPID keys not configured');
+        }
+
+        $webPush = new WebPush([
+            'VAPID' => [
+                'subject' => $this->subject,
+                'publicKey' => $this->publicKey,
+                'privateKey' => $this->privateKey,
+            ],
+        ]);
+
+        $vendorSub = WebPushSubscription::create([
+            'endpoint' => $subscription->getEndpoint(),
+            'publicKey' => $subscription->getP256dh(),
+            'authToken' => $subscription->getAuth(),
+        ]);
+
+        try {
+            $report = $webPush->sendOneNotification($vendorSub, $payload->toJson());
+        } catch (\ErrorException | \RuntimeException $e) {
+            // Network blip or malformed payload — log and let the next
+            // dispatcher pass try again. Don't propagate; one bad endpoint
+            // must not abort delivery for the remaining recipients.
+            $this->logger->warning('Web Push send failed: {reason}', [
+                'reason' => $e->getMessage(),
+                'endpoint' => $subscription->getEndpoint(),
+            ]);
+            return new PushSendResult(false, false, null, $e->getMessage());
+        }
+
+        return new PushSendResult(
+            success: $report->isSuccess(),
+            subscriptionExpired: $report->isSubscriptionExpired(),
+            statusCode: $report->getResponse()?->getStatusCode(),
+            reason: $report->getReason(),
+        );
+    }
+
+    private function isConfigured(): bool
+    {
+        return !empty($this->publicKey)
+            && !empty($this->privateKey)
+            && !empty($this->subject);
+    }
+}

--- a/api/src/Repository/PushSubscriptionRepository.php
+++ b/api/src/Repository/PushSubscriptionRepository.php
@@ -3,6 +3,7 @@
 namespace App\Repository;
 
 use App\Entity\PushSubscription;
+use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -14,5 +15,13 @@ class PushSubscriptionRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, PushSubscription::class);
+    }
+
+    /**
+     * @return PushSubscription[]
+     */
+    public function findActiveForUser(User $user): array
+    {
+        return $this->findBy(['user' => $user]);
     }
 }

--- a/api/tests/Api/NotificationTest.php
+++ b/api/tests/Api/NotificationTest.php
@@ -6,8 +6,10 @@ use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use App\Command\DispatchNotificationDigestCommand;
 use App\Command\DispatchTaskRemindersCommand;
 use App\Entity\Notification;
+use App\Entity\PushSubscription;
 use App\Entity\Task;
 use App\Entity\User;
+use App\Tests\Push\InMemoryPushSender;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -27,8 +29,28 @@ class NotificationTest extends ApiTestCase
         // Wipe the join tables before the entity tables so Postgres doesn't
         // bail on residual FK rows from a previous test class.
         $this->entityManager->createQuery('DELETE FROM App\Entity\Notification')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\PushSubscription')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+
+        $this->pushSender()->reset();
+    }
+
+    private function pushSender(): InMemoryPushSender
+    {
+        return static::getContainer()->get(InMemoryPushSender::class);
+    }
+
+    private function seedPushSubscription(User $user, string $endpoint): PushSubscription
+    {
+        $sub = new PushSubscription();
+        $sub->setUser($user);
+        $sub->setEndpoint($endpoint);
+        $sub->setP256dh('p256dh-' . bin2hex(random_bytes(4)));
+        $sub->setAuth('auth-' . bin2hex(random_bytes(4)));
+        $this->entityManager->persist($sub);
+        $this->entityManager->flush();
+        return $sub;
     }
 
     public function testListNotificationsRequiresAuth(): void
@@ -282,6 +304,93 @@ class NotificationTest extends ApiTestCase
         $this->entityManager->persist($task);
         $this->entityManager->flush();
         return $task;
+    }
+
+    public function testDispatcherSendsPushWhenEnabledAndSubscribed(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $alice->setPreferences(['pushNotificationsEnabled' => true]);
+        $this->entityManager->flush();
+        $this->seedPushSubscription($alice, 'https://fcm.example/alice-laptop');
+        $this->seedPushSubscription($alice, 'https://fcm.example/alice-phone');
+        $this->seedDueTask($alice, 'Standup');
+
+        $this->runDispatcher();
+
+        // Both registrations get a push (one row per device).
+        $sends = $this->pushSender()->sends;
+        $this->assertCount(2, $sends);
+        $endpoints = array_map(fn ($s) => $s['endpoint'], $sends);
+        sort($endpoints);
+        $this->assertSame(
+            ['https://fcm.example/alice-laptop', 'https://fcm.example/alice-phone'],
+            $endpoints,
+        );
+        $this->assertSame('Reminder: Standup', $sends[0]['payload']->title);
+    }
+
+    public function testDispatcherSkipsPushWhenPreferenceDisabled(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        // Default for `pushNotificationsEnabled` is false; subscriptions
+        // can exist on the user from a previous opt-in but the dispatcher
+        // must respect the current preference.
+        $this->seedPushSubscription($alice, 'https://fcm.example/alice');
+        $this->seedDueTask($alice, 'Standup');
+
+        $this->runDispatcher();
+
+        $this->assertSame([], $this->pushSender()->sends);
+    }
+
+    public function testDispatcherNoOpsForUserWithoutSubscriptions(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $alice->setPreferences(['pushNotificationsEnabled' => true]);
+        $this->entityManager->flush();
+        $this->seedDueTask($alice, 'Standup');
+
+        $this->runDispatcher();
+
+        // Preference is on but no devices registered — no sends, no errors.
+        $this->assertSame([], $this->pushSender()->sends);
+    }
+
+    public function testDispatcherPrunesExpiredSubscriptions(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $alice->setPreferences(['pushNotificationsEnabled' => true]);
+        $this->entityManager->flush();
+        $this->seedPushSubscription($alice, 'https://fcm.example/alive');
+        $this->seedPushSubscription($alice, 'https://fcm.example/dead');
+
+        $this->pushSender()->expiredEndpoints = ['https://fcm.example/dead'];
+
+        $this->seedDueTask($alice, 'Standup');
+        $this->runDispatcher();
+
+        // The 410 row gets pruned so the next dispatcher pass doesn't
+        // re-attempt it; the working row stays.
+        $this->entityManager->clear();
+        $remaining = $this->entityManager->getRepository(PushSubscription::class)->findAll();
+        $endpoints = array_map(fn ($s) => $s->getEndpoint(), $remaining);
+        $this->assertSame(['https://fcm.example/alive'], $endpoints);
+    }
+
+    public function testDispatcherDoesNotResendPushOnIdempotentRerun(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $alice->setPreferences(['pushNotificationsEnabled' => true]);
+        $this->entityManager->flush();
+        $this->seedPushSubscription($alice, 'https://fcm.example/alice');
+        $this->seedDueTask($alice, 'Standup');
+
+        $this->runDispatcher();
+        $this->runDispatcher();
+
+        // The second pass skips the already-created notification row, so
+        // it must skip the push too — cron retries can't double-buzz.
+        $this->assertCount(1, $this->pushSender()->sends);
     }
 
     public function testDigestGroupsPendingNotificationsForHourlyUser(): void

--- a/api/tests/Push/InMemoryPushSender.php
+++ b/api/tests/Push/InMemoryPushSender.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Tests\Push;
+
+use App\Entity\PushSubscription;
+use App\Push\PushPayload;
+use App\Push\PushSendResult;
+use App\Push\PushSenderInterface;
+
+/**
+ * Recording test double for `PushSenderInterface`. Captures every send so
+ * tests can assert what would have been delivered, and lets a test mark
+ * specific endpoints as "expired" to exercise the dispatcher's pruning of
+ * dead subscription rows.
+ */
+final class InMemoryPushSender implements PushSenderInterface
+{
+    /** @var list<array{endpoint: string, payload: PushPayload}> */
+    public array $sends = [];
+
+    /** @var list<string> Endpoints to report back as expired (404/410). */
+    public array $expiredEndpoints = [];
+
+    public function send(PushSubscription $subscription, PushPayload $payload): PushSendResult
+    {
+        $endpoint = $subscription->getEndpoint();
+        $this->sends[] = ['endpoint' => $endpoint, 'payload' => $payload];
+
+        $expired = in_array($endpoint, $this->expiredEndpoints, true);
+        return new PushSendResult(
+            success: !$expired,
+            subscriptionExpired: $expired,
+            statusCode: $expired ? 410 : 201,
+        );
+    }
+
+    public function reset(): void
+    {
+        $this->sends = [];
+        $this->expiredEndpoints = [];
+    }
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -151,7 +151,7 @@ The digest commands stamp each notification with `digestedAt` once shipped, so r
 
 ## Web Push (VAPID)
 
-Web Push delivery (#100) signs requests to the browser's push service with a VAPID key pair. The endpoints (`POST /me/push-subscriptions`, `DELETE /me/push-subscriptions/{id}`) and storage are wired up; the actual `web-push` send + service-worker handler land in a follow-up. When that follow-up adds the dispatcher integration, point it at:
+Web Push delivery (#100) signs requests to the browser's push service with a VAPID key pair. The reminder dispatcher (`app:tasks:reminders:dispatch`) sends a Web Push to every registered device of a recipient who has `pushNotificationsEnabled=true`; subscriptions the push service rejects with 404/410 are pruned inline so dead endpoints don't accumulate. The PWA service worker that turns these payloads into desktop notifications is the remaining piece of #100 and lands in a follow-up.
 
 | Env var | Purpose |
 | --- | --- |
@@ -159,4 +159,6 @@ Web Push delivery (#100) signs requests to the browser's push service with a VAP
 | `VAPID_PRIVATE_KEY` | Base64-url-encoded P-256 private key. **Server-only** — never exposed to clients. |
 | `VAPID_SUBJECT` | `mailto:` or `https://` contact for push services to reach you about issues. |
 
-Generate a fresh pair with `web-push generate-vapid-keys` (Node) or any equivalent tool, store the private key as a Kubernetes Secret, and never rotate it without re-prompting users — the public key changes invalidate every existing subscription row.
+Leaving any of the three slots empty disables push send: the dispatcher logs a warning, the in-app notification + email paths still run, and existing subscription rows are left untouched. This keeps a fresh checkout green without forcing every contributor to generate a key pair.
+
+Generate a fresh pair with `web-push generate-vapid-keys` (Node) or any equivalent tool, store the private key as a Kubernetes Secret, and never rotate it without re-prompting users — public-key changes invalidate every existing subscription row.


### PR DESCRIPTION
## Summary

Closes the dispatcher slice of #100 (#82 / #85 follow-up).

`DispatchTaskRemindersCommand` now sends a Web Push to every device the recipient has registered, gated on the `pushNotificationsEnabled` preference. Subscriptions the browser's push service rejects with 404/410 are pruned inline so dead endpoints don't keep getting retried.

Delivery goes through a new `App\Push\PushSenderInterface`:
- `App\Push\WebPushSender` — prod implementation, wraps `minishlink/web-push`, reads `VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY` / `VAPID_SUBJECT` (documented in `docs/deployment.md`).
- `App\Tests\Push\InMemoryPushSender` — recording test double, aliased into the interface under `when@test` so the suite never opens a real socket.

Leaving any VAPID slot empty disables push send (warning logged, in-app + email paths still run, rows untouched) — fresh checkouts stay green without anyone generating a key pair.

## What's not in this PR

- PWA service worker + settings-page subscribe / unsubscribe flow. That needs a public-key endpoint and tighter coordination with the Notifications-toggle UI; bundling it would have ballooned the diff. It's the next PR for #100.

## Test plan

- [x] `bin/phpunit` — full suite (353 tests / 840 assertions) green
- [x] `bin/console -e test doctrine:schema:validate` — schema in sync
- [x] New dispatcher coverage in `tests/Api/NotificationTest.php`:
  - sends one push per registered device when preference is on
  - skips push entirely when preference is off (even if a row exists)
  - no-ops when preference is on but user has no subscriptions
  - prunes the row on a 410 response from the push service
  - idempotent rerun does not re-deliver