### PR TITLE
chore(deps): bump tailwind-merge from 2.6.1 to 3.5.0

### DIFF
--- a/pwa/package.json
+++ b/pwa/package.json
@@ -46,7 +46,7 @@
     "react-dom": "^19.2.5",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
-    "tailwind-merge": "^2.6.1",
+    "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.4",
     "tw-animate-css": "^1.4.0"
   },

--- a/pwa/pnpm-lock.yaml
+++ b/pwa/pnpm-lock.yaml
@@ -121,8 +121,8 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1
       tailwind-merge:
-        specifier: ^2.6.1
-        version: 2.6.1
+        specifier: ^3.5.0
+        version: 3.5.0
       tailwindcss:
         specifier: ^4.2.4
         version: 4.2.4
@@ -4008,8 +4008,8 @@ packages:
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
 
-  tailwind-merge@2.6.1:
-    resolution: {integrity: sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==}
+  tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
   tailwindcss@4.2.4:
     resolution: {integrity: sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==}
@@ -8923,7 +8923,7 @@ snapshots:
 
   tabbable@6.4.0: {}
 
-  tailwind-merge@2.6.1: {}
+  tailwind-merge@3.5.0: {}
 
   tailwindcss@4.2.4: {}
 


### PR DESCRIPTION
## Summary

Replaces dependabot's #64. tailwind-merge v3 drops Tailwind CSS v3 in favour of v4 — and Aura is already on Tailwind CSS v4 (per CLAUDE.md). Staying on tailwind-merge 2.x against Tailwind v4 means \`twMerge()\` doesn't fully recognise the v4 class shape and silently misses dedupe opportunities.

The v3.0 [breaking changes](https://github.com/dcastil/tailwind-merge/blob/v3.0.0/docs/changelog/v2-to-v3-migration.md) are all scoped to customisation APIs (\`createTailwindMerge\`, \`extendTailwindMerge\`, \`orderSensitiveModifiers\`, custom prefixes / separators) which Aura doesn't touch — \`pwa/lib/utils.ts\` only calls \`twMerge(clsx(inputs))\`. No deprecated Tailwind v3 utilities (\`flex-grow-*\`, \`bg-opacity-*\`, \`decoration-clone\`, etc.) are present in the codebase.

## Test plan

- [ ] CI: PWA typecheck (#150's new gate) passes against the v3 type defs
- [ ] CI: e2e green