### PR TITLE
chore(deps): bump lucide-react from 0.469.0 to 1.14.0

### DIFF
--- a/pwa/package.json
+++ b/pwa/package.json
@@ -34,7 +34,7 @@
     "date-fns": "^4.1.0",
     "formik": "^2.4.9",
     "isomorphic-unfetch": "^4.0.2",
-    "lucide-react": "^0.469.0",
+    "lucide-react": "^1.14.0",
     "next": "^16.2.4",
     "next-themes": "^0.4.6",
     "postcss": "^8.5.13",

--- a/pwa/pnpm-lock.yaml
+++ b/pwa/pnpm-lock.yaml
@@ -85,8 +85,8 @@ importers:
         specifier: ^4.0.2
         version: 4.0.2
       lucide-react:
-        specifier: ^0.469.0
-        version: 0.469.0(react@19.2.5)
+        specifier: ^1.14.0
+        version: 1.14.0(react@19.2.5)
       next:
         specifier: ^16.2.4
         version: 16.2.4(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -3128,8 +3128,8 @@ packages:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
 
-  lucide-react@0.469.0:
-    resolution: {integrity: sha512-28vvUnnKQ/dBwiCQtwJw7QauYnE7yd2Cyp4tTTJpvglX4EMpbflcdBgrgToX2j71B3YvugK/NH3BGUk+E/p/Fw==}
+  lucide-react@1.14.0:
+    resolution: {integrity: sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -7612,7 +7612,7 @@ snapshots:
     dependencies:
       yallist: 4.0.0
 
-  lucide-react@0.469.0(react@19.2.5):
+  lucide-react@1.14.0(react@19.2.5):
     dependencies:
       react: 19.2.5
 


### PR DESCRIPTION
## Summary

Replaces dependabot's #71. Major bump to Lucide v1.

The headline v1 breaking change is the removal of brand-logo icons (GitHub, Twitter, etc.) per the project's [brand-logo statement](https://lucide.dev/brand-logo-statement). None of those are imported by Aura — a sweep of the 31 files that import from \`lucide-react\` shows only generic UI/utility icons (AlertCircle, ChevronLeft, FileText, Loader2, Search, Trash2, …).

Other v1 changes are non-breaking for our usage:
- \`aria-hidden\` is now applied by default on icons (we don't depend on the prior default).
- UMD build dropped — we only consume ESM via the bundler.
- New optional context providers (additive).

## Test plan

- [ ] CI: PWA typecheck (#150) catches any icon import that v1 actually renamed/removed
- [ ] CI: e2e green