### PR TITLE
fix(pwa): treat missing completedOn as not-complete in search

### DIFF
--- a/pwa/components/common/SearchBar.tsx
+++ b/pwa/components/common/SearchBar.tsx
@@ -118,7 +118,7 @@ const SearchBar = () => {
             id: hit["@id"],
             title: hit.title,
             description: hit.description,
-            completed: hit.completedOn !== null,
+            completed: Boolean(hit.completedOn),
           })),
         );
         setActiveIndex(-1);

--- a/pwa/pages/search.tsx
+++ b/pwa/pages/search.tsx
@@ -628,7 +628,7 @@ const Results = ({ filters, onPageChange }: ResultsProps) => {
 };
 
 const ResultRow = ({ hit, query }: { hit: TaskHit; query: string }) => {
-  const completed = hit.completedOn !== null;
+  const completed = Boolean(hit.completedOn);
   return (
     <li
       id={encodeURIComponent(hit["@id"])}


### PR DESCRIPTION
## Summary
- Search results were rendering every task with the completed state checked.
- Root cause: API Platform omits `null` fields from `task:read`, so `hit.completedOn` arrives as `undefined`. The strict `hit.completedOn !== null` check evaluated `true` for `undefined`, marking every hit as complete.
- Switched both call sites to a truthy check (`Boolean(hit.completedOn)`), which correctly handles both `null` (legacy) and `undefined` (current API behaviour).

Closes #156

## Test plan
- [ ] Visit `/search` (or use the global search bar), enter a query that matches an open task — verify the row no longer renders with the completed/strikethrough state.
- [ ] Mark a task complete, search for it — verify it still renders as completed.
- [ ] Confirm `/tasks` list view (which already used `!!task.completedOn`) is unchanged.