### PR TITLE
fix(api): drop legacy runtime/frankenphp-symfony for Symfony 7.4 native FrankenPHP

### DIFF
--- a/api/composer.json
+++ b/api/composer.json
@@ -16,7 +16,6 @@
         "nelmio/cors-bundle": "^2.2",
         "phpdocumentor/reflection-docblock": "^6.0",
         "phpstan/phpdoc-parser": "^2.0",
-        "runtime/frankenphp-symfony": "^1.0",
         "scheb/2fa-backup-code": "^8.5",
         "scheb/2fa-bundle": "^8.5",
         "scheb/2fa-totp": "^8.5",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d7b84d45bf77546e5ff80690ccfe9ebe",
+    "content-hash": "e17eaddb0aa6e8c0c659db1e942468b2",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -4540,58 +4540,6 @@
                 "source": "https://github.com/ralouphie/getallheaders/tree/develop"
             },
             "time": "2019-03-08T08:55:37+00:00"
-        },
-        {
-            "name": "runtime/frankenphp-symfony",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-runtime/frankenphp-symfony.git",
-                "reference": "873ce3b2ca032373c237f2f271be489d05735278"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-runtime/frankenphp-symfony/zipball/873ce3b2ca032373c237f2f271be489d05735278",
-                "reference": "873ce3b2ca032373c237f2f271be489d05735278",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
-                "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0",
-                "symfony/runtime": "^5.4 || ^6.0 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^10.5.58"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Runtime\\FrankenPhpSymfony\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Kévin Dunglas",
-                    "email": "kevin@dunglas.dev"
-                }
-            ],
-            "description": "FrankenPHP runtime for Symfony",
-            "support": {
-                "issues": "https://github.com/php-runtime/frankenphp-symfony/issues",
-                "source": "https://github.com/php-runtime/frankenphp-symfony/tree/1.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/nyholm",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-12-18T07:44:23+00:00"
         },
         {
             "name": "scheb/2fa-backup-code",

--- a/api/frankenphp/Caddyfile
+++ b/api/frankenphp/Caddyfile
@@ -7,7 +7,6 @@
 		{$FRANKENPHP_CONFIG}
 
 		worker {
-			env APP_RUNTIME Runtime\FrankenPhpSymfony\Runtime
 			file ./public/index.php
 
 			{$FRANKENPHP_WORKER_CONFIG}

--- a/api/frankenphp/worker.Caddyfile
+++ b/api/frankenphp/worker.Caddyfile
@@ -1,4 +1,3 @@
 worker {
 	file ./public/index.php
-	env APP_RUNTIME Runtime\FrankenPhpSymfony\Runtime
 }


### PR DESCRIPTION
## Summary
The 1.0.0 \`runtime/frankenphp-symfony\` runner was crashing every request inside FrankenPHP worker mode with:

\`\`\`
PHP Fatal error: Uncaught ArgumentCountError: Too few arguments to function
Symfony\Component\HttpKernel\EventListener\ProfilerListener::onKernelTerminate(),
0 passed and exactly 1 expected
\`\`\`

The fatal got tacked onto the JSON response body, which is what surfaced in the browser as \`Unexpected token '<', "<br /> <b>"... is not valid JSON\` (#161). Repeated worker crashes also wedged FrankenPHP's healthcheck and made the dev container appear "stuck."

Symfony 7.4 ships [native FrankenPHP worker support](https://frankenphp.dev/docs/symfony/) and no longer needs the third-party shim. Removing the package and the matching \`env APP_RUNTIME …\` lines from both Caddyfiles lets Symfony's own runtime detect the FrankenPHP environment and run the worker loop.

### Changes
- \`api/composer.json\` / \`api/composer.lock\`: drop \`runtime/frankenphp-symfony\`.
- \`api/frankenphp/Caddyfile\`: remove \`env APP_RUNTIME Runtime\FrankenPhpSymfony\Runtime\` from the worker block.
- \`api/frankenphp/worker.Caddyfile\`: same.

Closes #161

## Test plan
- [ ] \`docker compose up -d\` then \`docker compose exec php composer install\` (or rebuild image so vendor reflects the lock change).
- [ ] Restart \`php\` container; verify it stays \`healthy\`.
- [ ] Browse the PWA across tasks/projects/discussions/etc.; confirm no \`Unexpected token '<'\` errors and \`docker compose logs php\` stays clear of \`ArgumentCountError\`.
- [ ] Run a sequence of API calls (\`/tasks\`, \`/projects\`, \`/comments\`, \`/me/assignable-users\`, etc.) and verify all return JSON.