### PR TITLE
feat(pwa): add Docs dropdown to navbar (API + Components)

### DIFF
--- a/pwa/components/common/Navbar.tsx
+++ b/pwa/components/common/Navbar.tsx
@@ -1,10 +1,16 @@
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { Menu } from "lucide-react";
+import { ChevronDown, Menu } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { displayName } from "@/lib/userDisplay";
 import UserAvatar from "@/components/user/UserAvatar";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Separator } from "@/components/ui/separator";
 import {
   Sheet,
@@ -29,11 +35,9 @@ const NAV_LINKS = [
   { href: "/tags", label: "Tags" },
 ];
 
-// Backend tooling surfaced inside the PWA chrome. These are served by
-// Caddy (FrankenPHP), not Next.js, so they're regular <a> links rather
-// than <Link>s. The API doc browser is public; the Mercure debugger is
-// admin-only.
-const PUBLIC_EXTERNAL_LINKS = [{ href: "/docs", label: "API" }];
+// Backend tooling surfaced inside the PWA chrome. The Mercure debugger
+// is served by Caddy (FrankenPHP), not Next.js, so it's a regular <a>
+// link rather than a <Link>. Admin-only.
 const ADMIN_EXTERNAL_LINKS = [
   { href: "/.well-known/mercure/ui/", label: "Mercure" },
 ];
@@ -53,13 +57,22 @@ const Navbar = () => {
           >
             Aura
           </Link>
-          {PUBLIC_EXTERNAL_LINKS.map(({ href, label }) => (
-            <Button key={href} asChild variant="ghost" size="sm">
-              <a href={href} target="_blank" rel="noopener noreferrer">
-                {label}
-              </a>
-            </Button>
-          ))}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="sm" className="gap-1">
+                Docs
+                <ChevronDown className="h-3.5 w-3.5" aria-hidden />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start">
+              <DropdownMenuItem asChild>
+                <a href="/docs">API</a>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <Link href="/dev/components">Components</Link>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
 
         <div className="flex items-center gap-1">


### PR DESCRIPTION
## Summary
Replaces the standalone "API" link at the top of the navbar with a **Docs** dropdown menu containing:
- **API** — existing \`/docs\` Swagger UI (same-window navigation; the page is served by Caddy/FrankenPHP, not Next, so it's still a plain \`<a href>\`).
- **Components** — \`/dev/components\` index.

The dropdown is permanent (visible in production too). The component library page is contributor-facing but unguarded, so there's no reason to hide it behind \`NODE_ENV\`.

Closes #160

## Test plan
- [ ] Open the app — verify a "Docs" button with chevron appears next to the Aura wordmark, in both signed-in and signed-out states.
- [ ] Click it — both "API" and "Components" entries should appear.
- [ ] Click "API" → \`/docs\` loads in the same window.
- [ ] Click "Components" → routes (in-app) to \`/dev/components\`.
- [ ] Sanity check: Admin / Mercure links remain admin-only inside the user-menu sheet.