### PR TITLE
debug(tasks): instrument toggle path to root-cause race (#193)

### DIFF
--- a/e2e/tests/tasks.spec.js
+++ b/e2e/tests/tasks.spec.js
@@ -16,24 +16,18 @@ test.describe("Tasks", () => {
     await expect(page).toHaveURL(/\/signin/);
   });
 
-  // FIXME(spaces-pwa): the post-uncheck `expect(checkbox).not.toBeChecked()`
-  // assertion has reproduced an intermittent CI-only race across PRs 188,
-  // 189, 191, and 192. The trace consistently shows `input.checked=true`
-  // for the full polling window after `uncheck()` itself succeeded
-  // (i.e. checked=false at click time). Five different code-side fixes
-  // have not stuck:
-  //   - functional setState form on the optimistic update (#188)
-  //   - explicit toBeChecked / not.toBeChecked sync barriers (#188)
-  //   - merge-server-response after PATCH success (#189/PR3)
-  //   - tasksRef-driven toggle direction so the closure can't be stale (#192)
-  //   - dropping the response merge so the row only re-renders once (#192)
-  //   - increasing the timeout from 5s to 15s as a polling bandage (#192)
-  // The last of those proves state genuinely never flips back on CI —
-  // it's not a polling-cadence issue. Skipping the test with `fixme` so
-  // PR 4 can land while the underlying race is investigated under
-  // dedicated traces. The other tasks tests (reorder, reminders, etc.)
-  // continue to exercise the toggle path implicitly.
-  test.fixme("user can create, complete, and delete a task", async ({ page }) => {
+  test("user can create, complete, and delete a task", async ({ page }) => {
+    // DEBUG(spaces-toggle-race #193): pipe page console messages
+    // tagged by the page-side instrumentation through to test
+    // stdout so the CI log shows the exact setTasks sequence
+    // leading up to the failure.
+    page.on("console", (msg) => {
+      const text = msg.text();
+      if (text.includes("[toggle:") || text.includes("[tasks:")) {
+        // eslint-disable-next-line no-console
+        console.log(`PAGE ${msg.type()}: ${text}`);
+      }
+    });
     await registerAndSignIn(page, uniqueEmail());
 
     await page.goto(`${BASE_URL}/tasks`);

--- a/e2e/tests/tasks.spec.js
+++ b/e2e/tests/tasks.spec.js
@@ -23,7 +23,11 @@ test.describe("Tasks", () => {
     // leading up to the failure.
     page.on("console", (msg) => {
       const text = msg.text();
-      if (text.includes("[toggle:") || text.includes("[tasks:")) {
+      if (
+        text.includes("[toggle:") ||
+        text.includes("[tasks:") ||
+        text.includes("[setTasks:")
+      ) {
         // eslint-disable-next-line no-console
         console.log(`PAGE ${msg.type()}: ${text}`);
       }

--- a/pwa/pages/tasks.tsx
+++ b/pwa/pages/tasks.tsx
@@ -1351,6 +1351,12 @@ const Tasks = () => {
   const tasksRef = useRef<Task[]>(tasks);
   useEffect(() => {
     tasksRef.current = tasks;
+    console.warn(
+      "[tasks:state-changed] count=",
+      tasks.length,
+      "summary=",
+      tasks.map((t) => `${t.title}=${t.completedOn ? "DONE" : "OPEN"}`).join(","),
+    );
   }, [tasks]);
   const [allTags, setAllTags] = useState<Tag[]>([]);
   const [assignableUsers, setAssignableUsers] = useState<AssigneeOption[]>([]);
@@ -1519,6 +1525,7 @@ const Tasks = () => {
   };
 
   const handleToggle = async (task: Task) => {
+    console.warn("[toggle:start]", task.title, "task.completedOn=", task.completedOn);
     // Optimistic toggle: flip the checkbox immediately so the UI feels
     // responsive and so controlled-input assertions in tests see the new
     // state without waiting for the server round-trip.
@@ -1540,6 +1547,14 @@ const Tasks = () => {
     const nextCompletedOn = current.completedOn
       ? null
       : new Date().toISOString();
+    console.warn(
+      "[toggle:direction] current.completedOn=",
+      current.completedOn,
+      "next=",
+      nextCompletedOn,
+      "ref-len=",
+      tasksRef.current.length,
+    );
     // Completing a recurring task spawns a fresh occurrence server-side; we
     // need to refetch so that new row appears in the list. Toggling *off*
     // (un-completing) doesn't need a refetch.
@@ -1547,11 +1562,16 @@ const Tasks = () => {
       !current.completedOn &&
       current.recurrenceRule !== null &&
       current.dueDate !== null;
-    setTasks((prev) =>
-      prev.map((t) =>
+    setTasks((prev) => {
+      const out = prev.map((t) =>
         t["@id"] === task["@id"] ? { ...t, completedOn: nextCompletedOn } : t,
-      ),
-    );
+      );
+      console.warn(
+        "[toggle:setTasks-optimistic]",
+        out.find((t) => t["@id"] === task["@id"])?.completedOn,
+      );
+      return out;
+    });
     setError(null);
 
     try {
@@ -1561,6 +1581,7 @@ const Tasks = () => {
         headers: { "Content-Type": "application/merge-patch+json" },
         body: JSON.stringify({ completedOn: nextCompletedOn }),
       });
+      console.warn("[toggle:patch-resolved]", res.status, res.ok);
       if (!res.ok) {
         throw new Error("Failed to update task.");
       }

--- a/pwa/pages/tasks.tsx
+++ b/pwa/pages/tasks.tsx
@@ -1446,7 +1446,9 @@ const Tasks = () => {
       const tagsData: Collection<Tag> = await tagsRes.json();
       const assignablesData: Collection<AssigneeOption> = await assignablesRes.json();
       const projectsData: Collection<ProjectMembership> = await projectsRes.json();
-      setTasks(tasksData.member ?? tasksData["hydra:member"] ?? []);
+      const _loaded = tasksData.member ?? tasksData["hydra:member"] ?? [];
+      console.warn("[setTasks:loadData]", _loaded.map((t: Task) => `${t.title}=${t.completedOn ? "DONE" : "OPEN"}`).join(","));
+      setTasks(_loaded);
       setAllTags(tagsData.member ?? tagsData["hydra:member"] ?? []);
       setAssignableUsers(
         assignablesData.member ?? assignablesData["hydra:member"] ?? [],
@@ -1514,6 +1516,7 @@ const Tasks = () => {
       // needs (owner, tags, assignees, attachments, position assigned
       // server-side), so a local insert is both faster and resilient.
       const created: Task = await res.json();
+      console.warn("[setTasks:handleCreate]", `${created.title}=${created.completedOn ? "DONE" : "OPEN"}`);
       setTasks((prev) => [created, ...prev]);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to create task.");
@@ -1600,6 +1603,7 @@ const Tasks = () => {
         await loadData();
       }
     } catch (err) {
+      console.warn("[setTasks:toggle-catch] err=", err instanceof Error ? err.message : String(err));
       setTasks((prev) =>
         prev.map((t) =>
           t["@id"] === task["@id"] ? { ...t, completedOn: previousCompletedOn } : t,
@@ -1645,6 +1649,7 @@ const Tasks = () => {
         );
       }
     } catch (err) {
+      console.warn("[setTasks:title-revert]");
       setTasks(previous);
       setError(err instanceof Error ? err.message : "Failed to update title.");
     }
@@ -1677,6 +1682,7 @@ const Tasks = () => {
         );
       }
     } catch (err) {
+      console.warn("[setTasks:desc-revert]");
       setTasks(previous);
       setError(err instanceof Error ? err.message : "Failed to update description.");
     }
@@ -1711,6 +1717,7 @@ const Tasks = () => {
         );
       }
     } catch (err) {
+      console.warn("[setTasks:recurrence-revert]");
       setTasks(previous);
       setError(err instanceof Error ? err.message : "Failed to update recurrence.");
     }
@@ -1738,6 +1745,7 @@ const Tasks = () => {
         );
       }
     } catch (err) {
+      console.warn("[setTasks:duedate-revert]");
       setTasks(previous);
       setError(err instanceof Error ? err.message : "Failed to update due date.");
     }
@@ -1772,6 +1780,7 @@ const Tasks = () => {
         );
       }
     } catch (err) {
+      console.warn("[setTasks:reminders-revert]");
       setTasks(previous);
       setError(err instanceof Error ? err.message : "Failed to update reminders.");
     }
@@ -1806,6 +1815,7 @@ const Tasks = () => {
         );
       }
     } catch (err) {
+      console.warn("[setTasks:assignees-revert]");
       setTasks(previous);
       setError(err instanceof Error ? err.message : "Failed to update assignees.");
     }
@@ -1831,6 +1841,7 @@ const Tasks = () => {
         throw new Error("Failed to update tags.");
       }
     } catch (err) {
+      console.warn("[setTasks:tags-revert]");
       setTasks(previous);
       setError(err instanceof Error ? err.message : "Failed to update tags.");
     }
@@ -1972,6 +1983,7 @@ const Tasks = () => {
         );
       }
       const updated = (await res.json()) as Task;
+      console.warn("[setTasks:attach-media]", `${updated.title}=${updated.completedOn ? "DONE" : "OPEN"}`);
       setTasks((current) =>
         current.map((t) => (t["@id"] === task["@id"] ? updated : t)),
       );
@@ -1994,6 +2006,7 @@ const Tasks = () => {
         throw new Error("Failed to remove attachment.");
       }
       const updated = (await res.json()) as Task;
+      console.warn("[setTasks:detach-media]", `${updated.title}=${updated.completedOn ? "DONE" : "OPEN"}`);
       setTasks((current) =>
         current.map((t) => (t["@id"] === task["@id"] ? updated : t)),
       );
@@ -2071,6 +2084,7 @@ const Tasks = () => {
     const previous = tasks;
     const reordered = arrayMove(tasks, oldIndex, newIndex);
     // Apply optimistically — snappy UX, rolled back below if the server rejects.
+    console.warn("[setTasks:reorder]");
     setTasks(reordered);
     setError(null);
 
@@ -2085,6 +2099,7 @@ const Tasks = () => {
         throw new Error("Failed to save new order.");
       }
     } catch (err) {
+      console.warn("[setTasks:reorder-revert]");
       setTasks(previous);
       setError(err instanceof Error ? err.message : "Failed to save new order.");
     }


### PR DESCRIPTION
## What

Draft PR to surface CI logs for the long-running tasks-toggle race tracked in [#193](https://github.com/roboparker/Aura/issues/193). Instruments `pwa/pages/tasks.tsx` with `console.warn` checkpoints at every step of the toggle flow and a `useEffect` mirror of the tasks state. The Playwright spec pipes anything tagged `[toggle:` or `[tasks:` to stdout so the failing CI run will dump the exact sequence of setState calls leading to the assertion failure.

## Status

Not for merge. Once a CI failure produces useful logs, I'll diagnose, ship a real fix in a separate PR, and close this draft.