### PR TITLE
fix(docker): pin pnpm to 9.1.3 to unblock CI

### DIFF
--- a/pwa/Dockerfile
+++ b/pwa/Dockerfile
@@ -10,9 +10,16 @@ FROM node_upstream AS base
 
 WORKDIR /srv/app
 
+# Pin pnpm to the version recorded in pwa/package.json's `packageManager`
+# field. Using `pnpm@latest` here would override that pin with whatever
+# was uploaded to npm at CI time — pnpm 11.x in particular requires a
+# `pnpm setup` step to add `/root/.local/share/pnpm/bin` to PATH, and
+# `corepack prepare --activate pnpm@latest` doesn't run it. Result: a
+# rebuild against an unrelated PR fails at this step the next time pnpm
+# ships a major. Pinning explicitly keeps the image reproducible.
 RUN npm install -g corepack@latest && \
     corepack enable && \
-	corepack prepare --activate pnpm@latest && \
+	corepack prepare --activate pnpm@9.1.3 && \
 	pnpm config -g set store-dir /.pnpm-store
 
 # Next.js collects completely anonymous telemetry data about general usage.


### PR DESCRIPTION
## What

CI is currently broken on every PR (and on `main` itself, post-merge of [#195](https://github.com/roboparker/Aura/pull/195)) because `pwa/Dockerfile` calls `corepack prepare --activate pnpm@latest`, and the latest pnpm release on npm now requires a `pnpm setup` step before activation:

```
[ERROR] The configured global bin directory "/root/.local/share/pnpm/bin" is not in PATH
Run "pnpm setup" to update your shell configuration.
```

`corepack prepare` doesn't run `pnpm setup`, so the image fails to build. Every CI run after the regression hit npm now fails at the Docker build step before any test executes.

## Fix

Pin pnpm to 9.1.3 — the version already recorded in `pwa/package.json`'s `packageManager` field. Reproducible builds, no surprise upgrades.

## Test plan

- [ ] CI green on this PR
- [ ] CI returns to passing on every other open PR after this lands

Unblocks [#153](https://github.com/roboparker/Aura/issues/153) (and every other open PR).