### PR TITLE
chore(dev): port-forward watcher for Docker Desktop on Windows

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -60,6 +60,28 @@ the script.
 
 `.env` is gitignored, so each worktree's values stay local.
 
+### Docker Desktop on Windows: port-forward auto-recovery
+
+Docker Desktop on Windows occasionally stops forwarding traffic from the
+host to the WSL2 distro after sleep/hibernate cycles. Symptom: the
+container's healthcheck (run inside the docker network) keeps reporting
+healthy, but `curl https://localhost` from the host hangs indefinitely
+and the PWA UI sits on "Loading…".
+
+The fix is to restart the affected container so Docker Desktop rebuilds
+the port forward (`docker compose restart php`). To automate this in
+the background, run:
+
+```bash
+scripts/watch-port-forward.sh
+```
+
+The script polls `https://localhost/docs` every 30 seconds and restarts
+the `php` service after 3 consecutive failures. Override defaults via
+env vars (`POLL_INTERVAL`, `FAIL_THRESHOLD`, `WATCH_URL`,
+`WATCH_SERVICE`, `PROBE_TIMEOUT`, `COOLDOWN`). Stop with Ctrl-C; intended
+to run in its own terminal alongside `docker compose up`.
+
 ## Production (Docker Compose)
 
 Use `compose.prod.yaml` with overrides:

--- a/scripts/watch-port-forward.sh
+++ b/scripts/watch-port-forward.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+# Auto-recovers Docker Desktop's WSL→Windows port-forward bridge by
+# restarting the php container when the published port stops
+# answering from the host.
+#
+# Why this exists: Docker Desktop on Windows occasionally stops
+# forwarding traffic from the Windows host to the WSL2 distro after
+# sleep/hibernate cycles. The container's own healthcheck (running
+# inside the network) keeps reporting healthy, but `curl
+# https://localhost` from the host hangs. Restarting the php
+# container forces Docker to rebuild the port-forward.
+#
+# Usage:
+#   scripts/watch-port-forward.sh
+#   POLL_INTERVAL=10 FAIL_THRESHOLD=2 scripts/watch-port-forward.sh
+#   WATCH_URL=https://localhost/docs scripts/watch-port-forward.sh
+#
+# Stop with Ctrl-C. Intended to run in its own terminal alongside
+# `docker compose up`.
+
+set -e
+
+URL="${WATCH_URL:-https://localhost/docs}"
+SERVICE="${WATCH_SERVICE:-php}"
+POLL_INTERVAL="${POLL_INTERVAL:-30}"
+FAIL_THRESHOLD="${FAIL_THRESHOLD:-3}"
+PROBE_TIMEOUT="${PROBE_TIMEOUT:-5}"
+COOLDOWN="${COOLDOWN:-30}"
+
+log() {
+  printf '[watch-port-forward %s] %s\n' "$(date -Iseconds 2>/dev/null || date)" "$*"
+}
+
+log "watching $URL (poll=${POLL_INTERVAL}s, threshold=${FAIL_THRESHOLD} fails) — Ctrl-C to stop"
+
+fails=0
+while :; do
+  if curl -k -fsS -o /dev/null --max-time "$PROBE_TIMEOUT" "$URL"; then
+    if [ "$fails" -gt 0 ]; then
+      log "probe ok again after $fails failure(s)"
+    fi
+    fails=0
+  else
+    fails=$((fails + 1))
+    log "probe failed ($fails/$FAIL_THRESHOLD): $URL"
+    if [ "$fails" -ge "$FAIL_THRESHOLD" ]; then
+      log "restarting service '$SERVICE' to rebuild Docker Desktop's port-forward..."
+      if docker compose restart "$SERVICE"; then
+        log "restart issued; cooling down ${COOLDOWN}s before re-probing"
+        sleep "$COOLDOWN"
+      else
+        log "docker compose restart $SERVICE failed; will keep probing"
+      fi
+      fails=0
+    fi
+  fi
+  sleep "$POLL_INTERVAL"
+done


### PR DESCRIPTION
## Summary
Adds \`scripts/watch-port-forward.sh\` — a tiny shell loop that detects when Docker Desktop's WSL→Windows port-forward bridge breaks (host-side \`curl https://localhost\` starts hanging while the container's own healthcheck still reports healthy) and runs \`docker compose restart php\` to rebuild the forward.

Pure dev tooling. Sits next to \`scripts/worktree-env.sh\`, is not invoked by \`docker compose\`, and isn't shipped to production. Documented under "Docker Desktop on Windows: port-forward auto-recovery" in \`docs/deployment.md\`.

## Why
Recurring symptom on this stack: after a Windows sleep/hibernate cycle, the PWA sign-in (and any other authed call) starts hanging from the browser. The container is healthy from inside the docker network — only the port forward is broken. Manually \`docker compose restart php\` fixes it. This script automates that.

Defaults (override via env vars):
- \`POLL_INTERVAL\`=30s — probe cadence.
- \`FAIL_THRESHOLD\`=3 — consecutive failures before restart.
- \`WATCH_URL\`=\`https://localhost/docs\` — the probe target.
- \`WATCH_SERVICE\`=\`php\` — the compose service to restart.
- \`PROBE_TIMEOUT\`=5s, \`COOLDOWN\`=30s.

## Test plan
- [ ] Run \`scripts/watch-port-forward.sh\` in a terminal alongside \`docker compose up\`. Verify it logs the watch banner and stays quiet while \`https://localhost/docs\` is reachable.
- [ ] Simulate a port-forward break (\`docker compose stop php\`) and confirm the script restarts the service after 3 consecutive failures.
- [ ] Override one env var (\`FAIL_THRESHOLD=1 scripts/watch-port-forward.sh\`) and confirm it kicks in after a single probe failure.