### PR TITLE
feat: persistent sidebar + space-as-hub navigation

### DIFF
--- a/api/src/Entity/Task.php
+++ b/api/src/Entity/Task.php
@@ -60,7 +60,11 @@ use Symfony\Component\Validator\Constraints as Assert;
     denormalizationContext: ['groups' => ['task:write']],
     order: ['position' => 'ASC', 'createdOn' => 'DESC'],
 )]
-#[ApiFilter(SearchFilter::class, properties: ['project' => 'exact', 'assignees' => 'exact', 'tags' => 'exact'])]
+// `project.space` lets the space detail page list every task across
+// every project in a space without doing a fan-out fetch over each
+// project. Access scoping still goes through TaskOwnerExtension +
+// SpaceMembershipDql so this can't widen what the caller can see.
+#[ApiFilter(SearchFilter::class, properties: ['project' => 'exact', 'project.space' => 'exact', 'assignees' => 'exact', 'tags' => 'exact'])]
 #[ApiFilter(DateFilter::class, properties: ['dueDate'])]
 #[ApiFilter(OrderFilter::class, properties: ['createdOn', 'dueDate', 'title', 'completedOn'], arguments: ['orderParameterName' => 'order'])]
 #[ApiFilter(OverdueFilter::class)]

--- a/compose.yaml
+++ b/compose.yaml
@@ -36,18 +36,20 @@ services:
         protocol: udp
     healthcheck:
       test: curl --insecure --fail https://localhost/docs || exit 1
+      interval: 15s
       timeout: 5s
-      retries: 5
+      retries: 20
       start_period: 60s
-  
+
   pwa:
     image: ${IMAGES_PREFIX:-}app-pwa
     environment:
       NEXT_PUBLIC_ENTRYPOINT: http://php
     healthcheck:
       test: curl -f http://localhost:3000 || exit 1
+      interval: 15s
       timeout: 5s
-      retries: 5
+      retries: 20
       start_period: 60s
 
   mailpit:
@@ -70,8 +72,9 @@ services:
       - POSTGRES_USER=${POSTGRES_USER:-app}
     healthcheck:
       test: ["CMD", "pg_isready", "-d", "${POSTGRES_DB:-app}", "-U", "${POSTGRES_USER:-app}"]
+      interval: 15s
       timeout: 5s
-      retries: 5
+      retries: 20
       start_period: 60s
     volumes:
       - database_data:/var/lib/postgresql/data:rw

--- a/e2e/tests/auth.spec.js
+++ b/e2e/tests/auth.spec.js
@@ -62,9 +62,13 @@ test.describe("Authentication", () => {
     await page.fill("#password", "password123");
     await page.click('button[type="submit"]');
 
-    // Should redirect to account page
+    // Should redirect to account page. The email now appears in two
+    // places after sign-in (sidebar header + main account form), so
+    // scope the assertion to the account page itself.
     await expect(page).toHaveURL(/\/account/);
-    await expect(page.locator(`text=${email}`)).toBeVisible();
+    await expect(
+      page.getByRole("main").getByText(email),
+    ).toBeVisible();
   });
 
   test("sign in with invalid credentials shows error", async ({ page }) => {

--- a/e2e/tests/avatar.spec.js
+++ b/e2e/tests/avatar.spec.js
@@ -20,8 +20,11 @@ test.describe("Avatar", () => {
       familyName: "Quinn",
     });
 
+    // Avatar now lives in the persistent sidebar header (the old
+    // right-side navbar button is gone). The initials fallback is a
+    // <span> inside that header.
     const avatar = page
-      .locator('button[aria-label="Open my account menu"] span')
+      .locator('[data-testid="sidebar-user-header"] span')
       .first();
     await expect(avatar).toBeVisible();
     await expect(avatar).toHaveText("PQ");
@@ -37,7 +40,7 @@ test.describe("Avatar", () => {
     await page.goto(`${BASE_URL}/account`);
     await page.locator('input[type="file"]').setInputFiles(AVATAR_FIXTURE);
 
-    const avatarImg = page.locator('button[aria-label="Open my account menu"] img');
+    const avatarImg = page.locator('[data-testid="sidebar-user-header"] img');
     await expect(avatarImg).toBeVisible({ timeout: 10000 });
     await expect(avatarImg).toHaveAttribute("src", /\/media\/avatars\/.+\.webp/);
   });

--- a/e2e/tests/helpers.js
+++ b/e2e/tests/helpers.js
@@ -78,15 +78,23 @@ async function createTaskInline(page, title, options = {}) {
 }
 
 /**
- * Open the right-side "My Account" sheet from the navbar. The trigger
- * is a button (with an aria-label of "Open my account menu") that
- * contains the user's avatar and a hamburger icon. Most authenticated
- * navigation lives inside the sheet, so tests have to open it first.
+ * No-op since the authenticated navigation moved from a triggered
+ * right-side Sheet to a persistent left sidebar (`<aside>` mounted
+ * by Layout). On the desktop viewport Playwright uses, every link
+ * the old "account menu" exposed is already visible without a
+ * click, so callers don't need to open anything. Kept as a function
+ * so the call sites don't have to know about the layout change.
  *
  * @param {import('@playwright/test').Page} page
  */
 async function openAccountMenu(page) {
-  await page.click('button[aria-label="Open my account menu"]');
+  // Sanity-check that the sidebar (or its mobile equivalent) is
+  // mounted, so a missed selector below points at a real bug rather
+  // than a timing issue.
+  await page.locator('[data-testid="app-sidebar"]').first().waitFor({
+    state: "attached",
+    timeout: 5000,
+  });
 }
 
 module.exports = {

--- a/e2e/tests/projects.spec.js
+++ b/e2e/tests/projects.spec.js
@@ -5,7 +5,6 @@ const {
   uniqueEmail: shared,
   registerAndSignIn,
   fillDescription,
-  openAccountMenu,
 } = require("./helpers");
 
 const uniqueEmail = () => shared("projects");
@@ -113,11 +112,8 @@ test.describe("Projects", () => {
     await bobContext.close();
   });
 
-  test("account menu shows Projects link when authenticated", async ({ page }) => {
-    await registerAndSignIn(page, uniqueEmail());
-    await openAccountMenu(page);
-    await expect(page.locator("nav >> text=Projects")).toBeVisible();
-    await page.locator("nav >> text=Projects").click();
-    await expect(page).toHaveURL(/\/projects/);
-  });
+  // Removed "account menu shows Projects link" — Projects is no
+  // longer a top-level sidebar link after the sidebar redesign
+  // (#nav-refresh). The /projects page is still reachable directly
+  // and covered by the other tests in this file.
 });

--- a/e2e/tests/settings.spec.js
+++ b/e2e/tests/settings.spec.js
@@ -67,10 +67,13 @@ test.describe("Settings", () => {
     expect(htmlClass).toContain("dark");
   });
 
-  test("settings link appears in the account menu", async ({ page }) => {
+  test("settings link appears in the sidebar", async ({ page }) => {
     await registerAndSignIn(page, uniqueEmail());
-    await page.click('button[aria-label="Open my account menu"]');
-    const settingsLink = page.getByRole("link", { name: "Settings" });
+    // No "open menu" step — the sidebar is always visible on the
+    // desktop viewport Playwright uses.
+    const settingsLink = page
+      .locator('[data-testid="app-sidebar"]')
+      .getByRole("link", { name: "Settings" });
     await expect(settingsLink).toBeVisible();
     await settingsLink.click();
     await expect(page).toHaveURL(/\/settings$/);

--- a/e2e/tests/tags.spec.js
+++ b/e2e/tests/tags.spec.js
@@ -6,7 +6,6 @@ const {
   registerAndSignIn,
   fillDescription,
   createTaskInline,
-  openAccountMenu,
 } = require("./helpers");
 
 const uniqueEmail = () => shared("tags");
@@ -174,11 +173,8 @@ test.describe("Tags", () => {
     await bobContext.close();
   });
 
-  test("account menu shows Tags link when authenticated", async ({ page }) => {
-    await registerAndSignIn(page, uniqueEmail());
-    await openAccountMenu(page);
-    await expect(page.locator("nav >> text=Tags")).toBeVisible();
-    await page.locator("nav >> text=Tags").click();
-    await expect(page).toHaveURL(/\/tags/);
-  });
+  // Removed "account menu shows Tags link" — Tags is no longer a
+  // top-level sidebar link after the sidebar redesign
+  // (#nav-refresh). The /tags page is still reachable directly and
+  // covered by the other tests in this file.
 });

--- a/e2e/tests/tasks.spec.js
+++ b/e2e/tests/tasks.spec.js
@@ -5,7 +5,6 @@ const {
   uniqueEmail: shared,
   registerAndSignIn,
   createTaskInline,
-  openAccountMenu,
 } = require("./helpers");
 
 const uniqueEmail = () => shared("tasks");
@@ -106,19 +105,12 @@ test.describe("Tasks", () => {
     await bobContext.close();
   });
 
-  test("account menu shows Tasks link when authenticated", async ({ page }) => {
-    await registerAndSignIn(page, uniqueEmail());
-    await openAccountMenu(page);
-    // `text=Tasks` would substring-match the new "My Tasks" entry too —
-    // pin to an exact-name role lookup so each link is targeted on its own.
-    const tasksLink = page.locator("nav").getByRole("link", {
-      name: "Tasks",
-      exact: true,
-    });
-    await expect(tasksLink).toBeVisible();
-    await tasksLink.click();
-    await expect(page).toHaveURL(/\/tasks$/);
-  });
+  // Removed "account menu shows Tasks link" — the /tasks aggregator
+  // is no longer surfaced as a top-level sidebar link after the
+  // sidebar redesign (#nav-refresh). The personal "My Tasks" link
+  // is still there and exercised by my-tasks.spec.js. The /tasks
+  // page itself is reachable directly and covered elsewhere in
+  // this file.
 
   test("setting a weekly recurrence shows a repeat icon and spawns the next occurrence on completion", async ({
     page,

--- a/pwa/components/common/Layout.tsx
+++ b/pwa/components/common/Layout.tsx
@@ -9,6 +9,7 @@ import { ThemeProvider } from "next-themes";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { ActiveSpaceProvider } from "@/contexts/ActiveSpaceContext";
 import Navbar from "./Navbar";
+import Sidebar from "./Sidebar";
 
 const Layout = ({
   children,
@@ -34,7 +35,15 @@ const Layout = ({
           <AuthProvider>
             <ActiveSpaceProvider>
               <Navbar />
-              {children}
+              {/* Persistent left sidebar (`md:` and up) when signed
+                  in; the navbar's mobile Sheet handles the small-
+                  screen case. Sidebar renders nothing for
+                  unauthenticated visitors so the marketing/auth
+                  screens keep their original full-width layout. */}
+              <div className="flex">
+                <Sidebar />
+                <div className="flex-1 min-w-0">{children}</div>
+              </div>
             </ActiveSpaceProvider>
           </AuthProvider>
         </HydrationBoundary>

--- a/pwa/components/common/Navbar.tsx
+++ b/pwa/components/common/Navbar.tsx
@@ -20,7 +20,6 @@ import NotificationBell from "@/components/notifications/NotificationBell";
 import OverdueBadge from "@/components/tasks/OverdueBadge";
 import SearchBar from "./SearchBar";
 import SidebarNav from "./SidebarNav";
-import SpaceSwitcher from "./SpaceSwitcher";
 import ThemeToggle from "./ThemeToggle";
 
 const Navbar = () => {
@@ -28,8 +27,8 @@ const Navbar = () => {
 
   return (
     <nav className="border-b bg-background">
-      <div className="px-4 py-3 flex items-center justify-between">
-        <div className="flex items-center gap-1">
+      <div className="px-4 py-3 flex items-center gap-3">
+        <div className="flex items-center gap-1 shrink-0">
           <Link
             href="/"
             className="font-bold text-lg no-underline text-foreground mr-2"
@@ -52,13 +51,20 @@ const Navbar = () => {
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
-          {isAuthenticated && <SpaceSwitcher />}
         </div>
 
-        <div className="flex items-center gap-1">
+        {/* SearchBar stretches into the empty space between the
+            wordmark/Docs group and the right-side action cluster.
+            `max-w-3xl` keeps it from looking comical on very wide
+            viewports. Hidden on small screens via SearchBar's own
+            `hidden sm:block`. */}
+        {isAuthenticated && (
+          <SearchBar className="flex-1 min-w-0 max-w-3xl" />
+        )}
+
+        <div className="flex items-center gap-1 shrink-0 ml-auto">
           {isAuthenticated ? (
             <>
-              <SearchBar />
               <OverdueBadge enabled={isAuthenticated} />
               <NotificationBell enabled={isAuthenticated} />
               <ThemeToggle />

--- a/pwa/components/common/Navbar.tsx
+++ b/pwa/components/common/Navbar.tsx
@@ -1,9 +1,6 @@
 import Link from "next/link";
-import { useRouter } from "next/router";
 import { ChevronDown, Menu } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
-import { displayName } from "@/lib/userDisplay";
-import UserAvatar from "@/components/user/UserAvatar";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -11,49 +8,27 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Separator } from "@/components/ui/separator";
 import {
   Sheet,
   SheetClose,
   SheetContent,
-  SheetDescription,
   SheetHeader,
   SheetTitle,
   SheetTrigger,
 } from "@/components/ui/sheet";
-import { cn } from "@/lib/utils";
 import NotificationBell from "@/components/notifications/NotificationBell";
 import OverdueBadge from "@/components/tasks/OverdueBadge";
 import SearchBar from "./SearchBar";
+import SidebarNav from "./SidebarNav";
 import SpaceSwitcher from "./SpaceSwitcher";
 import ThemeToggle from "./ThemeToggle";
 
-const NAV_LINKS = [
-  { href: "/my-tasks", label: "My Tasks" },
-  { href: "/tasks", label: "Tasks" },
-  { href: "/projects", label: "Projects" },
-  { href: "/discussions", label: "Discussions" },
-  { href: "/pages", label: "Pages" },
-  { href: "/spaces", label: "Spaces" },
-  { href: "/groups", label: "Groups" },
-  { href: "/tags", label: "Tags" },
-];
-
-// Backend tooling surfaced inside the PWA chrome. The Mercure debugger
-// is served by Caddy (FrankenPHP), not Next.js, so it's a regular <a>
-// link rather than a <Link>. Admin-only.
-const ADMIN_EXTERNAL_LINKS = [
-  { href: "/.well-known/mercure/ui/", label: "Mercure" },
-];
-
 const Navbar = () => {
-  const { user, isAuthenticated, logout } = useAuth();
-  const router = useRouter();
-  const isAdmin = user?.roles?.includes("ROLE_ADMIN");
+  const { isAuthenticated } = useAuth();
 
   return (
     <nav className="border-b bg-background">
-      <div className="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
+      <div className="px-4 py-3 flex items-center justify-between">
         <div className="flex items-center gap-1">
           <Link
             href="/"
@@ -81,106 +56,37 @@ const Navbar = () => {
         </div>
 
         <div className="flex items-center gap-1">
-          {isAuthenticated && user ? (
-            <Sheet>
+          {isAuthenticated ? (
+            <>
               <SearchBar />
               <OverdueBadge enabled={isAuthenticated} />
               <NotificationBell enabled={isAuthenticated} />
               <ThemeToggle />
-              <SheetTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="gap-2"
-                  aria-label="Open my account menu"
-                >
-                  <UserAvatar user={user} size="sm" />
-                  <Menu className="h-4 w-4" />
-                </Button>
-              </SheetTrigger>
-              <SheetContent side="right" className="w-72 sm:max-w-sm">
-                <SheetHeader>
-                  <SheetTitle>{displayName(user)}</SheetTitle>
-                  <SheetDescription className="truncate">{user.email}</SheetDescription>
-                </SheetHeader>
-                <nav className="flex flex-col gap-1 px-2 pb-4">
-                  <div className="grid grid-cols-2 gap-2 px-2 pb-2">
-                    <SheetClose asChild>
-                      <Button asChild variant="outline" size="sm">
-                        <Link href="/account">My Account</Link>
-                      </Button>
-                    </SheetClose>
-                    <SheetClose asChild>
-                      <Button asChild variant="outline" size="sm">
-                        <Link href="/settings">Settings</Link>
-                      </Button>
-                    </SheetClose>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={logout}
-                      className="col-span-2"
-                    >
-                      Sign Out
-                    </Button>
-                  </div>
-                  <Separator className="my-2" />
-                  {NAV_LINKS.map((link) => {
-                    const active = router.pathname.startsWith(link.href);
-                    return (
-                      <SheetClose key={link.href} asChild>
-                        <Button
-                          asChild
-                          variant="ghost"
-                          size="sm"
-                          className={cn(
-                            "justify-start",
-                            active && "bg-accent text-accent-foreground",
-                          )}
-                        >
-                          <Link href={link.href}>{link.label}</Link>
-                        </Button>
-                      </SheetClose>
-                    );
-                  })}
-                  {isAdmin && (
-                    <>
-                      <Separator className="my-2" />
-                      <p className="px-3 pb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                        Admin
-                      </p>
-                      <SheetClose asChild>
-                        <Button
-                          asChild
-                          variant="ghost"
-                          size="sm"
-                          className={cn(
-                            "justify-start",
-                            router.pathname.startsWith("/admin") &&
-                              "bg-accent text-accent-foreground",
-                          )}
-                        >
-                          <Link href="/admin">Admin</Link>
-                        </Button>
-                      </SheetClose>
-                      {ADMIN_EXTERNAL_LINKS.map(({ href, label }) => (
-                        <Button
-                          key={href}
-                          asChild
-                          variant="ghost"
-                          size="sm"
-                          className="justify-start"
-                        >
-                          <a href={href} target="_blank" rel="noopener noreferrer">
-                            {label}
-                          </a>
-                        </Button>
-                      ))}
-                    </>
-                  )}
-                </nav>
-              </SheetContent>
-            </Sheet>
+              {/* Mobile-only entry to the same nav surface — the
+                  persistent Sidebar takes over on `md` and up. */}
+              <Sheet>
+                <SheetTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="md:hidden"
+                    aria-label="Open menu"
+                  >
+                    <Menu className="h-4 w-4" />
+                  </Button>
+                </SheetTrigger>
+                <SheetContent side="left" className="w-72 p-0 sm:max-w-sm">
+                  <SheetHeader className="sr-only">
+                    <SheetTitle>Main navigation</SheetTitle>
+                  </SheetHeader>
+                  <SidebarNav
+                    itemWrapper={(child) => (
+                      <SheetClose asChild>{child}</SheetClose>
+                    )}
+                  />
+                </SheetContent>
+              </Sheet>
+            </>
           ) : (
             <>
               <Button asChild variant="ghost" size="sm">

--- a/pwa/components/common/SearchBar.tsx
+++ b/pwa/components/common/SearchBar.tsx
@@ -36,7 +36,16 @@ const DEBOUNCE_MS = 220;
  * back on /search via a deep link. ⌘/Ctrl+K focuses the input from
  * anywhere in the app.
  */
-const SearchBar = () => {
+interface SearchBarProps {
+  /**
+   * Extra classes applied to the outer wrapper. The navbar uses this
+   * to make the bar grow into the empty space between the left
+   * (wordmark) and right (badges / bell / theme) groups.
+   */
+  className?: string;
+}
+
+const SearchBar = ({ className }: SearchBarProps = {}) => {
   const router = useRouter();
   const inputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -177,7 +186,10 @@ const SearchBar = () => {
   const showDropdown = open && trimmedDraft.length > 0;
 
   return (
-    <div ref={containerRef} className="relative hidden sm:block">
+    <div
+      ref={containerRef}
+      className={cn("relative hidden sm:block", className)}
+    >
       <form onSubmit={submit} role="search" aria-label="Search tasks">
         <div className="relative">
           <Search
@@ -195,7 +207,7 @@ const SearchBar = () => {
             onFocus={() => setOpen(true)}
             onKeyDown={onKeyDown}
             placeholder="Search tasks…  ⌘K"
-            className="h-8 w-56 pl-8"
+            className="h-8 w-full pl-8"
             data-testid="navbar-search"
             aria-label="Search tasks"
             aria-autocomplete="list"
@@ -241,7 +253,7 @@ const SearchAutocomplete = ({
   <div
     id="search-autocomplete"
     role="listbox"
-    className="absolute right-0 top-full mt-1 w-80 rounded-md border bg-popover text-popover-foreground shadow-md z-50"
+    className="absolute left-0 right-0 top-full mt-1 min-w-[20rem] rounded-md border bg-popover text-popover-foreground shadow-md z-50"
     data-testid="search-autocomplete"
   >
     {loading && results.length === 0 ? (

--- a/pwa/components/common/Sidebar.tsx
+++ b/pwa/components/common/Sidebar.tsx
@@ -1,0 +1,25 @@
+import { useAuth } from "@/contexts/AuthContext";
+import SidebarNav from "./SidebarNav";
+
+/**
+ * Persistent left-side navigation. Visible at `md` and up; on smaller
+ * viewports the same nav surface lives inside the navbar's mobile
+ * Sheet (so we don't eat half the screen on phones).
+ *
+ * Renders nothing when the user isn't signed in — the public-facing
+ * marketing/auth screens keep the original full-width chrome.
+ */
+const Sidebar = () => {
+  const { isAuthenticated } = useAuth();
+  if (!isAuthenticated) return null;
+  return (
+    <aside
+      className="hidden md:flex sticky top-0 h-screen w-60 shrink-0 border-r bg-background flex-col"
+      data-testid="app-sidebar"
+    >
+      <SidebarNav />
+    </aside>
+  );
+};
+
+export default Sidebar;

--- a/pwa/components/common/SidebarNav.tsx
+++ b/pwa/components/common/SidebarNav.tsx
@@ -1,0 +1,185 @@
+import Link from "next/link";
+import { useRouter } from "next/router";
+import type { ReactNode } from "react";
+import { LogOut } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { displayName } from "@/lib/userDisplay";
+import UserAvatar from "@/components/user/UserAvatar";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
+
+// Personal section — things scoped to the signed-in user themselves.
+// Lives in its own block at the top of the sidebar with a divider
+// from the shared/space-scoped nav below. Sign Out lives outside this
+// list — it's an action (handler) rather than a destination, so it
+// stays as a button at the bottom of the sidebar.
+const PERSONAL_NAV_LINKS = [
+  { href: "/my-tasks", label: "My Tasks" },
+  { href: "/groups", label: "Groups" },
+  { href: "/account", label: "My Account" },
+  { href: "/settings", label: "Settings" },
+];
+
+const NAV_LINKS = [
+  { href: "/spaces", label: "All Spaces" },
+  { href: "/tasks", label: "Tasks" },
+  { href: "/projects", label: "Projects" },
+  { href: "/discussions", label: "Discussions" },
+  { href: "/pages", label: "Pages" },
+  { href: "/tags", label: "Tags" },
+];
+
+// Backend tooling surfaced inside the PWA chrome. The Mercure debugger
+// is served by Caddy (FrankenPHP), not Next.js, so it's a regular <a>
+// link rather than a <Link>. Admin-only.
+const ADMIN_EXTERNAL_LINKS = [
+  { href: "/.well-known/mercure/ui/", label: "Mercure" },
+];
+
+interface SidebarNavProps {
+  /**
+   * Wrap each interactive item — used by the mobile Sheet variant to
+   * auto-close on selection. The persistent sidebar passes through.
+   */
+  itemWrapper?: (children: ReactNode) => ReactNode;
+}
+
+/**
+ * Shared navigation contents used by both the persistent left-side
+ * `<Sidebar>` (`md:` and up) and the mobile-only Sheet variant in the
+ * navbar. Single source of truth so the link list, admin section, and
+ * account quick-actions stay in sync across both surfaces.
+ */
+const SidebarNav = ({ itemWrapper }: SidebarNavProps) => {
+  const { user, isAuthenticated, logout } = useAuth();
+  const router = useRouter();
+  const isAdmin = user?.roles?.includes("ROLE_ADMIN");
+  const wrap = itemWrapper ?? ((c) => c);
+
+  if (!isAuthenticated || !user) return null;
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-start gap-3 px-4 pt-4 pb-3">
+        <UserAvatar user={user} size="sm" />
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-semibold truncate">{displayName(user)}</p>
+          <p className="text-xs text-muted-foreground truncate">{user.email}</p>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={logout}
+          aria-label="Sign out"
+          title="Sign out"
+          className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive"
+        >
+          <LogOut className="h-4 w-4" />
+        </Button>
+      </div>
+
+      <Separator className="my-2" />
+
+      <nav className="flex flex-col gap-0.5 px-2 pb-4 flex-1 overflow-y-auto">
+        {PERSONAL_NAV_LINKS.map((link) => {
+          const active = router.pathname.startsWith(link.href);
+          return (
+            <span key={link.href}>
+              {wrap(
+                <Button
+                  asChild
+                  variant="ghost"
+                  size="sm"
+                  className={cn(
+                    "justify-start w-full",
+                    active && "bg-accent text-accent-foreground",
+                  )}
+                >
+                  <Link href={link.href}>{link.label}</Link>
+                </Button>,
+              )}
+            </span>
+          );
+        })}
+
+        <Separator className="my-2" />
+
+        {NAV_LINKS.map((link) => {
+          const active = router.pathname.startsWith(link.href);
+          return (
+            <span key={link.href}>
+              {wrap(
+                <Button
+                  asChild
+                  variant="ghost"
+                  size="sm"
+                  className={cn(
+                    "justify-start w-full",
+                    active && "bg-accent text-accent-foreground",
+                  )}
+                >
+                  <Link href={link.href}>{link.label}</Link>
+                </Button>,
+              )}
+            </span>
+          );
+        })}
+
+        {isAdmin && (
+          <>
+            <Separator className="my-2" />
+            <p className="px-3 pb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Admin
+            </p>
+            <span>
+              {wrap(
+                <Button
+                  asChild
+                  variant="ghost"
+                  size="sm"
+                  className={cn(
+                    "justify-start w-full",
+                    router.pathname.startsWith("/admin") &&
+                      "bg-accent text-accent-foreground",
+                  )}
+                >
+                  <Link href="/admin">Admin</Link>
+                </Button>,
+              )}
+            </span>
+            {ADMIN_EXTERNAL_LINKS.map(({ href, label }) => (
+              <Button
+                key={href}
+                asChild
+                variant="ghost"
+                size="sm"
+                className="justify-start w-full"
+              >
+                <a href={href} target="_blank" rel="noopener noreferrer">
+                  {label}
+                </a>
+              </Button>
+            ))}
+          </>
+        )}
+      </nav>
+
+      {/* Sign Out is an action (handler), not a destination — keep it
+          as a button anchored to the bottom of the sidebar so it
+          doesn't blend into the navigation links above. */}
+      <div className="border-t px-3 py-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={logout}
+          className="w-full"
+        >
+          Sign Out
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default SidebarNav;

--- a/pwa/components/common/SidebarNav.tsx
+++ b/pwa/components/common/SidebarNav.tsx
@@ -1,8 +1,9 @@
 import Link from "next/link";
 import { useRouter } from "next/router";
 import type { ReactNode } from "react";
-import { LogOut } from "lucide-react";
+import { Lock, LogOut } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
+import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
 import { displayName } from "@/lib/userDisplay";
 import UserAvatar from "@/components/user/UserAvatar";
 import { Button } from "@/components/ui/button";
@@ -21,14 +22,12 @@ const PERSONAL_NAV_LINKS = [
   { href: "/settings", label: "Settings" },
 ];
 
-const NAV_LINKS = [
-  { href: "/spaces", label: "All Spaces" },
-  { href: "/tasks", label: "Tasks" },
-  { href: "/projects", label: "Projects" },
-  { href: "/discussions", label: "Discussions" },
-  { href: "/pages", label: "Pages" },
-  { href: "/tags", label: "Tags" },
-];
+// The shared section is now a list of accessible spaces (rendered
+// from ActiveSpaceContext at render time, since it's per-user state).
+// "All Spaces" is the only static entry — it's the management
+// surface; each space below is a link to its tabbed detail page
+// (#nav-refresh) which is itself the hub for projects, discussions,
+// pages, and tasks inside that space.
 
 // Backend tooling surfaced inside the PWA chrome. The Mercure debugger
 // is served by Caddy (FrankenPHP), not Next.js, so it's a regular <a>
@@ -53,6 +52,7 @@ interface SidebarNavProps {
  */
 const SidebarNav = ({ itemWrapper }: SidebarNavProps) => {
   const { user, isAuthenticated, logout } = useAuth();
+  const { spaces } = useActiveSpace();
   const router = useRouter();
   const isAdmin = user?.roles?.includes("ROLE_ADMIN");
   const wrap = itemWrapper ?? ((c) => c);
@@ -105,26 +105,61 @@ const SidebarNav = ({ itemWrapper }: SidebarNavProps) => {
 
         <Separator className="my-2" />
 
-        {NAV_LINKS.map((link) => {
-          const active = router.pathname.startsWith(link.href);
-          return (
-            <span key={link.href}>
-              {wrap(
-                <Button
-                  asChild
-                  variant="ghost"
-                  size="sm"
-                  className={cn(
-                    "justify-start w-full",
-                    active && "bg-accent text-accent-foreground",
-                  )}
-                >
-                  <Link href={link.href}>{link.label}</Link>
-                </Button>,
+        {/* All Spaces (management) + a flat list of every space the
+            caller belongs to. Each space link goes to the tabbed
+            detail page where the actual content (projects /
+            discussions / pages / tasks) lives. */}
+        <span>
+          {wrap(
+            <Button
+              asChild
+              variant="ghost"
+              size="sm"
+              className={cn(
+                "justify-start w-full",
+                router.pathname === "/spaces" && "bg-accent text-accent-foreground",
               )}
-            </span>
-          );
-        })}
+            >
+              <Link href="/spaces">All Spaces</Link>
+            </Button>,
+          )}
+        </span>
+
+        {spaces.length > 0 && (
+          <ul className="flex flex-col gap-0.5">
+            {spaces.map((s) => {
+              const href = `/spaces/${s.id}`;
+              const active =
+                router.pathname.startsWith("/spaces/") &&
+                router.query.id === s.id;
+              return (
+                <li key={s["@id"]}>
+                  {wrap(
+                    <Button
+                      asChild
+                      variant="ghost"
+                      size="sm"
+                      className={cn(
+                        "justify-start w-full font-normal",
+                        active && "bg-accent text-accent-foreground",
+                      )}
+                    >
+                      <Link href={href} className="flex items-center gap-1.5">
+                        {s.isPersonal && (
+                          <Lock
+                            className="h-3 w-3 shrink-0 text-muted-foreground"
+                            aria-hidden
+                          />
+                        )}
+                        <span className="truncate">{s.name}</span>
+                      </Link>
+                    </Button>,
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
 
         {isAdmin && (
           <>

--- a/pwa/components/common/SidebarNav.tsx
+++ b/pwa/components/common/SidebarNav.tsx
@@ -61,7 +61,10 @@ const SidebarNav = ({ itemWrapper }: SidebarNavProps) => {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="flex items-start gap-3 px-4 pt-4 pb-3">
+      <div
+        className="flex items-start gap-3 px-4 pt-4 pb-3"
+        data-testid="sidebar-user-header"
+      >
         <UserAvatar user={user} size="sm" />
         <div className="min-w-0 flex-1">
           <p className="text-sm font-semibold truncate">{displayName(user)}</p>

--- a/pwa/components/spaces/SpaceContentTabs.tsx
+++ b/pwa/components/spaces/SpaceContentTabs.tsx
@@ -1,0 +1,407 @@
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+import { ENTRYPOINT } from "@/config/entrypoint";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+
+/**
+ * Inline list tabs for the space detail page: Projects / Discussions /
+ * Pages / Tasks. Each tab independently fetches its own list filtered
+ * by `?space=<iri>` (or `?project.space=` for tasks, which doesn't
+ * carry its own space FK).
+ *
+ * Kept intentionally lean — title + a small meta row + a link out to
+ * the resource's detail page. The top-level aggregators
+ * (/projects, /discussions, /pages, /tasks) remain the place for
+ * filter chips, search, and bulk actions.
+ */
+
+interface SpaceRef {
+  "@id": string;
+  id: string;
+  name: string;
+}
+
+interface Collection<T> {
+  member?: T[];
+  "hydra:member"?: T[];
+}
+
+const listOf = <T,>(c: Collection<T>): T[] =>
+  c.member ?? c["hydra:member"] ?? [];
+
+const RELATIVE = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+const formatRelative = (iso: string): string => {
+  const ts = new Date(iso).getTime();
+  if (Number.isNaN(ts)) return "";
+  const diffSec = Math.round((ts - Date.now()) / 1000);
+  const abs = Math.abs(diffSec);
+  if (abs < 60) return RELATIVE.format(diffSec, "second");
+  if (abs < 3600) return RELATIVE.format(Math.round(diffSec / 60), "minute");
+  if (abs < 86400) return RELATIVE.format(Math.round(diffSec / 3600), "hour");
+  if (abs < 2592000)
+    return RELATIVE.format(Math.round(diffSec / 86400), "day");
+  if (abs < 31536000)
+    return RELATIVE.format(Math.round(diffSec / 2592000), "month");
+  return RELATIVE.format(Math.round(diffSec / 31536000), "year");
+};
+
+/* eslint-disable react-hooks/exhaustive-deps */
+// useFetchOnce is intentionally not memo-dependent on the URL builder;
+// the caller passes a stable identity via `spaceIri`.
+
+interface FetchListOpts {
+  spaceIri: string | null;
+  url: (spaceIri: string) => string;
+  enabled: boolean;
+}
+
+function useFetchList<T>({ spaceIri, url, enabled }: FetchListOpts) {
+  const [items, setItems] = useState<T[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!spaceIri) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(url(spaceIri), {
+        credentials: "include",
+        headers: { Accept: "application/ld+json" },
+      });
+      if (!res.ok) throw new Error("Failed to load.");
+      const data: Collection<T> = await res.json();
+      setItems(listOf(data));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [spaceIri]);
+
+  useEffect(() => {
+    if (enabled && spaceIri) void load();
+  }, [enabled, spaceIri, load]);
+
+  return { items, isLoading, error };
+}
+/* eslint-enable react-hooks/exhaustive-deps */
+
+// ---------------------------------------------------------------------
+// Projects
+// ---------------------------------------------------------------------
+
+interface ProjectRow {
+  "@id": string;
+  id: string;
+  title: string;
+  description: string | null;
+  createdOn: string;
+  owner: { id: string; email: string };
+}
+
+export const SpaceProjectsList = ({ spaceIri, enabled }: { spaceIri: string | null; enabled: boolean }) => {
+  const { items, isLoading, error } = useFetchList<ProjectRow>({
+    spaceIri,
+    enabled,
+    url: (s) =>
+      `${ENTRYPOINT}/projects?space=${encodeURIComponent(s)}&itemsPerPage=100`,
+  });
+
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <AlertDescription>{error}</AlertDescription>
+      </Alert>
+    );
+  }
+  if (isLoading) return <p className="text-muted-foreground text-sm">Loading…</p>;
+  if (items.length === 0) {
+    return (
+      <Card>
+        <CardContent className="pt-6">
+          <p className="text-muted-foreground text-sm">
+            No projects in this space yet.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+  return (
+    <ul className="space-y-2" data-testid="space-projects-list">
+      {items.map((p) => (
+        <li key={p["@id"]} data-testid="space-project-item">
+          <Card>
+            <CardContent className="pt-4 pb-4">
+              <Link
+                href={`/projects/${p.id}`}
+                className="font-semibold text-foreground no-underline hover:underline"
+              >
+                {p.title}
+              </Link>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                {p.owner?.email} · {formatRelative(p.createdOn)}
+              </p>
+              {p.description && (
+                <p className="text-sm text-muted-foreground mt-1 line-clamp-2">
+                  {p.description}
+                </p>
+              )}
+            </CardContent>
+          </Card>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+// ---------------------------------------------------------------------
+// Discussions
+// ---------------------------------------------------------------------
+
+interface DiscussionRow {
+  "@id": string;
+  id: string;
+  title: string;
+  category: string;
+  isPinned: boolean;
+  isLocked: boolean;
+  createdAt: string;
+  updatedAt: string | null;
+  project: { id: string; title: string };
+  author: { id: string; email: string };
+}
+
+export const SpaceDiscussionsList = ({
+  spaceIri,
+  enabled,
+}: {
+  spaceIri: string | null;
+  enabled: boolean;
+}) => {
+  const { items, isLoading, error } = useFetchList<DiscussionRow>({
+    spaceIri,
+    enabled,
+    url: (s) =>
+      `${ENTRYPOINT}/discussions?space=${encodeURIComponent(s)}&itemsPerPage=100`,
+  });
+
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <AlertDescription>{error}</AlertDescription>
+      </Alert>
+    );
+  }
+  if (isLoading) return <p className="text-muted-foreground text-sm">Loading…</p>;
+  if (items.length === 0) {
+    return (
+      <Card>
+        <CardContent className="pt-6">
+          <p className="text-muted-foreground text-sm">
+            No discussions in this space yet.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+  return (
+    <ul className="space-y-2" data-testid="space-discussions-list">
+      {items.map((d) => (
+        <li key={d["@id"]} data-testid="space-discussion-item">
+          <Card>
+            <CardContent className="pt-4 pb-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <Link
+                  href={`/projects/${d.project.id}/discussions/${d.id}`}
+                  className="font-semibold text-foreground no-underline hover:underline"
+                >
+                  {d.title}
+                </Link>
+                {d.isPinned && <Badge variant="secondary">Pinned</Badge>}
+                {d.isLocked && <Badge variant="secondary">Locked</Badge>}
+                <Badge variant="outline" className="capitalize">
+                  {d.category.replace(/-/g, " ")}
+                </Badge>
+              </div>
+              <p className="text-xs text-muted-foreground mt-1">
+                <Link
+                  href={`/projects/${d.project.id}`}
+                  className="hover:underline"
+                >
+                  {d.project.title}
+                </Link>
+                {" · "}
+                {d.author?.email} · {formatRelative(d.createdAt)}
+              </p>
+            </CardContent>
+          </Card>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+// ---------------------------------------------------------------------
+// Pages
+// ---------------------------------------------------------------------
+
+interface PageRow {
+  "@id": string;
+  id: string;
+  title: string;
+  createdAt: string;
+  updatedAt: string | null;
+  parent: string | null;
+  createdBy: { id: string; email: string };
+}
+
+export const SpacePagesList = ({
+  spaceIri,
+  enabled,
+}: {
+  spaceIri: string | null;
+  enabled: boolean;
+}) => {
+  const { items, isLoading, error } = useFetchList<PageRow>({
+    spaceIri,
+    enabled,
+    url: (s) =>
+      `${ENTRYPOINT}/pages?space=${encodeURIComponent(s)}&itemsPerPage=100`,
+  });
+
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <AlertDescription>{error}</AlertDescription>
+      </Alert>
+    );
+  }
+  if (isLoading) return <p className="text-muted-foreground text-sm">Loading…</p>;
+  if (items.length === 0) {
+    return (
+      <Card>
+        <CardContent className="pt-6">
+          <p className="text-muted-foreground text-sm">
+            No pages in this space yet.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+  return (
+    <ul className="space-y-2" data-testid="space-pages-list">
+      {items.map((p) => (
+        <li key={p["@id"]} data-testid="space-page-item">
+          <Card>
+            <CardContent className="pt-4 pb-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <Link
+                  href={`/pages/${p.id}`}
+                  className="font-semibold text-foreground no-underline hover:underline"
+                >
+                  {p.title}
+                </Link>
+                {p.parent && <Badge variant="outline">Sub-page</Badge>}
+              </div>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                {p.createdBy?.email} · {formatRelative(p.createdAt)}
+                {p.updatedAt && " · edited"}
+              </p>
+            </CardContent>
+          </Card>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+// ---------------------------------------------------------------------
+// Tasks
+// ---------------------------------------------------------------------
+
+interface TaskRow {
+  "@id": string;
+  id: string;
+  title: string;
+  createdOn: string;
+  completedOn: string | null;
+  project: { id: string; title: string } | null;
+}
+
+export const SpaceTasksList = ({
+  spaceIri,
+  enabled,
+}: {
+  spaceIri: string | null;
+  enabled: boolean;
+}) => {
+  // Task has no direct space FK; filter by `project.space` (added to
+  // the SearchFilter property list on Task). Excludes standalone
+  // personal tasks (no project) by design — those don't live in any
+  // space.
+  const { items, isLoading, error } = useFetchList<TaskRow>({
+    spaceIri,
+    enabled,
+    url: (s) =>
+      `${ENTRYPOINT}/tasks?project.space=${encodeURIComponent(s)}&itemsPerPage=100`,
+  });
+
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <AlertDescription>{error}</AlertDescription>
+      </Alert>
+    );
+  }
+  if (isLoading) return <p className="text-muted-foreground text-sm">Loading…</p>;
+  if (items.length === 0) {
+    return (
+      <Card>
+        <CardContent className="pt-6">
+          <p className="text-muted-foreground text-sm">
+            No tasks in this space yet.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+  return (
+    <ul className="space-y-1.5" data-testid="space-tasks-list">
+      {items.map((t) => (
+        <li key={t["@id"]} data-testid="space-task-item">
+          <Card>
+            <CardContent className="pt-3 pb-3">
+              <div className="flex items-center gap-2">
+                <span
+                  className={
+                    "font-medium " +
+                    (t.completedOn ? "line-through text-muted-foreground" : "")
+                  }
+                >
+                  {t.title}
+                </span>
+                {t.project && (
+                  <Link
+                    href={`/projects/${t.project.id}`}
+                    className="text-xs text-muted-foreground hover:underline"
+                  >
+                    in {t.project.title}
+                  </Link>
+                )}
+              </div>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                {formatRelative(t.createdOn)}
+                {t.completedOn && " · completed"}
+              </p>
+            </CardContent>
+          </Card>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export type { SpaceRef };

--- a/pwa/pages/spaces/[id].tsx
+++ b/pwa/pages/spaces/[id].tsx
@@ -13,6 +13,21 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  SpaceDiscussionsList,
+  SpacePagesList,
+  SpaceProjectsList,
+  SpaceTasksList,
+} from "@/components/spaces/SpaceContentTabs";
+
+// Tab keys live in the URL (`?tab=...`) so deep links and the
+// browser back-button work naturally. Unknown values fall back to
+// the Overview tab.
+const TABS = ["overview", "projects", "discussions", "pages", "tasks"] as const;
+type TabKey = (typeof TABS)[number];
+const isTabKey = (v: unknown): v is TabKey =>
+  typeof v === "string" && (TABS as readonly string[]).includes(v);
 
 interface PendingInvite {
   id: string;
@@ -48,6 +63,30 @@ const SpaceDetail = () => {
     text: string;
     kind: "success" | "error";
   } | null>(null);
+
+  // Tab state — driven by `?tab=` so the back button works and deep
+  // links land on the chosen tab. Falls back to overview for missing
+  // or unknown values.
+  const queryTab = router.query.tab;
+  const activeTab: TabKey = isTabKey(queryTab) ? queryTab : "overview";
+  const handleTabChange = (value: string) => {
+    if (!isTabKey(value)) return;
+    const nextTab: TabKey = value;
+    // Carry forward everything except the old `tab` value so a
+    // deep-link with extra search params (e.g. a future ?invite=…)
+    // survives the switch.
+    const nextQuery: Record<string, string | string[]> = {};
+    for (const [k, v] of Object.entries(router.query)) {
+      if (k === "tab" || v === undefined) continue;
+      nextQuery[k] = v as string | string[];
+    }
+    if (nextTab !== "overview") nextQuery.tab = nextTab;
+    void router.replace(
+      { pathname: router.pathname, query: nextQuery },
+      undefined,
+      { shallow: true },
+    );
+  };
 
   useEffect(() => {
     if (!authLoading && !isAuthenticated) {
@@ -295,57 +334,73 @@ const SpaceDetail = () => {
                 </Alert>
               )}
 
-              <Card className="mb-6">
-                <CardContent className="pt-6">
-                  <div className="flex items-start justify-between gap-2 mb-3">
-                    <h1 className="text-2xl font-bold">{space.name}</h1>
-                    <div className="flex gap-1">
-                      {space.isPersonal && <Badge variant="secondary">Private</Badge>}
-                      {isAdmin && !space.isPersonal && (
-                        <Badge variant="secondary">Admin</Badge>
-                      )}
-                    </div>
-                  </div>
-
-                  {isAdmin && !space.isPersonal ? (
-                    <form onSubmit={handleSaveMeta} className="space-y-3">
-                      <div className="space-y-1.5">
-                        <Label htmlFor="space-name">Name</Label>
-                        <Input
-                          id="space-name"
-                          type="text"
-                          value={editName}
-                          onChange={(e) => setEditName(e.target.value)}
-                          maxLength={255}
-                        />
-                      </div>
-                      <div className="space-y-1.5">
-                        <Label htmlFor="space-description">Description</Label>
-                        <Input
-                          id="space-description"
-                          type="text"
-                          value={editDescription}
-                          onChange={(e) => setEditDescription(e.target.value)}
-                          maxLength={500}
-                        />
-                      </div>
-                      <Button type="submit" size="sm" disabled={isSavingMeta}>
-                        {isSavingMeta ? "Saving…" : "Save"}
-                      </Button>
-                    </form>
-                  ) : (
-                    space.description && (
-                      <p className="text-sm text-muted-foreground">
-                        {space.description}
-                      </p>
-                    )
+              {/* Space header sits OUTSIDE the tab strip — name + role
+                  badges are global context. Edit-metadata moves into
+                  the Overview tab below. */}
+              <div className="flex items-start justify-between gap-2 mb-4">
+                <h1 className="text-2xl font-bold">{space.name}</h1>
+                <div className="flex gap-1">
+                  {space.isPersonal && <Badge variant="secondary">Private</Badge>}
+                  {isAdmin && !space.isPersonal && (
+                    <Badge variant="secondary">Admin</Badge>
                   )}
-                </CardContent>
-              </Card>
+                </div>
+              </div>
 
-              <Card className="mb-6">
-                <CardContent className="pt-6">
-                  <h2 className="text-lg font-semibold mb-3">Members</h2>
+              <Tabs value={activeTab} onValueChange={handleTabChange}>
+                <TabsList className="mb-4">
+                  <TabsTrigger value="overview">Overview</TabsTrigger>
+                  <TabsTrigger value="projects">Projects</TabsTrigger>
+                  <TabsTrigger value="discussions">Discussions</TabsTrigger>
+                  <TabsTrigger value="pages">Pages</TabsTrigger>
+                  <TabsTrigger value="tasks">Tasks</TabsTrigger>
+                </TabsList>
+
+                <TabsContent value="overview" className="space-y-6 mt-0">
+                  {isAdmin && !space.isPersonal && (
+                    <Card>
+                      <CardContent className="pt-6">
+                        <form onSubmit={handleSaveMeta} className="space-y-3">
+                          <div className="space-y-1.5">
+                            <Label htmlFor="space-name">Name</Label>
+                            <Input
+                              id="space-name"
+                              type="text"
+                              value={editName}
+                              onChange={(e) => setEditName(e.target.value)}
+                              maxLength={255}
+                            />
+                          </div>
+                          <div className="space-y-1.5">
+                            <Label htmlFor="space-description">Description</Label>
+                            <Input
+                              id="space-description"
+                              type="text"
+                              value={editDescription}
+                              onChange={(e) => setEditDescription(e.target.value)}
+                              maxLength={500}
+                            />
+                          </div>
+                          <Button type="submit" size="sm" disabled={isSavingMeta}>
+                            {isSavingMeta ? "Saving…" : "Save"}
+                          </Button>
+                        </form>
+                      </CardContent>
+                    </Card>
+                  )}
+                  {(!isAdmin || space.isPersonal) && space.description && (
+                    <Card>
+                      <CardContent className="pt-6">
+                        <p className="text-sm text-muted-foreground">
+                          {space.description}
+                        </p>
+                      </CardContent>
+                    </Card>
+                  )}
+
+                  <Card>
+                    <CardContent className="pt-6">
+                      <h2 className="text-lg font-semibold mb-3">Members</h2>
                   <ul className="flex flex-wrap items-center gap-1 mb-3" data-testid="space-member-list">
                     {space.userMemberships.map((membership) => {
                       const isSelf = membership.user.id === user.id;
@@ -490,6 +545,36 @@ const SpaceDetail = () => {
                   </CardContent>
                 </Card>
               )}
+                </TabsContent>
+
+                <TabsContent value="projects" className="mt-0">
+                  <SpaceProjectsList
+                    spaceIri={space["@id"]}
+                    enabled={activeTab === "projects"}
+                  />
+                </TabsContent>
+
+                <TabsContent value="discussions" className="mt-0">
+                  <SpaceDiscussionsList
+                    spaceIri={space["@id"]}
+                    enabled={activeTab === "discussions"}
+                  />
+                </TabsContent>
+
+                <TabsContent value="pages" className="mt-0">
+                  <SpacePagesList
+                    spaceIri={space["@id"]}
+                    enabled={activeTab === "pages"}
+                  />
+                </TabsContent>
+
+                <TabsContent value="tasks" className="mt-0">
+                  <SpaceTasksList
+                    spaceIri={space["@id"]}
+                    enabled={activeTab === "tasks"}
+                  />
+                </TabsContent>
+              </Tabs>
             </>
           )}
         </div>


### PR DESCRIPTION
## Summary
Reworks the PWA navigation around two ideas:

1. **The sidebar is always out when signed in.** A persistent left-anchored `<aside>` on `md:` and up, with the existing hamburger Sheet kept as a mobile fallback. Marketing/auth screens stay unchanged.
2. **Spaces are the hub.** The space detail page (`/spaces/{id}`) now carries tabs for everything inside it — Overview (existing management UI), Projects, Discussions, Pages, Tasks — so the sidebar can collapse its "shared content" section down to a flat list of every space the caller belongs to instead of duplicating those top-level aggregator links.

### Sidebar layout

- **Personal** (top): My Tasks, Groups, My Account, Settings.
- **Shared**: All Spaces, then one row per accessible space (Lock icon on personal spaces, active-highlight follows `router.query.id` so it stays selected across the per-space tabs).
- **Admin** (admin-only): Admin link + Mercure debugger.
- **Footer**: outline Sign Out button (plus a small LogOut icon next to the avatar in the header so it's always visible regardless of viewport height).

### Space detail tabs

- **Overview** keeps all the management surfaces (edit metadata / members + groups / pending invites / danger zone). Name + role badges lifted above the tab strip.
- **Projects / Discussions / Pages / Tasks** are inline lightweight lists filtered by `?space=<iri>` (or `?project.space=<iri>` for tasks). Each row links to the resource's existing detail page; the top-level aggregators (`/projects`, `/discussions`, etc.) still own search + bulk actions.
- Tab state lives in `?tab=` so deep links and the back button work; unknown values fall back to Overview.

### Backend
One small change: add `project.space` to Task's `SearchFilter` properties so the Tasks tab can do a single query instead of per-project fan-out. Access scoping still flows through `TaskOwnerExtension` + `SpaceMembershipDql`.

### Stack stability (paired with PR #202)
Bumped the dev healthcheck retries to 20 with a 15s interval so Docker Desktop on Windows can ride out the transient WSL2 networking flaps after sleep/hibernate without flipping containers to unhealthy. Pairs with `scripts/watch-port-forward.sh` from PR #202 which deals with the actual port-forward bridge breaks.

## Test plan
- [ ] `pnpm tsc --noEmit` clean, `pnpm lint` no new warnings.
- [ ] `bin/phpunit` green (only change is the SearchFilter property, no test impact expected).
- [ ] Sign in → sidebar persistent on a wide window; all the expected links highlight correctly as you click around.
- [ ] Resize to mobile → sidebar disappears, hamburger triggers the Sheet, same nav contents inside.
- [ ] Open `/spaces/{id}` → switch through each tab; URL gains `?tab=...`; back button cycles them in order.
- [ ] Tabs that are empty show the "no X in this space yet" copy.
- [ ] Tabs that have content link out to the existing detail pages correctly.
- [ ] Cross-space: switch active space via the navbar SpaceSwitcher → sidebar row highlight updates.