### PR TITLE
test: redirect coverage for every authed page (#201)

### DIFF
--- a/e2e/tests/auth-redirect.spec.js
+++ b/e2e/tests/auth-redirect.spec.js
@@ -2,7 +2,55 @@
 const { test, expect } = require("@playwright/test");
 const { BASE_URL, uniqueEmail } = require("./helpers");
 
+// Stand-in for a route-param value on detail pages. Pages mount and
+// fire their auth check before any data fetch resolves, so the
+// redirect happens whether or not the ID is real.
+const PLACEHOLDER_UUID = "00000000-0000-0000-0000-000000000000";
+
+// Every authed route the PWA exposes (#201). If a new authed page is
+// added without a redirect guard the parameterised test below will
+// fail on it. Pages with route params use PLACEHOLDER_UUID; the auth
+// check runs before any fetch, so a non-existent ID is fine.
+const AUTHED_PATHS = [
+  "/account",
+  "/settings",
+  "/admin",
+  "/my-tasks",
+  "/tasks",
+  "/projects",
+  `/projects/${PLACEHOLDER_UUID}`,
+  `/projects/${PLACEHOLDER_UUID}/custom-fields`,
+  `/projects/${PLACEHOLDER_UUID}/discussions`,
+  `/projects/${PLACEHOLDER_UUID}/discussions/${PLACEHOLDER_UUID}`,
+  "/discussions",
+  "/pages",
+  `/pages/${PLACEHOLDER_UUID}`,
+  "/spaces",
+  `/spaces/${PLACEHOLDER_UUID}`,
+  "/groups",
+  `/groups/${PLACEHOLDER_UUID}`,
+  "/tags",
+  "/search",
+];
+
 test.describe("Auth redirect", () => {
+  for (const path of AUTHED_PATHS) {
+    test(`unauthenticated visit to ${path} redirects to /signin`, async ({
+      page,
+    }) => {
+      await page.goto(`${BASE_URL}${path}`);
+      // Lands on /signin and preserves the original path on ?next so a
+      // subsequent sign-in can bounce the user back. The encoded value
+      // can differ slightly (slashes, query, etc.), so we just check
+      // for the path fragment inside the encoded next param.
+      await expect(page).toHaveURL(/\/signin/);
+      const url = new URL(page.url());
+      const next = url.searchParams.get("next");
+      expect(next, `?next missing for ${path}`).toBeTruthy();
+      expect(next, `?next mismatched for ${path}`).toBe(path);
+    });
+  }
+
   test("unauthenticated visit to a restricted page lands on /signin with ?next, then comes back after login", async ({
     page,
     request,


### PR DESCRIPTION
## Summary
Closes #201.

Every authed page in the PWA already wires `signinHrefForCurrent(router.asPath)` into a `useEffect` so an unauthenticated visitor gets bounced to `/signin?next=<path>`. The original report on #201 described stuck-on-Loading / broken-authed-shell behaviour, which I couldn't reproduce in the browser — but only 5 of ~17 authed pages had a dedicated redirect test, so nothing was stopping a future page from regressing.

This PR adds a single parameterised `auth-redirect.spec.js` block that walks every authed route (top-level pages + detail pages with placeholder UUIDs) and asserts:
1. The unauthed visit lands on `/signin`.
2. The original path is preserved on `?next` so post-login bounces back.

Detail pages use `00000000-0000-0000-0000-000000000000` because the auth check fires before any data fetch resolves — the redirect doesn't depend on whether the ID is real.

If any page in the list ever stops redirecting (or someone adds a new authed page without the guard), CI will fail on it specifically.

## Test plan
- [ ] `npx playwright test auth-redirect.spec.js --project=chromium` runs every parameterised case green.
- [ ] Smoke in incognito: visit each path from `AUTHED_PATHS`; expect bounce to `/signin?next=<the-path>`; sign in; land back on the original path.