### PR TITLE
fix: drop stale loadData responses that overwrite optimistic state (#205)

### DIFF
--- a/pwa/pages/tasks.tsx
+++ b/pwa/pages/tasks.tsx
@@ -1407,6 +1407,22 @@ const Tasks = () => {
     : "";
 
   const loadData = useCallback(async (signal?: AbortSignal) => {
+    // Snapshot tasks-state identity at the start of the fan-out. If
+    // anything mutates `tasks` between now and when our response lands
+    // (a handleToggle / handleCreate / etc. firing optimistically),
+    // the reference will change and we drop the response on the floor
+    // — otherwise the late server snapshot stomps the user's
+    // optimistic edit back to whatever was committed when the GET was
+    // issued. This is the root cause of the long-running uncheck flake
+    // (#205): debug logs showed two `loadData` responses landing
+    // *after* the optimistic uncomplete, each overwriting tasks state.
+    // AbortController on the effect (#193) catches one source but
+    // can't catch races where the loadData was already past the
+    // signal check, and the trace in #205 shows additional loadData
+    // calls with no matching effect-mount log — covering whatever the
+    // additional source is, this guard makes the responses safe to
+    // arrive late.
+    const tasksSnapshot = tasksRef.current;
     setError(null);
     try {
       // Tasks, tags, the assignable-users universe, and the projects-with-
@@ -1458,12 +1474,21 @@ const Tasks = () => {
         console.warn("[loadData:aborted-after-parse]");
         return;
       }
-      const _loaded = tasksData.member ?? tasksData["hydra:member"] ?? [];
-      console.warn(
-        "[loadData:setTasks]",
-        _loaded.map((t: Task) => `${t.title}=${t.completedOn ? "DONE" : "OPEN"}`).join(","),
-      );
-      setTasks(_loaded);
+      // Identity guard — see comment at the top of this callback. If a
+      // local mutation slipped in while we were waiting, dropping our
+      // tasks-stomp is the right move; the tag / assignable-user /
+      // project-member lists below are still safe to refresh since
+      // none of them carry optimistic UI state.
+      if (tasksRef.current !== tasksSnapshot) {
+        console.warn("[loadData:stale-snapshot-skipped-setTasks]");
+      } else {
+        const _loaded = tasksData.member ?? tasksData["hydra:member"] ?? [];
+        console.warn(
+          "[loadData:setTasks]",
+          _loaded.map((t: Task) => `${t.title}=${t.completedOn ? "DONE" : "OPEN"}`).join(","),
+        );
+        setTasks(_loaded);
+      }
       setAllTags(tagsData.member ?? tagsData["hydra:member"] ?? []);
       setAssignableUsers(
         assignablesData.member ?? assignablesData["hydra:member"] ?? [],


### PR DESCRIPTION
## Summary
Closes #205. Fixes the long-running `tests/tasks.spec.js:18 'Buy groceries uncheck'` flake that's been hitting CI on PRs #198, #200, #202, #203, and #204.

## Root cause
The existing debug logs in `pwa/pages/tasks.tsx` captured a clean reproduction in a recent failing run. Trace excerpt:

```
[tasks:state] 1 Buy groceries=OPEN          (create succeeded)
[tasks:state] 1 Buy groceries=DONE          (toggle complete — correct)
[tasks:state] 1 Buy groceries=OPEN          (toggle uncomplete — correct)
[loadData:setTasks] Buy groceries=DONE      ← LATE fetch lands with pre-PATCH snapshot
[tasks:state] 1 Buy groceries=DONE          ← optimistic state stomped
[loadData:setTasks]                         ← another LATE fetch with empty
[tasks:state] 0                             ← state cleared
```

Two `loadData` responses arrived *after* the optimistic uncomplete and overwrote it. The `AbortController` from #193 catches the StrictMode mount/cleanup race but not whatever's firing the additional loadData calls in CI — and chasing every possible source is whack-a-mole.

## Fix
Snapshot `tasksRef.current` at the start of `loadData`. When the fan-out's responses come back, if the ref no longer points at the same array, drop the `setTasks` call. Any local mutation (create / toggle / title / due-date / etc.) produces a new array reference, so this identity check reliably guards against every late-overwrite source.

The other state fields (`allTags`, `assignableUsers`, `projectMembers`) keep refreshing since they carry no optimistic UI state.

This is the third pass at the same flake — #193 added the abort path, an earlier attempt tried a merge-back-from-PATCH-response (per the in-code comment around line 1613). The snapshot guard is the catch-all that doesn't depend on identifying the source.

## Test plan
- [ ] `npx playwright test tasks.spec.js --project=chromium` runs the full file green (especially the create/complete/uncomplete/delete test).
- [ ] Watch CI on this PR — should clear the persistent flake. The diagnostic logs (`[tasks:state]`, `[loadData:*]`) stay in place; they're cheap and would be the first signal if a related regression appears later.
- [ ] After this lands, the per-page `console.warn` diagnostics can be removed in a follow-up cleanup if the fix proves stable.