### PR TITLE
feat: project copy with opt-in discussion clone (#182 deep-copy)

### DIFF
--- a/api/src/Controller/ProjectCopyController.php
+++ b/api/src/Controller/ProjectCopyController.php
@@ -3,6 +3,7 @@
 namespace App\Controller;
 
 use App\Entity\CustomFieldDefinition;
+use App\Entity\Discussion;
 use App\Entity\Project;
 use App\Entity\Space;
 use App\Entity\Tag;
@@ -30,8 +31,8 @@ use Symfony\Component\Uid\Uuid;
  *    primary thing copy buys you.
  *  - The clone's `createdBy` is the current user — not the source's
  *    owner. Fresh audit history.
- *  - Discussions, attachments, and comments are NOT copied (each is
- *    its own thing with per-row authorship + conversational state).
+ *  - Attachments are NOT copied (per-row authorship + binary storage
+ *    that doesn't transplant cleanly).
  *  - Tasks: opt-in via `includeTasks: true` on the body. When opted in,
  *    each task is cloned with title + description + dueDate +
  *    recurrenceRule + position + tags (only tags the caller owns).
@@ -39,6 +40,13 @@ use Symfony\Component\Uid\Uuid;
  *    custom field values are deliberately dropped — those are
  *    user-specific state, and CFV would need an old-CFD→new-CFD
  *    mapping that's a heavier slice on its own.
+ *  - Discussions: opt-in via `includeDiscussions: true`. Each
+ *    discussion thread is cloned with title + body + category; the
+ *    clone's `author` is the caller (fresh audit history). `isPinned`
+ *    and `isLocked` reset to false — those are moderation state tied
+ *    to the source thread, not to the content. Mirrors the v1 scope
+ *    of {@see DiscussionCopyController}; discussions don't have a
+ *    comments model so there's nothing else to carry.
  *
  * Auth bar: caller must be able to read the source (membership in
  * its space) AND be a member of the target space. Target defaults
@@ -159,6 +167,30 @@ class ProjectCopyController extends AbstractController
             }
         }
 
+        // Optional discussion clone (#182 deep-copy). Opt-in via
+        // `includeDiscussions: true`. Each thread's title + body +
+        // category move over; the clone's author is the caller so the
+        // audit history starts fresh, and pin/lock reset to false
+        // because they're moderation state tied to the source thread,
+        // not properties of the content itself. Same v1 scope as
+        // DiscussionCopyController.
+        $discussionsCloned = 0;
+        if (true === ($payload['includeDiscussions'] ?? false)) {
+            $sourceDiscussions = $this->em->getRepository(Discussion::class)
+                ->findBy(['project' => $source], ['createdAt' => 'ASC']);
+            foreach ($sourceDiscussions as $sourceDiscussion) {
+                $cloneDiscussion = (new Discussion())
+                    ->setProject($copy)
+                    ->setSpace($target)
+                    ->setAuthor($user)
+                    ->setTitle($sourceDiscussion->getTitle())
+                    ->setBody($sourceDiscussion->getBody())
+                    ->setCategory($sourceDiscussion->getCategory());
+                $this->em->persist($cloneDiscussion);
+                ++$discussionsCloned;
+            }
+        }
+
         $this->em->flush();
 
         return $this->json([
@@ -167,6 +199,7 @@ class ProjectCopyController extends AbstractController
             'title' => $copy->getTitle(),
             'space' => '/spaces/' . $target->getId(),
             'tasksCloned' => $tasksCloned,
+            'discussionsCloned' => $discussionsCloned,
         ], 201);
     }
 

--- a/api/tests/Api/ProjectCopyTest.php
+++ b/api/tests/Api/ProjectCopyTest.php
@@ -4,6 +4,7 @@ namespace App\Tests\Api;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use App\Entity\CustomFieldDefinition;
+use App\Entity\Discussion;
 use App\Entity\Project;
 use App\Entity\Space;
 use App\Entity\SpaceMembership;
@@ -32,6 +33,7 @@ class ProjectCopyTest extends ApiTestCase
 
         $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Tag')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Discussion')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\CustomFieldDefinition')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Space')->execute();
@@ -344,6 +346,160 @@ class ProjectCopyTest extends ApiTestCase
             ->findBy(['project' => $copyId], ['position' => 'ASC']);
         $titlesByPosition = array_map(fn (Task $t) => $t->getTitle(), $cloned);
         $this->assertSame(['A', 'B', 'C'], $titlesByPosition);
+    }
+
+    public function testIncludeDiscussionsFalseLeavesThreadsOnSourceOnly(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $source = $this->createSpace($alice, 'Source');
+        $project = $this->createProject($alice, 'Backend', $source);
+        $this->seedDiscussion($alice, $project, 'Kickoff', 'Welcome');
+        $this->seedDiscussion($alice, $project, 'RFC: API shape', 'Should we…');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/projects/' . $project->getId() . '/copy', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertSame(0, $client->getResponse()->toArray()['discussionsCloned']);
+
+        $this->entityManager->clear();
+        $copyId = $client->getResponse()->toArray()['id'];
+        $cloneDiscussions = $this->entityManager->getRepository(Discussion::class)
+            ->findBy(['project' => $copyId]);
+        $this->assertCount(0, $cloneDiscussions);
+
+        // Source's threads untouched.
+        $sourceDiscussions = $this->entityManager->getRepository(Discussion::class)
+            ->findBy(['project' => $project]);
+        $this->assertCount(2, $sourceDiscussions);
+    }
+
+    public function testIncludeDiscussionsClonesContentAndCategory(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $source = $this->createSpace($alice, 'Source');
+        $project = $this->createProject($alice, 'Backend', $source);
+        $thread = $this->seedDiscussion(
+            $alice,
+            $project,
+            'Naming bikeshed',
+            'Let us argue forever.',
+            Discussion::CATEGORY_IDEAS,
+        );
+        // Source thread is pinned + locked — those should NOT carry
+        // (they're moderation state, not content).
+        $thread->setIsPinned(true);
+        $thread->setIsLocked(true);
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/projects/' . $project->getId() . '/copy', [
+            'json' => ['includeDiscussions' => true],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertSame(1, $client->getResponse()->toArray()['discussionsCloned']);
+
+        $this->entityManager->clear();
+        $copyId = $client->getResponse()->toArray()['id'];
+        /** @var Discussion[] $cloned */
+        $cloned = $this->entityManager->getRepository(Discussion::class)
+            ->findBy(['project' => $copyId]);
+        $this->assertCount(1, $cloned);
+        $this->assertSame('Naming bikeshed', $cloned[0]->getTitle());
+        $this->assertSame('Let us argue forever.', $cloned[0]->getBody());
+        $this->assertSame(Discussion::CATEGORY_IDEAS, $cloned[0]->getCategory());
+        $this->assertFalse($cloned[0]->isPinned(), 'Clone resets pin state.');
+        $this->assertFalse($cloned[0]->isLocked(), 'Clone resets lock state.');
+    }
+
+    public function testIncludeDiscussionsAuthorIsCallerNotSourceAuthor(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $source = $this->createSpace($alice, 'Shared');
+        $this->ensureSpaceMembership($source, $bob);
+        $project = $this->createProject($alice, 'P', $source);
+        $this->seedDiscussion($alice, $project, 'Aliceʼs thread', 'Posted by Alice.');
+
+        // Bob copies — clone's discussion author should be Bob.
+        $client = static::createClient();
+        $client->loginUser($bob);
+        $client->request('POST', '/projects/' . $project->getId() . '/copy', [
+            'json' => ['includeDiscussions' => true],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+
+        $this->entityManager->clear();
+        $copyId = $client->getResponse()->toArray()['id'];
+        /** @var Discussion[] $cloned */
+        $cloned = $this->entityManager->getRepository(Discussion::class)
+            ->findBy(['project' => $copyId]);
+        $this->assertCount(1, $cloned);
+        $this->assertSame(
+            (string) $bob->getId(),
+            (string) $cloned[0]->getAuthor()->getId(),
+            'Clone thread author = caller (fresh audit history).',
+        );
+    }
+
+    public function testIncludeDiscussionsCarriesIntoOtherSpace(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $source = $this->createSpace($alice, 'Source');
+        $target = $this->createSpace($alice, 'Target');
+        $project = $this->createProject($alice, 'P', $source);
+        $this->seedDiscussion($alice, $project, 'A', 'a');
+        $this->seedDiscussion($alice, $project, 'B', 'b');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/projects/' . $project->getId() . '/copy', [
+            'json' => [
+                'space' => '/spaces/' . $target->getId(),
+                'includeDiscussions' => true,
+            ],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertSame(2, $client->getResponse()->toArray()['discussionsCloned']);
+
+        $this->entityManager->clear();
+        $copyId = $client->getResponse()->toArray()['id'];
+        /** @var Discussion[] $cloned */
+        $cloned = $this->entityManager->getRepository(Discussion::class)
+            ->findBy(['project' => $copyId]);
+        $this->assertCount(2, $cloned);
+        foreach ($cloned as $thread) {
+            $this->assertSame(
+                (string) $target->getId(),
+                (string) $thread->getSpace()->getId(),
+                'Cloned thread\'s denormalised space follows the target project\'s space.',
+            );
+        }
+    }
+
+    private function seedDiscussion(
+        User $author,
+        Project $project,
+        string $title,
+        string $body,
+        string $category = Discussion::CATEGORY_GENERAL,
+    ): Discussion {
+        $discussion = new Discussion();
+        $discussion->setProject($project);
+        $discussion->setAuthor($author);
+        $discussion->setTitle($title);
+        $discussion->setBody($body);
+        $discussion->setCategory($category);
+        $this->entityManager->persist($discussion);
+        $this->entityManager->flush();
+        return $discussion;
     }
 
     /**

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -113,6 +113,9 @@ const ProjectDetail = () => {
   // Opt-in deep-copy: when true, the POST body asks the server to
   // also clone the project's tasks (#182 deep-copy slice).
   const [copyIncludeTasks, setCopyIncludeTasks] = useState(false);
+  // Opt-in deep-copy: also clone the project's discussion threads
+  // (#182 deep-copy slice).
+  const [copyIncludeDiscussions, setCopyIncludeDiscussions] = useState(false);
 
   useEffect(() => {
     if (!authLoading && !isAuthenticated) {
@@ -296,10 +299,16 @@ const ProjectDetail = () => {
     try {
       // Empty body = clone into the source's own space; specifying a
       // target uses the picker's current selection. The server accepts
-      // both shapes. `includeTasks` is opt-in deep-copy.
-      const body: { space?: string; includeTasks?: boolean } = {};
+      // both shapes. `includeTasks` / `includeDiscussions` are opt-in
+      // deep-copy flags.
+      const body: {
+        space?: string;
+        includeTasks?: boolean;
+        includeDiscussions?: boolean;
+      } = {};
       if (moveTargetIri) body.space = moveTargetIri;
       if (copyIncludeTasks) body.includeTasks = true;
+      if (copyIncludeDiscussions) body.includeDiscussions = true;
       const res = await fetch(
         `${ENTRYPOINT}/projects/${encodeURIComponent(project.id)}/copy`,
         {
@@ -494,6 +503,21 @@ const ProjectDetail = () => {
                             data-testid="project-copy-include-tasks"
                           />
                           include tasks
+                        </label>
+                        <label
+                          className="flex items-center gap-1.5 text-xs text-muted-foreground select-none"
+                          data-testid="project-copy-include-discussions-label"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={copyIncludeDiscussions}
+                            onChange={(e) =>
+                              setCopyIncludeDiscussions(e.target.checked)
+                            }
+                            className="h-3.5 w-3.5"
+                            data-testid="project-copy-include-discussions"
+                          />
+                          include discussions
                         </label>
                         {moveMessage && (
                           <span


### PR DESCRIPTION
## Summary
- PR 3/3 of the #182 deep-copy series. Adds an opt-in `includeDiscussions: true` body flag to `POST /projects/{id}/copy` that clones each discussion thread (title + body + category) into the new project.
- Author becomes the caller (fresh audit history). `isPinned` / `isLocked` reset to false because those are moderation state tied to the source thread, not properties of the content.
- Response payload gains a `discussionsCloned` count alongside `tasksCloned`.
- PWA gains an "include discussions" checkbox next to "include tasks" on the project detail's Copy affordance.

### Why pivot from "discussion copy with comments"?
While building this slice I discovered discussions don't actually have a comments model — `Comment.php` is for tasks, `PageComment.php` is for pages. The aspirational "Comments NOT copied" note in `DiscussionCopyController`'s docstring referred to something that doesn't exist. Since the #182 spirit is "deep-copy variants for the move/copy verbs", I pivoted PR 3/3 to a project-level deep-copy of discussions — completing the project copy story as `project + CFDs + tasks + discussions`.

## Stacking
This PR is based on `feature/copy-project-with-tasks` (PR 212) since both extend `ProjectCopyController`. Once PR 212 merges, GitHub will retarget this to `main` automatically.

## Test plan
- [x] `bin/phpunit tests/Api/ProjectCopyTest.php` — 17 tests passing (13 existing + 4 new for `includeDiscussions`)
- [x] `pnpm lint` clean
- [ ] E2E unaffected (the new checkbox is opt-in and has its own test-id)

## Tests added
- `testIncludeDiscussionsFalseLeavesThreadsOnSourceOnly` — default behavior unchanged
- `testIncludeDiscussionsClonesContentAndCategory` — title/body/category carry over, pin/lock reset
- `testIncludeDiscussionsAuthorIsCallerNotSourceAuthor` — fresh audit history
- `testIncludeDiscussionsCarriesIntoOtherSpace` — denormalised `space` follows target project

Closes the deep-copy slice for #182 (3/3).