### PR TITLE
docs(pwa): dev pages for common/ layout components + watch-port-forward.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,9 @@ docker compose up -d
 ```
 Linked worktrees get ports in the 20000+ range; the main checkout keeps default ports. See `docs/deployment.md` for details.
 
+### Docker Desktop port flaps (Windows)
+Docker Desktop occasionally stops forwarding host → WSL2 ports after sleep/hibernate; containers stay healthy but `https://localhost` hangs from the host. Run `scripts/watch-port-forward.sh` in a side terminal — it polls the host URL and restarts the `php` container when the forward dies, which rebuilds the bridge. Tunables via env vars (`WATCH_URL`, `WATCH_SERVICE`, `POLL_INTERVAL`, `FAIL_THRESHOLD`, `PROBE_TIMEOUT`, `COOLDOWN`); see the script header.
+
 ### API Development
 ```bash
 cd api

--- a/pwa/components/dev/registry.ts
+++ b/pwa/components/dev/registry.ts
@@ -9,6 +9,7 @@ export type RegistryEntry = {
     | "Editor"
     | "User"
     | "Theme"
+    | "Layout"
     | "Discussions"
     | "Custom fields";
   description: string;
@@ -40,6 +41,12 @@ export const componentRegistry: RegistryEntry[] = [
   { slug: "markdown-editor", name: "MarkdownEditor", category: "Editor", description: "BlockNote-backed WYSIWYG markdown editor." },
   { slug: "markdown-view", name: "MarkdownView", category: "Editor", description: "Read-only markdown renderer." },
   { slug: "user-avatar", name: "UserAvatar", category: "User", description: "Avatar with image fallback to personalized initials." },
+  { slug: "layout", name: "Layout", category: "Layout", description: "App-shell wrapper: providers + persistent Navbar and Sidebar." },
+  { slug: "navbar", name: "Navbar", category: "Layout", description: "Top app bar with wordmark, search, badges, theme toggle, and mobile sheet." },
+  { slug: "sidebar", name: "Sidebar", category: "Layout", description: "Persistent left navigation column (md and up, authenticated only)." },
+  { slug: "sidebar-nav", name: "SidebarNav", category: "Layout", description: "Shared nav contents used by the persistent sidebar and the mobile sheet." },
+  { slug: "search-bar", name: "SearchBar", category: "Layout", description: "Navbar task search with debounced autocomplete and ⌘K focus." },
+  { slug: "space-switcher", name: "SpaceSwitcher", category: "Layout", description: "Active-space dropdown that persists the choice via ActiveSpaceContext." },
   { slug: "discussions-panel", name: "DiscussionsPanel", category: "Discussions", description: "Project discussion board with list, filter, create, edit, pin/lock." },
   { slug: "custom-fields-manager", name: "CustomFieldsManager", category: "Custom fields", description: "Owner-managed list + composer for per-project custom field definitions." },
   { slug: "theme-toggle", name: "ThemeToggle", category: "Theme", description: "Dark/light/system theme switcher." },

--- a/pwa/pages/dev/components/index.tsx
+++ b/pwa/pages/dev/components/index.tsx
@@ -12,6 +12,7 @@ const categories = [
   "Editor",
   "User",
   "Theme",
+  "Layout",
   "Discussions",
   "Custom fields",
 ] as const;

--- a/pwa/pages/dev/components/layout.tsx
+++ b/pwa/pages/dev/components/layout.tsx
@@ -1,0 +1,31 @@
+import Layout from "@/components/common/Layout";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const LayoutPage = () => (
+  <ComponentDoc
+    name="Layout"
+    description="App-shell wrapper used by _app.tsx. Mounts ThemeProvider, QueryClientProvider, HydrationBoundary, AuthProvider, and ActiveSpaceProvider, then renders the persistent Navbar + Sidebar around page content. Sidebar collapses to nothing for unauthenticated visitors so marketing and auth screens keep their full-width chrome."
+    importPath={`import Layout from "@/components/common/Layout";`}
+    examples={[
+      {
+        title: "Wrapping the app",
+        code: `// pages/_app.tsx
+<Layout dehydratedState={pageProps.dehydratedState}>
+  <Component {...pageProps} />
+</Layout>`,
+        preview: (
+          <p className="text-sm text-muted-foreground">
+            Mounted once at the top of <code className="mx-1">_app.tsx</code>.
+            Previewing live here would nest a second Layout (with its own
+            providers, navbar, and sidebar) inside the existing one — keep the
+            example as a code snippet only.
+          </p>
+        ),
+      },
+    ]}
+  />
+);
+
+void Layout;
+
+export default LayoutPage;

--- a/pwa/pages/dev/components/navbar.tsx
+++ b/pwa/pages/dev/components/navbar.tsx
@@ -1,0 +1,28 @@
+import Navbar from "@/components/common/Navbar";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const NavbarPage = () => (
+  <ComponentDoc
+    name="Navbar"
+    description="Top app bar: Aura wordmark + Docs dropdown on the left, SearchBar in the middle (auth-only), OverdueBadge + NotificationBell + ThemeToggle on the right, and a mobile Sheet trigger that mounts SidebarNav inside a slide-over. Signed-out visitors see Sign In / Sign Up buttons instead of the badges and bell."
+    importPath={`import Navbar from "@/components/common/Navbar";`}
+    examples={[
+      {
+        title: "Rendered by Layout",
+        code: `// components/common/Layout.tsx
+<Navbar />`,
+        preview: (
+          <p className="text-sm text-muted-foreground">
+            Mounted once by <code className="mx-1">Layout</code>. Previewing live
+            here would render a second navbar below the real one — keep the
+            example as a code snippet only.
+          </p>
+        ),
+      },
+    ]}
+  />
+);
+
+void Navbar;
+
+export default NavbarPage;

--- a/pwa/pages/dev/components/search-bar.tsx
+++ b/pwa/pages/dev/components/search-bar.tsx
@@ -1,0 +1,30 @@
+import SearchBar from "@/components/common/SearchBar";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const SearchBarPage = () => (
+  <ComponentDoc
+    name="SearchBar"
+    description="Always-visible task search input mounted in the navbar with a debounced live autocomplete dropdown (max 6 hits). Submitting Enter or clicking 'View all results' navigates to /search; clicking a single result jumps there with the result's IRI in the hash so the page can scroll/highlight it in context. ⌘/Ctrl+K focuses the input from anywhere in the app. Pre-fills from ?q= and the legacy ?search= so deep links feel continuous."
+    importPath={`import SearchBar from "@/components/common/SearchBar";`}
+    examples={[
+      {
+        title: "Default (in navbar)",
+        code: `<SearchBar className="flex-1 min-w-0 max-w-3xl" />`,
+        preview: (
+          <p className="text-sm text-muted-foreground">
+            Mounted by <code className="mx-1">Navbar</code> for authenticated
+            users. The bar is already visible at the top of this page — try{" "}
+            <kbd className="rounded border bg-muted px-1.5 py-0.5 text-xs">
+              ⌘K
+            </kbd>{" "}
+            to focus it.
+          </p>
+        ),
+      },
+    ]}
+  />
+);
+
+void SearchBar;
+
+export default SearchBarPage;

--- a/pwa/pages/dev/components/sidebar-nav.tsx
+++ b/pwa/pages/dev/components/sidebar-nav.tsx
@@ -1,0 +1,43 @@
+import SidebarNav from "@/components/common/SidebarNav";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const SidebarNavPage = () => (
+  <ComponentDoc
+    name="SidebarNav"
+    description="Shared navigation surface used by both the persistent Sidebar (md and up) and the mobile Sheet variant in the Navbar. Renders the signed-in user header, personal links (My Tasks, Groups, Account, Settings), the active-space list (with a lock icon for personal spaces), an Admin section for ROLE_ADMIN users, and a Sign Out button anchored to the bottom."
+    importPath={`import SidebarNav from "@/components/common/SidebarNav";`}
+    examples={[
+      {
+        title: "Persistent sidebar (default)",
+        code: `<SidebarNav />`,
+        preview: (
+          <p className="text-sm text-muted-foreground">
+            Reads from AuthContext and ActiveSpaceContext — renders nothing
+            until the visitor is signed in. Visible inside the real Sidebar on
+            the left of this page.
+          </p>
+        ),
+      },
+      {
+        title: "Mobile Sheet variant",
+        description:
+          "The Navbar's mobile menu wraps each link in a SheetClose so tapping a destination auto-dismisses the slide-over.",
+        code: `<SidebarNav
+  itemWrapper={(child) => (
+    <SheetClose asChild>{child}</SheetClose>
+  )}
+/>`,
+        preview: (
+          <p className="text-sm text-muted-foreground">
+            Used inside the navbar's mobile <code className="mx-1">Sheet</code>{" "}
+            (below the md breakpoint).
+          </p>
+        ),
+      },
+    ]}
+  />
+);
+
+void SidebarNav;
+
+export default SidebarNavPage;

--- a/pwa/pages/dev/components/sidebar.tsx
+++ b/pwa/pages/dev/components/sidebar.tsx
@@ -1,0 +1,31 @@
+import Sidebar from "@/components/common/Sidebar";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const SidebarPage = () => (
+  <ComponentDoc
+    name="Sidebar"
+    description="Persistent left-side navigation rendered by Layout at md and up. Wraps SidebarNav in a sticky 240px-wide column. Renders nothing when the visitor isn't authenticated — public marketing and auth screens keep their original full-width chrome."
+    importPath={`import Sidebar from "@/components/common/Sidebar";`}
+    examples={[
+      {
+        title: "Rendered by Layout",
+        code: `// components/common/Layout.tsx
+<div className="flex">
+  <Sidebar />
+  <div className="flex-1 min-w-0">{children}</div>
+</div>`,
+        preview: (
+          <p className="text-sm text-muted-foreground">
+            Mounted once by <code className="mx-1">Layout</code> and visible on
+            the left of this very page (md and up). Previewing live would
+            duplicate the active-page sidebar inside itself.
+          </p>
+        ),
+      },
+    ]}
+  />
+);
+
+void Sidebar;
+
+export default SidebarPage;

--- a/pwa/pages/dev/components/space-switcher.tsx
+++ b/pwa/pages/dev/components/space-switcher.tsx
@@ -1,0 +1,27 @@
+import SpaceSwitcher from "@/components/common/SpaceSwitcher";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const SpaceSwitcherPage = () => (
+  <ComponentDoc
+    name="SpaceSwitcher"
+    description="Active-space dropdown surfaced next to the Aura wordmark in the navbar. Picks the user's current space and persists the choice via ActiveSpaceContext (localStorage key `aura.activeSpaceId`), so listing pages (`/projects`, `/discussions`) scope to it. Personal spaces wear a lock icon. Renders 'Loading…' until the space list resolves and nothing if the user has no spaces."
+    importPath={`import SpaceSwitcher from "@/components/common/SpaceSwitcher";`}
+    examples={[
+      {
+        title: "Default (in navbar)",
+        code: `<SpaceSwitcher />`,
+        preview: (
+          <p className="text-sm text-muted-foreground">
+            Mounted by <code className="mx-1">Navbar</code> for authenticated
+            users with at least one space loaded. The dropdown is already
+            visible in the navbar at the top of this page.
+          </p>
+        ),
+      },
+    ]}
+  />
+);
+
+void SpaceSwitcher;
+
+export default SpaceSwitcherPage;


### PR DESCRIPTION
## Summary
- Add `/dev/components` doc pages for the six `pwa/components/common/` pieces that drifted off the registry: `Layout`, `Navbar`, `Sidebar`, `SidebarNav`, `SearchBar`, `SpaceSwitcher` (new `Layout` category).
- Update `CLAUDE.md` with a "Docker Desktop port flaps (Windows)" note pointing at `scripts/watch-port-forward.sh` (shipped in 1f4b6bc but never mentioned next to `scripts/worktree-env.sh`).

## Context
CLAUDE.md says every shared component under `pwa/components/{editor,user,common}/` should have a `/dev/components/<slug>` page. `common/` had drifted as Sidebar / SidebarNav (#203), SpaceSwitcher (#192), and SearchBar (#139) landed without registry entries. This PR is purely doc-only — no behavior change.

Each new page follows the existing `ComponentDoc` + `void Component` pattern (same as `discussions-panel.tsx`), since these components are tightly coupled to AuthContext / ActiveSpaceContext / router state and the doc page already lives inside the real app shell. Previews are explanatory text rather than a second mounted instance.

## Test plan
- [ ] `/dev/components` lists a new "Layout" category with six entries
- [ ] Each new slug (`/dev/components/layout`, `/navbar`, `/sidebar`, `/sidebar-nav`, `/search-bar`, `/space-switcher`) renders without console errors
- [ ] `pnpm tsc --noEmit` passes (CI typecheck)
- [ ] `pnpm lint` passes