### PR TITLE
fix(api): clear Filter::getDescription phpstan baseline

### DIFF
--- a/api/phpstan-baseline.neon
+++ b/api/phpstan-baseline.neon
@@ -4,15 +4,6 @@
 
 parameters:
     ignoreErrors:
-        # API Platform's FilterInterface::getDescription() return shape
-        # narrows `openapi` to `ApiPlatform\OpenApi\Model\Parameter`, but
-        # the runtime accepts a plain array. Switching every filter to
-        # Parameter objects is a bigger lift than this PR.
-        -
-            message: '#Method App\\Filter\\[A-Za-z]+::getDescription\(\) should return array.*but returns array#'
-            paths:
-                - src/Filter/*.php
-
         # Doctrine relationship properties typed `?Foo` on the PHP side
         # while the JoinColumn is `nullable: false`. Tightening the PHP
         # type breaks runtime initialisation paths that build entities

--- a/api/src/Filter/DiscussionSearchFilter.php
+++ b/api/src/Filter/DiscussionSearchFilter.php
@@ -5,6 +5,7 @@ namespace App\Filter;
 use ApiPlatform\Doctrine\Orm\Filter\AbstractFilter;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\OpenApi\Model\Parameter;
 use App\Entity\Discussion;
 use Doctrine\ORM\QueryBuilder;
 
@@ -89,9 +90,11 @@ final class DiscussionSearchFilter extends AbstractFilter
                 'type' => 'string',
                 'required' => false,
                 'description' => 'Postgres full-text search across discussion title and body. Pinned threads first, then ranked by relevance.',
-                'openapi' => [
-                    'example' => 'pricing question',
-                ],
+                'openapi' => new Parameter(
+                    name: self::PARAMETER,
+                    in: 'query',
+                    example: 'pricing question',
+                ),
             ],
         ];
     }

--- a/api/src/Filter/OverdueFilter.php
+++ b/api/src/Filter/OverdueFilter.php
@@ -5,6 +5,7 @@ namespace App\Filter;
 use ApiPlatform\Doctrine\Orm\Filter\AbstractFilter;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\OpenApi\Model\Parameter;
 use App\Entity\Task;
 use Doctrine\ORM\QueryBuilder;
 
@@ -60,10 +61,12 @@ final class OverdueFilter extends AbstractFilter
                 'type' => 'bool',
                 'required' => false,
                 'description' => 'When true, restricts the collection to overdue tasks (incomplete with a past due date).',
-                'openapi' => [
-                    'example' => true,
-                    'allowEmptyValue' => false,
-                ],
+                'openapi' => new Parameter(
+                    name: self::PARAMETER,
+                    in: 'query',
+                    allowEmptyValue: false,
+                    example: true,
+                ),
             ],
         ];
     }

--- a/api/src/Filter/PageSearchFilter.php
+++ b/api/src/Filter/PageSearchFilter.php
@@ -5,6 +5,7 @@ namespace App\Filter;
 use ApiPlatform\Doctrine\Orm\Filter\AbstractFilter;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\OpenApi\Model\Parameter;
 use App\Entity\Page;
 use Doctrine\ORM\QueryBuilder;
 
@@ -87,9 +88,11 @@ final class PageSearchFilter extends AbstractFilter
                 'type' => 'string',
                 'required' => false,
                 'description' => 'Postgres full-text search across page title and body. Ranked by relevance.',
-                'openapi' => [
-                    'example' => 'onboarding',
-                ],
+                'openapi' => new Parameter(
+                    name: self::PARAMETER,
+                    in: 'query',
+                    example: 'onboarding',
+                ),
             ],
         ];
     }

--- a/api/src/Filter/ProjectSearchFilter.php
+++ b/api/src/Filter/ProjectSearchFilter.php
@@ -5,6 +5,7 @@ namespace App\Filter;
 use ApiPlatform\Doctrine\Orm\Filter\AbstractFilter;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\OpenApi\Model\Parameter;
 use App\Entity\Project;
 use Doctrine\ORM\QueryBuilder;
 
@@ -88,9 +89,11 @@ final class ProjectSearchFilter extends AbstractFilter
                 'type' => 'string',
                 'required' => false,
                 'description' => 'Postgres full-text search across project title and description. Ranked by relevance.',
-                'openapi' => [
-                    'example' => 'launch checklist',
-                ],
+                'openapi' => new Parameter(
+                    name: self::PARAMETER,
+                    in: 'query',
+                    example: 'launch checklist',
+                ),
             ],
         ];
     }

--- a/api/src/Filter/TaskSearchFilter.php
+++ b/api/src/Filter/TaskSearchFilter.php
@@ -5,6 +5,7 @@ namespace App\Filter;
 use ApiPlatform\Doctrine\Orm\Filter\AbstractFilter;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\OpenApi\Model\Parameter;
 use App\Entity\Comment;
 use App\Entity\CustomFieldValue;
 use App\Entity\Task;
@@ -124,9 +125,11 @@ final class TaskSearchFilter extends AbstractFilter
                 'type' => 'string',
                 'required' => false,
                 'description' => 'Postgres full-text search across task title, description, comments, and custom field values. Ranked by relevance.',
-                'openapi' => [
-                    'example' => 'launch checklist',
-                ],
+                'openapi' => new Parameter(
+                    name: self::PARAMETER,
+                    in: 'query',
+                    example: 'launch checklist',
+                ),
             ],
         ];
     }

--- a/api/src/Filter/TaskStatusFilter.php
+++ b/api/src/Filter/TaskStatusFilter.php
@@ -5,6 +5,7 @@ namespace App\Filter;
 use ApiPlatform\Doctrine\Orm\Filter\AbstractFilter;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\OpenApi\Model\Parameter;
 use App\Entity\Task;
 use Doctrine\ORM\QueryBuilder;
 
@@ -60,9 +61,13 @@ final class TaskStatusFilter extends AbstractFilter
                 'type' => 'string',
                 'required' => false,
                 'description' => 'Filter tasks by status: "open" (not yet completed) or "completed".',
-                'openapi' => [
-                    'enum' => ['open', 'completed'],
-                ],
+                // enum lives on the parameter's schema, not as a sibling
+                // attribute, so it has to ride along inside `schema`.
+                'openapi' => new Parameter(
+                    name: self::PARAMETER,
+                    in: 'query',
+                    schema: ['type' => 'string', 'enum' => ['open', 'completed']],
+                ),
             ],
         ];
     }


### PR DESCRIPTION
## Summary

Drops the last phpstan-baseline pattern I could realistically fix: the six API Platform filters whose `getDescription()` returned `'openapi' => [...]` array literals, where the parent docblock pins that key to `ApiPlatform\OpenApi\Model\Parameter`.

Each filter now constructs a `Parameter` object with the original semantics preserved:
- `TaskSearchFilter`, `DiscussionSearchFilter`, `PageSearchFilter`, `ProjectSearchFilter` — `example` as a named arg.
- `OverdueFilter` — `allowEmptyValue: false` + `example: true`.
- `TaskStatusFilter` — the `enum` moves into the parameter's `schema` (where the OpenAPI spec actually puts it; sitting next to `example` was already structurally wrong even though API Platform's normalizer accepted it).

## Verification

- ✅ Local `phpstan analyse src/Filter` is clean (`No errors`).
- ✅ Local `phpcs src/Filter` is clean.
- Baseline pattern for `App\Filter\*::getDescription` removed.

## What's still baselined

The other two broad patterns (entity nullable relationships, test `$entityManager` type) stay — both were tried in #232 and reverted because they break runtime (PrePersist initialization for entities, private container alias for the EM lookup).

## Test plan

- [ ] CI green — Tests, PHPStan, PHPCS, Doctrine Schema, PWA Typecheck, E2E, Docker Lint
- [ ] OpenAPI doc still renders sensibly with the new Parameter objects (manual smoke if you want — the structural change is `enum` moving inside `schema`)