### PR TITLE
fix(api): clear remaining phpstan baseline patterns

### DIFF
--- a/api/phpstan-baseline.neon
+++ b/api/phpstan-baseline.neon
@@ -3,26 +3,4 @@
 # after clearing a batch. Anything new fails CI; baselined errors do not.
 
 parameters:
-    ignoreErrors:
-        # Doctrine relationship properties typed `?Foo` on the PHP side
-        # while the JoinColumn is `nullable: false`. Tightening the PHP
-        # type breaks runtime initialisation paths that build entities
-        # incrementally before the PrePersist listener / state processor
-        # assigns the required relation; leaving as nullable + baselined
-        # is safer than chasing every construction site.
-        -
-            message: '#Property App\\Entity\\[A-Za-z]+::\$[a-zA-Z]+ type mapping mismatch: property can contain App\\Entity\\[A-Za-z]+\|null but database expects#'
-            paths:
-                - src/Entity/*.php
-
-        # Test classes type `$entityManager` as EntityManagerInterface but
-        # fetch it via `->get('doctrine')->getManager()` which is declared
-        # to return ObjectManager. Switching to `get(EntityManagerInterface::class)`
-        # fails at runtime because the alias is private in the regular
-        # container; switching every test to the test-container accessor
-        # is mechanical noise. PHPStan-side narrowing not worth a project
-        # convention change.
-        -
-            message: '#Property App\\Tests\\Api\\[A-Za-z]+::\$(em|entityManager) \(Doctrine\\ORM\\EntityManagerInterface\) does not accept Doctrine\\Persistence\\ObjectManager\.#'
-            paths:
-                - tests/Api/*.php
+    ignoreErrors: []

--- a/api/phpstan.dist.neon
+++ b/api/phpstan.dist.neon
@@ -32,6 +32,13 @@ parameters:
         # (with our custom UUID generator service) when typing
         # ::getRepository(), QueryBuilder, etc.
         objectManagerLoader: tests/phpstan/object-manager.php
+        # Required relations (JoinColumn nullable: false) are declared as
+        # `?Foo` on the PHP side because our entities are constructed
+        # incrementally — PrePersist listeners and state processors
+        # populate the FK at flush time. The PHP type still permits
+        # uninitialized states during the construction → persist window
+        # without forcing every call site to pass the relation up front.
+        allowNullablePropertyForRequiredField: true
     parallel:
         # Each worker forks a child PHP process; the analyzer reads vendor/
         # over a bind-mount on dev machines which can race under WSL2/Docker

--- a/api/tests/Api/ActivityHistoryTest.php
+++ b/api/tests/Api/ActivityHistoryTest.php
@@ -25,7 +25,9 @@ class ActivityHistoryTest extends ApiTestCase
     {
         self::bootKernel();
         $container = static::getContainer();
-        $this->entityManager = $container->get('doctrine')->getManager();
+        $em = $container->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
 
         // Wipe in dependency order. ext_log_entries has no FK so we
         // truncate it via DQL last to keep cross-test runs clean.

--- a/api/tests/Api/ApiTokenTest.php
+++ b/api/tests/Api/ApiTokenTest.php
@@ -15,7 +15,9 @@ class ApiTokenTest extends ApiTestCase
     protected function setUp(): void
     {
         $kernel = self::bootKernel();
-        $this->entityManager = $kernel->getContainer()->get('doctrine')->getManager();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
 
         $this->entityManager->createQuery('DELETE FROM App\Entity\ApiToken')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();

--- a/api/tests/Api/CommentTest.php
+++ b/api/tests/Api/CommentTest.php
@@ -20,8 +20,9 @@ class CommentTest extends ApiTestCase
     protected function setUp(): void
     {
         $kernel = self::bootKernel();
-        $this->entityManager = $kernel->getContainer()
-            ->get('doctrine')->getManager();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
 
         // Notifications hold FKs to both Comment and Task (mention rows
         // and reminder rows respectively); wipe them first so the bulk

--- a/api/tests/Api/CommentsMercureTokenTest.php
+++ b/api/tests/Api/CommentsMercureTokenTest.php
@@ -19,7 +19,9 @@ class CommentsMercureTokenTest extends ApiTestCase
     {
         self::bootKernel();
         $container = static::getContainer();
-        $this->entityManager = $container->get('doctrine')->getManager();
+        $em = $container->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
 
         $this->entityManager->createQuery('DELETE FROM App\Entity\Comment')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();

--- a/api/tests/Api/CustomFieldDefinitionTest.php
+++ b/api/tests/Api/CustomFieldDefinitionTest.php
@@ -18,8 +18,9 @@ class CustomFieldDefinitionTest extends ApiTestCase
     protected function setUp(): void
     {
         $kernel = self::bootKernel();
-        $this->entityManager = $kernel->getContainer()
-            ->get('doctrine')->getManager();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
 
         $this->entityManager->createQuery('DELETE FROM App\Entity\CustomFieldDefinition')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();

--- a/api/tests/Api/CustomFieldFooterTest.php
+++ b/api/tests/Api/CustomFieldFooterTest.php
@@ -27,8 +27,9 @@ class CustomFieldFooterTest extends ApiTestCase
     protected function setUp(): void
     {
         $kernel = self::bootKernel();
-        $this->entityManager = $kernel->getContainer()
-            ->get('doctrine')->getManager();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
 
         $this->entityManager->createQuery('DELETE FROM App\Entity\CustomFieldValue')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\CustomFieldDefinition')->execute();

--- a/api/tests/Api/DiscussionCopyTest.php
+++ b/api/tests/Api/DiscussionCopyTest.php
@@ -23,8 +23,9 @@ class DiscussionCopyTest extends ApiTestCase
     protected function setUp(): void
     {
         $kernel = self::bootKernel();
-        $this->entityManager = $kernel->getContainer()
-            ->get('doctrine')->getManager();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
 
         $this->entityManager->createQuery('DELETE FROM App\Entity\Discussion')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();

--- a/api/tests/Api/DiscussionMoveTest.php
+++ b/api/tests/Api/DiscussionMoveTest.php
@@ -23,8 +23,9 @@ class DiscussionMoveTest extends ApiTestCase
     protected function setUp(): void
     {
         $kernel = self::bootKernel();
-        $this->entityManager = $kernel->getContainer()
-            ->get('doctrine')->getManager();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
 
         $this->entityManager->createQuery('DELETE FROM App\Entity\Discussion')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();

--- a/api/tests/Api/DiscussionTest.php
+++ b/api/tests/Api/DiscussionTest.php
@@ -19,8 +19,9 @@ class DiscussionTest extends ApiTestCase
     protected function setUp(): void
     {
         $kernel = self::bootKernel();
-        $this->entityManager = $kernel->getContainer()
-            ->get('doctrine')->getManager();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
 
         $this->entityManager->createQuery('DELETE FROM App\Entity\Discussion')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();

--- a/api/tests/Api/EmailChangeTest.php
+++ b/api/tests/Api/EmailChangeTest.php
@@ -15,8 +15,9 @@ class EmailChangeTest extends ApiTestCase
     protected function setUp(): void
     {
         $kernel = self::bootKernel();
-        $this->entityManager = $kernel->getContainer()
-            ->get('doctrine')->getManager();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
 
         $this->entityManager->createQuery('DELETE FROM App\Entity\EmailChangeRequest')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();

--- a/api/tests/Api/McpTest.php
+++ b/api/tests/Api/McpTest.php
@@ -31,7 +31,9 @@ class McpTest extends ApiTestCase
     protected function setUp(): void
     {
         $kernel = self::bootKernel();
-        $this->entityManager = $kernel->getContainer()->get('doctrine')->getManager();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
 
         $this->entityManager->createQuery('DELETE FROM App\Entity\ApiToken')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Comment')->execute();

--- a/api/tests/Api/MediaObjectDownloadTest.php
+++ b/api/tests/Api/MediaObjectDownloadTest.php
@@ -25,7 +25,9 @@ class MediaObjectDownloadTest extends ApiTestCase
         // exposes private services; `$kernel->getContainer()` is the
         // production container, which has `media.storage` compiled away.
         $container = static::getContainer();
-        $this->entityManager = $container->get('doctrine')->getManager();
+        $em = $container->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
         $this->storage = $container->get('media.storage');
 
         $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();

--- a/api/tests/Api/MediaObjectTest.php
+++ b/api/tests/Api/MediaObjectTest.php
@@ -16,7 +16,9 @@ class MediaObjectTest extends ApiTestCase
     protected function setUp(): void
     {
         $kernel = self::bootKernel();
-        $this->entityManager = $kernel->getContainer()->get('doctrine')->getManager();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
         $this->entityManager->createQuery('DELETE FROM App\Entity\MediaObject')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
 

--- a/api/tests/Api/NotificationTest.php
+++ b/api/tests/Api/NotificationTest.php
@@ -24,8 +24,9 @@ class NotificationTest extends ApiTestCase
     protected function setUp(): void
     {
         $kernel = self::bootKernel();
-        $this->entityManager = $kernel->getContainer()
-            ->get('doctrine')->getManager();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
 
         // Wipe the join tables before the entity tables so Postgres doesn't
         // bail on residual FK rows from a previous test class.

--- a/api/tests/Api/PageCopyTest.php
+++ b/api/tests/Api/PageCopyTest.php
@@ -22,8 +22,9 @@ class PageCopyTest extends ApiTestCase
     protected function setUp(): void
     {
         $kernel = self::bootKernel();
-        $this->entityManager = $kernel->getContainer()
-            ->get('doctrine')->getManager();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
 
         $this->entityManager->createQuery('DELETE FROM App\Entity\Comment')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Page')->execute();

--- a/api/tests/Api/PageMoveTest.php
+++ b/api/tests/Api/PageMoveTest.php
@@ -23,8 +23,9 @@ class PageMoveTest extends ApiTestCase
     protected function setUp(): void
     {
         $kernel = self::bootKernel();
-        $this->entityManager = $kernel->getContainer()
-            ->get('doctrine')->getManager();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
 
         $this->entityManager->createQuery('DELETE FROM App\Entity\Comment')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Page')->execute();

--- a/api/tests/Api/PageTest.php
+++ b/api/tests/Api/PageTest.php
@@ -24,8 +24,9 @@ class PageTest extends ApiTestCase
     protected function setUp(): void
     {
         $kernel = self::bootKernel();
-        $this->entityManager = $kernel->getContainer()
-            ->get('doctrine')->getManager();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
 
         $this->entityManager->createQuery('DELETE FROM App\Entity\Comment')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Page')->execute();

--- a/api/tests/Api/PasswordTest.php
+++ b/api/tests/Api/PasswordTest.php
@@ -16,8 +16,9 @@ class PasswordTest extends ApiTestCase
     protected function setUp(): void
     {
         $kernel = self::bootKernel();
-        $this->entityManager = $kernel->getContainer()
-            ->get('doctrine')->getManager();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
 
         // Clean tables before each test
         $this->entityManager->createQuery('DELETE FROM App\Entity\PasswordResetToken')->execute();

--- a/api/tests/Api/ProjectCopyTest.php
+++ b/api/tests/Api/ProjectCopyTest.php
@@ -26,8 +26,9 @@ class ProjectCopyTest extends ApiTestCase
     protected function setUp(): void
     {
         $kernel = self::bootKernel();
-        $this->entityManager = $kernel->getContainer()
-            ->get('doctrine')->getManager();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
 
         $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Tag')->execute();

--- a/api/tests/Api/ProjectMoveTest.php
+++ b/api/tests/Api/ProjectMoveTest.php
@@ -24,8 +24,9 @@ class ProjectMoveTest extends ApiTestCase
     protected function setUp(): void
     {
         $kernel = self::bootKernel();
-        $this->entityManager = $kernel->getContainer()
-            ->get('doctrine')->getManager();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
 
         $this->entityManager->createQuery('DELETE FROM App\Entity\CustomFieldDefinition')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();

--- a/api/tests/Api/ProjectTest.php
+++ b/api/tests/Api/ProjectTest.php
@@ -19,8 +19,9 @@ class ProjectTest extends ApiTestCase
     protected function setUp(): void
     {
         $kernel = self::bootKernel();
-        $this->entityManager = $kernel->getContainer()
-            ->get('doctrine')->getManager();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
 
         // task.project_id, space.created_by_id cascade/SET-NULL via FK,
         // so deleting parents is enough to clean state between tests.

--- a/api/tests/Api/PushSubscriptionTest.php
+++ b/api/tests/Api/PushSubscriptionTest.php
@@ -15,8 +15,9 @@ class PushSubscriptionTest extends ApiTestCase
     protected function setUp(): void
     {
         $kernel = self::bootKernel();
-        $this->entityManager = $kernel->getContainer()
-            ->get('doctrine')->getManager();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
 
         $this->entityManager->createQuery('DELETE FROM App\Entity\PushSubscription')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();

--- a/api/tests/Api/SpaceAttachmentTest.php
+++ b/api/tests/Api/SpaceAttachmentTest.php
@@ -20,7 +20,9 @@ class SpaceAttachmentTest extends ApiTestCase
     {
         self::bootKernel();
         $container = static::getContainer();
-        $this->entityManager = $container->get('doctrine')->getManager();
+        $em = $container->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
         $this->storage = $container->get('media.storage');
 
         $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();

--- a/api/tests/Api/SpaceInviteTest.php
+++ b/api/tests/Api/SpaceInviteTest.php
@@ -26,8 +26,9 @@ class SpaceInviteTest extends ApiTestCase
     protected function setUp(): void
     {
         $kernel = self::bootKernel();
-        $this->entityManager = $kernel->getContainer()
-            ->get('doctrine')->getManager();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
 
         $this->entityManager->createQuery('DELETE FROM App\Entity\UserInvite')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Space')->execute();

--- a/api/tests/Api/SpaceTest.php
+++ b/api/tests/Api/SpaceTest.php
@@ -16,8 +16,9 @@ class SpaceTest extends ApiTestCase
     protected function setUp(): void
     {
         $kernel = self::bootKernel();
-        $this->entityManager = $kernel->getContainer()
-            ->get('doctrine')->getManager();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
 
         // Wipe in dependency order so FK cascades fire cleanly. Spaces
         // cascade their memberships; users cascade everything else.

--- a/api/tests/Api/TagTest.php
+++ b/api/tests/Api/TagTest.php
@@ -16,8 +16,9 @@ class TagTest extends ApiTestCase
     protected function setUp(): void
     {
         $kernel = self::bootKernel();
-        $this->entityManager = $kernel->getContainer()
-            ->get('doctrine')->getManager();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
 
         // task_tag rows are cleared automatically via FK cascade when Tasks
         // and Tags are deleted, so no explicit DELETE for the join table.

--- a/api/tests/Api/TaskAttachmentTest.php
+++ b/api/tests/Api/TaskAttachmentTest.php
@@ -18,8 +18,9 @@ class TaskAttachmentTest extends ApiTestCase
     protected function setUp(): void
     {
         $kernel = self::bootKernel();
-        $this->entityManager = $kernel->getContainer()
-            ->get('doctrine')->getManager();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
 
         // Wipe in dependency-safe order; the join table is cleaned up via
         // the FK cascades when its sides go.

--- a/api/tests/Api/TaskCustomFieldValueTest.php
+++ b/api/tests/Api/TaskCustomFieldValueTest.php
@@ -23,8 +23,9 @@ class TaskCustomFieldValueTest extends ApiTestCase
     protected function setUp(): void
     {
         $kernel = self::bootKernel();
-        $this->entityManager = $kernel->getContainer()
-            ->get('doctrine')->getManager();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
 
         // Order matters: values FK to task + definition; definitions FK
         // to project. Clear from leaves to roots.

--- a/api/tests/Api/TaskTest.php
+++ b/api/tests/Api/TaskTest.php
@@ -21,8 +21,9 @@ class TaskTest extends ApiTestCase
     protected function setUp(): void
     {
         $kernel = self::bootKernel();
-        $this->entityManager = $kernel->getContainer()
-            ->get('doctrine')->getManager();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
 
         // Notification + Comment hold FKs to Task; clear them first so
         // the bulk Task delete below doesn't fail when search-fixture

--- a/api/tests/Api/TwoFactorTest.php
+++ b/api/tests/Api/TwoFactorTest.php
@@ -16,7 +16,9 @@ class TwoFactorTest extends ApiTestCase
     protected function setUp(): void
     {
         $kernel = self::bootKernel();
-        $this->em = $kernel->getContainer()->get('doctrine')->getManager();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->em = $em;
         $this->em->createQuery('DELETE FROM App\Entity\User')->execute();
     }
 

--- a/api/tests/Api/UserGroupTest.php
+++ b/api/tests/Api/UserGroupTest.php
@@ -15,8 +15,9 @@ class UserGroupTest extends ApiTestCase
     protected function setUp(): void
     {
         $kernel = self::bootKernel();
-        $this->entityManager = $kernel->getContainer()
-            ->get('doctrine')->getManager();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
 
         $this->entityManager->createQuery('DELETE FROM App\Entity\UserGroup')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();

--- a/api/tests/Api/UserInviteTest.php
+++ b/api/tests/Api/UserInviteTest.php
@@ -17,8 +17,9 @@ class UserInviteTest extends ApiTestCase
     protected function setUp(): void
     {
         $kernel = self::bootKernel();
-        $this->entityManager = $kernel->getContainer()
-            ->get('doctrine')->getManager();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
 
         // Order matters — group_invite -> user_invite -> user_group -> user.
         $this->entityManager->createQuery('DELETE FROM App\Entity\GroupInvite')->execute();

--- a/api/tests/Api/UserPreferencesTest.php
+++ b/api/tests/Api/UserPreferencesTest.php
@@ -14,8 +14,9 @@ class UserPreferencesTest extends ApiTestCase
     protected function setUp(): void
     {
         $kernel = self::bootKernel();
-        $this->entityManager = $kernel->getContainer()
-            ->get('doctrine')->getManager();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
         $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
     }
 

--- a/api/tests/Api/UserTest.php
+++ b/api/tests/Api/UserTest.php
@@ -15,8 +15,9 @@ class UserTest extends ApiTestCase
     protected function setUp(): void
     {
         $kernel = self::bootKernel();
-        $this->entityManager = $kernel->getContainer()
-            ->get('doctrine')->getManager();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
 
         // Clean user table before each test
         $this->entityManager->createQuery('DELETE FROM App\Entity\MediaObject')->execute();


### PR DESCRIPTION
## Summary

Drops both remaining baseline patterns. Baseline is now **empty** (`ignoreErrors: []`).

Two separate techniques for the two categories, since each had a different reason for being baselined in the first place:

### 1. Doctrine 'type mapping mismatch' (22 entities)

Set phpstan-doctrine's `allowNullablePropertyForRequiredField: true` in `phpstan.dist.neon`.

Required relations stay declared as `?Foo $x = null` on the PHP side — #232's attempt to make them non-nullable broke runtime because tests do `new Project()` then access `getSpace()` before the PrePersist `ProjectSpaceDefaultListener` fires. The new config knob silences the informational warning without forcing a constructor-injection refactor across every test fixture. The DB schema still enforces NOT NULL at flush time.

### 2. Test `$entityManager` type (34 test files)

Introduce an intermediate typed local var. `Doctrine\Persistence\ObjectManager` comes back from `->get('doctrine')->getManager()`; narrowing happens on a temp variable via `assert()` **before** assignment to the typed property — so phpstan sees the assignment as `EMI → EMI` rather than `ObjectManager → EMI`:

```php
$em = $kernel->getContainer()->get('doctrine')->getManager();
assert($em instanceof EntityManagerInterface);
$this->entityManager = $em;
```

#232 tried switching to `->get(EntityManagerInterface::class)` which fails at runtime because that alias is private in the kernel's regular container (only the test container makes it public, via `static::getContainer()` — a wider pattern change).

## Verification

- ✅ Local `phpcs` clean across all 34 modified test files.
- Local `phpstan` couldn't be run end-to-end (WSL2 / Docker Desktop segfaults parallel workers 30/30 retries) — CI on Linux is the validation gate, same as previous baseline-clearing PRs.

## Test plan

- [ ] CI green — Tests, PHPStan, PHPCS, Doctrine Schema, PWA Typecheck, E2E, Docker Lint
- [ ] PHPStan baseline file is empty after this lands; any new error fails CI