### PR TITLE
chore(phpstan): bump level 5 → 6

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ bin/phpunit                           # Run tests
 ```
 
 ### Static analysis (PHPStan)
-PHPStan runs against `api/src` and `api/tests` at **level 5** as a required CI check. Config lives in [api/phpstan.dist.neon](api/phpstan.dist.neon); pre-existing violations are deferred via [api/phpstan-baseline.neon](api/phpstan-baseline.neon) so CI only fails on *new* errors.
+PHPStan runs against `api/src` and `api/tests` at **level 6** as a required CI check. Config lives in [api/phpstan.dist.neon](api/phpstan.dist.neon); the baseline is currently empty — every error fails CI. If you ever need to defer a fix, regenerate [api/phpstan-baseline.neon](api/phpstan-baseline.neon) with `docker compose run --rm phpstan analyse --generate-baseline=phpstan-baseline.neon`.
 
 Extensions wired up:
 - `phpstan/phpstan-symfony` — service-id / config-resolver awareness via `var/cache/test/App_KernelTestDebugContainer.xml`, console application loaded from [api/tests/phpstan/console-application.php](api/tests/phpstan/console-application.php).

--- a/api/phpstan.dist.neon
+++ b/api/phpstan.dist.neon
@@ -8,7 +8,7 @@ includes:
     - vendor/phpstan/phpstan-phpunit/rules.neon
 
 parameters:
-    level: 5
+    level: 6
     paths:
         - src
         - tests

--- a/api/src/CustomField/Footer/FooterAggregator.php
+++ b/api/src/CustomField/Footer/FooterAggregator.php
@@ -81,6 +81,9 @@ final class FooterAggregator
         return $rows;
     }
 
+    /**
+     * @param list<string> $taskIds
+     */
     private function compute(CustomFieldDefinition $definition, string $aggKind, array $taskIds): mixed
     {
         // No tasks in scope — every aggregate is either null or 0.
@@ -115,6 +118,9 @@ final class FooterAggregator
         return null;
     }
 
+    /**
+     * @param list<string> $taskIds
+     */
     private function countNonNull(?string $definitionId, array $taskIds): int
     {
         if (null === $definitionId) {
@@ -136,6 +142,9 @@ final class FooterAggregator
         return (int) $stmt->fetchOne();
     }
 
+    /**
+     * @param list<string> $taskIds
+     */
     private function aggregateNumeric(CustomFieldDefinition $definition, string $aggKind, array $taskIds): mixed
     {
         $definitionId = $definition->getId()?->toRfc4122();
@@ -200,6 +209,9 @@ final class FooterAggregator
         return $numeric;
     }
 
+    /**
+     * @param list<string> $taskIds
+     */
     private function aggregateDate(CustomFieldDefinition $definition, string $aggKind, array $taskIds): mixed
     {
         $definitionId = $definition->getId()?->toRfc4122();

--- a/api/src/Entity/ActivityLog.php
+++ b/api/src/Entity/ActivityLog.php
@@ -14,6 +14,8 @@ use Gedmo\Loggable\Entity\Repository\LogEntryRepository;
  * and we don't need to map Gedmo's vendor namespace separately. The
  * legacy `array` column type on `data` is aliased to JSON in
  * `config/packages/doctrine.yaml` (DBAL 4 dropped the original).
+ *
+ * @extends AbstractLogEntry<object>
  */
 #[ORM\Entity(repositoryClass: LogEntryRepository::class)]
 #[ORM\Table(name: 'ext_log_entries')]

--- a/api/src/Filter/DiscussionSearchFilter.php
+++ b/api/src/Filter/DiscussionSearchFilter.php
@@ -35,7 +35,7 @@ final class DiscussionSearchFilter extends AbstractFilter
      */
     protected function filterProperty(
         string $property,
-        $value,
+        mixed $value,
         QueryBuilder $queryBuilder,
         QueryNameGeneratorInterface $queryNameGenerator,
         string $resourceClass,

--- a/api/src/Filter/OverdueFilter.php
+++ b/api/src/Filter/OverdueFilter.php
@@ -25,7 +25,7 @@ final class OverdueFilter extends AbstractFilter
 
     protected function filterProperty(
         string $property,
-        $value,
+        mixed $value,
         QueryBuilder $queryBuilder,
         QueryNameGeneratorInterface $queryNameGenerator,
         string $resourceClass,

--- a/api/src/Filter/PageSearchFilter.php
+++ b/api/src/Filter/PageSearchFilter.php
@@ -34,7 +34,7 @@ final class PageSearchFilter extends AbstractFilter
      */
     protected function filterProperty(
         string $property,
-        $value,
+        mixed $value,
         QueryBuilder $queryBuilder,
         QueryNameGeneratorInterface $queryNameGenerator,
         string $resourceClass,

--- a/api/src/Filter/ProjectSearchFilter.php
+++ b/api/src/Filter/ProjectSearchFilter.php
@@ -35,7 +35,7 @@ final class ProjectSearchFilter extends AbstractFilter
      */
     protected function filterProperty(
         string $property,
-        $value,
+        mixed $value,
         QueryBuilder $queryBuilder,
         QueryNameGeneratorInterface $queryNameGenerator,
         string $resourceClass,

--- a/api/src/Filter/TaskSearchFilter.php
+++ b/api/src/Filter/TaskSearchFilter.php
@@ -42,7 +42,7 @@ final class TaskSearchFilter extends AbstractFilter
      */
     protected function filterProperty(
         string $property,
-        $value,
+        mixed $value,
         QueryBuilder $queryBuilder,
         QueryNameGeneratorInterface $queryNameGenerator,
         string $resourceClass,

--- a/api/src/Filter/TaskStatusFilter.php
+++ b/api/src/Filter/TaskStatusFilter.php
@@ -27,7 +27,7 @@ final class TaskStatusFilter extends AbstractFilter
      */
     protected function filterProperty(
         string $property,
-        $value,
+        mixed $value,
         QueryBuilder $queryBuilder,
         QueryNameGeneratorInterface $queryNameGenerator,
         string $resourceClass,

--- a/api/src/Mcp/McpInputHelper.php
+++ b/api/src/Mcp/McpInputHelper.php
@@ -112,6 +112,8 @@ final class McpInputHelper
      * when the field is absent. Tools that want to clear a date pass an
      * explicit empty string, which we map to a sentinel via the
      * 3-arg overload below.
+     *
+     * @param array<string, mixed> $args
      */
     public function optionalDateTime(array $args, string $key): ?\DateTimeImmutable
     {
@@ -154,6 +156,7 @@ final class McpInputHelper
      * Page/limit clamping shared by every list tool. Defaults match the
      * API Platform global default (30 per page).
      *
+     * @param array<string, mixed> $args
      * @return array{page: int, limit: int}
      */
     public function pagination(array $args, int $maxLimit = 100): array

--- a/api/tests/Api/McpTest.php
+++ b/api/tests/Api/McpTest.php
@@ -308,6 +308,9 @@ class McpTest extends ApiTestCase
         return $client->getResponse()->toArray();
     }
 
+    /**
+     * @param list<string> $scopes
+     */
     private function mintToken(User $user, string $name, ?\DateTimeImmutable $expiresAt = null, array $scopes = []): string
     {
         $plain = ApiToken::PLAINTEXT_PREFIX . bin2hex(random_bytes(16));

--- a/api/tests/Api/UserTest.php
+++ b/api/tests/Api/UserTest.php
@@ -249,6 +249,9 @@ class UserTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(403);
     }
 
+    /**
+     * @param list<string> $roles
+     */
     private function createTestUser(string $email, string $plainPassword, array $roles = ['ROLE_USER']): User
     {
         $container = static::getContainer();


### PR DESCRIPTION
## Summary

Draft to surface the size of the level 6 cleanup.

Level 6 adds:
- Missing parameter/return/property typehints
- `array<>` / `iterable<>` shape phpdoc requirements

We're empty-baseline at level 5 right now, so this PR is **expected to fail PHPStan** until we either fix or baseline the new errors.

## Plan

1. Push and let CI report the error count.
2. If it's small (~10–30) → fix all in this PR, ship clean.
3. If it's large → either:
   - baseline + iterative cleanup PRs, or
   - bump back down and pick a different ambition target.