### PR TITLE
chore(phpstan): bump level 6 → 7

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ bin/phpunit                           # Run tests
 ```
 
 ### Static analysis (PHPStan)
-PHPStan runs against `api/src` and `api/tests` at **level 6** as a required CI check. Config lives in [api/phpstan.dist.neon](api/phpstan.dist.neon); the baseline is currently empty — every error fails CI. If you ever need to defer a fix, regenerate [api/phpstan-baseline.neon](api/phpstan-baseline.neon) with `docker compose run --rm phpstan analyse --generate-baseline=phpstan-baseline.neon`.
+PHPStan runs against `api/src` and `api/tests` at **level 7** as a required CI check. Config lives in [api/phpstan.dist.neon](api/phpstan.dist.neon); the baseline is currently empty — every error fails CI. If you ever need to defer a fix, regenerate [api/phpstan-baseline.neon](api/phpstan-baseline.neon) with `docker compose run --rm phpstan analyse --generate-baseline=phpstan-baseline.neon`.
 
 Extensions wired up:
 - `phpstan/phpstan-symfony` — service-id / config-resolver awareness via `var/cache/test/App_KernelTestDebugContainer.xml`, console application loaded from [api/tests/phpstan/console-application.php](api/tests/phpstan/console-application.php).

--- a/api/phpstan.dist.neon
+++ b/api/phpstan.dist.neon
@@ -8,7 +8,7 @@ includes:
     - vendor/phpstan/phpstan-phpunit/rules.neon
 
 parameters:
-    level: 6
+    level: 7
     paths:
         - src
         - tests

--- a/api/src/Controller/McpController.php
+++ b/api/src/Controller/McpController.php
@@ -91,6 +91,9 @@ class McpController extends AbstractController
             return new JsonResponse($responses);
         }
 
+        // phpstan can't narrow array_is_list()'s false branch back to
+        // the string-keyed half of the union, so re-state the shape.
+        /** @var array<string, mixed> $payload */
         $response = $this->dispatch($payload, $request, $user);
         if (null === $response) {
             // Notification — no response body, but HTTP 202 is the

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -308,6 +308,11 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TwoFact
 
     public function getUserIdentifier(): string
     {
+        // The Email + NotBlank validators guarantee a non-empty value by
+        // the time a User is persisted; assert here so the
+        // UserInterface's non-empty-string return contract is satisfied
+        // even when phpstan can't see through the validation pipeline.
+        assert('' !== $this->email);
         return $this->email;
     }
 

--- a/api/tests/Api/MediaObjectTest.php
+++ b/api/tests/Api/MediaObjectTest.php
@@ -29,7 +29,7 @@ class MediaObjectTest extends ApiTestCase
     protected function tearDown(): void
     {
         if (is_dir($this->tempDir)) {
-            foreach (glob($this->tempDir . '/*') as $file) {
+            foreach (glob($this->tempDir . '/*') ?: [] as $file) {
                 @unlink($file);
             }
             @rmdir($this->tempDir);
@@ -132,7 +132,10 @@ class MediaObjectTest extends ApiTestCase
         $path = $this->tempDir . '/sample.png';
         // 128x128 PNG is large enough for the 256 cover() to exercise real processing.
         $image = imagecreatetruecolor(128, 128);
-        imagefill($image, 0, 0, imagecolorallocate($image, 200, 100, 50));
+        self::assertNotFalse($image);
+        $color = imagecolorallocate($image, 200, 100, 50);
+        self::assertNotFalse($color);
+        imagefill($image, 0, 0, $color);
         imagepng($image, $path);
         imagedestroy($image);
 

--- a/api/tests/Api/SpaceInviteTest.php
+++ b/api/tests/Api/SpaceInviteTest.php
@@ -133,9 +133,11 @@ class SpaceInviteTest extends ApiTestCase
             ->findOneBy(['email' => 'newcomer@example.com']);
         $this->assertNotNull($invite, 'A UserInvite row should have been created.');
         $this->assertCount(1, $invite->getSpaceInvites());
+        $firstInvite = $invite->getSpaceInvites()->first();
+        self::assertNotFalse($firstInvite);
         $this->assertSame(
             (string) $space->getId(),
-            (string) $invite->getSpaceInvites()->first()->getSpace()->getId(),
+            (string) $firstInvite->getSpace()->getId(),
         );
         $this->assertNull($invite->getAcceptedAt());
     }
@@ -195,6 +197,7 @@ class SpaceInviteTest extends ApiTestCase
         $space = $this->getSharedSpace($admin);
         $invite = $this->seedInvite($admin, $space, 'pending@example.com');
         $spaceInvite = $invite->getSpaceInvites()->first();
+        self::assertNotFalse($spaceInvite);
 
         $client = static::createClient();
         $client->loginUser($admin);

--- a/api/tests/Api/SpaceTest.php
+++ b/api/tests/Api/SpaceTest.php
@@ -58,7 +58,8 @@ class SpaceTest extends ApiTestCase
         // Creator is admin; no other memberships.
         $this->assertCount(1, $personal->getUserMemberships());
         $membership = $personal->getUserMemberships()->first();
-        $this->assertTrue($alice->getId()->equals($membership->getUser()?->getId()));
+        self::assertNotFalse($membership);
+        $this->assertTrue($alice->getId()?->equals($membership->getUser()?->getId()));
         $this->assertSame(Space::ROLE_ADMIN, $membership->getRole());
     }
 
@@ -124,7 +125,9 @@ class SpaceTest extends ApiTestCase
         $this->assertFalse($space->getIsPersonal());
         $this->assertTrue($alice->getId()->equals($space->getCreatedBy()?->getId()));
         $this->assertCount(1, $space->getUserMemberships());
-        $this->assertSame(Space::ROLE_ADMIN, $space->getUserMemberships()->first()->getRole());
+        $firstMembership = $space->getUserMemberships()->first();
+        self::assertNotFalse($firstMembership);
+        $this->assertSame(Space::ROLE_ADMIN, $firstMembership->getRole());
     }
 
     public function testIsPersonalIgnoredOnCreate(): void

--- a/api/tests/Api/TagTest.php
+++ b/api/tests/Api/TagTest.php
@@ -182,8 +182,11 @@ class TagTest extends ApiTestCase
 
         $this->entityManager->clear();
         $reloaded = $this->entityManager->getRepository(Task::class)->find($task->getId());
+        $this->assertNotNull($reloaded);
         $this->assertCount(1, $reloaded->getTags());
-        $this->assertSame('Writing', $reloaded->getTags()->first()->getTitle());
+        $firstTag = $reloaded->getTags()->first();
+        self::assertNotFalse($firstTag);
+        $this->assertSame('Writing', $firstTag->getTitle());
     }
 
     public function testRemoveTagFromTaskViaPatch(): void
@@ -206,8 +209,11 @@ class TagTest extends ApiTestCase
         $this->assertResponseIsSuccessful();
         $this->entityManager->clear();
         $reloaded = $this->entityManager->getRepository(Task::class)->find($task->getId());
+        $this->assertNotNull($reloaded);
         $this->assertCount(1, $reloaded->getTags());
-        $this->assertSame('Keep', $reloaded->getTags()->first()->getTitle());
+        $firstTag = $reloaded->getTags()->first();
+        self::assertNotFalse($firstTag);
+        $this->assertSame('Keep', $firstTag->getTitle());
     }
 
     public function testCannotAttachOtherUsersTag(): void

--- a/api/tests/Api/TwoFactorTest.php
+++ b/api/tests/Api/TwoFactorTest.php
@@ -60,7 +60,10 @@ class TwoFactorTest extends ApiTestCase
         $secret = json_decode($client->getResponse()->getContent(false), true)['secret'];
 
         $reloaded = $this->reloadUser('v@example.com');
-        $code = TOTP::createFromSecret($reloaded->getDecryptedTotpSecret())->now();
+        $totpSecret = $reloaded->getDecryptedTotpSecret();
+        self::assertNotNull($totpSecret);
+        self::assertNotSame('', $totpSecret);
+        $code = TOTP::createFromSecret($totpSecret)->now();
 
         $client->request('POST', '/me/2fa/verify', ['json' => ['code' => $code]]);
 
@@ -130,7 +133,10 @@ class TwoFactorTest extends ApiTestCase
         ]);
         $this->assertResponseStatusCodeSame(401);
 
-        $code = TOTP::createFromSecret($this->reloadUser('tfa@example.com')->getDecryptedTotpSecret())->now();
+        $totpSecret = $this->reloadUser('tfa@example.com')->getDecryptedTotpSecret();
+        self::assertNotNull($totpSecret);
+        self::assertNotSame('', $totpSecret);
+        $code = TOTP::createFromSecret($totpSecret)->now();
 
         $client->request('POST', '/auth/2fa-check', ['json' => ['code' => $code]]);
 

--- a/api/tests/Api/UserGroupTest.php
+++ b/api/tests/Api/UserGroupTest.php
@@ -56,7 +56,7 @@ class UserGroupTest extends ApiTestCase
         $this->assertCount(1, $group->getMembers());
         $firstMember = $group->getMembers()->first();
         self::assertNotFalse($firstMember);
-        $this->assertTrue($user->getId()?->equals($firstMember->getId()));
+        $this->assertTrue($user->getId()->equals($firstMember->getId()));
     }
 
     public function testCreateGroupRequiresTitle(): void

--- a/api/tests/Api/UserGroupTest.php
+++ b/api/tests/Api/UserGroupTest.php
@@ -51,10 +51,12 @@ class UserGroupTest extends ApiTestCase
         ]);
 
         $group = $this->reloadGroupByTitle('Backend team');
-        $this->assertTrue($user->getId()->equals($group->getOwner()?->getId()));
+        $this->assertTrue($user->getId()?->equals($group->getOwner()?->getId()));
         // Creator is auto-added to the member set on create.
         $this->assertCount(1, $group->getMembers());
-        $this->assertTrue($user->getId()->equals($group->getMembers()->first()->getId()));
+        $firstMember = $group->getMembers()->first();
+        self::assertNotFalse($firstMember);
+        $this->assertTrue($user->getId()?->equals($firstMember->getId()));
     }
 
     public function testCreateGroupRequiresTitle(): void

--- a/api/tests/Service/AvatarColorServiceTest.php
+++ b/api/tests/Service/AvatarColorServiceTest.php
@@ -40,14 +40,18 @@ class AvatarColorServiceTest extends TestCase
     private static function contrastAgainstWhite(string $hex): float
     {
         $rgb = sscanf($hex, '#%02x%02x%02x');
+        self::assertIsArray($rgb);
         [$r, $g, $b] = array_map(self::channelLuminance(...), $rgb);
         $luminance = 0.2126 * $r + 0.7152 * $g + 0.0722 * $b;
         return (1.0 + 0.05) / ($luminance + 0.05);
     }
 
-    private static function channelLuminance(int $channel): float
+    private static function channelLuminance(?int $channel): float
     {
-        $c = $channel / 255.0;
+        // Palette hex strings are well-formed (#RRGGBB) so sscanf always
+        // returns three ints — but its signature is `?int` per phpstan's
+        // strict typing, so handle null defensively for completeness.
+        $c = ($channel ?? 0) / 255.0;
         return $c <= 0.03928 ? $c / 12.92 : (($c + 0.055) / 1.055) ** 2.4;
     }
 }


### PR DESCRIPTION
## Summary

Draft to surface the size of the level 7 cleanup.

Level 7 adds:
- Partial union-type checks (calling a method that only exists on some members of a union)
- `iterable<T>` key checks
- A bunch of tighter checks around mixed values

Expected to fail PHPStan until we either fix or baseline the new errors.

## Plan

1. Push and let CI report the error count.
2. If it's small → fix all in this PR, ship clean.
3. If it's large → fix in chunks or baseline + iterate.