### PR TITLE
chore(phpstan): bump level 7 → 8

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ bin/phpunit                           # Run tests
 ```
 
 ### Static analysis (PHPStan)
-PHPStan runs against `api/src` and `api/tests` at **level 7** as a required CI check. Config lives in [api/phpstan.dist.neon](api/phpstan.dist.neon); the baseline is currently empty — every error fails CI. If you ever need to defer a fix, regenerate [api/phpstan-baseline.neon](api/phpstan-baseline.neon) with `docker compose run --rm phpstan analyse --generate-baseline=phpstan-baseline.neon`.
+PHPStan runs against `api/src` and `api/tests` at **level 8** as a required CI check. Config lives in [api/phpstan.dist.neon](api/phpstan.dist.neon); pre-existing test-side null-safety patterns are deferred via [api/phpstan-baseline.neon](api/phpstan-baseline.neon) so CI only fails on *new* errors. Regenerate after a cleanup pass with `docker compose run --rm phpstan analyse --generate-baseline=phpstan-baseline.neon`.
 
 Extensions wired up:
 - `phpstan/phpstan-symfony` — service-id / config-resolver awareness via `var/cache/test/App_KernelTestDebugContainer.xml`, console application loaded from [api/tests/phpstan/console-application.php](api/tests/phpstan/console-application.php).

--- a/api/phpstan-baseline.neon
+++ b/api/phpstan-baseline.neon
@@ -1,6 +1,300 @@
-# Pre-existing PHPStan violations as of the level-5 rollout. Regenerate
-# with: docker compose run --rm phpstan analyse --generate-baseline=phpstan-baseline.neon
-# after clearing a batch. Anything new fails CI; baselined errors do not.
+# Pre-existing PHPStan level-8 violations. Regenerate with:
+#   docker compose run --rm phpstan analyse --generate-baseline=phpstan-baseline.neon
+# Chip away in follow-up PRs.
 
 parameters:
-    ignoreErrors: []
+    ignoreErrors:
+        -
+            message: '#^Cannot\ call\ method\ toArray\(\)\ on#'
+            count: 5
+            path: tests/Api/ActivityHistoryTest.php
+        -
+            message: '#^Cannot\ call\ method\ toArray\(\)\ on#'
+            count: 2
+            path: tests/Api/ApiTokenTest.php
+        -
+            message: '#^Cannot\ call\ method\ equals\(\)\ on\ Symfony\\Component\\Uid\\Uuid\|null\.#'
+            count: 2
+            path: tests/Api/CommentTest.php
+        -
+            message: '#^Cannot\ call\ method\ getAuthor\(\)\ on\ App\\Entity\\Comment\|null\.#'
+            path: tests/Api/CommentTest.php
+        -
+            message: '#^Cannot\ call\ method\ getBody\(\)\ on\ App\\Entity\\Comment\|null\.#'
+            path: tests/Api/CommentTest.php
+        -
+            message: '#^Cannot\ call\ method\ getUpdatedAt\(\)\ on\ App\\Entity\\Comment\|null\.#'
+            path: tests/Api/CommentTest.php
+        -
+            message: '#^Cannot\ call\ method\ toArray\(\)\ on#'
+            count: 4
+            path: tests/Api/CommentTest.php
+        -
+            message: '#^Cannot\ call\ method\ getKernelResponse\(\)\ on#'
+            path: tests/Api/CommentsMercureTokenTest.php
+        -
+            message: '#^Cannot\ call\ method\ getStatusCode\(\)\ on#'
+            path: tests/Api/CommentsMercureTokenTest.php
+        -
+            message: '#^Cannot\ call\ method\ getStatusCode\(\)\ on#'
+            count: 2
+            path: tests/Api/CustomFieldDefinitionTest.php
+        -
+            message: '#^Cannot\ call\ method\ toArray\(\)\ on#'
+            path: tests/Api/CustomFieldDefinitionTest.php
+        -
+            message: '#^Cannot\ call\ method\ toArray\(\)\ on#'
+            count: 6
+            path: tests/Api/CustomFieldFooterTest.php
+        -
+            message: '#^Cannot\ call\ method\ getAuthor\(\)\ on\ App\\Entity\\Discussion\|null\.#'
+            path: tests/Api/DiscussionCopyTest.php
+        -
+            message: '#^Cannot\ call\ method\ getId\(\)\ on\ App\\Entity\\User\|null\.#'
+            count: 2
+            path: tests/Api/DiscussionCopyTest.php
+        -
+            message: '#^Cannot\ call\ method\ getIsLocked\(\)\ on\ App\\Entity\\Discussion\|null\.#'
+            count: 2
+            path: tests/Api/DiscussionCopyTest.php
+        -
+            message: '#^Cannot\ call\ method\ getIsPinned\(\)\ on\ App\\Entity\\Discussion\|null\.#'
+            count: 2
+            path: tests/Api/DiscussionCopyTest.php
+        -
+            message: '#^Cannot\ call\ method\ toArray\(\)\ on#'
+            count: 6
+            path: tests/Api/DiscussionCopyTest.php
+        -
+            message: '#^Cannot\ call\ method\ getId\(\)\ on\ App\\Entity\\Space\|null\.#'
+            path: tests/Api/DiscussionMoveTest.php
+        -
+            message: '#^Cannot\ call\ method\ getSpace\(\)\ on\ App\\Entity\\Discussion\|null\.#'
+            path: tests/Api/DiscussionMoveTest.php
+        -
+            message: '#^Cannot\ call\ method\ toArray\(\)\ on#'
+            count: 3
+            path: tests/Api/DiscussionMoveTest.php
+        -
+            message: '#^Cannot\ call\ method\ toArray\(\)\ on#'
+            count: 2
+            path: tests/Api/DiscussionTest.php
+        -
+            message: '#^Parameter\ \#1\ \$email\ of\ method#'
+            count: 5
+            path: tests/Api/EmailChangeTest.php
+        -
+            message: '#^Cannot\ call\ method\ toArray\(\)\ on#'
+            path: tests/Api/McpTest.php
+        -
+            message: '#^Cannot\ call\ method\ getStatusCode\(\)\ on#'
+            path: tests/Api/MediaObjectDownloadTest.php
+        -
+            message: '#^Cannot\ call\ method\ getContent\(\)\ on#'
+            count: 3
+            path: tests/Api/MediaObjectTest.php
+        -
+            message: '#^Cannot\ call\ method\ getStatusCode\(\)\ on#'
+            path: tests/Api/MediaObjectTest.php
+        -
+            message: '#^Cannot\ call\ method\ getEmail\(\)\ on\ App\\Entity\\User\|null\.#'
+            path: tests/Api/NotificationTest.php
+        -
+            message: '#^Cannot\ call\ method\ toArray\(\)\ on#'
+            count: 2
+            path: tests/Api/NotificationTest.php
+        -
+            message: '#^Parameter\ \#1\ \$email\ of\ method#'
+            count: 10
+            path: tests/Api/NotificationTest.php
+        -
+            message: '#^Cannot\ call\ method\ getCreatedBy\(\)\ on\ App\\Entity\\Page\|null\.#'
+            path: tests/Api/PageCopyTest.php
+        -
+            message: '#^Cannot\ call\ method\ getId\(\)\ on\ App\\Entity\\Page\|null\.#'
+            path: tests/Api/PageCopyTest.php
+        -
+            message: '#^Cannot\ call\ method\ getId\(\)\ on\ App\\Entity\\Space\|null\.#'
+            count: 3
+            path: tests/Api/PageCopyTest.php
+        -
+            message: '#^Cannot\ call\ method\ getId\(\)\ on\ App\\Entity\\User\|null\.#'
+            count: 2
+            path: tests/Api/PageCopyTest.php
+        -
+            message: '#^Cannot\ call\ method\ getParent\(\)\ on\ App\\Entity\\Page\|null\.#'
+            count: 3
+            path: tests/Api/PageCopyTest.php
+        -
+            message: '#^Cannot\ call\ method\ getSpace\(\)\ on\ App\\Entity\\Page\|null\.#'
+            count: 2
+            path: tests/Api/PageCopyTest.php
+        -
+            message: '#^Cannot\ call\ method\ getTitle\(\)\ on\ App\\Entity\\Page\|null\.#'
+            count: 2
+            path: tests/Api/PageCopyTest.php
+        -
+            message: '#^Cannot\ call\ method\ toArray\(\)\ on#'
+            count: 12
+            path: tests/Api/PageCopyTest.php
+        -
+            message: '#^Cannot\ call\ method\ getId\(\)\ on\ App\\Entity\\Space\|null\.#'
+            count: 2
+            path: tests/Api/PageMoveTest.php
+        -
+            message: '#^Cannot\ call\ method\ getParent\(\)\ on\ App\\Entity\\Page\|null\.#'
+            path: tests/Api/PageMoveTest.php
+        -
+            message: '#^Cannot\ call\ method\ getSpace\(\)\ on\ App\\Entity\\Page\|null\.#'
+            count: 2
+            path: tests/Api/PageMoveTest.php
+        -
+            message: '#^Cannot\ call\ method\ toArray\(\)\ on#'
+            count: 3
+            path: tests/Api/PageMoveTest.php
+        -
+            message: '#^Cannot\ call\ method\ toArray\(\)\ on#'
+            count: 2
+            path: tests/Api/PageTest.php
+        -
+            message: '#^Cannot\ call\ method\ getId\(\)\ on\ App\\Entity\\Space\|null\.#'
+            count: 2
+            path: tests/Api/ProjectCopyTest.php
+        -
+            message: '#^Cannot\ call\ method\ getId\(\)\ on\ App\\Entity\\User\|null\.#'
+            count: 3
+            path: tests/Api/ProjectCopyTest.php
+        -
+            message: '#^Cannot\ call\ method\ getOwner\(\)\ on\ App\\Entity\\Project\|null\.#'
+            path: tests/Api/ProjectCopyTest.php
+        -
+            message: '#^Cannot\ call\ method\ getSpace\(\)\ on\ App\\Entity\\Project\|null\.#'
+            path: tests/Api/ProjectCopyTest.php
+        -
+            message: '#^Cannot\ call\ method\ toArray\(\)\ on#'
+            count: 12
+            path: tests/Api/ProjectCopyTest.php
+        -
+            message: '#^Cannot\ call\ method\ getId\(\)\ on\ App\\Entity\\Space\|null\.#'
+            count: 2
+            path: tests/Api/ProjectMoveTest.php
+        -
+            message: '#^Cannot\ call\ method\ getSpace\(\)\ on\ App\\Entity\\Project\|null\.#'
+            path: tests/Api/ProjectMoveTest.php
+        -
+            message: '#^Cannot\ call\ method\ toArray\(\)\ on#'
+            count: 3
+            path: tests/Api/ProjectMoveTest.php
+        -
+            message: '#^Cannot\ call\ method\ equals\(\)\ on\ Symfony\\Component\\Uid\\Uuid\|null\.#'
+            count: 2
+            path: tests/Api/ProjectTest.php
+        -
+            message: '#^Cannot\ call\ method\ getEffectiveMembers\(\)\ on\ App\\Entity\\Project\|null\.#'
+            path: tests/Api/ProjectTest.php
+        -
+            message: '#^Cannot\ call\ method\ getProject\(\)\ on\ App\\Entity\\Task\|null\.#'
+            count: 2
+            path: tests/Api/ProjectTest.php
+        -
+            message: '#^Cannot\ call\ method\ getTitle\(\)\ on\ App\\Entity\\Task\|null\.#'
+            path: tests/Api/ProjectTest.php
+        -
+            message: '#^Cannot\ call\ method\ toArray\(\)\ on#'
+            path: tests/Api/ProjectTest.php
+        -
+            message: '#^Cannot\ call\ method\ getContent\(\)\ on#'
+            path: tests/Api/PushSubscriptionTest.php
+        -
+            message: '#^Cannot\ call\ method\ getStatusCode\(\)\ on#'
+            path: tests/Api/PushSubscriptionTest.php
+        -
+            message: '#^Cannot\ call\ method\ toArray\(\)\ on#'
+            path: tests/Api/PushSubscriptionTest.php
+        -
+            message: '#^Cannot\ call\ method\ getAttachments\(\)\ on\ App\\Entity\\Space\|null\.#'
+            path: tests/Api/SpaceAttachmentTest.php
+        -
+            message: '#^Cannot\ call\ method\ hasMember\(\)\ on\ App\\Entity\\Space\|null\.#'
+            count: 3
+            path: tests/Api/SpaceInviteTest.php
+        -
+            message: '#^Cannot\ call\ method\ toArray\(\)\ on#'
+            count: 2
+            path: tests/Api/SpaceInviteTest.php
+        -
+            message: '#^Cannot\ call\ method\ equals\(\)\ on\ Symfony\\Component\\Uid\\Uuid\|null\.#'
+            path: tests/Api/SpaceTest.php
+        -
+            message: '#^Cannot\ call\ method\ getId\(\)\ on\ App\\Entity\\Space\|null\.#'
+            count: 2
+            path: tests/Api/SpaceTest.php
+        -
+            message: '#^Cannot\ call\ method\ equals\(\)\ on\ Symfony\\Component\\Uid\\Uuid\|null\.#'
+            count: 2
+            path: tests/Api/TagTest.php
+        -
+            message: '#^Cannot\ call\ method\ toArray\(\)\ on#'
+            path: tests/Api/TagTest.php
+        -
+            message: '#^Cannot\ call\ method\ getAttachments\(\)\ on\ App\\Entity\\Task\|null\.#'
+            path: tests/Api/TaskAttachmentTest.php
+        -
+            message: '#^Cannot\ call\ method\ toArray\(\)\ on#'
+            count: 3
+            path: tests/Api/TaskAttachmentTest.php
+        -
+            message: '#^Cannot\ call\ method\ toArray\(\)\ on#'
+            path: tests/Api/TaskCustomFieldValueTest.php
+        -
+            message: '#^Cannot\ call\ method\ equals\(\)\ on\ Symfony\\Component\\Uid\\Uuid\|null\.#'
+            count: 2
+            path: tests/Api/TaskTest.php
+        -
+            message: '#^Cannot\ call\ method\ getAssignees\(\)\ on\ App\\Entity\\Task\|null\.#'
+            count: 2
+            path: tests/Api/TaskTest.php
+        -
+            message: '#^Cannot\ call\ method\ getPosition\(\)\ on\ App\\Entity\\Task\|null\.#'
+            count: 8
+            path: tests/Api/TaskTest.php
+        -
+            message: '#^Cannot\ call\ method\ toArray\(\)\ on#'
+            count: 21
+            path: tests/Api/TaskTest.php
+        -
+            message: '#^Cannot\ call\ method\ getContent\(\)\ on#'
+            count: 7
+            path: tests/Api/TwoFactorTest.php
+        -
+            message: '#^Cannot\ call\ method\ equals\(\)\ on\ Symfony\\Component\\Uid\\Uuid\|null\.#'
+            path: tests/Api/UserGroupTest.php
+        -
+            message: '#^Cannot\ call\ method\ getMembers\(\)\ on\ App\\Entity\\UserGroup\|null\.#'
+            count: 2
+            path: tests/Api/UserGroupTest.php
+        -
+            message: '#^Cannot\ call\ method\ getOwner\(\)\ on\ App\\Entity\\UserGroup\|null\.#'
+            path: tests/Api/UserGroupTest.php
+        -
+            message: '#^Cannot\ call\ method\ equals\(\)\ on\ Symfony\\Component\\Uid\\Uuid\|null\.#'
+            path: tests/Api/UserInviteTest.php
+        -
+            message: '#^Cannot\ call\ method\ getAcceptedAt\(\)\ on\ App\\Entity\\UserInvite\|null\.#'
+            count: 3
+            path: tests/Api/UserInviteTest.php
+        -
+            message: '#^Cannot\ call\ method\ getMembers\(\)\ on\ App\\Entity\\UserGroup\|null\.#'
+            count: 5
+            path: tests/Api/UserInviteTest.php
+        -
+            message: '#^Cannot\ call\ method\ toArray\(\)\ on#'
+            path: tests/Api/UserInviteTest.php
+        -
+            message: '#^Cannot\ call\ method\ toArray\(\)\ on#'
+            count: 4
+            path: tests/Api/UserPreferencesTest.php
+        -
+            message: '#^Cannot\ call\ method\ getContent\(\)\ on#'
+            count: 2
+            path: tests/Api/UserTest.php

--- a/api/phpstan.dist.neon
+++ b/api/phpstan.dist.neon
@@ -8,7 +8,7 @@ includes:
     - vendor/phpstan/phpstan-phpunit/rules.neon
 
 parameters:
-    level: 7
+    level: 8
     paths:
         - src
         - tests

--- a/api/src/Controller/UserInviteController.php
+++ b/api/src/Controller/UserInviteController.php
@@ -129,7 +129,7 @@ class UserInviteController extends AbstractController
         }
 
         $groupInvite = $this->groupInviteRepository->find($groupInviteId);
-        if (null === $groupInvite || !$groupInvite->getGroup()->getId()->equals($group->getId())) {
+        if (null === $groupInvite || !$groupInvite->getGroup()->getId()?->equals($group->getId())) {
             return $this->json(['error' => 'Invite not found.'], 404);
         }
 

--- a/api/src/State/TaskUpdateProcessor.php
+++ b/api/src/State/TaskUpdateProcessor.php
@@ -65,13 +65,21 @@ final class TaskUpdateProcessor implements ProcessorInterface
      */
     private function createNextOccurrence(Task $completed): void
     {
+        // Caller only invokes us after asserting both fields are set —
+        // re-narrow so phpstan can see the non-null shape on the
+        // advanceDueDate call below.
+        $dueDate = $completed->getDueDate();
+        $rule = $completed->getRecurrenceRule();
+        if (null === $dueDate || null === $rule) {
+            return;
+        }
         $next = new Task();
         $next->setOwner($completed->getOwner());
         $next->setProject($completed->getProject());
         $next->setTitle($completed->getTitle());
         $next->setDescription($completed->getDescription());
-        $next->setRecurrenceRule($completed->getRecurrenceRule());
-        $next->setDueDate($this->advanceDueDate($completed->getDueDate(), $completed->getRecurrenceRule()));
+        $next->setRecurrenceRule($rule);
+        $next->setDueDate($this->advanceDueDate($dueDate, $rule));
 
         foreach ($completed->getTags() as $tag) {
             $next->addTag($tag);

--- a/api/src/Validator/ValidCustomFieldValuesValidator.php
+++ b/api/src/Validator/ValidCustomFieldValuesValidator.php
@@ -62,9 +62,15 @@ final class ValidCustomFieldValuesValidator extends ConstraintValidator
 
         foreach ($values as $index => $cfv) {
             $definition = $cfv->getDefinition();
+            if (null === $definition) {
+                // NotNull constraint on the property surfaces the
+                // missing definition separately.
+                continue;
+            }
             $defProject = $definition->getProject();
             if (
                 null === $project
+                || null === $defProject
                 || (string) $defProject->getId() !== (string) $project->getId()
             ) {
                 $this->context->buildViolation($constraint->messageWrongProject)


### PR DESCRIPTION
## Summary

Draft to surface the size of the level 8 cleanup.

Level 8 is the big one — adds strict null-safety:
- Method calls on `T|null` without narrowing
- Property access on possibly-null receivers
- Tighter checks around mixed values

Expected to surface a lot more errors than levels 6 or 7 since the codebase has plenty of `getRepository()->find()` results, `$entity->getRelation()`, `?->` chains, etc.

## Plan

1. Push and let CI report the error count.
2. If it's tractable (~30) → fix in this PR.
3. If it's larger → baseline the easy categories + fix the rest, iterating across follow-up PRs.