### PR TITLE
chore(phpstan): bump level 8 → 9

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ bin/phpunit                           # Run tests
 ```
 
 ### Static analysis (PHPStan)
-PHPStan runs against `api/src` and `api/tests` at **level 8** as a required CI check. Config lives in [api/phpstan.dist.neon](api/phpstan.dist.neon); pre-existing test-side null-safety patterns are deferred via [api/phpstan-baseline.neon](api/phpstan-baseline.neon) so CI only fails on *new* errors. Regenerate after a cleanup pass with `docker compose run --rm phpstan analyse --generate-baseline=phpstan-baseline.neon`.
+PHPStan runs against `api/src` and `api/tests` at **level 9** as a required CI check. Config lives in [api/phpstan.dist.neon](api/phpstan.dist.neon); pre-existing mixed-type accesses (mostly nested key lookups on JSON-RPC responses in test helpers) are deferred via [api/phpstan-baseline.neon](api/phpstan-baseline.neon) so CI only fails on *new* errors. Regenerate after a cleanup pass with `docker compose run --rm phpstan analyse --generate-baseline=phpstan-baseline.neon`.
 
 Extensions wired up:
 - `phpstan/phpstan-symfony` — service-id / config-resolver awareness via `var/cache/test/App_KernelTestDebugContainer.xml`, console application loaded from [api/tests/phpstan/console-application.php](api/tests/phpstan/console-application.php).

--- a/api/phpstan-baseline.neon
+++ b/api/phpstan-baseline.neon
@@ -1,6 +1,202 @@
-# Pre-existing PHPStan level-8 violations. Regenerate with:
+# Pre-existing PHPStan level-9 violations. Mostly mixed-type nested
+# accesses in tests. Regenerate with
 #   docker compose run --rm phpstan analyse --generate-baseline=phpstan-baseline.neon
 # Chip away in follow-up PRs.
 
 parameters:
-    ignoreErrors: []
+    ignoreErrors:
+        -
+            message: '#^Parameter\ \#1\ \$value\ of\ function\ count\ expects\ array\|Countable,\ mixed#'
+            path: src/Controller/AssignableUsersController.php
+        -
+            message: '#^Cannot\ access\ offset\ ''id''\ on\ mixed\.#'
+            path: src/Controller/CustomFieldFooterController.php
+        -
+            message: '#^Method\ App\\Controller\\McpController::decode\(\)\ should\ return#'
+            path: src/Controller/McpController.php
+        -
+            message: '#^Parameter\ \#1\ \$arguments\ of\ method\ array<mixed,\ mixed>\ given\.#'
+            path: src/Controller/McpController.php
+        -
+            message: '#^Parameter\ \#1\ \$rows\ of\ static\ method#'
+            path: src/Controller/PageActivityController.php
+        -
+            message: '#^Parameter\ \#1\ \$rows\ of\ static\ method#'
+            path: src/Controller/TaskActivityController.php
+        -
+            message: '#^Cannot\ cast\ mixed\ to\ string\.#'
+            count: 3
+            path: src/Controller/TwoFactorController.php
+        -
+            message: '#^Cannot\ cast\ mixed\ to\ float\.#'
+            path: src/CustomField/Footer/FooterAggregator.php
+        -
+            message: '#^Cannot\ cast\ mixed\ to\ int\.#'
+            path: src/CustomField/Footer/FooterAggregator.php
+        -
+            message: '#^Method\ App\\Repository\\UserInviteRepository::findByEmail\(\)\ should#'
+            path: src/Repository/UserInviteRepository.php
+        -
+            message: '#^Cannot\ access\ offset\ ''assignees''\ on\ mixed\.#'
+            path: tests/Api/McpTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''author''\ on\ mixed\.#'
+            path: tests/Api/McpTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''body''\ on\ mixed\.#'
+            path: tests/Api/McpTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''capabilities''\ on\ mixed\.#'
+            path: tests/Api/McpTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''content''\ on\ mixed\.#'
+            count: 3
+            path: tests/Api/McpTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''email''\ on\ mixed\.#'
+            count: 2
+            path: tests/Api/McpTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''isError''\ on\ mixed\.#'
+            count: 9
+            path: tests/Api/McpTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''items''\ on\ mixed\.#'
+            path: tests/Api/McpTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''name''\ on\ mixed\.#'
+            path: tests/Api/McpTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''owner''\ on\ mixed\.#'
+            path: tests/Api/McpTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''serverInfo''\ on\ mixed\.#'
+            path: tests/Api/McpTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''status''\ on\ mixed\.#'
+            count: 2
+            path: tests/Api/McpTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''structuredContent''\ on\ mixed\.#'
+            count: 6
+            path: tests/Api/McpTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''text''\ on\ mixed\.#'
+            count: 3
+            path: tests/Api/McpTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''title''\ on\ mixed\.#'
+            path: tests/Api/McpTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''tools''\ on\ mixed\.#'
+            path: tests/Api/McpTest.php
+        -
+            message: '#^Cannot\ access\ offset\ 0\ on\ mixed\.#'
+            count: 3
+            path: tests/Api/McpTest.php
+        -
+            message: '#^Parameter\ \#1\ \$array\ of\ function\ array_column\ expects\ array,\ mixed#'
+            count: 3
+            path: tests/Api/McpTest.php
+        -
+            message: '#^Parameter\ \#2\ \$array\ of\ method#'
+            path: tests/Api/McpTest.php
+        -
+            message: '#^Parameter\ \#2\ \$haystack\ of\ method#'
+            count: 3
+            path: tests/Api/McpTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''@id''\ on\ mixed\.#'
+            path: tests/Api/MediaObjectTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''avatarUrls''\ on\ mixed\.#'
+            path: tests/Api/MediaObjectTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''kind''\ on\ mixed\.#'
+            path: tests/Api/MediaObjectTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''profile''\ on\ mixed\.#'
+            path: tests/Api/MediaObjectTest.php
+        -
+            message: '#^Parameter\ \#2\ \$array\ of\ method#'
+            path: tests/Api/MediaObjectTest.php
+        -
+            message: '#^Parameter\ \#2\ \$string\ of\ method#'
+            path: tests/Api/MediaObjectTest.php
+        -
+            message: '#^Parameter\ \#1\ \$callback\ of\ function\ array_map\ expects#'
+            path: tests/Api/ProjectCopyTest.php
+        -
+            message: '#^Parameter\ \#2\ \$array\ of\ function\ array_map\ expects\ array,\ mixed\ given\.#'
+            path: tests/Api/ProjectCopyTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''email''\ on\ mixed\.#'
+            count: 2
+            path: tests/Api/TwoFactorTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''enabled''\ on\ mixed\.#'
+            count: 2
+            path: tests/Api/TwoFactorTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''provisioningUri''\ on\ mixed\.#'
+            path: tests/Api/TwoFactorTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''recoveryCodes''\ on\ mixed\.#'
+            count: 3
+            path: tests/Api/TwoFactorTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''requiresTwoFactor''\ on\ mixed\.#'
+            path: tests/Api/TwoFactorTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''secret''\ on\ mixed\.#'
+            count: 2
+            path: tests/Api/TwoFactorTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''twoFactor''\ on\ mixed\.#'
+            path: tests/Api/TwoFactorTest.php
+        -
+            message: '#^Parameter\ \#2\ \$haystack\ of\ method#'
+            count: 2
+            path: tests/Api/TwoFactorTest.php
+        -
+            message: '#^Parameter\ \#2\ \$string\ of\ method#'
+            path: tests/Api/TwoFactorTest.php
+        -
+            message: '#^Parameter\ \#2\ \.\.\.\$arrays\ of\ function\ array_intersect\ expects\ array,#'
+            path: tests/Api/TwoFactorTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''avatarUrls''\ on\ mixed\.#'
+            count: 2
+            path: tests/Api/UserTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''email''\ on\ mixed\.#'
+            path: tests/Api/UserTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''familyName''\ on\ mixed\.#'
+            path: tests/Api/UserTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''givenName''\ on\ mixed\.#'
+            path: tests/Api/UserTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''personalizedColor''\ on\ mixed\.#'
+            count: 2
+            path: tests/Api/UserTest.php
+        -
+            message: '#^Parameter\ \#2\ \$array\ of\ method#'
+            count: 2
+            path: tests/Api/UserTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''@id''\ on\ mixed\.#'
+            path: tests/Service/CommentMercurePublisherTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''body''\ on\ mixed\.#'
+            count: 2
+            path: tests/Service/CommentMercurePublisherTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''comment''\ on\ mixed\.#'
+            count: 3
+            path: tests/Service/CommentMercurePublisherTest.php
+        -
+            message: '#^Cannot\ access\ offset\ ''type''\ on\ mixed\.#'
+            count: 2
+            path: tests/Service/CommentMercurePublisherTest.php

--- a/api/phpstan-baseline.neon
+++ b/api/phpstan-baseline.neon
@@ -15,7 +15,7 @@ parameters:
             message: '#^Method\ App\\Controller\\McpController::decode\(\)\ should\ return#'
             path: src/Controller/McpController.php
         -
-            message: '#^Parameter\ \#1\ \$arguments\ of\ method\ array<mixed,\ mixed>\ given\.#'
+            message: '#^Parameter\ \#1\ \$arguments\ of\ method\ App\\Mcp\\Tool\\McpToolInterface::invoke\(\)#'
             path: src/Controller/McpController.php
         -
             message: '#^Parameter\ \#1\ \$rows\ of\ static\ method#'

--- a/api/phpstan.dist.neon
+++ b/api/phpstan.dist.neon
@@ -8,7 +8,7 @@ includes:
     - vendor/phpstan/phpstan-phpunit/rules.neon
 
 parameters:
-    level: 8
+    level: 9
     paths:
         - src
         - tests

--- a/api/src/Controller/DiscussionCopyController.php
+++ b/api/src/Controller/DiscussionCopyController.php
@@ -49,7 +49,7 @@ class DiscussionCopyController extends AbstractController
             return $this->json(['error' => 'Discussion not found.'], 404);
         }
 
-        $payload = json_decode($request->getContent(), true) ?? [];
+        $payload = $request->toArray();
         $rawSpace = $payload['space'] ?? null;
         $target = $sourceSpace;
         if (is_string($rawSpace) && '' !== trim($rawSpace)) {

--- a/api/src/Controller/DiscussionMoveController.php
+++ b/api/src/Controller/DiscussionMoveController.php
@@ -47,7 +47,7 @@ class DiscussionMoveController extends AbstractController
             return $this->json(['error' => 'Discussion not found.'], 404);
         }
 
-        $payload = json_decode($request->getContent(), true) ?? [];
+        $payload = $request->toArray();
         $rawSpace = $payload['space'] ?? null;
         if (!is_string($rawSpace) || '' === trim($rawSpace)) {
             return $this->json(['error' => 'Target `space` IRI is required.'], 400);

--- a/api/src/Controller/EmailChangeController.php
+++ b/api/src/Controller/EmailChangeController.php
@@ -46,7 +46,7 @@ class EmailChangeController extends AbstractController
             return $this->json(['error' => 'Not authenticated.'], 401);
         }
 
-        $data = json_decode($request->getContent(), true) ?? [];
+        $data = $request->toArray();
         $newEmail = trim((string) ($data['newEmail'] ?? ''));
 
         if ('' === $newEmail) {
@@ -98,7 +98,7 @@ class EmailChangeController extends AbstractController
     #[Route('/auth/confirm-email-change', name: 'auth_confirm_email_change', methods: ['POST'])]
     public function confirm(Request $request): JsonResponse
     {
-        $data = json_decode($request->getContent(), true) ?? [];
+        $data = $request->toArray();
         $plainToken = (string) ($data['token'] ?? '');
 
         if ('' === $plainToken) {
@@ -145,7 +145,7 @@ class EmailChangeController extends AbstractController
     #[Route('/auth/revert-email-change', name: 'auth_revert_email_change', methods: ['POST'])]
     public function revert(Request $request): JsonResponse
     {
-        $data = json_decode($request->getContent(), true) ?? [];
+        $data = $request->toArray();
         $plainToken = (string) ($data['token'] ?? '');
 
         if ('' === $plainToken) {

--- a/api/src/Controller/PageCopyController.php
+++ b/api/src/Controller/PageCopyController.php
@@ -68,7 +68,7 @@ class PageCopyController extends AbstractController
             return $this->json(['error' => 'Page not found.'], 404);
         }
 
-        $payload = json_decode($request->getContent(), true) ?? [];
+        $payload = $request->toArray();
         $rawSpace = $payload['space'] ?? null;
         $target = $sourceSpace;
         if (is_string($rawSpace) && '' !== trim($rawSpace)) {

--- a/api/src/Controller/PageMoveController.php
+++ b/api/src/Controller/PageMoveController.php
@@ -57,7 +57,7 @@ class PageMoveController extends AbstractController
             return $this->json(['error' => 'Page not found.'], 404);
         }
 
-        $payload = json_decode($request->getContent(), true) ?? [];
+        $payload = $request->toArray();
         $rawSpace = $payload['space'] ?? null;
         if (!is_string($rawSpace) || '' === trim($rawSpace)) {
             return $this->json(['error' => 'Target `space` IRI is required.'], 400);

--- a/api/src/Controller/PasswordController.php
+++ b/api/src/Controller/PasswordController.php
@@ -40,7 +40,7 @@ class PasswordController extends AbstractController
             return $this->json(['error' => 'Not authenticated.'], 401);
         }
 
-        $data = json_decode($request->getContent(), true) ?? [];
+        $data = $request->toArray();
         $currentPassword = (string) ($data['currentPassword'] ?? '');
         $newPassword = (string) ($data['newPassword'] ?? '');
 
@@ -69,7 +69,7 @@ class PasswordController extends AbstractController
     #[Route('/auth/forgot-password', name: 'auth_forgot_password', methods: ['POST'])]
     public function forgotPassword(Request $request): JsonResponse
     {
-        $data = json_decode($request->getContent(), true) ?? [];
+        $data = $request->toArray();
         $email = (string) ($data['email'] ?? '');
 
         // Always return 200 to prevent email enumeration
@@ -105,7 +105,7 @@ class PasswordController extends AbstractController
     #[Route('/auth/reset-password', name: 'auth_reset_password', methods: ['POST'])]
     public function resetPassword(Request $request): JsonResponse
     {
-        $data = json_decode($request->getContent(), true) ?? [];
+        $data = $request->toArray();
         $plainToken = (string) ($data['token'] ?? '');
         $newPassword = (string) ($data['newPassword'] ?? '');
 

--- a/api/src/Controller/ProjectCopyController.php
+++ b/api/src/Controller/ProjectCopyController.php
@@ -73,7 +73,7 @@ class ProjectCopyController extends AbstractController
             return $this->json(['error' => 'Project not found.'], 404);
         }
 
-        $payload = json_decode($request->getContent(), true) ?? [];
+        $payload = $request->toArray();
         $rawSpace = $payload['space'] ?? null;
         $target = $source->getSpace();
         if (is_string($rawSpace) && '' !== trim($rawSpace)) {

--- a/api/src/Controller/ProjectMemberController.php
+++ b/api/src/Controller/ProjectMemberController.php
@@ -54,7 +54,7 @@ class ProjectMemberController extends AbstractController
             return $this->json(['error' => 'Project is not attached to a space.'], 500);
         }
 
-        $payload = json_decode($request->getContent(), true) ?? [];
+        $payload = $request->toArray();
         $email = is_string($payload['email'] ?? null) ? trim($payload['email']) : '';
         if ('' === $email) {
             return $this->json(['error' => 'Email is required.'], 400);

--- a/api/src/Controller/ProjectMoveController.php
+++ b/api/src/Controller/ProjectMoveController.php
@@ -59,7 +59,7 @@ class ProjectMoveController extends AbstractController
             return $this->json(['error' => 'Project not found.'], 404);
         }
 
-        $payload = json_decode($request->getContent(), true) ?? [];
+        $payload = $request->toArray();
         $rawSpace = $payload['space'] ?? null;
         if (!is_string($rawSpace) || '' === trim($rawSpace)) {
             return $this->json(['error' => 'Target `space` IRI is required.'], 400);

--- a/api/src/Controller/SpaceMemberController.php
+++ b/api/src/Controller/SpaceMemberController.php
@@ -66,7 +66,7 @@ class SpaceMemberController extends AbstractController
             return $this->json(['error' => 'Only space admins can add members.'], 403);
         }
 
-        $payload = json_decode($request->getContent(), true) ?? [];
+        $payload = $request->toArray();
         $email = is_string($payload['email'] ?? null) ? trim($payload['email']) : '';
         if ('' === $email) {
             return $this->json(['error' => 'Email is required.'], 400);

--- a/api/src/Controller/TaskAssigneeController.php
+++ b/api/src/Controller/TaskAssigneeController.php
@@ -43,7 +43,7 @@ class TaskAssigneeController extends AbstractController
             return $this->json(['error' => 'Task not found.'], 404);
         }
 
-        $payload = json_decode($request->getContent(), true) ?? [];
+        $payload = $request->toArray();
         $userId = is_string($payload['userId'] ?? null) ? trim($payload['userId']) : '';
         if ('' === $userId || !Uuid::isValid($userId)) {
             return $this->json(['error' => 'A valid userId is required.'], 400);

--- a/api/src/Controller/UserGroupMemberController.php
+++ b/api/src/Controller/UserGroupMemberController.php
@@ -65,7 +65,7 @@ class UserGroupMemberController extends AbstractController
             return $this->json(['error' => 'Only the group owner can add members.'], 403);
         }
 
-        $payload = json_decode($request->getContent(), true) ?? [];
+        $payload = $request->toArray();
         $email = is_string($payload['email'] ?? null) ? trim($payload['email']) : '';
         if ('' === $email) {
             return $this->json(['error' => 'Email is required.'], 400);


### PR DESCRIPTION
## Summary

Draft to surface the size of the level 9 cleanup. Level 9 makes phpstan strict about `mixed` — any operation on a `mixed` value (method call, array access, comparison, cast) needs a narrowing check first.

Expected hot spots: `json_decode` returns, `$request->getPayload()->all()` accesses, API Platform `$context`/processor returns, the `mixed` params we declared during the level-6 typehint pass.

## Plan

1. Push and let CI report the total.
2. If <100, fix here.
3. If larger, baseline + iterate as we did at level 8.