### PR TITLE
chore(phpstan): clear src/ controllers from level-10 baseline

### DIFF
--- a/api/phpstan-baseline.neon
+++ b/api/phpstan-baseline.neon
@@ -8,33 +8,6 @@ parameters:
     ignoreErrors:
         -
             identifier: argument.type
-            path: src/Controller/CustomFieldFooterController.php
-        -
-            identifier: cast.string
-            count: 3
-            path: src/Controller/EmailChangeController.php
-        -
-            identifier: argument.type
-            path: src/Controller/McpController.php
-        -
-            identifier: cast.string
-            count: 5
-            path: src/Controller/PasswordController.php
-        -
-            identifier: argument.type
-            path: src/Controller/ProjectActivityController.php
-        -
-            identifier: cast.int
-            path: src/Controller/ProjectActivityController.php
-        -
-            identifier: method.nonObject
-            count: 8
-            path: src/Controller/ProjectActivityController.php
-        -
-            identifier: return.type
-            path: src/Controller/TwoFactorController.php
-        -
-            identifier: argument.type
             count: 4
             path: tests/Api/ActivityHistoryTest.php
         -

--- a/api/src/Controller/CustomFieldFooterController.php
+++ b/api/src/Controller/CustomFieldFooterController.php
@@ -134,6 +134,7 @@ class CustomFieldFooterController extends AbstractController
 
         $dueDate = $request->query->all()['dueDate'] ?? null;
         if (is_array($dueDate)) {
+            /** @var array<string, mixed> $dueDate */
             $this->applyDueDateBounds($qb, $dueDate);
         }
 

--- a/api/src/Controller/EmailChangeController.php
+++ b/api/src/Controller/EmailChangeController.php
@@ -47,7 +47,8 @@ class EmailChangeController extends AbstractController
         }
 
         $data = $request->toArray();
-        $newEmail = trim((string) ($data['newEmail'] ?? ''));
+        $rawEmail = $data['newEmail'] ?? '';
+        $newEmail = trim(is_string($rawEmail) ? $rawEmail : '');
 
         if ('' === $newEmail) {
             return $this->json(['error' => 'New email is required.'], 422);
@@ -99,7 +100,8 @@ class EmailChangeController extends AbstractController
     public function confirm(Request $request): JsonResponse
     {
         $data = $request->toArray();
-        $plainToken = (string) ($data['token'] ?? '');
+        $rawToken = $data['token'] ?? '';
+        $plainToken = is_string($rawToken) ? $rawToken : '';
 
         if ('' === $plainToken) {
             return $this->json(['error' => 'Token is required.'], 400);
@@ -146,7 +148,8 @@ class EmailChangeController extends AbstractController
     public function revert(Request $request): JsonResponse
     {
         $data = $request->toArray();
-        $plainToken = (string) ($data['token'] ?? '');
+        $rawToken = $data['token'] ?? '';
+        $plainToken = is_string($rawToken) ? $rawToken : '';
 
         if ('' === $plainToken) {
             return $this->json(['error' => 'Token is required.'], 400);

--- a/api/src/Controller/McpController.php
+++ b/api/src/Controller/McpController.php
@@ -83,6 +83,12 @@ class McpController extends AbstractController
         if (array_is_list($payload)) {
             $responses = [];
             foreach ($payload as $envelope) {
+                // Belt + braces: a batch entry could be a non-array
+                // (malformed client), drop those.
+                if (!is_array($envelope)) {
+                    continue;
+                }
+                /** @var array<string, mixed> $envelope */
                 $resp = $this->dispatch($envelope, $request, $user);
                 if (null !== $resp) {
                     $responses[] = $resp;

--- a/api/src/Controller/PasswordController.php
+++ b/api/src/Controller/PasswordController.php
@@ -41,8 +41,8 @@ class PasswordController extends AbstractController
         }
 
         $data = $request->toArray();
-        $currentPassword = (string) ($data['currentPassword'] ?? '');
-        $newPassword = (string) ($data['newPassword'] ?? '');
+        $currentPassword = self::stringField($data, 'currentPassword');
+        $newPassword = self::stringField($data, 'newPassword');
 
         if (!$this->hasher->isPasswordValid($user, $currentPassword)) {
             return $this->json(['error' => 'Current password is incorrect.'], 400);
@@ -70,7 +70,7 @@ class PasswordController extends AbstractController
     public function forgotPassword(Request $request): JsonResponse
     {
         $data = $request->toArray();
-        $email = (string) ($data['email'] ?? '');
+        $email = self::stringField($data, 'email');
 
         // Always return 200 to prevent email enumeration
         $response = $this->json([
@@ -106,8 +106,8 @@ class PasswordController extends AbstractController
     public function resetPassword(Request $request): JsonResponse
     {
         $data = $request->toArray();
-        $plainToken = (string) ($data['token'] ?? '');
-        $newPassword = (string) ($data['newPassword'] ?? '');
+        $plainToken = self::stringField($data, 'token');
+        $newPassword = self::stringField($data, 'newPassword');
 
         if ('' === $plainToken) {
             return $this->json(['error' => 'Token is required.'], 400);
@@ -155,5 +155,18 @@ class PasswordController extends AbstractController
             ));
 
         $this->mailer->send($email);
+    }
+
+    /**
+     * Plucks a string field from a JSON body, defaulting to '' for
+     * missing / non-string values. Avoids the cast.string violation
+     * that comes with `(string) ($data[$key] ?? '')`.
+     *
+     * @param array<int|string, mixed> $data
+     */
+    private static function stringField(array $data, string $key): string
+    {
+        $value = $data[$key] ?? null;
+        return is_string($value) ? $value : '';
     }
 }

--- a/api/src/Controller/ProjectActivityController.php
+++ b/api/src/Controller/ProjectActivityController.php
@@ -72,7 +72,7 @@ class ProjectActivityController extends AbstractController
             $where .= ' OR (l.objectClass = :taskClass AND l.objectId IN (:taskIds))';
         }
 
-        $applyParams = function ($qb) use ($project, $taskIds) {
+        $applyParams = function (\Doctrine\ORM\QueryBuilder $qb) use ($project, $taskIds): \Doctrine\ORM\QueryBuilder {
             $qb->setParameter('projectClass', Project::class)
                 ->setParameter('projectId', (string) $project->getId());
             if (!empty($taskIds)) {
@@ -84,11 +84,13 @@ class ProjectActivityController extends AbstractController
 
         // Count and select share filters but the count must NOT carry
         // ORDER BY — Postgres rejects mixing it with COUNT(*).
-        $totalItems = (int) $applyParams(
+        $rawTotal = $applyParams(
             $repo->createQueryBuilder('l')
                 ->select('COUNT(l.id)')
                 ->where($where),
         )->getQuery()->getSingleScalarResult();
+        $totalItems = is_numeric($rawTotal) ? (int) $rawTotal : 0;
+        /** @var ActivityLog[] $rows */
         $rows = $applyParams(
             $repo->createQueryBuilder('l')
                 ->where($where)

--- a/api/src/Controller/TwoFactorController.php
+++ b/api/src/Controller/TwoFactorController.php
@@ -149,7 +149,11 @@ class TwoFactorController extends AbstractController
     private function jsonBody(Request $request): array
     {
         $decoded = json_decode($request->getContent(), true);
-        return is_array($decoded) ? $decoded : [];
+        if (!is_array($decoded)) {
+            return [];
+        }
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
     }
 
     /**


### PR DESCRIPTION
## Summary
First chip-away on the level-10 baseline. 8 baseline entries / 24 errors cleared at the source — all in `src/Controller/`.

- **EmailChange / Password**: replace `(string) ($data[$key] ?? '')` with `is_string()`-narrowed reads. Password gets a private `stringField()` helper to dedupe.
- **ProjectActivityController**: type the `$applyParams` closure as `Doctrine\ORM\QueryBuilder`; `is_numeric` guard before `(int)` on `getSingleScalarResult()`; `@var ActivityLog[]` before passing the result to `ActivityFeedSerializer::serialize()`.
- **CustomFieldFooterController**: `@var array<string, mixed>` on the `is_array`-narrowed `query.all()['dueDate']` before calling `applyDueDateBounds()` (`is_array` alone doesn't narrow to string keys at level 10).
- **McpController**: `is_array()` filter + `@var` on `$envelope` inside the JSON-RPC batch loop so `dispatch()` sees the `array<string, mixed>` it expects.
- **TwoFactorController::jsonBody**: `@var` on the narrowed decoded payload so the `@return` shape holds.

Test-file baseline entries (~140 left) will come in a follow-up.

## Test plan
- [ ] PHPStan green at level 10 with the trimmed baseline
- [ ] Tests / PHPCS / Typecheck / E2E / Doctrine Schema green