### PR TITLE
chore(phpstan): clear 12 small test files from level-10 baseline

### DIFF
--- a/api/phpstan-baseline.neon
+++ b/api/phpstan-baseline.neon
@@ -20,77 +20,12 @@ parameters:
             path: tests/Api/ActivityHistoryTest.php
         -
             identifier: argument.type
-            count: 3
-            path: tests/Api/ApiTokenTest.php
-        -
-            identifier: argument.type
-            count: 4
-            path: tests/Api/CommentTest.php
-        -
-            identifier: offsetAccess.nonOffsetAccessible
-            count: 2
-            path: tests/Api/CommentTest.php
-        -
-            identifier: argument.type
-            path: tests/Api/CustomFieldDefinitionTest.php
-        -
-            identifier: offsetAccess.nonOffsetAccessible
-            path: tests/Api/CustomFieldDefinitionTest.php
-        -
-            identifier: argument.type
             count: 2
             path: tests/Api/CustomFieldFooterTest.php
         -
             identifier: offsetAccess.nonOffsetAccessible
             count: 14
             path: tests/Api/CustomFieldFooterTest.php
-        -
-            identifier: argument.type
-            count: 2
-            path: tests/Api/DiscussionTest.php
-        -
-            identifier: offsetAccess.nonOffsetAccessible
-            count: 2
-            path: tests/Api/DiscussionTest.php
-        -
-            identifier: argument.type
-            count: 2
-            path: tests/Api/NotificationTest.php
-        -
-            identifier: offsetAccess.nonOffsetAccessible
-            count: 2
-            path: tests/Api/NotificationTest.php
-        -
-            identifier: argument.type
-            count: 2
-            path: tests/Api/PageTest.php
-        -
-            identifier: offsetAccess.nonOffsetAccessible
-            count: 2
-            path: tests/Api/PageTest.php
-        -
-            identifier: argument.type
-            path: tests/Api/ProjectCopyTest.php
-        -
-            identifier: argument.type
-            path: tests/Api/ProjectTest.php
-        -
-            identifier: offsetAccess.nonOffsetAccessible
-            path: tests/Api/ProjectTest.php
-        -
-            identifier: argument.type
-            path: tests/Api/PushSubscriptionTest.php
-        -
-            identifier: offsetAccess.nonOffsetAccessible
-            path: tests/Api/PushSubscriptionTest.php
-        -
-            identifier: argument.type
-            count: 2
-            path: tests/Api/SpaceInviteTest.php
-        -
-            identifier: offsetAccess.nonOffsetAccessible
-            count: 6
-            path: tests/Api/SpaceInviteTest.php
         -
             identifier: argument.type
             count: 2
@@ -123,13 +58,3 @@ parameters:
             identifier: offsetAccess.nonOffsetAccessible
             count: 17
             path: tests/Api/TaskTest.php
-        -
-            identifier: argument.type
-            path: tests/Api/UserInviteTest.php
-        -
-            identifier: offsetAccess.nonOffsetAccessible
-            count: 2
-            path: tests/Api/UserInviteTest.php
-        -
-            identifier: offsetAccess.nonOffsetAccessible
-            path: tests/Api/UserPreferencesTest.php

--- a/api/tests/Api/ApiTokenTest.php
+++ b/api/tests/Api/ApiTokenTest.php
@@ -40,13 +40,15 @@ class ApiTokenTest extends ApiTestCase
         $body = $response->toArray();
         $this->assertSame('Local CLI', $body['name']);
         $this->assertArrayHasKey('plainToken', $body);
-        $this->assertStringStartsWith(ApiToken::PLAINTEXT_PREFIX, $body['plainToken']);
+        $plainToken = $body['plainToken'];
+        $this->assertIsString($plainToken);
+        $this->assertStringStartsWith(ApiToken::PLAINTEXT_PREFIX, $plainToken);
 
         // The persisted hash should be the sha256 of the returned plaintext.
         $repo = $this->entityManager->getRepository(ApiToken::class);
         $token = $repo->findOneBy(['name' => 'Local CLI']);
         $this->assertNotNull($token);
-        $this->assertSame(hash('sha256', $body['plainToken']), $token->getTokenHash());
+        $this->assertSame(hash('sha256', $plainToken), $token->getTokenHash());
     }
 
     public function testListReturnsOnlyOwnTokens(): void
@@ -64,7 +66,9 @@ class ApiTokenTest extends ApiTestCase
         $response = $client->getResponse();
         self::assertNotNull($response);
         $body = $response->toArray();
-        $names = array_column($body['member'] ?? [], 'name');
+        $members = $body['member'] ?? [];
+        $this->assertIsArray($members);
+        $names = array_column($members, 'name');
         $this->assertSame(['Alice CLI'], $names);
     }
 

--- a/api/tests/Api/CommentTest.php
+++ b/api/tests/Api/CommentTest.php
@@ -162,9 +162,11 @@ class CommentTest extends ApiTestCase
         $this->assertResponseIsSuccessful();
         $response = $client->getResponse();
         self::assertNotNull($response);
+        $members = $response->toArray()['member'] ?? [];
+        $this->assertIsArray($members);
         $bodies = array_map(
-            fn ($c) => $c['body'],
-            $response->toArray()['member'] ?? [],
+            static fn (mixed $c): mixed => is_array($c) ? $c['body'] ?? null : null,
+            $members,
         );
         $this->assertSame(['My note.'], $bodies);
     }
@@ -194,9 +196,11 @@ class CommentTest extends ApiTestCase
         $this->assertResponseIsSuccessful();
         $response = $client->getResponse();
         self::assertNotNull($response);
+        $members = $response->toArray()['member'] ?? [];
+        $this->assertIsArray($members);
         $bodies = array_map(
-            fn ($c) => $c['body'],
-            $response->toArray()['member'] ?? [],
+            static fn (mixed $c): mixed => is_array($c) ? $c['body'] ?? null : null,
+            $members,
         );
         $this->assertSame(['First', 'Second'], $bodies);
     }
@@ -437,9 +441,11 @@ class CommentTest extends ApiTestCase
         $response = $client->getResponse();
         self::assertNotNull($response);
         $created = $response->toArray();
+        $iri = $created['@id'];
+        $this->assertIsString($iri);
 
         // Edit keeps the same mention — must NOT create a second notification.
-        $client->request('PATCH', $created['@id'], [
+        $client->request('PATCH', $iri, [
             'json' => ['body' => 'Hey @bob (small typo fix)'],
             'headers' => ['Content-Type' => 'application/merge-patch+json'],
         ]);
@@ -472,8 +478,10 @@ class CommentTest extends ApiTestCase
         $response = $client->getResponse();
         self::assertNotNull($response);
         $created = $response->toArray();
+        $iri = $created['@id'];
+        $this->assertIsString($iri);
 
-        $client->request('PATCH', $created['@id'], [
+        $client->request('PATCH', $iri, [
             'json' => ['body' => 'Hey @bob and @carol'],
             'headers' => ['Content-Type' => 'application/merge-patch+json'],
         ]);

--- a/api/tests/Api/CustomFieldDefinitionTest.php
+++ b/api/tests/Api/CustomFieldDefinitionTest.php
@@ -106,9 +106,11 @@ class CustomFieldDefinitionTest extends ApiTestCase
         $this->assertResponseIsSuccessful();
         $response = $client->getResponse();
         self::assertNotNull($response);
+        $members = $response->toArray()['member'] ?? [];
+        $this->assertIsArray($members);
         $names = array_map(
-            fn ($c) => $c['name'],
-            $response->toArray()['member'] ?? [],
+            static fn (mixed $c): mixed => is_array($c) ? $c['name'] ?? null : null,
+            $members,
         );
         $this->assertSame(['A1'], $names);
     }

--- a/api/tests/Api/DiscussionTest.php
+++ b/api/tests/Api/DiscussionTest.php
@@ -122,9 +122,11 @@ class DiscussionTest extends ApiTestCase
         $this->assertResponseIsSuccessful();
         $response = $client->getResponse();
         self::assertNotNull($response);
+        $members = $response->toArray()['member'] ?? [];
+        $this->assertIsArray($members);
         $titles = array_map(
-            fn ($d) => $d['title'],
-            $response->toArray()['member'] ?? [],
+            static fn (mixed $d): mixed => is_array($d) ? $d['title'] ?? null : null,
+            $members,
         );
         $this->assertSame(['A1'], $titles);
     }
@@ -142,9 +144,11 @@ class DiscussionTest extends ApiTestCase
         $this->assertResponseIsSuccessful();
         $response = $client->getResponse();
         self::assertNotNull($response);
+        $members = $response->toArray()['member'] ?? [];
+        $this->assertIsArray($members);
         $titles = array_map(
-            fn ($d) => $d['title'],
-            $response->toArray()['member'] ?? [],
+            static fn (mixed $d): mixed => is_array($d) ? $d['title'] ?? null : null,
+            $members,
         );
         $this->assertSame(['Idea one'], $titles);
     }

--- a/api/tests/Api/JsonBodyAssertions.php
+++ b/api/tests/Api/JsonBodyAssertions.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Tests\Api;
+
+/**
+ * Tiny assertion helpers for narrowing values read out of JSON
+ * response bodies. The underlying values come back from
+ * {@see \Symfony\Contracts\HttpClient\ResponseInterface::toArray()}
+ * (or `json_decode($response->getContent(), true)`) as `mixed`, which
+ * PHPStan at level 10 won't let us cast / iterate / `assertCount()`
+ * without an explicit guard.
+ *
+ * Use this in tests instead of hand-rolling `assertIsArray()` /
+ * `assertIsString()` at every access site:
+ *
+ *   $items = $this->arrayField($body, 'items');     // array<int|string, mixed>
+ *   $name  = $this->stringField($item, 'name');     // string
+ *   $count = $this->intField($body, 'totalItems');  // int
+ *
+ * Each helper asserts the value's type (failing the test if the JSON
+ * shape drifts) and returns a properly-typed value so subsequent reads
+ * stay in well-typed land.
+ */
+trait JsonBodyAssertions
+{
+    /**
+     * @param array<int|string, mixed> $body
+     * @return array<int|string, mixed>
+     */
+    private function arrayField(array $body, int|string $key): array
+    {
+        $this->assertArrayHasKey($key, $body);
+        $value = $body[$key];
+        $this->assertIsArray($value);
+        return $value;
+    }
+
+    /**
+     * @param array<int|string, mixed> $body
+     */
+    private function stringField(array $body, int|string $key): string
+    {
+        $this->assertArrayHasKey($key, $body);
+        $value = $body[$key];
+        $this->assertIsString($value);
+        return $value;
+    }
+
+    /**
+     * @param array<int|string, mixed> $body
+     */
+    private function intField(array $body, int|string $key): int
+    {
+        $this->assertArrayHasKey($key, $body);
+        $value = $body[$key];
+        $this->assertIsInt($value);
+        return $value;
+    }
+
+    /**
+     * @param array<int|string, mixed> $body
+     */
+    private function boolField(array $body, int|string $key): bool
+    {
+        $this->assertArrayHasKey($key, $body);
+        $value = $body[$key];
+        $this->assertIsBool($value);
+        return $value;
+    }
+}

--- a/api/tests/Api/NotificationTest.php
+++ b/api/tests/Api/NotificationTest.php
@@ -75,9 +75,11 @@ class NotificationTest extends ApiTestCase
         $this->assertResponseIsSuccessful();
         $response = $client->getResponse();
         self::assertNotNull($response);
+        $members = $response->toArray()['member'] ?? [];
+        $this->assertIsArray($members);
         $titles = array_map(
-            fn ($n) => $n['title'],
-            $response->toArray()['member'] ?? [],
+            static fn (mixed $n): mixed => is_array($n) ? $n['title'] ?? null : null,
+            $members,
         );
         $this->assertSame(['For Alice'], $titles);
         $this->assertNotNull($aliceNote->getId());
@@ -134,9 +136,11 @@ class NotificationTest extends ApiTestCase
         $this->assertResponseIsSuccessful();
         $response = $client->getResponse();
         self::assertNotNull($response);
+        $members = $response->toArray()['member'] ?? [];
+        $this->assertIsArray($members);
         $titles = array_map(
-            fn ($n) => $n['title'],
-            $response->toArray()['member'] ?? [],
+            static fn (mixed $n): mixed => is_array($n) ? $n['title'] ?? null : null,
+            $members,
         );
         $this->assertSame(['Unread'], $titles);
         $this->assertNotNull($unread->getId());

--- a/api/tests/Api/PageTest.php
+++ b/api/tests/Api/PageTest.php
@@ -104,9 +104,11 @@ class PageTest extends ApiTestCase
         $this->assertResponseIsSuccessful();
         $response = $client->getResponse();
         self::assertNotNull($response);
+        $members = $response->toArray()['member'] ?? [];
+        $this->assertIsArray($members);
         $titles = array_map(
-            fn ($p) => $p['title'],
-            $response->toArray()['member'] ?? [],
+            static fn (mixed $p): mixed => is_array($p) ? $p['title'] ?? null : null,
+            $members,
         );
         $this->assertSame(['Alice page'], $titles);
     }
@@ -284,9 +286,11 @@ class PageTest extends ApiTestCase
         $this->assertResponseIsSuccessful();
         $response = $client->getResponse();
         self::assertNotNull($response);
+        $members = $response->toArray()['member'] ?? [];
+        $this->assertIsArray($members);
         $titles = array_map(
-            fn ($p) => $p['title'],
-            $response->toArray()['member'] ?? [],
+            static fn (mixed $p): mixed => is_array($p) ? $p['title'] ?? null : null,
+            $members,
         );
         $this->assertSame(['Onboarding guide'], $titles);
     }

--- a/api/tests/Api/ProjectCopyTest.php
+++ b/api/tests/Api/ProjectCopyTest.php
@@ -84,10 +84,12 @@ class ProjectCopyTest extends ApiTestCase
         $this->assertSame('select.single', $defs[0]->getTypeKey());
         $options = $defs[0]->getConfig()['options'] ?? [];
         $this->assertIsArray($options);
-        /** @var list<array{key: string}> $options */
         $this->assertSame(
             ['low', 'med', 'high'],
-            array_map(static fn (array $o) => $o['key'], $options),
+            array_map(
+                static fn (mixed $o): mixed => is_array($o) ? $o['key'] ?? null : null,
+                $options,
+            ),
         );
         $this->assertSame('Notes', $defs[1]->getName());
 

--- a/api/tests/Api/ProjectCopyTest.php
+++ b/api/tests/Api/ProjectCopyTest.php
@@ -382,6 +382,8 @@ class ProjectCopyTest extends ApiTestCase
 
     /**
      * @param string[]|null $options
+     *
+     * @param list<string>|null $options
      */
     private function seedDefinition(Project $project, string $name, string $type, ?array $options = null, int $position = 0): CustomFieldDefinition
     {

--- a/api/tests/Api/ProjectTest.php
+++ b/api/tests/Api/ProjectTest.php
@@ -234,8 +234,13 @@ class ProjectTest extends ApiTestCase
         $this->assertResponseIsSuccessful();
         $response = $client->getResponse();
         self::assertNotNull($response);
-        $response = $response->toArray();
-        $titles = array_map(fn ($t) => $t['title'], $response['member']);
+        $body = $response->toArray();
+        $members = $body['member'] ?? [];
+        $this->assertIsArray($members);
+        $titles = array_map(
+            static fn (mixed $t): mixed => is_array($t) ? $t['title'] ?? null : null,
+            $members,
+        );
         $this->assertSame(['Alice project task'], $titles);
     }
 

--- a/api/tests/Api/PushSubscriptionTest.php
+++ b/api/tests/Api/PushSubscriptionTest.php
@@ -90,9 +90,11 @@ class PushSubscriptionTest extends ApiTestCase
         $this->assertResponseIsSuccessful();
         $response = $client->getResponse();
         self::assertNotNull($response);
+        $members = $response->toArray()['member'] ?? [];
+        $this->assertIsArray($members);
         $endpoints = array_map(
-            fn ($s) => $s['endpoint'],
-            $response->toArray()['member'] ?? [],
+            static fn (mixed $s): mixed => is_array($s) ? $s['endpoint'] ?? null : null,
+            $members,
         );
         $this->assertSame(['https://fcm.example/a'], $endpoints);
     }

--- a/api/tests/Api/SpaceInviteTest.php
+++ b/api/tests/Api/SpaceInviteTest.php
@@ -190,8 +190,12 @@ class SpaceInviteTest extends ApiTestCase
         $response = $client->getResponse();
         self::assertNotNull($response);
         $payload = $response->toArray();
-        $this->assertCount(1, $payload['invites']);
-        $this->assertSame('pending@example.com', $payload['invites'][0]['email']);
+        $invites = $payload['invites'] ?? null;
+        $this->assertIsArray($invites);
+        $this->assertCount(1, $invites);
+        $first = $invites[0] ?? null;
+        $this->assertIsArray($first);
+        $this->assertSame('pending@example.com', $first['email']);
     }
 
     public function testRevokeInviteDropsParentWhenLastAttachment(): void
@@ -232,9 +236,13 @@ class SpaceInviteTest extends ApiTestCase
         self::assertNotNull($response);
         $payload = $response->toArray();
         $this->assertSame('pending@example.com', $payload['email']);
-        $this->assertCount(1, $payload['spaces']);
-        $this->assertSame((string) $space->getId(), $payload['spaces'][0]['id']);
-        $this->assertSame($space->getName(), $payload['spaces'][0]['name']);
+        $spaces = $payload['spaces'] ?? null;
+        $this->assertIsArray($spaces);
+        $this->assertCount(1, $spaces);
+        $first = $spaces[0] ?? null;
+        $this->assertIsArray($first);
+        $this->assertSame((string) $space->getId(), $first['id']);
+        $this->assertSame($space->getName(), $first['name']);
     }
 
     public function testSignupWithInviteTokenAttachesUserToSpace(): void

--- a/api/tests/Api/UserInviteTest.php
+++ b/api/tests/Api/UserInviteTest.php
@@ -212,8 +212,12 @@ class UserInviteTest extends ApiTestCase
         $response = $client->getResponse();
         self::assertNotNull($response);
         $body = $response->toArray();
-        $this->assertCount(1, $body['invites']);
-        $this->assertSame('newcomer@example.com', $body['invites'][0]['email']);
+        $invites = $body['invites'] ?? null;
+        $this->assertIsArray($invites);
+        $this->assertCount(1, $invites);
+        $first = $invites[0] ?? null;
+        $this->assertIsArray($first);
+        $this->assertSame('newcomer@example.com', $first['email']);
     }
 
     public function testNonOwnerMemberCannotListInvites(): void

--- a/api/tests/Api/UserPreferencesTest.php
+++ b/api/tests/Api/UserPreferencesTest.php
@@ -9,6 +9,8 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 class UserPreferencesTest extends ApiTestCase
 {
+    use JsonBodyAssertions;
+
     private EntityManagerInterface $entityManager;
 
     protected function setUp(): void
@@ -191,8 +193,7 @@ class UserPreferencesTest extends ApiTestCase
         $response = $client->getResponse();
         self::assertNotNull($response);
         $body = $response->toArray();
-        $this->assertArrayHasKey('preferences', $body);
-        $this->assertSame('dark', $body['preferences']['theme']);
+        $this->assertSame('dark', $this->arrayField($body, 'preferences')['theme']);
     }
 
     /**


### PR DESCRIPTION
## Summary
Chip-away #2 on the level-10 baseline. 12 test files / 40 baseline errors cleared at the source.

- `assertIsArray()` narrowing on `$response->toArray()['member']` before `array_map()` / `assertCount()`.
- Closure parameter typed as `mixed` (was `array`) + `is_array()` guard inside, to satisfy `array_map`'s `(callable(mixed): mixed)` contract at level 10.
- `assertIsString()` before passing `$body['@id']` to `Client::request()` (PATCH expects string).

Adds a small shared trait `tests/Api/JsonBodyAssertions.php` with `arrayField()`/`stringField()`/`intField()`/`boolField()` helpers. Wired into `UserPreferencesTest` as a demonstration; the other 11 files use inline narrowing for now to keep the diff focused. Future cleanups can adopt the trait per-file.

**Remaining baseline (~120 errors across 6 files):** ActivityHistoryTest, CustomFieldFooterTest, TagTest, TaskAttachmentTest, TaskCustomFieldValueTest, TaskTest.

## Test plan
- [ ] PHPStan green at level 10 with the trimmed baseline
- [ ] Tests / PHPCS / Typecheck / E2E / Doctrine Schema green