### PR TITLE
chore(phpstan): add phpstan-strict-rules

### DIFF
--- a/api/composer.json
+++ b/api/composer.json
@@ -48,6 +48,7 @@
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-doctrine": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",
+        "phpstan/phpstan-strict-rules": "^2.0",
         "phpstan/phpstan-symfony": "^2.0",
         "phpunit/phpunit": "^9.6",
         "squizlabs/php_codesniffer": "^3.10",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2c04ec6e264b414f1cf4f5335df7588b",
+    "content-hash": "495e74f41bc8804dab2ceeaa2e019e20",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -12015,6 +12015,57 @@
                 "source": "https://github.com/phpstan/phpstan-phpunit/tree/2.0.16"
             },
             "time": "2026-02-14T09:05:21+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-strict-rules",
+            "version": "2.0.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-strict-rules.git",
+                "reference": "9b000a578b85b32945b358b172c7b20e91189024"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/9b000a578b85b32945b358b172c7b20e91189024",
+                "reference": "9b000a578b85b32945b358b172c7b20e91189024",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpstan": "^2.1.39"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.6"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Extra strict and opinionated rules for PHPStan",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-strict-rules/issues",
+                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/2.0.11"
+            },
+            "time": "2026-05-02T06:54:10+00:00"
         },
         {
             "name": "phpstan/phpstan-symfony",

--- a/api/phpstan-baseline.neon
+++ b/api/phpstan-baseline.neon
@@ -219,3 +219,18 @@ parameters:
         -
             identifier: varTag.type
             path: tests/Api/TaskTest.php
+        -
+            identifier: varTag.type
+            path: tests/Api/UserGroupTest.php
+        -
+            identifier: varTag.type
+            path: tests/Api/UserInviteTest.php
+        -
+            identifier: varTag.type
+            path: tests/Api/UserPreferencesTest.php
+        -
+            identifier: varTag.type
+            path: tests/Api/UserTest.php
+        -
+            identifier: if.condNotBoolean
+            path: tests/bootstrap.php

--- a/api/phpstan-baseline.neon
+++ b/api/phpstan-baseline.neon
@@ -1,8 +1,221 @@
-# PHPStan level-10 baseline.
+# Baseline for the phpstan-strict-rules bump.
 #
-# Empty for now — the previous chip-away PRs cleared every entry.
-# Regenerate after adding new violations with
+# The dominant violation is staticMethod.dynamicCall — strict-rules
+# wants $this->assertSame() (and every other PHPUnit Assert::*)
+# called as self:: / static:: / ClassName::. That is a style
+# preference, not a correctness check, and $this-> is PHPUnit-
+# idiomatic, so ignore the identifier wholesale.
+#
+# Other entries are real strict-rule violations queued for chip-away.
+# Regenerate after a cleanup pass via
 #   docker compose run --rm phpstan analyse --generate-baseline=phpstan-baseline.neon
 
 parameters:
-    ignoreErrors: []
+    ignoreErrors:
+        -
+            identifier: staticMethod.dynamicCall
+        -
+            identifier: ternary.shortNotAllowed
+            path: src/Command/DispatchNotificationDigestCommand.php
+        -
+            identifier: ternary.shortNotAllowed
+            path: src/Command/DispatchTaskRemindersCommand.php
+        -
+            identifier: cast.useless
+            path: src/Controller/CustomFieldFooterController.php
+        -
+            identifier: booleanAnd.rightNotBoolean
+            path: src/Controller/DiscussionMoveController.php
+        -
+            identifier: cast.useless
+            count: 2
+            path: src/Controller/EmailChangeController.php
+        -
+            identifier: ternary.shortNotAllowed
+            count: 2
+            path: src/Controller/EmailChangeController.php
+        -
+            identifier: if.condNotBoolean
+            path: src/Controller/MediaObjectDownloadController.php
+        -
+            identifier: ternary.shortNotAllowed
+            count: 2
+            path: src/Controller/MediaObjectDownloadController.php
+        -
+            identifier: booleanAnd.rightNotBoolean
+            path: src/Controller/PageMoveController.php
+        -
+            identifier: ternary.shortNotAllowed
+            path: src/Controller/PasswordController.php
+        -
+            identifier: empty.notAllowed
+            count: 2
+            path: src/Controller/ProjectActivityController.php
+        -
+            identifier: if.condNotBoolean
+            path: src/Controller/ProjectCopyController.php
+        -
+            identifier: if.condNotBoolean
+            path: src/Controller/ProjectMemberController.php
+        -
+            identifier: booleanAnd.rightNotBoolean
+            path: src/Controller/ProjectMoveController.php
+        -
+            identifier: booleanNot.exprNotBoolean
+            path: src/Controller/SpaceInviteController.php
+        -
+            identifier: if.condNotBoolean
+            path: src/Controller/SpaceMemberController.php
+        -
+            identifier: ternary.condNotBoolean
+            path: src/Controller/SpaceMemberController.php
+        -
+            identifier: booleanAnd.rightNotBoolean
+            path: src/Controller/TaskAssigneeController.php
+        -
+            identifier: booleanNot.exprNotBoolean
+            path: src/Controller/TaskReorderController.php
+        -
+            identifier: ternary.condNotBoolean
+            path: src/Controller/UserGroupMemberController.php
+        -
+            identifier: booleanNot.exprNotBoolean
+            path: src/Controller/UserInviteController.php
+        -
+            identifier: method.childReturnType
+            path: src/CustomField/Type/AbstractTypeStrategy.php
+        -
+            identifier: method.childReturnType
+            path: src/CustomField/Type/Date/AbstractDateStrategy.php
+        -
+            identifier: method.childReturnType
+            path: src/CustomField/Type/Numeric/AbstractNumericStrategy.php
+        -
+            identifier: method.childReturnType
+            path: src/CustomField/Type/Numeric/MoneyStrategy.php
+        -
+            identifier: if.condNotBoolean
+            path: src/Mcp/Tool/DownloadFileTool.php
+        -
+            identifier: empty.notAllowed
+            count: 3
+            path: src/Push/WebPushSender.php
+        -
+            identifier: booleanNot.exprNotBoolean
+            path: src/Security/ApiTokenAuthenticator.php
+        -
+            identifier: ternary.shortNotAllowed
+            path: src/Security/ApiTokenAuthenticator.php
+        -
+            identifier: booleanNot.exprNotBoolean
+            path: src/Service/CommentMentionService.php
+        -
+            identifier: if.condNotBoolean
+            path: src/Service/CommentMentionService.php
+        -
+            identifier: cast.useless
+            path: src/Service/ImageUploadService.php
+        -
+            identifier: ternary.shortNotAllowed
+            count: 5
+            path: src/Service/ImageUploadService.php
+        -
+            identifier: ternary.shortNotAllowed
+            path: src/Service/InviteMailer.php
+        -
+            identifier: cast.useless
+            path: src/State/TaskUpdateProcessor.php
+        -
+            identifier: if.condNotBoolean
+            count: 2
+            path: src/State/UserPasswordHasherProcessor.php
+        -
+            identifier: varTag.type
+            path: tests/Api/ActivityHistoryTest.php
+        -
+            identifier: varTag.type
+            path: tests/Api/ApiTokenTest.php
+        -
+            identifier: varTag.type
+            path: tests/Api/CommentTest.php
+        -
+            identifier: varTag.type
+            path: tests/Api/CommentsMercureTokenTest.php
+        -
+            identifier: varTag.type
+            path: tests/Api/CustomFieldDefinitionTest.php
+        -
+            identifier: varTag.type
+            path: tests/Api/CustomFieldFooterTest.php
+        -
+            identifier: varTag.type
+            path: tests/Api/DiscussionCopyTest.php
+        -
+            identifier: varTag.type
+            path: tests/Api/DiscussionMoveTest.php
+        -
+            identifier: varTag.type
+            path: tests/Api/DiscussionTest.php
+        -
+            identifier: booleanNot.exprNotBoolean
+            path: tests/Api/EmailChangeTest.php
+        -
+            identifier: varTag.type
+            path: tests/Api/McpTest.php
+        -
+            identifier: varTag.type
+            path: tests/Api/MediaObjectDownloadTest.php
+        -
+            identifier: ternary.shortNotAllowed
+            path: tests/Api/MediaObjectTest.php
+        -
+            identifier: varTag.type
+            path: tests/Api/MediaObjectTest.php
+        -
+            identifier: varTag.type
+            path: tests/Api/NotificationTest.php
+        -
+            identifier: varTag.type
+            path: tests/Api/PageCopyTest.php
+        -
+            identifier: varTag.type
+            path: tests/Api/PageMoveTest.php
+        -
+            identifier: varTag.type
+            path: tests/Api/PageTest.php
+        -
+            identifier: varTag.type
+            path: tests/Api/ProjectCopyTest.php
+        -
+            identifier: varTag.type
+            path: tests/Api/ProjectMoveTest.php
+        -
+            identifier: varTag.type
+            path: tests/Api/ProjectTest.php
+        -
+            identifier: cast.useless
+            path: tests/Api/PushSubscriptionTest.php
+        -
+            identifier: varTag.type
+            path: tests/Api/PushSubscriptionTest.php
+        -
+            identifier: varTag.type
+            path: tests/Api/SpaceAttachmentTest.php
+        -
+            identifier: varTag.type
+            path: tests/Api/SpaceInviteTest.php
+        -
+            identifier: varTag.type
+            path: tests/Api/SpaceTest.php
+        -
+            identifier: varTag.type
+            path: tests/Api/TagTest.php
+        -
+            identifier: varTag.type
+            path: tests/Api/TaskAttachmentTest.php
+        -
+            identifier: varTag.type
+            path: tests/Api/TaskCustomFieldValueTest.php
+        -
+            identifier: varTag.type
+            path: tests/Api/TaskTest.php

--- a/api/phpstan.dist.neon
+++ b/api/phpstan.dist.neon
@@ -1,5 +1,6 @@
 includes:
     - phpstan-baseline.neon
+    - vendor/phpstan/phpstan-strict-rules/rules.neon
     - vendor/phpstan/phpstan-symfony/extension.neon
     - vendor/phpstan/phpstan-symfony/rules.neon
     - vendor/phpstan/phpstan-doctrine/extension.neon


### PR DESCRIPTION
## Summary
Layers `phpstan/phpstan-strict-rules` (~30 additional semantic checks) on top of level 10. Pushing without a baseline first to surface what new violations appear; baseline + chip-away follow-ups will land in subsequent PRs.

Strict rules cover:
- Strict comparisons (`===` / `!==`)
- No short-ternary on non-bool
- No Yoda-condition inversions
- Explicit nullability in unions
- Always-true / always-false / unreachable code

## Test plan
- [ ] PHPStan job either passes (unlikely — there are usually new violations to baseline) or shows the new violations to be deferred / cleared
- [ ] All other checks remain green