### PR TITLE
chore(phpstan): clear remaining strict-rule violations

### DIFF
--- a/api/phpstan-baseline.neon
+++ b/api/phpstan-baseline.neon
@@ -1,62 +1,16 @@
-# Baseline for the phpstan-strict-rules bump.
+# Baseline for phpstan-strict-rules.
 #
 # The dominant violation is staticMethod.dynamicCall — strict-rules
 # wants $this->assertSame() (and every other PHPUnit Assert::*)
 # called as self:: / static:: / ClassName::. That is a style
 # preference, not a correctness check, and $this-> is PHPUnit-
-# idiomatic, so ignore the identifier wholesale.
+# idiomatic, so ignore the identifier wholesale. Every other
+# strict-rule violation is cleared at the source.
 #
-# Other entries are real strict-rule violations queued for chip-away.
-# Regenerate after a cleanup pass via
+# Regenerate after adding new violations via
 #   docker compose run --rm phpstan analyse --generate-baseline=phpstan-baseline.neon
 
 parameters:
     ignoreErrors:
         -
             identifier: staticMethod.dynamicCall
-        -
-            identifier: cast.useless
-            path: src/Controller/CustomFieldFooterController.php
-        -
-            identifier: if.condNotBoolean
-            path: src/Controller/MediaObjectDownloadController.php
-        -
-            identifier: ternary.shortNotAllowed
-            count: 2
-            path: src/Controller/MediaObjectDownloadController.php
-        -
-            identifier: booleanNot.exprNotBoolean
-            path: src/Controller/SpaceInviteController.php
-        -
-            identifier: ternary.condNotBoolean
-            path: src/Controller/SpaceMemberController.php
-        -
-            identifier: ternary.condNotBoolean
-            path: src/Controller/UserGroupMemberController.php
-        -
-            identifier: booleanNot.exprNotBoolean
-            path: src/Controller/UserInviteController.php
-        -
-            identifier: method.childReturnType
-            path: src/CustomField/Type/AbstractTypeStrategy.php
-        -
-            identifier: method.childReturnType
-            path: src/CustomField/Type/Date/AbstractDateStrategy.php
-        -
-            identifier: method.childReturnType
-            path: src/CustomField/Type/Numeric/AbstractNumericStrategy.php
-        -
-            identifier: method.childReturnType
-            path: src/CustomField/Type/Numeric/MoneyStrategy.php
-        -
-            identifier: cast.useless
-            path: src/Service/ImageUploadService.php
-        -
-            identifier: cast.useless
-            path: src/State/TaskUpdateProcessor.php
-        -
-            identifier: booleanNot.exprNotBoolean
-            path: tests/Api/EmailChangeTest.php
-        -
-            identifier: if.condNotBoolean
-            path: tests/bootstrap.php

--- a/api/src/Controller/CustomFieldFooterController.php
+++ b/api/src/Controller/CustomFieldFooterController.php
@@ -125,7 +125,7 @@ class CustomFieldFooterController extends AbstractController
             }
         }
 
-        if ('true' === strtolower((string) $request->query->get('overdue', ''))) {
+        if ('true' === strtolower($request->query->get('overdue', ''))) {
             $qb->andWhere('t.completedOn IS NULL')
                 ->andWhere('t.dueDate IS NOT NULL')
                 ->andWhere('t.dueDate < :now')

--- a/api/src/Controller/MediaObjectDownloadController.php
+++ b/api/src/Controller/MediaObjectDownloadController.php
@@ -80,9 +80,10 @@ class MediaObjectDownloadController extends AbstractController
             return new JsonResponse(['error' => 'Not found.'], 404);
         }
 
+        $originalName = $media->getOriginalName();
         $disposition = HeaderUtils::makeDisposition(
             HeaderUtils::DISPOSITION_ATTACHMENT,
-            $media->getOriginalName() ?: 'download',
+            '' !== $originalName ? $originalName : 'download',
         );
 
         return new StreamedResponse(
@@ -94,7 +95,7 @@ class MediaObjectDownloadController extends AbstractController
             },
             200,
             [
-                'Content-Type' => $media->getMimeType() ?: 'application/octet-stream',
+                'Content-Type' => '' !== $media->getMimeType() ? $media->getMimeType() : 'application/octet-stream',
                 'Content-Length' => (string) $media->getByteSize(),
                 'Content-Disposition' => $disposition,
                 // Force a revalidation so updated/replaced bytes never get

--- a/api/src/Controller/SpaceInviteController.php
+++ b/api/src/Controller/SpaceInviteController.php
@@ -91,7 +91,7 @@ class SpaceInviteController extends AbstractController
         }
 
         $spaceInvite = $this->spaceInviteRepository->find($spaceInviteId);
-        if (null === $spaceInvite || !$spaceInvite->getSpace()->getId()?->equals($space->getId())) {
+        if (null === $spaceInvite || true !== $spaceInvite->getSpace()->getId()?->equals($space->getId())) {
             return $this->json(['error' => 'Invite not found.'], 404);
         }
 

--- a/api/src/Controller/SpaceMemberController.php
+++ b/api/src/Controller/SpaceMemberController.php
@@ -139,7 +139,7 @@ class SpaceMemberController extends AbstractController
             $invite->setExpiresAt($expiresAt);
         }
 
-        $existing = $invite->getId()
+        $existing = null !== $invite->getId()
             ? $this->spaceInviteRepository->findByInviteAndSpace($invite, $space)
             : null;
         if (null === $existing) {

--- a/api/src/Controller/UserGroupMemberController.php
+++ b/api/src/Controller/UserGroupMemberController.php
@@ -128,7 +128,7 @@ class UserGroupMemberController extends AbstractController
             $invite->setExpiresAt($expiresAt);
         }
 
-        $existingGroupInvite = $invite->getId()
+        $existingGroupInvite = null !== $invite->getId()
             ? $this->groupInviteRepository->findByInviteAndGroup($invite, $group)
             : null;
         if (null === $existingGroupInvite) {

--- a/api/src/Controller/UserInviteController.php
+++ b/api/src/Controller/UserInviteController.php
@@ -129,7 +129,7 @@ class UserInviteController extends AbstractController
         }
 
         $groupInvite = $this->groupInviteRepository->find($groupInviteId);
-        if (null === $groupInvite || !$groupInvite->getGroup()->getId()?->equals($group->getId())) {
+        if (null === $groupInvite || true !== $groupInvite->getGroup()->getId()?->equals($group->getId())) {
             return $this->json(['error' => 'Invite not found.'], 404);
         }
 

--- a/api/src/CustomField/Type/AbstractTypeStrategy.php
+++ b/api/src/CustomField/Type/AbstractTypeStrategy.php
@@ -35,7 +35,7 @@ abstract class AbstractTypeStrategy implements CustomFieldTypeInterface
      * non-null value). Kinds that can compute richer aggregates
      * (numeric: sum/avg/min/max, date: min/max) override.
      *
-     * @return list<string>
+     * @return list<value-of<\App\CustomField\Footer\FooterKind>>
      */
     public function supportedAggregations(): array
     {

--- a/api/src/CustomField/Type/Date/AbstractDateStrategy.php
+++ b/api/src/CustomField/Type/Date/AbstractDateStrategy.php
@@ -40,7 +40,7 @@ abstract class AbstractDateStrategy extends AbstractTypeStrategy
     }
 
     /**
-     * @return list<string>
+     * @return list<value-of<\App\CustomField\Footer\FooterKind>>
      */
     public function supportedAggregations(): array
     {

--- a/api/src/CustomField/Type/Numeric/AbstractNumericStrategy.php
+++ b/api/src/CustomField/Type/Numeric/AbstractNumericStrategy.php
@@ -41,7 +41,7 @@ abstract class AbstractNumericStrategy extends AbstractTypeStrategy
     }
 
     /**
-     * @return list<string>
+     * @return list<value-of<\App\CustomField\Footer\FooterKind>>
      */
     public function supportedAggregations(): array
     {

--- a/api/src/CustomField/Type/Numeric/MoneyStrategy.php
+++ b/api/src/CustomField/Type/Numeric/MoneyStrategy.php
@@ -53,7 +53,7 @@ final class MoneyStrategy extends AbstractTypeStrategy
     }
 
     /**
-     * @return list<string>
+     * @return list<value-of<\App\CustomField\Footer\FooterKind>>
      */
     public function supportedAggregations(): array
     {

--- a/api/src/Service/ImageUploadService.php
+++ b/api/src/Service/ImageUploadService.php
@@ -162,7 +162,7 @@ final class ImageUploadService
         if ($file->getSize() > self::MAX_ATTACHMENT_BYTES) {
             throw new BadRequestHttpException(sprintf(
                 'File is larger than %d MB.',
-                (int) (self::MAX_ATTACHMENT_BYTES / 1024 / 1024),
+                intdiv(self::MAX_ATTACHMENT_BYTES, 1024 * 1024),
             ));
         }
 

--- a/api/src/State/TaskUpdateProcessor.php
+++ b/api/src/State/TaskUpdateProcessor.php
@@ -107,7 +107,7 @@ final class TaskUpdateProcessor implements ProcessorInterface
      */
     private function advanceDueDate(\DateTimeImmutable $current, array $rule): \DateTimeImmutable
     {
-        $interval = max(1, (int) $rule['interval']);
+        $interval = max(1, $rule['interval']);
         // \DateTimeImmutable::modify is calendar-aware: "+1 month" off Jan 31
         // becomes Mar 3 (skipping Feb), which is the standard PHP behaviour
         // and matches what users intuitively expect for monthly recurrence.

--- a/api/tests/Api/EmailChangeTest.php
+++ b/api/tests/Api/EmailChangeTest.php
@@ -231,7 +231,7 @@ class EmailChangeTest extends ApiTestCase
         $email = $this->getMailerMessage(0);
         self::assertNotNull($email);
         self::assertInstanceOf(\Symfony\Component\Mime\Email::class, $email);
-        if (!preg_match('#/revert-email-change\?token=([0-9a-f]+)#', (string) $email->getTextBody(), $m)) {
+        if (1 !== preg_match('#/revert-email-change\?token=([0-9a-f]+)#', (string) $email->getTextBody(), $m)) {
             $this->fail('Revert email did not contain a revert link.');
         }
         $plainRevertToken = $m[1];

--- a/api/tests/bootstrap.php
+++ b/api/tests/bootstrap.php
@@ -6,6 +6,6 @@ require dirname(__DIR__) . '/vendor/autoload.php';
 
 (new Dotenv())->bootEnv(dirname(__DIR__) . '/.env');
 
-if ($_SERVER['APP_DEBUG']) {
+if (true === ($_SERVER['APP_DEBUG'] ?? false) || '1' === ($_SERVER['APP_DEBUG'] ?? null)) {
     umask(0000);
 }


### PR DESCRIPTION
## Summary
Final chip-away on the strict-rules baseline. 15 entries cleared at the source. Baseline is now a single wildcard `staticMethod.dynamicCall` ignore (for PHPUnit's `$this->assertX()` idiom); every other strict-rules violation is cleared.

**Patterns cleared:**
- `cast.useless`: drop redundant `(string)` / `(int)` casts; switch byte-to-MB conversion to `intdiv()`.
- `method.childReturnType`: widen child `@return list<string>` to `list<value-of<FooterKind>>` across the 4 strategy classes so they match the interface contract.
- `ternary.shortNotAllowed`: `$x ?: 'fallback'` → explicit empty-check long ternary.
- `booleanNot.exprNotBoolean`: `!$x?->equals()` → `true !== $x?->equals()`; `!preg_match()` → `1 !== preg_match()`.
- `ternary.condNotBoolean`: `$id ? X : null` → `null !== $id ? X : null`.
- `if.condNotBoolean`: `$_SERVER['APP_DEBUG']` → explicit truthy check in tests/bootstrap.php.

## Test plan
- [ ] PHPStan green at strict-rules with the single-entry baseline
- [ ] Tests / PHPCS / Typecheck / E2E / Doctrine Schema green