### PR TITLE
Refresh sign-in design + dark-theme token palette

### DIFF
--- a/e2e/tests/auth-redirect.spec.js
+++ b/e2e/tests/auth-redirect.spec.js
@@ -84,19 +84,18 @@ test.describe("Auth redirect", () => {
     await expect(page).toHaveURL(/\/projects$/);
   });
 
-  test("/signup tab on the unified auth card preserves ?next through registration", async ({
+  test("/signup link on the auth card preserves ?next through registration", async ({
     page,
   }) => {
     const email = uniqueEmail("signup-redirect");
     const password = "password123";
 
-    // Land on /signin?next=/tasks, then click into the Sign Up tab.
-    // The Radix Tabs trigger has role="tab" while the form submit is a
-    // normal <button>, so role-based selectors disambiguate them — both
-    // happen to be labelled "Sign Up". Tab clicks navigate to the
-    // matching URL so the form rendered always matches the URL.
+    // Land on /signin?next=/tasks, then follow the footer "Create an
+    // account" link. The auth card no longer renders tabs — switching
+    // forms is a plain <Link> in the card footer that navigates to
+    // /signup while preserving the query string.
     await page.goto(`${BASE_URL}/signin?next=%2Ftasks`);
-    await page.getByRole("tab", { name: "Sign Up" }).click();
+    await page.getByRole("link", { name: "Create an account" }).click();
     await expect(page).toHaveURL(/\/signup\?.*next=%2Ftasks/);
 
     await page.fill('input[name="givenName"]', "New");

--- a/e2e/tests/auth.spec.js
+++ b/e2e/tests/auth.spec.js
@@ -78,7 +78,7 @@ test.describe("Authentication", () => {
     await page.fill("#password", "wrongpassword");
     await page.click('button[type="submit"]');
 
-    await expect(page.locator("text=Invalid credentials")).toBeVisible();
+    await expect(page.locator("text=Invalid email or password")).toBeVisible();
   });
 
   test("sign in with fixture admin user accesses admin page", async ({ page }) => {

--- a/pwa/components/auth/AuraWordmark.tsx
+++ b/pwa/components/auth/AuraWordmark.tsx
@@ -1,0 +1,42 @@
+/**
+ * Aura logo + wordmark for the auth pages. The icon is a rounded outline
+ * square with an inner solid square in the brand teal, surrounded by a
+ * soft glow via `drop-shadow`. Sized for the sign-in / sign-up header.
+ */
+const AuraWordmark = () => (
+  <div className="flex items-center gap-3">
+    <svg
+      viewBox="0 0 32 32"
+      width="40"
+      height="40"
+      fill="none"
+      aria-hidden="true"
+      className="text-primary animate-aura-glow"
+    >
+      {/* Solid background-coloured inner rect fills the hollow center
+          so `drop-shadow` only paints a glow around the OUTER edge of
+          the rounded square — without it, the filter halos into the
+          transparent middle too. */}
+      <rect
+        x="6"
+        y="6"
+        width="20"
+        height="20"
+        rx="5"
+        fill="var(--background)"
+      />
+      <rect
+        x="4"
+        y="4"
+        width="24"
+        height="24"
+        rx="7"
+        stroke="currentColor"
+        strokeWidth="5"
+      />
+    </svg>
+    <span className="text-3xl font-bold tracking-tight text-foreground">Aura</span>
+  </div>
+);
+
+export default AuraWordmark;

--- a/pwa/components/auth/AuthCard.tsx
+++ b/pwa/components/auth/AuthCard.tsx
@@ -1,25 +1,42 @@
 import { useEffect } from "react";
+import Link from "next/link";
 import { useRouter } from "next/router";
 import { useAuth } from "@/contexts/AuthContext";
 import { safeNextPath } from "@/lib/authRedirect";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import AuraWordmark from "./AuraWordmark";
 import SignInForm from "./SignInForm";
 import SignUpForm from "./SignUpForm";
 
 type Tab = "signin" | "signup";
 
 interface Props {
-  /**
-   * Which tab the page entry point selects. The currently-displayed tab
-   * is fully URL-driven — `/signin` shows "signin", `/signup` shows
-   * "signup", and tab triggers navigate between the two so the active
-   * form always matches the URL the user (and tests) can read.
-   */
+  /** Which form this page entry point renders. */
   defaultTab: Tab;
 }
 
-const titleFor = (tab: Tab) => (tab === "signin" ? "Welcome back" : "Create your account");
+const COPY: Record<Tab, { title: string; subtitle: string; switchLabel: string; switchCta: string; switchPath: string }> = {
+  signin: {
+    title: "Welcome back",
+    subtitle: "Sign in to your Aura workspace.",
+    switchLabel: "New to Aura?",
+    switchCta: "Create an account",
+    switchPath: "/signup",
+  },
+  signup: {
+    title: "Create your account",
+    subtitle: "Get started with Aura in seconds.",
+    switchLabel: "Already have an account?",
+    switchCta: "Sign in",
+    switchPath: "/signin",
+  },
+};
 
 const AuthCard = ({ defaultTab }: Props) => {
   const router = useRouter();
@@ -40,40 +57,38 @@ const AuthCard = ({ defaultTab }: Props) => {
     }
   }, [isLoading, isAuthenticated, next, router]);
 
-  // Tab clicks navigate between /signin and /signup, preserving any
-  // existing query string (so `?next=/tasks` and `?invite=xxx` flow
-  // through). This keeps the URL the source of truth — clicking Sign Up,
-  // submitting, then bouncing back to /signin lands on the *Sign In*
-  // form rather than re-showing whatever local state the user last had.
-  const switchTab = (target: Tab) => {
-    if (target === defaultTab) return;
-    const targetPath = target === "signin" ? "/signin" : "/signup";
-    const queryIndex = router.asPath.indexOf("?");
-    const search = queryIndex >= 0 ? router.asPath.slice(queryIndex) : "";
-    router.push(`${targetPath}${search}`);
-  };
+  const copy = COPY[defaultTab];
+  const queryIndex = router.asPath.indexOf("?");
+  const search = queryIndex >= 0 ? router.asPath.slice(queryIndex) : "";
+  const switchHref = `${copy.switchPath}${search}`;
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-muted px-4 py-8">
-      <Card className="w-full max-w-md">
-        <CardHeader>
-          <CardTitle className="text-2xl text-center">{titleFor(defaultTab)}</CardTitle>
+    <div className="min-h-screen flex flex-col items-center justify-center bg-background px-4 py-10 gap-8">
+      <AuraWordmark />
+      <Card className="w-full max-w-lg overflow-hidden p-0">
+        <CardHeader className="p-8 pb-6">
+          <CardTitle className="text-3xl font-bold">{copy.title}</CardTitle>
+          <CardDescription className="text-base">{copy.subtitle}</CardDescription>
         </CardHeader>
-        <CardContent className="space-y-4">
-          <Tabs value={defaultTab} onValueChange={(value) => switchTab(value as Tab)}>
-            <TabsList className="grid grid-cols-2 w-full">
-              <TabsTrigger value="signin">Sign In</TabsTrigger>
-              <TabsTrigger value="signup">Sign Up</TabsTrigger>
-            </TabsList>
-            <TabsContent value="signin" className="mt-4">
-              <SignInForm next={next} registered={registered} reset={reset} />
-            </TabsContent>
-            <TabsContent value="signup" className="mt-4">
-              <SignUpForm inviteToken={inviteToken} next={next} />
-            </TabsContent>
-          </Tabs>
+        <CardContent className="p-8 pt-2">
+          {defaultTab === "signin" ? (
+            <SignInForm next={next} registered={registered} reset={reset} />
+          ) : (
+            <SignUpForm inviteToken={inviteToken} next={next} />
+          )}
         </CardContent>
+        <div className="border-t border-border bg-background px-8 py-5 text-center text-sm text-muted-foreground">
+          {copy.switchLabel}{" "}
+          <Link href={switchHref} className="text-primary font-semibold hover:text-foreground">
+            {copy.switchCta}
+          </Link>
+        </div>
       </Card>
+      <p className="text-xs text-muted-foreground tracking-wide">
+        <a href="/privacy" className="hover:text-foreground">privacy</a>
+        <span className="mx-2 opacity-60">•</span>
+        <a href="/terms" className="hover:text-foreground">terms</a>
+      </p>
     </div>
   );
 };

--- a/pwa/components/auth/SignInForm.tsx
+++ b/pwa/components/auth/SignInForm.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { Formik, Form } from "formik";
 import { useAuth } from "@/contexts/AuthContext";
 import { safeNextPath } from "@/lib/authRedirect";
-import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { FormikField } from "@/components/ui/formik-field";
 import TwoFactorChallengeForm from "./TwoFactorChallengeForm";
@@ -37,6 +37,7 @@ const SignInForm = ({ next, registered, reset }: Props) => {
   // already on a server cookie — there's nothing useful to put in the URL,
   // and a back-button to /signin should restart, not resume.
   const [twoFactorPrompt, setTwoFactorPrompt] = useState(false);
+  const [ssoNotice, setSsoNotice] = useState<string | null>(null);
 
   if (twoFactorPrompt) {
     return (
@@ -65,6 +66,12 @@ const SignInForm = ({ next, registered, reset }: Props) => {
         </Alert>
       )}
 
+      {ssoNotice && (
+        <Alert>
+          <AlertDescription>{ssoNotice}</AlertDescription>
+        </Alert>
+      )}
+
       <Formik<SignInValues>
         initialValues={{ email: "", password: "" }}
         validate={validate}
@@ -84,12 +91,32 @@ const SignInForm = ({ next, registered, reset }: Props) => {
         }}
       >
         {({ isSubmitting, status }) => (
-          <Form className="space-y-4" noValidate>
-            {status && (
-              <Alert variant="destructive">
-                <AlertDescription>{status}</AlertDescription>
-              </Alert>
-            )}
+          <Form className="space-y-5" noValidate>
+            {status && (() => {
+              const isCreds = /invalid credentials/i.test(status);
+              const title = isCreds ? "Invalid email or password" : status;
+              const description = isCreds
+                ? "Double-check your credentials. After 5 failed attempts we'll pause sign-in briefly."
+                : null;
+              return (
+                <Alert variant="destructive">
+                  <svg
+                    viewBox="0 0 10 10"
+                    width="10"
+                    height="10"
+                    aria-hidden="true"
+                    style={{
+                      filter:
+                        "drop-shadow(0 0 4px oklch(0.65 0.2 25 / 0.9)) drop-shadow(0 0 8px oklch(0.65 0.2 25 / 0.6))",
+                    }}
+                  >
+                    <rect x="1" y="1" width="8" height="8" rx="2" fill="currentColor" />
+                  </svg>
+                  <AlertTitle>{title}</AlertTitle>
+                  {description && <AlertDescription>{description}</AlertDescription>}
+                </Alert>
+              );
+            })()}
 
             <FormikField
               name="email"
@@ -97,6 +124,7 @@ const SignInForm = ({ next, registered, reset }: Props) => {
               label="Email"
               placeholder="you@example.com"
               autoComplete="email"
+              inputClassName="h-11 text-base"
             />
 
             <FormikField
@@ -105,17 +133,34 @@ const SignInForm = ({ next, registered, reset }: Props) => {
               label="Password"
               placeholder="Your password"
               autoComplete="current-password"
+              inputClassName="h-11 text-base"
+              labelAddon={
+                <Link
+                  href="/forgot-password"
+                  className="text-sm text-primary font-semibold hover:text-foreground"
+                >
+                  Forgot password?
+                </Link>
+              }
             />
 
-            <Button type="submit" disabled={isSubmitting} className="w-full">
-              {isSubmitting ? "Signing In..." : "Sign In"}
-            </Button>
-
-            <p className="text-center text-sm">
-              <Link href="/forgot-password" className="text-primary font-medium">
-                Forgot password?
-              </Link>
-            </p>
+            <div className="space-y-3 pt-2">
+              <Button
+                type="submit"
+                disabled={isSubmitting}
+                className="w-full h-12 text-base font-semibold"
+              >
+                {isSubmitting ? "Signing in..." : "Sign in"}
+              </Button>
+              <Button
+                type="button"
+                variant="secondary"
+                className="w-full h-12 text-base font-semibold text-foreground border border-border"
+                onClick={() => setSsoNotice("SSO sign-in isn't enabled for this workspace yet.")}
+              >
+                Sign in with SSO
+              </Button>
+            </div>
           </Form>
         )}
       </Formik>

--- a/pwa/components/ui/alert.tsx
+++ b/pwa/components/ui/alert.tsx
@@ -10,7 +10,7 @@ const alertVariants = cva(
       variant: {
         default: "bg-background text-foreground",
         destructive:
-          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+          "border-[oklch(0.42_0.12_25)] bg-[oklch(0.24_0.07_25)] text-[oklch(0.92_0.04_25)] [&>svg]:text-destructive",
       },
     },
     defaultVariants: {
@@ -33,7 +33,7 @@ const AlertTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <h5
     ref={ref}
-    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+    className={cn("mb-1 font-semibold leading-none tracking-tight", className)}
     {...props}
   />
 ));

--- a/pwa/components/ui/button.tsx
+++ b/pwa/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -22,8 +22,8 @@ const buttonVariants = cva(
       },
       size: {
         default: "h-9 px-4 py-2",
-        sm: "h-8 rounded-md px-3 text-xs",
-        lg: "h-10 rounded-md px-8",
+        sm: "h-8 rounded-lg px-3 text-xs",
+        lg: "h-10 rounded-lg px-8",
         icon: "h-9 w-9",
         // Used by the shadcn `Combobox` for inline chip-remove and trigger
         // buttons that sit inside an InputGroup.

--- a/pwa/components/ui/card.tsx
+++ b/pwa/components/ui/card.tsx
@@ -7,7 +7,7 @@ const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElemen
     <div
       ref={ref}
       className={cn(
-        "rounded-lg border bg-card text-card-foreground shadow-sm",
+        "rounded-[10px] border bg-card text-card-foreground shadow-sm",
         className,
       )}
       {...props}

--- a/pwa/components/ui/formik-field.tsx
+++ b/pwa/components/ui/formik-field.tsx
@@ -1,4 +1,4 @@
-import { Field, ErrorMessage } from "formik";
+import { Field, ErrorMessage, useField } from "formik";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
@@ -11,6 +11,11 @@ interface FormikFieldProps extends InputProps {
   description?: React.ReactNode;
   inputClassName?: string;
   containerClassName?: string;
+  /**
+   * Renders to the right of the label on the same row — e.g. a "Forgot
+   * password?" link next to the Password label. Omitted = label-only row.
+   */
+  labelAddon?: React.ReactNode;
 }
 
 export function FormikField({
@@ -19,17 +24,28 @@ export function FormikField({
   description,
   inputClassName,
   containerClassName,
+  labelAddon,
   id,
   ...inputProps
 }: FormikFieldProps) {
   const fieldId = id ?? name;
+  const [, meta] = useField(name);
+  const isInvalid = meta.touched && Boolean(meta.error);
   return (
     <div className={cn("space-y-1.5", containerClassName)}>
-      <Label htmlFor={fieldId}>{label}</Label>
+      {labelAddon ? (
+        <div className="flex items-center justify-between">
+          <Label htmlFor={fieldId}>{label}</Label>
+          {labelAddon}
+        </div>
+      ) : (
+        <Label htmlFor={fieldId}>{label}</Label>
+      )}
       <Field
         as={Input}
         id={fieldId}
         name={name}
+        aria-invalid={isInvalid || undefined}
         className={inputClassName}
         {...inputProps}
       />

--- a/pwa/components/ui/input.tsx
+++ b/pwa/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLI
       <input
         type={type}
         className={cn(
-          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-9 w-full rounded-md border border-input bg-muted px-3 py-1 text-sm shadow-sm file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-white aria-invalid:border-destructive aria-invalid:focus-visible:border-destructive disabled:cursor-not-allowed disabled:opacity-50",
           className,
         )}
         ref={ref}

--- a/pwa/components/ui/label.tsx
+++ b/pwa/components/ui/label.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const labelVariants = cva(
-  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+  "text-sm font-semibold leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
 );
 
 const Label = React.forwardRef<

--- a/pwa/components/ui/textarea.tsx
+++ b/pwa/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<
   return (
     <textarea
       className={cn(
-        "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50",
+        "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-white aria-invalid:border-destructive aria-invalid:focus-visible:border-destructive disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
       ref={ref}

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -66,6 +66,12 @@
     "@babel/core": "^7.19.0",
     "@popperjs/core": "^2.11.6"
   },
+  "browserslist": [
+    "chrome >= 111",
+    "firefox >= 113",
+    "safari >= 15.4",
+    "edge >= 111"
+  ],
   "pnpm": {
     "overrides": {
       "postcss@<8.5.10": "^8.5.10",

--- a/pwa/pages/dev/components/formik-field.tsx
+++ b/pwa/pages/dev/components/formik-field.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { Formik, Form } from "formik";
 import { FormikField } from "@/components/ui/formik-field";
 import { Button } from "@/components/ui/button";
@@ -24,6 +25,11 @@ const Demo = () => (
         label="Password"
         type="password"
         description="At least 8 characters."
+        labelAddon={
+          <Link href="#" className="text-xs text-primary font-medium">
+            Forgot password?
+          </Link>
+        }
       />
       <Button type="submit">Sign in</Button>
     </Form>

--- a/pwa/styles/globals.css
+++ b/pwa/styles/globals.css
@@ -6,65 +6,69 @@
 :root {
     --radius: 0.5rem;
 
-    /* Canonical shadcn neutral baseColor (light). */
-    --background: hsl(0 0% 100%);
-    --foreground: hsl(0 0% 3.9%);
+    /* Canonical shadcn neutral baseColor (light). Values are full
+       color expressions so `var(--token)` is directly usable as a
+       color — Tailwind v4 emits utilities like
+       `background-color: var(--background)`. */
+    --background:            hsl(0 0% 100%);
+    --foreground:            hsl(0 0% 3.9%);
 
-    --card: hsl(0 0% 100%);
-    --card-foreground: hsl(0 0% 3.9%);
+    --card:                  hsl(0 0% 100%);
+    --card-foreground:       hsl(0 0% 3.9%);
 
-    --popover: hsl(0 0% 100%);
-    --popover-foreground: hsl(0 0% 3.9%);
+    --popover:               hsl(0 0% 100%);
+    --popover-foreground:    hsl(0 0% 3.9%);
 
-    --primary: hsl(0 0% 9%);
-    --primary-foreground: hsl(0 0% 98%);
+    --primary:               hsl(0 0% 9%);
+    --primary-foreground:    hsl(0 0% 98%);
 
-    --secondary: hsl(0 0% 96.1%);
-    --secondary-foreground: hsl(0 0% 9%);
+    --secondary:             hsl(0 0% 96.1%);
+    --secondary-foreground:  hsl(0 0% 9%);
 
-    --muted: hsl(0 0% 96.1%);
-    --muted-foreground: hsl(0 0% 45.1%);
+    --muted:                 hsl(0 0% 96.1%);
+    --muted-foreground:      hsl(0 0% 45.1%);
 
-    --accent: hsl(0 0% 96.1%);
-    --accent-foreground: hsl(0 0% 9%);
+    --accent:                hsl(0 0% 96.1%);
+    --accent-foreground:     hsl(0 0% 9%);
 
-    --destructive: hsl(0 84.2% 60.2%);
-    --destructive-foreground: hsl(0 0% 98%);
+    --destructive:           hsl(0 84.2% 60.2%);
+    --destructive-foreground:hsl(0 0% 98%);
 
-    --border: hsl(0 0% 89.8%);
-    --input: hsl(0 0% 89.8%);
-    --ring: hsl(0 0% 3.9%);
+    --border:                hsl(0 0% 89.8%);
+    --input:                 hsl(0 0% 89.8%);
+    --ring:                  hsl(0 0% 3.9%);
 }
 
 .dark {
-    /* Canonical shadcn neutral baseColor (dark). */
-    --background: hsl(0 0% 3.9%);
-    --foreground: hsl(0 0% 98%);
+    --background:            #0d0e10;
+    --foreground:            #e9e9e6;
 
-    --card: hsl(0 0% 3.9%);
-    --card-foreground: hsl(0 0% 98%);
+    --card:                  #16181c;
+    --card-foreground:       #e9e9e6;
 
-    --popover: hsl(0 0% 3.9%);
-    --popover-foreground: hsl(0 0% 98%);
+    --popover:               #16181c;
+    --popover-foreground:    #e9e9e6;
 
-    --primary: hsl(0 0% 98%);
-    --primary-foreground: hsl(0 0% 9%);
+    --muted:                 #1d2025;
+    --muted-foreground:      #7a7e83;
 
-    --secondary: hsl(0 0% 14.9%);
-    --secondary-foreground: hsl(0 0% 98%);
+    --accent:                #23272d;            /* hover bg */
+    --accent-foreground:     #e9e9e6;
 
-    --muted: hsl(0 0% 14.9%);
-    --muted-foreground: hsl(0 0% 63.9%);
+    --primary:               hsl(165 64% 56%);
+    --primary-foreground:    #0c1410;
 
-    --accent: hsl(0 0% 14.9%);
-    --accent-foreground: hsl(0 0% 98%);
+    --secondary:             #1d2025;
+    --secondary-foreground:  #b6b8b2;
 
-    --destructive: hsl(0 62.8% 30.6%);
-    --destructive-foreground: hsl(0 0% 98%);
+    --destructive:           oklch(0.65 0.2 25);
+    --destructive-foreground:#ffffff;
 
-    --border: hsl(0 0% 14.9%);
-    --input: hsl(0 0% 14.9%);
-    --ring: hsl(0 0% 83.1%);
+    --border:                rgb(255 255 255 / 0.07);
+    --input:                 rgb(255 255 255 / 0.14);
+    --ring:                  hsl(165 64% 56%);
+
+    --radius:                0.5rem;
 }
 
 @theme inline {
@@ -94,8 +98,55 @@
 }
 
 @layer base {
+    /* Tailwind v4 dropped the default border color (v3 used gray-200).
+       Restore it so bare `border` / `border-t` etc. use --border instead
+       of falling back to currentColor (which paints borders white in
+       dark mode). */
+    *, ::after, ::before {
+        border-color: var(--border);
+    }
     body {
         @apply bg-background text-foreground;
+    }
+    /* Smooth color / border-color transitions on interactive elements.
+       The `body` prefix bumps specificity to (0,0,2) so this wins over
+       BlockNote's unlayered `a { transition: color .15s }` from
+       `@blocknote/mantine/style.css` (which is (0,0,1)) without needing
+       `!important`. Form-control transitions also live here so any
+       input/textarea/select picks up the 1s color + border-color fade
+       without each component having to opt in. */
+    body a {
+        transition: color 1000ms ease;
+    }
+    body input, body textarea, body select {
+        transition: color 1000ms ease, border-color 1000ms ease;
+    }
+}
+
+/* Slow pulse for the Aura wordmark icon on the auth pages — fades the
+   teal drop-shadow halo in and out so the logo feels "alive" without
+   demanding attention. Paired with .animate-aura-glow on the SVG. */
+@keyframes aura-glow-pulse {
+    0%, 100% {
+        filter:
+            drop-shadow(0 0 12px rgb(62 221 180 / 0.95))
+            drop-shadow(0 0 28px rgb(62 221 180 / 0.65));
+    }
+    50% {
+        filter:
+            drop-shadow(0 0 18px rgb(62 221 180 / 1))
+            drop-shadow(0 0 42px rgb(62 221 180 / 0.9));
+    }
+}
+.animate-aura-glow {
+    animation: aura-glow-pulse 2.8s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+    .animate-aura-glow {
+        animation: none;
+        filter:
+            drop-shadow(0 0 12px rgb(62 221 180 / 0.95))
+            drop-shadow(0 0 28px rgb(62 221 180 / 0.65));
     }
 }
 


### PR DESCRIPTION
## Summary

- Rebuilds `/signin` and `/signup` to match the new dark design: centered Aura wordmark (pulsing teal glow) above a 10px-radius card with "Welcome back" header, inline "Forgot password?" on the password label, primary/SSO buttons, two-tone footer with the auth switch link, and a privacy/terms strip below.
- Re-grounds the dark token palette around an elevation scale (`#0d0e10` base → `#16181c` card → `#1d2025` muted → `#23272d` accent), translucent-white borders (`0.07` / `0.14`), an oklch destructive (`oklch(0.65 0.2 25)`), and ink/ink-dark/ink-muted text tiers — all wired through the existing shadcn tokens so the rest of the app picks them up automatically.
- Tightens the shared primitives that drive the look: `Card` (10px radius, default `--border`), `Input` / `Textarea` (muted bg, focus-white / aria-invalid-red borders, 1s fade), `Button` (rounded-lg + `cursor-pointer`), `Label` (font-semibold), and the destructive `Alert` (oklch surface + glowing rounded-square dot).

## Notes

- New global rule in `globals.css` restores Tailwind v3's default `border-color` (Tailwind v4 dropped it, which is why every bare `border` was painting white in dark mode).
- `FormikField` now wires `aria-invalid` from Formik's `meta.touched && meta.error`, so the destructive border state is automatic everywhere it's used.
- Adds a browserslist (Chrome 111+, Firefox 113+, Safari 15.4+, Edge 111+) so Lightning CSS keeps `oklch()` expressions instead of downconverting to sRGB hex.
- "Sign in with SSO" is a placeholder button — it surfaces a "not enabled yet" notice; the real flow is tracked in #267. `/privacy` and `/terms` link targets are placeholders pending #268 and #269.

## Test plan

- [ ] `/signin` renders the new layout in dark mode; hard-refresh after pulling to bust the CSS bundle cache.
- [ ] Submit empty form → password field gets the white focus border on click and a red `oklch(0.65 0.2 25)` border on blur with the inline error.
- [ ] Submit bad credentials → destructive alert renders with the glowing red dot, "Invalid email or password" title, and helper description.
- [ ] Hover the "Forgot password?" / "Create an account" / privacy / terms links → green/muted fade to ink over ~1s.
- [ ] Click "Sign in with SSO" → placeholder notice appears.
- [ ] `/signup` still works as the inverse (links back to `/signin`).