### PR TITLE
feat(pwa): add default Terms and Privacy Policy pages

### DIFF
--- a/pwa/pages/index.tsx
+++ b/pwa/pages/index.tsx
@@ -213,6 +213,17 @@ const Home = () => {
               className="underline-offset-4 hover:underline"
             >
               GitHub
+            </Link>{" "}
+            ·{" "}
+            <Link href="/terms" className="underline-offset-4 hover:underline">
+              Terms
+            </Link>{" "}
+            ·{" "}
+            <Link
+              href="/privacy"
+              className="underline-offset-4 hover:underline"
+            >
+              Privacy
             </Link>
           </div>
         </footer>

--- a/pwa/pages/privacy.tsx
+++ b/pwa/pages/privacy.tsx
@@ -1,0 +1,189 @@
+import Head from "next/head";
+import Link from "next/link";
+
+const LAST_UPDATED = "May 17, 2026";
+
+const Privacy = () => (
+  <>
+    <Head>
+      <title>Privacy Policy — Aura</title>
+      <meta
+        name="description"
+        content="How Aura collects, uses, and protects your personal data."
+      />
+    </Head>
+
+    <main className="bg-background">
+      <div className="max-w-3xl mx-auto px-4 py-12 md:py-16">
+        <header className="mb-10">
+          <h1 className="text-3xl md:text-4xl font-bold tracking-tight text-foreground mb-2">
+            Privacy Policy
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Last updated: {LAST_UPDATED}
+          </p>
+        </header>
+
+        <div className="space-y-8 text-foreground leading-relaxed">
+          <section>
+            <p className="text-muted-foreground">
+              This Privacy Policy describes how Aura (the &quot;Service&quot;)
+              collects, uses, and protects your personal data when you use it.
+              By using the Service, you agree to the practices described here.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold mb-2">1. Information we collect</h2>
+            <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
+              <li>
+                <strong className="text-foreground">Account information.</strong>{" "}
+                Your email address, display name, and an optional avatar image
+                you upload.
+              </li>
+              <li>
+                <strong className="text-foreground">Content you create.</strong>{" "}
+                Tasks, projects, pages, discussions, comments, attachments,
+                tags, and other content you submit to the Service.
+              </li>
+              <li>
+                <strong className="text-foreground">Authentication data.</strong>{" "}
+                A hashed password and, if you enable two-factor authentication,
+                an encrypted TOTP secret and one-time backup codes.
+              </li>
+              <li>
+                <strong className="text-foreground">Usage data.</strong>{" "}
+                Basic technical information such as IP address, browser type,
+                and timestamps recorded in server logs for security and
+                operational purposes.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold mb-2">2. How we use your information</h2>
+            <p className="text-muted-foreground mb-2">We use your data to:</p>
+            <ul className="list-disc pl-6 space-y-1 text-muted-foreground">
+              <li>Provide, maintain, and improve the Service.</li>
+              <li>Authenticate you and keep your account secure.</li>
+              <li>Send transactional emails (sign-up confirmation, password reset, invites, notifications).</li>
+              <li>Respond to your requests, questions, and reports.</li>
+              <li>Detect, prevent, and address fraud, abuse, and technical issues.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold mb-2">3. Sharing</h2>
+            <p className="text-muted-foreground">
+              We do not sell your personal data. Content you create is visible
+              only to you and the collaborators you share it with (for example,
+              members of a space). We may share data with infrastructure
+              providers strictly to operate the Service, and we may disclose
+              information if required by law.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold mb-2">4. Data retention</h2>
+            <p className="text-muted-foreground">
+              We retain your account data and content for as long as your
+              account is active. When you delete your account, we delete the
+              associated personal data within a reasonable period, except where
+              retention is required for legal, security, or fraud-prevention
+              purposes.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold mb-2">5. Security</h2>
+            <p className="text-muted-foreground">
+              We use industry-standard measures to protect your data — including
+              hashed passwords, encrypted two-factor secrets, secure transport
+              (HTTPS), and access controls. No system is perfectly secure, so
+              we cannot guarantee absolute security.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold mb-2">6. Your rights</h2>
+            <p className="text-muted-foreground mb-2">
+              Depending on your location, you may have the right to:
+            </p>
+            <ul className="list-disc pl-6 space-y-1 text-muted-foreground">
+              <li>Access the personal data we hold about you.</li>
+              <li>Correct inaccurate or incomplete data.</li>
+              <li>Delete your account and associated data.</li>
+              <li>Export your data in a portable format.</li>
+              <li>Object to or restrict certain processing.</li>
+            </ul>
+            <p className="text-muted-foreground mt-2">
+              You can exercise most of these rights directly from your account
+              settings. For anything else, contact us using the details below.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold mb-2">7. Cookies and local storage</h2>
+            <p className="text-muted-foreground">
+              We use cookies and browser local storage for essential
+              functionality such as keeping you signed in and remembering your
+              active space and theme preferences. We do not use third-party
+              advertising or tracking cookies.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold mb-2">8. Children</h2>
+            <p className="text-muted-foreground">
+              The Service is not intended for children under the age of 13 (or
+              the equivalent minimum age in your jurisdiction). We do not
+              knowingly collect personal data from children.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold mb-2">9. Changes to this policy</h2>
+            <p className="text-muted-foreground">
+              We may update this Privacy Policy from time to time. When we do,
+              we will revise the &quot;Last updated&quot; date above. If the
+              changes are material, we will make reasonable efforts to notify
+              you.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold mb-2">10. Contact</h2>
+            <p className="text-muted-foreground">
+              Questions about this policy or your data? Reach out via the
+              project&apos;s{" "}
+              <Link
+                href="https://github.com/roboparker/Aura"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary underline-offset-4 hover:underline"
+              >
+                GitHub repository
+              </Link>
+              .
+            </p>
+          </section>
+
+          <section className="pt-4 border-t">
+            <p className="text-sm text-muted-foreground">
+              See also our{" "}
+              <Link
+                href="/terms"
+                className="text-primary underline-offset-4 hover:underline"
+              >
+                Terms and Conditions
+              </Link>
+              .
+            </p>
+          </section>
+        </div>
+      </div>
+    </main>
+  </>
+);
+
+export default Privacy;

--- a/pwa/pages/terms.tsx
+++ b/pwa/pages/terms.tsx
@@ -1,0 +1,152 @@
+import Head from "next/head";
+import Link from "next/link";
+
+const LAST_UPDATED = "May 17, 2026";
+
+const Terms = () => (
+  <>
+    <Head>
+      <title>Terms and Conditions — Aura</title>
+      <meta
+        name="description"
+        content="The terms and conditions that govern your use of Aura."
+      />
+    </Head>
+
+    <main className="bg-background">
+      <div className="max-w-3xl mx-auto px-4 py-12 md:py-16">
+        <header className="mb-10">
+          <h1 className="text-3xl md:text-4xl font-bold tracking-tight text-foreground mb-2">
+            Terms and Conditions
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Last updated: {LAST_UPDATED}
+          </p>
+        </header>
+
+        <div className="space-y-8 text-foreground leading-relaxed">
+          <section>
+            <p className="text-muted-foreground">
+              These Terms and Conditions (&quot;Terms&quot;) govern your access
+              to and use of Aura (the &quot;Service&quot;). By creating an
+              account or using the Service, you agree to be bound by these
+              Terms. If you do not agree, do not use the Service.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold mb-2">1. Your account</h2>
+            <p className="text-muted-foreground">
+              You are responsible for safeguarding the credentials used to
+              access your account and for any activity that occurs under it.
+              You must provide accurate information when registering and keep
+              it current. We may suspend or terminate accounts that violate
+              these Terms.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold mb-2">2. Acceptable use</h2>
+            <p className="text-muted-foreground mb-2">
+              You agree not to:
+            </p>
+            <ul className="list-disc pl-6 space-y-1 text-muted-foreground">
+              <li>Use the Service for any unlawful purpose or in violation of any applicable law.</li>
+              <li>Upload, post, or transmit content that is harmful, abusive, defamatory, or infringing.</li>
+              <li>Attempt to gain unauthorised access to the Service or any related systems.</li>
+              <li>Interfere with, disrupt, or place an unreasonable load on the Service.</li>
+              <li>Reverse engineer, decompile, or otherwise attempt to derive source code, except where permitted by law.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold mb-2">3. Your content</h2>
+            <p className="text-muted-foreground">
+              You retain ownership of the content you create, upload, or
+              share through the Service (&quot;Your Content&quot;). By using
+              the Service, you grant us a limited, non-exclusive license to
+              host, store, and display Your Content solely for the purpose of
+              operating and providing the Service to you and your collaborators.
+              You are responsible for Your Content and for ensuring you have
+              the right to share it.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold mb-2">4. Service availability</h2>
+            <p className="text-muted-foreground">
+              We aim to keep the Service available and reliable, but we do
+              not guarantee uninterrupted access. The Service is provided on
+              an &quot;as is&quot; and &quot;as available&quot; basis without
+              warranties of any kind, whether express or implied.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold mb-2">5. Termination</h2>
+            <p className="text-muted-foreground">
+              You may stop using the Service at any time and may delete your
+              account from your settings. We may suspend or terminate your
+              access if you breach these Terms or if we are required to do so
+              by law. Provisions that by their nature should survive
+              termination will do so.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold mb-2">6. Limitation of liability</h2>
+            <p className="text-muted-foreground">
+              To the maximum extent permitted by law, we will not be liable
+              for any indirect, incidental, special, consequential, or
+              punitive damages, or any loss of profits or revenues, whether
+              incurred directly or indirectly, arising from your use of the
+              Service.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold mb-2">7. Changes to these Terms</h2>
+            <p className="text-muted-foreground">
+              We may update these Terms from time to time. When we do, we
+              will revise the &quot;Last updated&quot; date above. If the
+              changes are material, we will make reasonable efforts to notify
+              you. Your continued use of the Service after an update
+              constitutes acceptance of the revised Terms.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold mb-2">8. Contact</h2>
+            <p className="text-muted-foreground">
+              Questions about these Terms? Reach out via the project&apos;s{" "}
+              <Link
+                href="https://github.com/roboparker/Aura"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary underline-offset-4 hover:underline"
+              >
+                GitHub repository
+              </Link>
+              .
+            </p>
+          </section>
+
+          <section className="pt-4 border-t">
+            <p className="text-sm text-muted-foreground">
+              See also our{" "}
+              <Link
+                href="/privacy"
+                className="text-primary underline-offset-4 hover:underline"
+              >
+                Privacy Policy
+              </Link>
+              .
+            </p>
+          </section>
+        </div>
+      </div>
+    </main>
+  </>
+);
+
+export default Terms;


### PR DESCRIPTION
## Description

Adds default `/terms` and `/privacy` static pages so the app has somewhere legitimate to link to from the marketing footer (and, eventually, the signup flow). Content is generic boilerplate covering the usual sections — acceptable use, content ownership, data collection, retention, user rights, cookies, etc. — and is intended to be swapped for real legal copy before launch.

The landing-page footer now links to both alongside the existing GitHub link, and the two pages cross-link to each other.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

## Component

- [ ] API (PHP/Symfony)
- [x] PWA (Next.js)
- [ ] Infrastructure (Docker/Helm)
- [ ] E2E Tests
- [ ] Documentation

## How Has This Been Tested?

Both pages are static JSX using only `next/head`, `next/link`, and Tailwind classes that already exist in the design tokens — no new dependencies, no data fetching, no client-state. They follow the same conventions as `forgot-password.tsx` / `index.tsx` and are wrapped automatically by the global `Layout` (Navbar + Sidebar) via `_app.tsx`.

To verify manually:

- `pnpm dev` and visit `/terms` and `/privacy`.
- Confirm the marketing footer (home page) renders the new Terms / Privacy links next to GitHub.

## Checklist

- [x] My code follows the project's conventions
- [ ] I have added tests that prove my fix or feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed