### PR TITLE
Auto-assign Dependabot PRs to roboparker + raise open-PR limit to 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
       interval: monthly
     assignees:
       - roboparker
+    open-pull-requests-limit: 10
   - package-ecosystem: composer
     directory: /api
     schedule:
@@ -16,7 +17,7 @@ updates:
       - dependencies
     assignees:
       - roboparker
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     ignore:
       # Symfony components are pinned to 7.2.* in composer.json — bumping a
       # single component to a new major (e.g. dotenv 8.0) desyncs the stack.
@@ -31,4 +32,4 @@ updates:
       - dependencies
     assignees:
       - roboparker
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,16 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    assignees:
+      - roboparker
   - package-ecosystem: composer
     directory: /api
     schedule:
       interval: daily
     labels:
       - dependencies
+    assignees:
+      - roboparker
     open-pull-requests-limit: 5
     ignore:
       # Symfony components are pinned to 7.2.* in composer.json — bumping a
@@ -25,4 +29,6 @@ updates:
       interval: daily
     labels:
       - dependencies
+    assignees:
+      - roboparker
     open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

- Add `assignees: [roboparker]` to every ecosystem block in `.github/dependabot.yml` (github-actions, composer, npm).
- Raise `open-pull-requests-limit` to **10** for all three ecosystems (composer + npm were at 5, github-actions was on the implicit default of 5).

## Why

The existing `.github/workflows/auto-assign.yml` assigns each PR to its author. Dependabot PRs are authored by `dependabot[bot]`, so they end up either unassigned or with the bot as assignee — they don't show up in my assigned-issues view until I look at the open-PR list directly. Setting `assignees` routes them straight to me on open.

The 5-PR cap was the bottleneck on a daily schedule — newer upgrades stalled behind older ones I hadn't reviewed yet. 10 lets the bot keep filing while older PRs queue for review.

## Test plan

- [ ] Wait for the next Dependabot run (daily for npm + composer, monthly for actions) and confirm new PRs land with me as assignee.
- [ ] Confirm Dependabot will now keep up to 10 open PRs per ecosystem instead of stopping at 5.