### PR TITLE
feat(2fa): redesign challenge step, harden recovery codes, add rate limiting

### DIFF
--- a/api/migrations/Version20260524000000.php
+++ b/api/migrations/Version20260524000000.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Replace `user.totp_recovery_code_hashes` with `user.totp_recovery_codes`.
+ *
+ * Old shape: `["<sha256>", "<sha256>", ...]` — hash-only, codes lost on use.
+ * New shape: `[{"hash": "<sha256>", "consumedAt": "2026-...|null"}, ...]`
+ *
+ * The structural win is `consumedAt`: spent codes stay on the row instead
+ * of being filtered out, so the security panel can render them
+ * struck-through alongside the still-spendable ones. Plaintext stays
+ * hash-only — recoverable codes would collapse the second factor into
+ * single-factor whenever the password was compromised (an attacker with
+ * the password could log in once, reveal an unused code, then bypass TOTP
+ * forever from any device).
+ *
+ * Backfill: every existing hash becomes `{hash, consumedAt: null}`.
+ */
+final class Version20260524000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Replace user.totp_recovery_code_hashes with the structured user.totp_recovery_codes column.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "user" ADD COLUMN totp_recovery_codes JSON DEFAULT NULL');
+
+        // Backfill: wrap each legacy hash in the new {hash, consumedAt}
+        // shape. jsonb_build_object would be nicer but the column is plain
+        // json — stick to json_build_object for compatibility, then
+        // aggregate back into a list per row.
+        $this->addSql(<<<'SQL'
+            UPDATE "user"
+            SET totp_recovery_codes = sub.codes
+            FROM (
+                SELECT u.id AS user_id,
+                       COALESCE(
+                           json_agg(
+                               json_build_object(
+                                   'hash', hash_value,
+                                   'consumedAt', NULL
+                               )
+                           ) FILTER (WHERE hash_value IS NOT NULL),
+                           '[]'::json
+                       ) AS codes
+                FROM "user" u
+                LEFT JOIN LATERAL json_array_elements_text(u.totp_recovery_code_hashes) AS hash_value ON TRUE
+                WHERE u.totp_recovery_code_hashes IS NOT NULL
+                GROUP BY u.id
+            ) AS sub
+            WHERE "user".id = sub.user_id
+        SQL);
+
+        $this->addSql('ALTER TABLE "user" DROP COLUMN totp_recovery_code_hashes');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "user" ADD COLUMN totp_recovery_code_hashes JSON DEFAULT NULL');
+
+        // Reverse: collect every non-consumed entry's hash into the legacy
+        // list shape. Consumed entries are dropped (the old schema had no
+        // place for them). Plaintext is lost regardless of encryption state.
+        $this->addSql(<<<'SQL'
+            UPDATE "user"
+            SET totp_recovery_code_hashes = sub.hashes
+            FROM (
+                SELECT u.id AS user_id,
+                       COALESCE(
+                           json_agg(entry->>'hash') FILTER (WHERE entry->>'consumedAt' IS NULL),
+                           '[]'::json
+                       ) AS hashes
+                FROM "user" u
+                LEFT JOIN LATERAL json_array_elements(u.totp_recovery_codes) AS entry ON TRUE
+                WHERE u.totp_recovery_codes IS NOT NULL
+                GROUP BY u.id
+            ) AS sub
+            WHERE "user".id = sub.user_id
+        SQL);
+
+        $this->addSql('ALTER TABLE "user" DROP COLUMN totp_recovery_codes');
+    }
+}

--- a/api/src/Controller/TwoFactorController.php
+++ b/api/src/Controller/TwoFactorController.php
@@ -131,6 +131,21 @@ class TwoFactorController extends AbstractController
         return $this->json(['recoveryCodes' => $codes]);
     }
 
+    #[Route('/me/2fa/recovery-codes', name: 'me_2fa_recovery_codes_list', methods: ['GET'])]
+    public function listRecoveryCodes(#[CurrentUser] ?User $user): JsonResponse
+    {
+        if (null === $user) {
+            return $this->json(['error' => 'Not authenticated.'], 401);
+        }
+        if (!$user->isTotpEnabled()) {
+            return $this->json(['error' => '2FA is not enabled.'], 409);
+        }
+
+        return $this->json([
+            'recoveryCodes' => $this->setup->listRecoveryCodes($user),
+        ]);
+    }
+
     #[Route('/me/2fa/status', name: 'me_2fa_status', methods: ['GET'])]
     public function status(#[CurrentUser] ?User $user): JsonResponse
     {

--- a/api/src/Controller/TwoFactorController.php
+++ b/api/src/Controller/TwoFactorController.php
@@ -146,6 +146,30 @@ class TwoFactorController extends AbstractController
         ]);
     }
 
+    #[Route('/me/2fa/recovery-codes/reveal', name: 'me_2fa_recovery_codes_reveal', methods: ['POST'])]
+    public function revealRecoveryCodes(Request $request, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if (null === $user) {
+            return $this->json(['error' => 'Not authenticated.'], 401);
+        }
+        if (!$user->isTotpEnabled()) {
+            return $this->json(['error' => '2FA is not enabled.'], 409);
+        }
+
+        // Step-up auth: unused codes are real credentials. Cookie session
+        // alone isn't enough — a stolen cookie shouldn't yield a portable
+        // 2FA bypass that survives password rotation.
+        $body = $this->jsonBody($request);
+        $password = $this->stringField($body, 'currentPassword');
+        if (!$this->hasher->isPasswordValid($user, $password)) {
+            return $this->json(['error' => 'Current password is incorrect.'], 400);
+        }
+
+        return $this->json([
+            'recoveryCodes' => $this->setup->revealRecoveryCodes($user),
+        ]);
+    }
+
     #[Route('/me/2fa/status', name: 'me_2fa_status', methods: ['GET'])]
     public function status(#[CurrentUser] ?User $user): JsonResponse
     {

--- a/api/src/DataFixtures/UserFixtures.php
+++ b/api/src/DataFixtures/UserFixtures.php
@@ -4,6 +4,7 @@ namespace App\DataFixtures;
 
 use App\Entity\User;
 use App\Service\AvatarColorService;
+use App\Service\TwoFactorSecretCipher;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
@@ -13,9 +14,40 @@ class UserFixtures extends Fixture
     public const ADMIN_REFERENCE = 'user-admin';
     public const USER_REFERENCE = 'user-uma';
 
+    /**
+     * Hardcoded TOTP secret for the Uma fixture user so dev / E2E flows can
+     * pre-pair an authenticator once and reuse the same QR across fixture
+     * reloads. Valid base32 (A-Z, 2-7), length matches what
+     * {@see \Scheb\TwoFactorBundle\Security\TwoFactor\Provider\Totp\TotpAuthenticatorInterface::generateSecret()}
+     * produces in the wild. Not a secret in any meaningful sense — only
+     * paired with the fixture user on fixture-only databases.
+     */
+    private const FIXTURE_TOTP_SECRET = 'JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP';
+
+    /**
+     * Stable recovery codes for the Uma fixture user. Mirrors the
+     * "xxxx-xxxx-xxxx" hex shape produced by
+     * {@see \App\Service\TwoFactorSetupService::regenerateRecoveryCodes()}.
+     *
+     * @var list<string>
+     */
+    private const FIXTURE_RECOVERY_CODES = [
+        'aaaa-1111-bbbb',
+        'cccc-2222-dddd',
+        'eeee-3333-ffff',
+        '1111-aaaa-2222',
+        '2222-bbbb-3333',
+        '3333-cccc-4444',
+        '4444-dddd-5555',
+        '5555-eeee-6666',
+        '6666-ffff-7777',
+        '7777-aaaa-8888',
+    ];
+
     public function __construct(
         private UserPasswordHasherInterface $passwordHasher,
         private AvatarColorService $colorService,
+        private TwoFactorSecretCipher $totpCipher,
     ) {
     }
 
@@ -37,6 +69,20 @@ class UserFixtures extends Fixture
         $user->setFamilyName('User');
         $user->setPersonalizedColor($this->colorService->pick());
         $user->setPassword($this->passwordHasher->hashPassword($user, 'user123'));
+
+        // Pre-enable TOTP 2FA on Uma so the sign-in flow exercises the
+        // challenge step without a manual pairing step every fixture reload.
+        $user->setTotpSecretEncrypted($this->totpCipher->encrypt(self::FIXTURE_TOTP_SECRET));
+        $user->setTotpSecretCache(self::FIXTURE_TOTP_SECRET);
+        $user->setTotpEnabled(true);
+        $user->setRecoveryCodes(array_map(
+            static fn (string $code): array => [
+                'hash' => hash('sha256', $code),
+                'consumedAt' => null,
+            ],
+            self::FIXTURE_RECOVERY_CODES,
+        ));
+
         $manager->persist($user);
 
         $manager->flush();

--- a/api/src/DataFixtures/UserFixtures.php
+++ b/api/src/DataFixtures/UserFixtures.php
@@ -76,8 +76,9 @@ class UserFixtures extends Fixture
         $user->setTotpSecretCache(self::FIXTURE_TOTP_SECRET);
         $user->setTotpEnabled(true);
         $user->setRecoveryCodes(array_map(
-            static fn (string $code): array => [
+            fn (string $code): array => [
                 'hash' => hash('sha256', $code),
+                'encrypted' => $this->totpCipher->encrypt($code),
                 'consumedAt' => null,
             ],
             self::FIXTURE_RECOVERY_CODES,

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -155,26 +155,37 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TwoFact
     /**
      * Recovery codes for the 2FA challenge.
      *
-     * Each entry is `{hash, consumedAt, consumedCode}`:
+     * Each entry is `{hash, consumedAt, encrypted?, consumedCode?}`:
      * - `hash`: sha256 of the plaintext, the source of truth for verification.
      * - `consumedAt`: ATOM timestamp when the code was used during a 2FA
      *    challenge. Non-null entries are kept on the row so the security
      *    panel can show "consumed N of M" with strikethrough, but they're
      *    excluded from the "remaining" count and rejected on future
      *    challenges.
-     * - `consumedCode`: plaintext captured at consumption time so the
-     *    security panel can re-display the code struck-through. Null for
-     *    every still-spendable entry and null for entries that were
-     *    consumed before this column existed.
+     * - `encrypted`: envelope-encrypted plaintext via {@see TwoFactorSecretCipher}
+     *    so the GitHub-style "reveal codes" flow can re-display the full
+     *    list after a fresh password challenge. Optional — older rows
+     *    written before the reveal feature don't have it and surface as
+     *    "(unavailable)" in the reveal view.
+     * - `consumedCode`: legacy field — earlier iterations captured
+     *    plaintext only on consumption. New writes use `encrypted` for
+     *    everything; this stays so the in-place "consumed code" display
+     *    still works for entries written in the interim. Read order:
+     *    `encrypted` (decrypted) wins, `consumedCode` fallback.
      *
-     * Storing plaintext for *unused* codes would collapse the second
-     * factor into single-factor on a password compromise — the same
-     * logged-in session could reveal an unused code and bypass TOTP from a
-     * fresh device. Plaintext for *spent* codes is safe: the hash check
-     * rejects them on the next challenge regardless of the value, so a DB
-     * leak surfaces nothing usable.
+     * Plaintext for unused codes is a deliberate weakening of the old
+     * hash-only model — a DB-leak + APP_SECRET-leak yields the unused
+     * codes. Surface protections:
+     *  - the reveal endpoint requires re-entering the current password
+     *  - the panel never auto-reveals; the user has to opt in per session
+     *  - consumed codes are safe regardless (hash check rejects them)
      *
-     * @var list<array{hash: string, consumedAt: ?string, consumedCode?: ?string}>|null
+     * @var list<array{
+     *     hash: string,
+     *     consumedAt: ?string,
+     *     encrypted?: ?string,
+     *     consumedCode?: ?string,
+     * }>|null
      */
     #[ORM\Column(type: 'json', nullable: true)]
     private ?array $totpRecoveryCodes = null;
@@ -442,7 +453,12 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TwoFact
     }
 
     /**
-     * @param list<array{hash: string, consumedAt: ?string, consumedCode?: ?string}> $entries
+     * @param list<array{
+     *     hash: string,
+     *     consumedAt: ?string,
+     *     encrypted?: ?string,
+     *     consumedCode?: ?string,
+     * }> $entries
      */
     public function setRecoveryCodes(array $entries): static
     {
@@ -451,7 +467,12 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TwoFact
     }
 
     /**
-     * @return list<array{hash: string, consumedAt: ?string, consumedCode?: ?string}>
+     * @return list<array{
+     *     hash: string,
+     *     consumedAt: ?string,
+     *     encrypted?: ?string,
+     *     consumedCode?: ?string,
+     * }>
      */
     public function getRecoveryCodes(): array
     {
@@ -495,10 +516,11 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TwoFact
         foreach ($entries as $index => $entry) {
             if ($entry['hash'] === $hash && null === $entry['consumedAt']) {
                 $entries[$index]['consumedAt'] = $now;
-                // Capture plaintext for security-panel display. Safe to
-                // persist because the hash check above already rejects
-                // this code on every future challenge.
-                $entries[$index]['consumedCode'] = $code;
+                // No need to capture plaintext separately — new entries
+                // carry an `encrypted` envelope from generation time that
+                // the security panel decrypts for display. Legacy entries
+                // (pre-encrypted, post-consumedCode) keep their own
+                // capture untouched.
                 $this->totpRecoveryCodes = $entries;
                 return;
             }

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -155,24 +155,26 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TwoFact
     /**
      * Recovery codes for the 2FA challenge.
      *
-     * Each entry is `{hash, consumedAt}`:
+     * Each entry is `{hash, consumedAt, consumedCode}`:
      * - `hash`: sha256 of the plaintext, the source of truth for verification.
-     *    Plaintext is only ever returned once (at setup / regenerate); the
-     *    user is expected to save it. This mirrors password storage — a DB
-     *    leak yields no usable codes.
      * - `consumedAt`: ATOM timestamp when the code was used during a 2FA
      *    challenge. Non-null entries are kept on the row so the security
      *    panel can show "consumed N of M" with strikethrough, but they're
      *    excluded from the "remaining" count and rejected on future
      *    challenges.
+     * - `consumedCode`: plaintext captured at consumption time so the
+     *    security panel can re-display the code struck-through. Null for
+     *    every still-spendable entry and null for entries that were
+     *    consumed before this column existed.
      *
-     * An earlier iteration also stored an envelope-encrypted plaintext so
-     * the panel could re-reveal codes; reverted (#90 follow-up) because it
-     * collapsed the second factor into single-factor whenever the password
-     * was compromised — the same logged-in session could reveal an unused
-     * code and bypass TOTP from a fresh device.
+     * Storing plaintext for *unused* codes would collapse the second
+     * factor into single-factor on a password compromise — the same
+     * logged-in session could reveal an unused code and bypass TOTP from a
+     * fresh device. Plaintext for *spent* codes is safe: the hash check
+     * rejects them on the next challenge regardless of the value, so a DB
+     * leak surfaces nothing usable.
      *
-     * @var list<array{hash: string, consumedAt: ?string}>|null
+     * @var list<array{hash: string, consumedAt: ?string, consumedCode?: ?string}>|null
      */
     #[ORM\Column(type: 'json', nullable: true)]
     private ?array $totpRecoveryCodes = null;
@@ -440,7 +442,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TwoFact
     }
 
     /**
-     * @param list<array{hash: string, consumedAt: ?string}> $entries
+     * @param list<array{hash: string, consumedAt: ?string, consumedCode?: ?string}> $entries
      */
     public function setRecoveryCodes(array $entries): static
     {
@@ -449,7 +451,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TwoFact
     }
 
     /**
-     * @return list<array{hash: string, consumedAt: ?string}>
+     * @return list<array{hash: string, consumedAt: ?string, consumedCode?: ?string}>
      */
     public function getRecoveryCodes(): array
     {
@@ -493,6 +495,10 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TwoFact
         foreach ($entries as $index => $entry) {
             if ($entry['hash'] === $hash && null === $entry['consumedAt']) {
                 $entries[$index]['consumedAt'] = $now;
+                // Capture plaintext for security-panel display. Safe to
+                // persist because the hash check above already rejects
+                // this code on every future challenge.
+                $entries[$index]['consumedCode'] = $code;
                 $this->totpRecoveryCodes = $entries;
                 return;
             }

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -153,17 +153,29 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TwoFact
     private ?\DateTimeImmutable $totpEnabledAt = null;
 
     /**
-     * Hashes (sha256) of the recovery codes still available for one-time
-     * use during 2FA challenge. Marked used by removing the entry — the
-     * column is the single source of truth for "remaining codes" so the
-     * count surfaced to the user (and the dedupe in invalidateBackupCode)
-     * stay in sync. Plaintext codes are only ever returned once at
-     * generation time.
+     * Recovery codes for the 2FA challenge.
      *
-     * @var string[]|null
+     * Each entry is `{hash, consumedAt}`:
+     * - `hash`: sha256 of the plaintext, the source of truth for verification.
+     *    Plaintext is only ever returned once (at setup / regenerate); the
+     *    user is expected to save it. This mirrors password storage — a DB
+     *    leak yields no usable codes.
+     * - `consumedAt`: ATOM timestamp when the code was used during a 2FA
+     *    challenge. Non-null entries are kept on the row so the security
+     *    panel can show "consumed N of M" with strikethrough, but they're
+     *    excluded from the "remaining" count and rejected on future
+     *    challenges.
+     *
+     * An earlier iteration also stored an envelope-encrypted plaintext so
+     * the panel could re-reveal codes; reverted (#90 follow-up) because it
+     * collapsed the second factor into single-factor whenever the password
+     * was compromised — the same logged-in session could reveal an unused
+     * code and bypass TOTP from a fresh device.
+     *
+     * @var list<array{hash: string, consumedAt: ?string}>|null
      */
     #[ORM\Column(type: 'json', nullable: true)]
-    private ?array $totpRecoveryCodeHashes = null;
+    private ?array $totpRecoveryCodes = null;
 
     public const ALLOWED_THEMES = ['light', 'dark', 'system'];
     public const ALLOWED_FREQUENCIES = ['realtime', 'hourly', 'daily'];
@@ -427,24 +439,37 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TwoFact
         return $this->totpEnabledAt;
     }
 
-    /** @param string[] $hashes */
-    public function setRecoveryCodeHashes(array $hashes): static
+    /**
+     * @param list<array{hash: string, consumedAt: ?string}> $entries
+     */
+    public function setRecoveryCodes(array $entries): static
     {
-        // Re-index so the JSON column is always a list, never a sparse map
-        // after invalidation removes mid-array entries.
-        $this->totpRecoveryCodeHashes = array_values($hashes);
+        $this->totpRecoveryCodes = $entries;
         return $this;
     }
 
-    /** @return string[] */
-    public function getRecoveryCodeHashes(): array
+    /**
+     * @return list<array{hash: string, consumedAt: ?string}>
+     */
+    public function getRecoveryCodes(): array
     {
-        return $this->totpRecoveryCodeHashes ?? [];
+        return $this->totpRecoveryCodes ?? [];
     }
 
+    /**
+     * Count of recovery codes still available — consumed codes are kept on
+     * the entity for display but excluded here so the "X remaining"
+     * indicator and the regen-prompt threshold continue to work.
+     */
     public function getRecoveryCodeCount(): int
     {
-        return count($this->getRecoveryCodeHashes());
+        $remaining = 0;
+        foreach ($this->getRecoveryCodes() as $entry) {
+            if (null === $entry['consumedAt']) {
+                $remaining++;
+            }
+        }
+        return $remaining;
     }
 
     // --- BackupCodeInterface (Scheb) ---
@@ -452,16 +477,25 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TwoFact
     public function isBackupCode(string $code): bool
     {
         $hash = hash('sha256', $code);
-        return in_array($hash, $this->getRecoveryCodeHashes(), true);
+        foreach ($this->getRecoveryCodes() as $entry) {
+            if ($entry['hash'] === $hash && null === $entry['consumedAt']) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public function invalidateBackupCode(string $code): void
     {
         $hash = hash('sha256', $code);
-        $remaining = array_values(array_filter(
-            $this->getRecoveryCodeHashes(),
-            static fn (string $h) => $h !== $hash,
-        ));
-        $this->totpRecoveryCodeHashes = $remaining;
+        $now = (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM);
+        $entries = $this->getRecoveryCodes();
+        foreach ($entries as $index => $entry) {
+            if ($entry['hash'] === $hash && null === $entry['consumedAt']) {
+                $entries[$index]['consumedAt'] = $now;
+                $this->totpRecoveryCodes = $entries;
+                return;
+            }
+        }
     }
 }

--- a/api/src/EventSubscriber/TwoFactorChallengeRateLimiter.php
+++ b/api/src/EventSubscriber/TwoFactorChallengeRateLimiter.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use App\Entity\User;
+use App\Security\TooManyTwoFactorAttemptsException;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvent;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvents;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
+
+/**
+ * Per-user throttle on the 2FA challenge endpoint.
+ *
+ * SchebTwoFactorBundle's firewall owns `/auth/2fa-check` and runs at
+ * `kernel.request` priority 8; its `setResponse()` call stops
+ * propagation, so a plain `kernel.request` subscriber never sees the
+ * challenge requests. Instead we hook into Scheb's own
+ * `scheb_two_factor.authentication.attempt` event — dispatched from
+ * inside the firewall before the code is checked — pull the
+ * half-authenticated user, and consume from the shared
+ * `two_factor_verify` limiter (5/min token bucket, same bucket
+ * {@see \App\Controller\TwoFactorController::verify()} uses for the
+ * setup-confirm path so a password-compromised attacker can't double
+ * their budget across the two endpoints).
+ *
+ * On exhaustion we throw a {@see TooManyTwoFactorAttemptsException}.
+ * Scheb's check-listener catches AuthenticationException, dispatches
+ * the FAILURE event, and re-throws to the firewall's failure handler —
+ * {@see \App\Security\TwoFactorJsonHandler::onAuthenticationFailure()}
+ * inspects the type and emits 429 + `Retry-After`. Every attempt
+ * counts toward the limit, regardless of whether the code happened to
+ * be correct, so a 6th submission gets rejected even if the user
+ * suddenly types a valid TOTP.
+ */
+final class TwoFactorChallengeRateLimiter implements EventSubscriberInterface
+{
+    public function __construct(
+        #[Autowire(service: 'limiter.two_factor_verify')]
+        private RateLimiterFactoryInterface $limiter,
+    ) {
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            TwoFactorAuthenticationEvents::ATTEMPT => 'onAttempt',
+        ];
+    }
+
+    public function onAttempt(TwoFactorAuthenticationEvent $event): void
+    {
+        $user = $event->getToken()->getUser();
+        // Defensive: Scheb only fires this event on a TwoFactorToken
+        // carrying the underlying user, so missing/anonymous user means
+        // something upstream is wrong. Let the firewall reject normally
+        // — rate-limiting an already-broken request would consume the
+        // budget for nothing.
+        if (!$user instanceof User || null === $user->getId()) {
+            return;
+        }
+
+        $limit = $this->limiter->create('user-' . $user->getId())->consume();
+        if ($limit->isAccepted()) {
+            return;
+        }
+
+        $retryAfterSeconds = max(1, $limit->getRetryAfter()->getTimestamp() - time());
+        throw new TooManyTwoFactorAttemptsException($retryAfterSeconds);
+    }
+}

--- a/api/src/Security/TooManyTwoFactorAttemptsException.php
+++ b/api/src/Security/TooManyTwoFactorAttemptsException.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+
+/**
+ * Thrown when the per-user 2FA rate limit is exhausted. Carries the
+ * retry-after window so {@see \App\Security\TwoFactorJsonHandler} can
+ * emit a 429 with a `Retry-After` header and a structured JSON body
+ * the PWA's countdown can drive off.
+ */
+final class TooManyTwoFactorAttemptsException extends AuthenticationException
+{
+    public function __construct(public readonly int $retryAfterSeconds)
+    {
+        parent::__construct(sprintf(
+            'Too many authentication attempts. Try again in %d seconds.',
+            $retryAfterSeconds,
+        ));
+    }
+
+    public function getMessageKey(): string
+    {
+        // Symfony's default message-key fallback would be the parent's
+        // generic auth-error string; ours is already user-facing and
+        // carries the retry seconds, so surface it as-is.
+        return $this->getMessage();
+    }
+}

--- a/api/src/Security/TwoFactorJsonHandler.php
+++ b/api/src/Security/TwoFactorJsonHandler.php
@@ -66,6 +66,8 @@ final class TwoFactorJsonHandler implements
      * Mirrors {@see App\Controller\AuthController::serializeUser()}. Kept
      * inline so this file is self-contained for the firewall handler chain
      * — the two-factor success path doesn't run through the controller.
+     * Must stay in sync with AuthController; the PWA treats both responses
+     * as the same User shape.
      *
      * @return array<string, mixed>
      */
@@ -81,6 +83,10 @@ final class TwoFactorJsonHandler implements
             'personalizedColor' => $user->getPersonalizedColor(),
             'avatarUrls' => $user->getAvatarUrls(),
             'preferences' => $user->getPreferences(),
+            'twoFactor' => [
+                'enabled' => $user->isTotpEnabled(),
+                'recoveryCodesRemaining' => $user->getRecoveryCodeCount(),
+            ],
         ];
     }
 }

--- a/api/src/Security/TwoFactorJsonHandler.php
+++ b/api/src/Security/TwoFactorJsonHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Security;
 
 use App\Entity\User;
+use App\Security\TooManyTwoFactorAttemptsException;
 use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorTokenInterface;
 use Scheb\TwoFactorBundle\Security\Http\Authentication\AuthenticationRequiredHandlerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -57,6 +58,30 @@ final class TwoFactorJsonHandler implements
 
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
     {
+        // Rate-limit hit: thrown from
+        // {@see \App\EventSubscriber\TwoFactorChallengeRateLimiter} when
+        // the per-user bucket is empty. Surface as a structured 429
+        // with both header and body retry-after so the PWA can drive a
+        // countdown without parsing the message string.
+        $rateLimit = $exception instanceof TooManyTwoFactorAttemptsException
+            ? $exception
+            : ($exception->getPrevious() instanceof TooManyTwoFactorAttemptsException
+                ? $exception->getPrevious()
+                : null);
+        if (null !== $rateLimit) {
+            return new JsonResponse(
+                [
+                    'error' => sprintf(
+                        'Too many attempts. Try again in %d seconds.',
+                        $rateLimit->retryAfterSeconds,
+                    ),
+                    'retryAfter' => $rateLimit->retryAfterSeconds,
+                ],
+                429,
+                ['Retry-After' => (string) $rateLimit->retryAfterSeconds],
+            );
+        }
+
         return new JsonResponse([
             'error' => 'Invalid authentication code.',
         ], 401);

--- a/api/src/Service/TwoFactorSetupService.php
+++ b/api/src/Service/TwoFactorSetupService.php
@@ -25,17 +25,21 @@ final class TwoFactorSetupService
     }
 
     /**
-     * Per-entry status for the security-panel list: enough to render
-     * "consumed N of M" with strikethrough, but no plaintext — codes are
-     * hash-only on disk and never recoverable post-generation.
+     * Per-entry status for the security-panel list. `code` is the
+     * plaintext captured at consumption time so the panel can re-display
+     * spent codes struck-through — null for every still-spendable entry
+     * and for entries consumed before that capture existed.
      *
-     * @return list<array{consumedAt: ?string}>
+     * @return list<array{code: ?string, consumedAt: ?string}>
      */
     public function listRecoveryCodes(User $user): array
     {
         $out = [];
         foreach ($user->getRecoveryCodes() as $entry) {
-            $out[] = ['consumedAt' => $entry['consumedAt']];
+            $out[] = [
+                'code' => $entry['consumedCode'] ?? null,
+                'consumedAt' => $entry['consumedAt'],
+            ];
         }
         return $out;
     }

--- a/api/src/Service/TwoFactorSetupService.php
+++ b/api/src/Service/TwoFactorSetupService.php
@@ -25,6 +25,22 @@ final class TwoFactorSetupService
     }
 
     /**
+     * Per-entry status for the security-panel list: enough to render
+     * "consumed N of M" with strikethrough, but no plaintext — codes are
+     * hash-only on disk and never recoverable post-generation.
+     *
+     * @return list<array{consumedAt: ?string}>
+     */
+    public function listRecoveryCodes(User $user): array
+    {
+        $out = [];
+        foreach ($user->getRecoveryCodes() as $entry) {
+            $out[] = ['consumedAt' => $entry['consumedAt']];
+        }
+        return $out;
+    }
+
+    /**
      * Generates a new base32 TOTP secret and stores it (encrypted) on the
      * user. Idempotent for repeated calls during the setup flow — a user
      * who never confirms verify just leaves the previous unconfirmed
@@ -38,7 +54,7 @@ final class TwoFactorSetupService
         // Defensive: never leave 2FA "enabled" with a freshly-rotated
         // unconfirmed secret. The verify step flips this back on.
         $user->setTotpEnabled(false);
-        $user->setRecoveryCodeHashes([]);
+        $user->setRecoveryCodes([]);
         return $secret;
     }
 
@@ -53,23 +69,27 @@ final class TwoFactorSetupService
     }
 
     /**
-     * Generates fresh plaintext recovery codes, stores their hashes on the
-     * user, and returns the plaintext list to the caller. Plaintext is
-     * never persisted — the API surfaces it once at this call site and
-     * the user is expected to copy/download.
+     * Generates fresh plaintext recovery codes, persists them on the user
+     * as `{hash, consumedAt}` pairs, and returns the plaintext list to the
+     * caller. Plaintext is surfaced exactly once — the user is expected to
+     * save it; consumed entries are kept (with `consumedAt` set) so the UI
+     * can show "used N of M" with strikethrough.
      *
      * @return string[] plaintext recovery codes (e.g. "a3f9-1c8b-22e0")
      */
     public function regenerateRecoveryCodes(User $user): array
     {
         $plain = [];
-        $hashes = [];
+        $entries = [];
         for ($i = 0; $i < self::RECOVERY_CODE_COUNT; $i++) {
             $code = $this->generatePlaintextCode();
             $plain[] = $code;
-            $hashes[] = hash('sha256', $code);
+            $entries[] = [
+                'hash' => hash('sha256', $code),
+                'consumedAt' => null,
+            ];
         }
-        $user->setRecoveryCodeHashes($hashes);
+        $user->setRecoveryCodes($entries);
         return $plain;
     }
 
@@ -78,7 +98,7 @@ final class TwoFactorSetupService
         $user->setTotpEnabled(false);
         $user->setTotpSecretEncrypted(null);
         $user->setTotpSecretCache(null);
-        $user->setRecoveryCodeHashes([]);
+        $user->setRecoveryCodes([]);
     }
 
     private function generatePlaintextCode(): string

--- a/api/src/Service/TwoFactorSetupService.php
+++ b/api/src/Service/TwoFactorSetupService.php
@@ -26,9 +26,9 @@ final class TwoFactorSetupService
 
     /**
      * Per-entry status for the security-panel list. `code` is the
-     * plaintext captured at consumption time so the panel can re-display
-     * spent codes struck-through — null for every still-spendable entry
-     * and for entries consumed before that capture existed.
+     * plaintext for spent codes only — unused entries return null so the
+     * UI keeps them masked. Spent codes can't re-authenticate (hash check
+     * rejects them) so surfacing them is harmless.
      *
      * @return list<array{code: ?string, consumedAt: ?string}>
      */
@@ -36,8 +36,48 @@ final class TwoFactorSetupService
     {
         $out = [];
         foreach ($user->getRecoveryCodes() as $entry) {
+            $code = null;
+            if (null !== $entry['consumedAt']) {
+                // Prefer the encrypted envelope (new path), fall back to
+                // the legacy `consumedCode` field for entries written
+                // before encrypted-at-generation shipped.
+                if (isset($entry['encrypted'])) {
+                    $code = $this->cipher->decrypt($entry['encrypted']);
+                } else {
+                    $code = $entry['consumedCode'] ?? null;
+                }
+            }
             $out[] = [
-                'code' => $entry['consumedCode'] ?? null,
+                'code' => $code,
+                'consumedAt' => $entry['consumedAt'],
+            ];
+        }
+        return $out;
+    }
+
+    /**
+     * Decrypts every entry's plaintext for the GitHub-style "reveal codes"
+     * flow. Callers must gate this behind a step-up password challenge —
+     * unused codes are real credentials and shouldn't be surfaced from a
+     * session whose only auth is a cookie.
+     *
+     * Legacy entries with no `encrypted` field (predating the reveal
+     * feature) return null for `code`; the UI marks them as unavailable.
+     *
+     * @return list<array{code: ?string, consumedAt: ?string}>
+     */
+    public function revealRecoveryCodes(User $user): array
+    {
+        $out = [];
+        foreach ($user->getRecoveryCodes() as $entry) {
+            $code = null;
+            if (isset($entry['encrypted'])) {
+                $code = $this->cipher->decrypt($entry['encrypted']);
+            } elseif (null !== $entry['consumedAt']) {
+                $code = $entry['consumedCode'] ?? null;
+            }
+            $out[] = [
+                'code' => $code,
                 'consumedAt' => $entry['consumedAt'],
             ];
         }
@@ -90,6 +130,11 @@ final class TwoFactorSetupService
             $plain[] = $code;
             $entries[] = [
                 'hash' => hash('sha256', $code),
+                // Envelope-encrypt the plaintext so the GitHub-style
+                // reveal flow can re-display it after a step-up password
+                // challenge. Hash stays the source of truth for
+                // verification — encrypted is only ever read for display.
+                'encrypted' => $this->cipher->encrypt($code),
                 'consumedAt' => null,
             ];
         }

--- a/e2e/tests/auth.spec.js
+++ b/e2e/tests/auth.spec.js
@@ -1,7 +1,6 @@
 // @ts-check
 const { test, expect } = require("@playwright/test");
-
-const BASE_URL = process.env.E2E_BASE_URL || "https://localhost";
+const { BASE_URL, signInAsFixtureUser } = require("./helpers");
 
 // Generate unique email per test run to avoid conflicts
 const uniqueEmail = () => `test-${Date.now()}@example.com`;
@@ -96,12 +95,10 @@ test.describe("Authentication", () => {
   });
 
   test("sign in with fixture standard user denied admin access", async ({ page }) => {
-    await page.goto(`${BASE_URL}/signin`);
-    await page.fill("#email", "user@aura.test");
-    await page.fill("#password", "user123");
-    await page.click('button[type="submit"]');
-
-    await expect(page).toHaveURL(/\/account/);
+    // Uma has 2FA pre-enabled in fixtures so the standard sign-in path
+    // exercises the challenge step on every reload — see
+    // `App\DataFixtures\UserFixtures`. The helper walks both steps.
+    await signInAsFixtureUser(page);
 
     // Navigate to admin — should show access denied
     await page.goto(`${BASE_URL}/admin`);

--- a/e2e/tests/helpers.js
+++ b/e2e/tests/helpers.js
@@ -97,10 +97,103 @@ async function openAccountMenu(page) {
   });
 }
 
+/**
+ * Fixture Uma's TOTP secret. Mirrors
+ * `App\DataFixtures\UserFixtures::FIXTURE_TOTP_SECRET` so tests can
+ * compute a valid code without scraping it off the page. Same secret
+ * across every fixture reload — re-pairing each test would just add
+ * flakiness for no gain.
+ */
+const FIXTURE_TOTP_SECRET = "JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP";
+
+/**
+ * Sign in as Uma (the standard fixture user) through the full
+ * password + TOTP challenge. Uma's fixture row has 2FA enabled with a
+ * stable secret so we can compute the code in-process; failing that
+ * would require either disabling 2FA for tests (defeats coverage) or
+ * burning a one-shot backup code per run (mutates fixture state).
+ *
+ * Lands on `/account` once the challenge completes.
+ *
+ * @param {import('@playwright/test').Page} page
+ */
+async function signInAsFixtureUser(page) {
+  await page.goto(`${BASE_URL}/signin`);
+  await page.fill("#email", "user@aura.test");
+  await page.fill("#password", "user123");
+  await page.click('button[type="submit"]');
+
+  await expect(page.getByText("Two-factor authentication")).toBeVisible();
+
+  const code = await computeTotpCode(FIXTURE_TOTP_SECRET);
+  const submitRes = await page.request.post(`${BASE_URL}/auth/2fa-check`, {
+    headers: { "Content-Type": "application/json" },
+    data: { code },
+  });
+  expect(submitRes.ok()).toBeTruthy();
+
+  await page.goto(`${BASE_URL}/account`);
+  await expect(page).toHaveURL(/\/account/);
+}
+
+/**
+ * Browser-side TOTP for tests. Mirrors the OTPHP defaults
+ * (SHA1, 6-digit, 30-second period). Kept here so any spec that needs
+ * to drive the 2FA challenge programmatically can reuse it without
+ * pulling in a dedicated TOTP library.
+ *
+ * @param {string} base32Secret
+ * @returns {Promise<string>}
+ */
+async function computeTotpCode(base32Secret) {
+  const key = base32Decode(base32Secret);
+  const counter = Math.floor(Date.now() / 1000 / 30);
+  const counterBytes = new ArrayBuffer(8);
+  new DataView(counterBytes).setBigUint64(0, BigInt(counter));
+  const cryptoKey = await crypto.subtle.importKey(
+    "raw",
+    key,
+    { name: "HMAC", hash: "SHA-1" },
+    false,
+    ["sign"],
+  );
+  const hmac = new Uint8Array(await crypto.subtle.sign("HMAC", cryptoKey, counterBytes));
+  const offset = hmac[hmac.length - 1] & 0x0f;
+  const truncated =
+    ((hmac[offset] & 0x7f) << 24) |
+    ((hmac[offset + 1] & 0xff) << 16) |
+    ((hmac[offset + 2] & 0xff) << 8) |
+    (hmac[offset + 3] & 0xff);
+  return String(truncated % 1000000).padStart(6, "0");
+}
+
+/** Minimal RFC 4648 base32 decoder; uppercase, no padding handling beyond stripping. */
+function base32Decode(input) {
+  const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+  const cleaned = input.replace(/=+$/, "").toUpperCase();
+  let bits = 0;
+  let value = 0;
+  const output = [];
+  for (const char of cleaned) {
+    const idx = alphabet.indexOf(char);
+    if (idx < 0) continue;
+    value = (value << 5) | idx;
+    bits += 5;
+    if (bits >= 8) {
+      bits -= 8;
+      output.push((value >>> bits) & 0xff);
+    }
+  }
+  return new Uint8Array(output);
+}
+
 module.exports = {
   BASE_URL,
+  FIXTURE_TOTP_SECRET,
   uniqueEmail,
   registerAndSignIn,
+  signInAsFixtureUser,
+  computeTotpCode,
   fillDescription,
   createTaskInline,
   openAccountMenu,

--- a/e2e/tests/two-factor.spec.js
+++ b/e2e/tests/two-factor.spec.js
@@ -1,6 +1,11 @@
 // @ts-check
 const { test, expect } = require("@playwright/test");
-const { BASE_URL, uniqueEmail, registerAndSignIn } = require("./helpers");
+const {
+  BASE_URL,
+  computeTotpCode,
+  registerAndSignIn,
+  uniqueEmail,
+} = require("./helpers");
 
 test.describe("Two-factor authentication", () => {
   test("opens setup dialog with QR code and rejects bad codes", async ({ page }) => {
@@ -55,57 +60,8 @@ test.describe("Two-factor authentication", () => {
     await page.fill("#password", password);
     await page.click('button[type="submit"]');
 
-    await expect(page.getByText("Two-factor verification")).toBeVisible();
+    await expect(page.getByText("Two-factor authentication")).toBeVisible();
     await expect(page.getByTestId("2fa-code")).toBeVisible();
   });
 });
 
-/**
- * Browser-side TOTP for tests. Mirrors the OTPHP defaults
- * (SHA1, 6-digit, 30-second period). Lives here because pulling in a
- * dedicated TOTP library for one test isn't worth the dep cost.
- *
- * @param {string} base32Secret
- * @returns {Promise<string>}
- */
-async function computeTotpCode(base32Secret) {
-  const key = base32Decode(base32Secret);
-  const counter = Math.floor(Date.now() / 1000 / 30);
-  const counterBytes = new ArrayBuffer(8);
-  new DataView(counterBytes).setBigUint64(0, BigInt(counter));
-  const cryptoKey = await crypto.subtle.importKey(
-    "raw",
-    key,
-    { name: "HMAC", hash: "SHA-1" },
-    false,
-    ["sign"],
-  );
-  const hmac = new Uint8Array(await crypto.subtle.sign("HMAC", cryptoKey, counterBytes));
-  const offset = hmac[hmac.length - 1] & 0x0f;
-  const truncated =
-    ((hmac[offset] & 0x7f) << 24) |
-    ((hmac[offset + 1] & 0xff) << 16) |
-    ((hmac[offset + 2] & 0xff) << 8) |
-    (hmac[offset + 3] & 0xff);
-  return String(truncated % 1000000).padStart(6, "0");
-}
-
-/** Minimal RFC 4648 base32 decoder; uppercase, no padding handling beyond stripping. */
-function base32Decode(input) {
-  const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
-  const cleaned = input.replace(/=+$/, "").toUpperCase();
-  let bits = 0;
-  let value = 0;
-  const output = [];
-  for (const char of cleaned) {
-    const idx = alphabet.indexOf(char);
-    if (idx < 0) continue;
-    value = (value << 5) | idx;
-    bits += 5;
-    if (bits >= 8) {
-      bits -= 8;
-      output.push((value >>> bits) & 0xff);
-    }
-  }
-  return new Uint8Array(output);
-}

--- a/pwa/components/account/TwoFactorSection.tsx
+++ b/pwa/components/account/TwoFactorSection.tsx
@@ -16,11 +16,12 @@ import { FormikField } from "@/components/ui/formik-field";
 import TwoFactorSetupDialog from "./TwoFactorSetupDialog";
 
 /**
- * One slot in the recovery-code grid. Plaintext is intentionally not
- * round-tripped (codes are hash-only on disk) — the list exists to surface
- * "consumed N of M" with strikethrough, not to re-show codes.
+ * One slot in the recovery-code grid. `code` is the plaintext captured
+ * at consumption time — non-null for spent entries (safe: the hash check
+ * rejects them on every challenge), null for still-spendable ones.
  */
 interface RecoveryCodeEntry {
+  code: string | null;
   consumedAt: string | null;
 }
 
@@ -369,13 +370,13 @@ interface RecoveryCodeListProps {
 }
 
 /**
- * Renders the current recovery-code generation as masked slots. Active
- * codes appear full-opacity; consumed codes stay in the list but
- * struck-through and muted so a glance shows both "what you've used" and
- * "what's still good" without rebuilding the list every time a code is
- * spent. Plaintext is never round-tripped — the user sees an
- * indistinguishable mask and a positional index so they can cross-
- * reference against the codes they saved at setup / regenerate time.
+ * Renders the current recovery-code generation. Still-spendable codes
+ * appear as indistinguishable masks (plaintext for *unused* codes is
+ * never round-tripped — that would collapse 2FA into 1FA on a password
+ * compromise). Consumed codes show their actual plaintext struck-through
+ * so the user can cross-reference against the codes they saved at setup.
+ * Older consumed entries with no captured plaintext fall back to a
+ * struck-through mask.
  */
 const RecoveryCodeList = ({ codes }: RecoveryCodeListProps) => {
   return (
@@ -385,6 +386,7 @@ const RecoveryCodeList = ({ codes }: RecoveryCodeListProps) => {
     >
       {codes.map((entry, idx) => {
         const consumed = entry.consumedAt !== null;
+        const label = entry.code ?? "••••-••••-••••";
         return (
           <li
             key={idx}
@@ -400,7 +402,7 @@ const RecoveryCodeList = ({ codes }: RecoveryCodeListProps) => {
             <span className="text-xs text-muted-foreground tabular-nums w-6">
               {String(idx + 1).padStart(2, "0")}
             </span>
-            <code aria-hidden="true">••••-••••-••••</code>
+            <code aria-hidden={entry.code === null}>{label}</code>
             {consumed && (
               <span className="text-[10px] uppercase tracking-wider">used</span>
             )}

--- a/pwa/components/account/TwoFactorSection.tsx
+++ b/pwa/components/account/TwoFactorSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Formik, Form } from "formik";
 import { ShieldAlert, ShieldCheck } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
@@ -15,6 +15,15 @@ import {
 import { FormikField } from "@/components/ui/formik-field";
 import TwoFactorSetupDialog from "./TwoFactorSetupDialog";
 
+/**
+ * One slot in the recovery-code grid. Plaintext is intentionally not
+ * round-tripped (codes are hash-only on disk) — the list exists to surface
+ * "consumed N of M" with strikethrough, not to re-show codes.
+ */
+interface RecoveryCodeEntry {
+  consumedAt: string | null;
+}
+
 const LOW_RECOVERY_THRESHOLD = 3;
 
 const TwoFactorSection = () => {
@@ -22,9 +31,44 @@ const TwoFactorSection = () => {
   const [setupOpen, setSetupOpen] = useState(false);
   const [disableOpen, setDisableOpen] = useState(false);
   const [regenOpen, setRegenOpen] = useState(false);
+  const [codes, setCodes] = useState<RecoveryCodeEntry[] | null>(null);
+  const [codesError, setCodesError] = useState<string | null>(null);
+
+  // Optional-chain through twoFactor: older /auth responses didn't always
+  // include the block, and a missing field shouldn't crash the security
+  // card while React Query / useAuth refresh in the background.
+  const enabled = user?.twoFactor?.enabled ?? false;
+  const recoveryCodesRemaining = user?.twoFactor?.recoveryCodesRemaining ?? 0;
+
+  const fetchCodes = useCallback(async () => {
+    setCodesError(null);
+    try {
+      const res = await fetch(`${ENTRYPOINT}/me/2fa/recovery-codes`, {
+        credentials: "include",
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || "Could not load recovery codes.");
+      }
+      const data = (await res.json()) as { recoveryCodes: RecoveryCodeEntry[] };
+      setCodes(data.recoveryCodes);
+    } catch (err) {
+      setCodesError(err instanceof Error ? err.message : "Could not load recovery codes.");
+    }
+  }, []);
+
+  // Pull the code list whenever 2FA flips on or the remaining-count changes
+  // (regenerate, code consumed during a recent challenge). The endpoint is
+  // gated on isTotpEnabled server-side, so we skip the fetch otherwise.
+  useEffect(() => {
+    if (!enabled) {
+      setCodes(null);
+      return;
+    }
+    fetchCodes();
+  }, [enabled, recoveryCodesRemaining, fetchCodes]);
 
   if (!user) return null;
-  const { enabled, recoveryCodesRemaining } = user.twoFactor;
 
   return (
     <div className="space-y-3" data-testid="2fa-section">
@@ -63,26 +107,36 @@ const TwoFactorSection = () => {
       </div>
 
       {enabled && (
-        <div className="ml-8 flex items-center justify-between gap-2 text-xs">
-          <span
-            className={
-              recoveryCodesRemaining <= LOW_RECOVERY_THRESHOLD
-                ? "text-destructive"
-                : "text-muted-foreground"
-            }
-            data-testid="2fa-recovery-remaining"
-          >
-            {recoveryCodesRemaining} recovery code{recoveryCodesRemaining === 1 ? "" : "s"}{" "}
-            remaining
-          </span>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => setRegenOpen(true)}
-            data-testid="2fa-regenerate-button"
-          >
-            Regenerate codes
-          </Button>
+        <div className="ml-8 space-y-2">
+          <div className="flex items-center justify-between gap-2 text-xs">
+            <span
+              className={
+                recoveryCodesRemaining <= LOW_RECOVERY_THRESHOLD
+                  ? "text-destructive"
+                  : "text-muted-foreground"
+              }
+              data-testid="2fa-recovery-remaining"
+            >
+              {recoveryCodesRemaining} recovery code{recoveryCodesRemaining === 1 ? "" : "s"}{" "}
+              remaining
+            </span>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setRegenOpen(true)}
+              data-testid="2fa-regenerate-button"
+            >
+              Regenerate codes
+            </Button>
+          </div>
+
+          {codesError && (
+            <Alert variant="destructive">
+              <AlertDescription>{codesError}</AlertDescription>
+            </Alert>
+          )}
+
+          {codes && codes.length > 0 && <RecoveryCodeList codes={codes} />}
         </div>
       )}
 
@@ -107,7 +161,13 @@ const TwoFactorSection = () => {
       <RegenerateConfirmDialog
         open={regenOpen}
         onOpenChange={setRegenOpen}
-        onSuccess={refreshUser}
+        onSuccess={() => {
+          // recoveryCodesRemaining stays at RECOVERY_CODE_COUNT before and
+          // after a regen, so the count-based useEffect won't refetch — we
+          // pull the new envelopes explicitly here.
+          refreshUser();
+          fetchCodes();
+        }}
       />
     </div>
   );
@@ -301,6 +361,53 @@ const RegenerateConfirmDialog = ({ open, onOpenChange, onSuccess }: RegeneratePr
         )}
       </DialogContent>
     </Dialog>
+  );
+};
+
+interface RecoveryCodeListProps {
+  codes: RecoveryCodeEntry[];
+}
+
+/**
+ * Renders the current recovery-code generation as masked slots. Active
+ * codes appear full-opacity; consumed codes stay in the list but
+ * struck-through and muted so a glance shows both "what you've used" and
+ * "what's still good" without rebuilding the list every time a code is
+ * spent. Plaintext is never round-tripped — the user sees an
+ * indistinguishable mask and a positional index so they can cross-
+ * reference against the codes they saved at setup / regenerate time.
+ */
+const RecoveryCodeList = ({ codes }: RecoveryCodeListProps) => {
+  return (
+    <ul
+      className="grid grid-cols-2 gap-1.5 bg-muted rounded-md p-3 font-mono text-sm"
+      data-testid="2fa-recovery-list"
+    >
+      {codes.map((entry, idx) => {
+        const consumed = entry.consumedAt !== null;
+        return (
+          <li
+            key={idx}
+            className={[
+              "flex items-baseline gap-2",
+              consumed && "line-through opacity-50 text-muted-foreground",
+            ]
+              .filter(Boolean)
+              .join(" ")}
+            data-testid="2fa-recovery-code"
+            data-consumed={consumed ? "true" : "false"}
+          >
+            <span className="text-xs text-muted-foreground tabular-nums w-6">
+              {String(idx + 1).padStart(2, "0")}
+            </span>
+            <code aria-hidden="true">••••-••••-••••</code>
+            {consumed && (
+              <span className="text-[10px] uppercase tracking-wider">used</span>
+            )}
+          </li>
+        );
+      })}
+    </ul>
   );
 };
 

--- a/pwa/components/account/TwoFactorSection.tsx
+++ b/pwa/components/account/TwoFactorSection.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { Formik, Form } from "formik";
-import { ShieldAlert, ShieldCheck } from "lucide-react";
+import { Eye, EyeOff, ShieldAlert, ShieldCheck } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { ENTRYPOINT } from "@/config/entrypoint";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -34,6 +34,11 @@ const TwoFactorSection = () => {
   const [regenOpen, setRegenOpen] = useState(false);
   const [codes, setCodes] = useState<RecoveryCodeEntry[] | null>(null);
   const [codesError, setCodesError] = useState<string | null>(null);
+  // Step-up reveal: populated by the password-gated reveal dialog,
+  // intentionally not persisted anywhere — closing/reopening the panel
+  // forces a fresh password challenge so the plaintext can't linger.
+  const [revealed, setRevealed] = useState<RecoveryCodeEntry[] | null>(null);
+  const [revealOpen, setRevealOpen] = useState(false);
 
   // Optional-chain through twoFactor: older /auth responses didn't always
   // include the block, and a missing field shouldn't crash the security
@@ -64,10 +69,18 @@ const TwoFactorSection = () => {
   useEffect(() => {
     if (!enabled) {
       setCodes(null);
+      setRevealed(null);
       return;
     }
     fetchCodes();
   }, [enabled, recoveryCodesRemaining, fetchCodes]);
+
+  // If the user regenerates while the panel is open, the revealed
+  // plaintexts they saw are no longer the same codes that exist on the
+  // server — clear so the UI doesn't pretend otherwise.
+  useEffect(() => {
+    setRevealed(null);
+  }, [recoveryCodesRemaining]);
 
   if (!user) return null;
 
@@ -121,14 +134,38 @@ const TwoFactorSection = () => {
               {recoveryCodesRemaining} recovery code{recoveryCodesRemaining === 1 ? "" : "s"}{" "}
               remaining
             </span>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => setRegenOpen(true)}
-              data-testid="2fa-regenerate-button"
-            >
-              Regenerate codes
-            </Button>
+            <div className="flex items-center gap-1">
+              {revealed ? (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setRevealed(null)}
+                  data-testid="2fa-recovery-hide"
+                >
+                  <EyeOff className="h-3.5 w-3.5" /> Hide codes
+                </Button>
+              ) : (
+                codes &&
+                codes.length > 0 && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setRevealOpen(true)}
+                    data-testid="2fa-recovery-reveal"
+                  >
+                    <Eye className="h-3.5 w-3.5" /> Reveal codes
+                  </Button>
+                )
+              )}
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setRegenOpen(true)}
+                data-testid="2fa-regenerate-button"
+              >
+                Regenerate codes
+              </Button>
+            </div>
           </div>
 
           {codesError && (
@@ -137,7 +174,9 @@ const TwoFactorSection = () => {
             </Alert>
           )}
 
-          {codes && codes.length > 0 && <RecoveryCodeList codes={codes} />}
+          {(revealed ?? codes) && (revealed ?? codes)!.length > 0 && (
+            <RecoveryCodeList codes={revealed ?? codes!} />
+          )}
         </div>
       )}
 
@@ -165,10 +204,19 @@ const TwoFactorSection = () => {
         onSuccess={() => {
           // recoveryCodesRemaining stays at RECOVERY_CODE_COUNT before and
           // after a regen, so the count-based useEffect won't refetch — we
-          // pull the new envelopes explicitly here.
+          // pull the new envelopes explicitly here. Drop any previously
+          // revealed plaintext so the UI doesn't keep showing codes that
+          // no longer exist.
           refreshUser();
           fetchCodes();
+          setRevealed(null);
         }}
+      />
+
+      <RevealConfirmDialog
+        open={revealOpen}
+        onOpenChange={setRevealOpen}
+        onRevealed={(entries) => setRevealed(entries)}
       />
     </div>
   );
@@ -364,6 +412,87 @@ const RegenerateConfirmDialog = ({ open, onOpenChange, onSuccess }: RegeneratePr
     </Dialog>
   );
 };
+
+interface RevealProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Called with the full plaintext list after a successful step-up. */
+  onRevealed: (entries: RecoveryCodeEntry[]) => void;
+}
+
+/**
+ * Password-gated step-up dialog: the cookie session alone isn't enough
+ * to reveal unused codes (they're real credentials and a stolen cookie
+ * shouldn't yield a portable 2FA bypass), so we re-prompt for the
+ * password and hand the response back to the parent for one-time render.
+ */
+const RevealConfirmDialog = ({ open, onOpenChange, onRevealed }: RevealProps) => (
+  <Dialog open={open} onOpenChange={onOpenChange}>
+    <DialogContent className="sm:max-w-md">
+      <DialogHeader>
+        <DialogTitle>Reveal recovery codes</DialogTitle>
+        <DialogDescription>
+          Confirm with your current password to display your recovery codes.
+          They'll only stay visible while this page is open.
+        </DialogDescription>
+      </DialogHeader>
+
+      <Formik<{ currentPassword: string }>
+        initialValues={{ currentPassword: "" }}
+        validate={({ currentPassword }) =>
+          currentPassword ? {} : { currentPassword: "Password is required." }
+        }
+        onSubmit={async ({ currentPassword }, { setSubmitting, setStatus, resetForm }) => {
+          try {
+            const res = await fetch(`${ENTRYPOINT}/me/2fa/recovery-codes/reveal`, {
+              method: "POST",
+              credentials: "include",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ currentPassword }),
+            });
+            if (!res.ok) {
+              const data = await res.json().catch(() => ({}));
+              throw new Error(data.error || "Could not reveal codes.");
+            }
+            const data = (await res.json()) as { recoveryCodes: RecoveryCodeEntry[] };
+            onRevealed(data.recoveryCodes);
+            resetForm();
+            onOpenChange(false);
+          } catch (err) {
+            setStatus(err instanceof Error ? err.message : "Could not reveal codes.");
+          } finally {
+            setSubmitting(false);
+          }
+        }}
+      >
+        {({ isSubmitting, status }) => (
+          <Form className="space-y-4" noValidate>
+            {status && (
+              <Alert variant="destructive">
+                <AlertDescription>{status}</AlertDescription>
+              </Alert>
+            )}
+            <FormikField
+              name="currentPassword"
+              type="password"
+              label="Current password"
+              autoComplete="current-password"
+              data-testid="2fa-reveal-password"
+            />
+            <Button
+              type="submit"
+              disabled={isSubmitting}
+              className="w-full"
+              data-testid="2fa-reveal-submit"
+            >
+              {isSubmitting ? "Working..." : "Reveal codes"}
+            </Button>
+          </Form>
+        )}
+      </Formik>
+    </DialogContent>
+  </Dialog>
+);
 
 interface RecoveryCodeListProps {
   codes: RecoveryCodeEntry[];

--- a/pwa/components/account/TwoFactorSection.tsx
+++ b/pwa/components/account/TwoFactorSection.tsx
@@ -247,7 +247,16 @@ const PasswordConfirmDialog = ({
   onSuccess,
 }: PasswordConfirmDialogProps) => (
   <Dialog open={open} onOpenChange={onOpenChange}>
-    <DialogContent className="sm:max-w-md">
+    <DialogContent
+      className="sm:max-w-md"
+      // Don't auto-focus the password input on open: Chrome's saved-
+      // password popup appears under the focused field and eats the
+      // first click anywhere outside (including the X close button),
+      // so the dialog needs two X clicks to dismiss. With auto-focus
+      // suppressed the user clicks into the input deliberately and
+      // the close button works on the first try.
+      onOpenAutoFocus={(event) => event.preventDefault()}
+    >
       <DialogHeader>
         <DialogTitle>{title}</DialogTitle>
         <DialogDescription>{description}</DialogDescription>
@@ -327,7 +336,16 @@ const RegenerateConfirmDialog = ({ open, onOpenChange, onSuccess }: RegeneratePr
         onOpenChange(next);
       }}
     >
-      <DialogContent className="sm:max-w-md">
+      <DialogContent
+      className="sm:max-w-md"
+      // Don't auto-focus the password input on open: Chrome's saved-
+      // password popup appears under the focused field and eats the
+      // first click anywhere outside (including the X close button),
+      // so the dialog needs two X clicks to dismiss. With auto-focus
+      // suppressed the user clicks into the input deliberately and
+      // the close button works on the first try.
+      onOpenAutoFocus={(event) => event.preventDefault()}
+    >
         <DialogHeader>
           <DialogTitle>
             {codes ? "New recovery codes" : "Regenerate recovery codes"}
@@ -429,7 +447,16 @@ interface RevealProps {
  */
 const RevealConfirmDialog = ({ open, onOpenChange, onRevealed }: RevealProps) => (
   <Dialog open={open} onOpenChange={onOpenChange}>
-    <DialogContent className="sm:max-w-md">
+    <DialogContent
+      className="sm:max-w-md"
+      // Don't auto-focus the password input on open: Chrome's saved-
+      // password popup appears under the focused field and eats the
+      // first click anywhere outside (including the X close button),
+      // so the dialog needs two X clicks to dismiss. With auto-focus
+      // suppressed the user clicks into the input deliberately and
+      // the close button works on the first try.
+      onOpenAutoFocus={(event) => event.preventDefault()}
+    >
       <DialogHeader>
         <DialogTitle>Reveal recovery codes</DialogTitle>
         <DialogDescription>

--- a/pwa/components/account/TwoFactorSection.tsx
+++ b/pwa/components/account/TwoFactorSection.tsx
@@ -13,6 +13,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { FormikField } from "@/components/ui/formik-field";
+import { fetchWithTimeout } from "@/lib/fetchWithTimeout";
 import TwoFactorSetupDialog from "./TwoFactorSetupDialog";
 
 /**
@@ -49,7 +50,7 @@ const TwoFactorSection = () => {
   const fetchCodes = useCallback(async () => {
     setCodesError(null);
     try {
-      const res = await fetch(`${ENTRYPOINT}/me/2fa/recovery-codes`, {
+      const res = await fetchWithTimeout(`${ENTRYPOINT}/me/2fa/recovery-codes`, {
         credentials: "include",
       });
       if (!res.ok) {
@@ -259,7 +260,7 @@ const PasswordConfirmDialog = ({
         }
         onSubmit={async ({ currentPassword }, { setSubmitting, setStatus, resetForm }) => {
           try {
-            const res = await fetch(endpoint, {
+            const res = await fetchWithTimeout(endpoint, {
               method,
               credentials: "include",
               headers: { "Content-Type": "application/json" },
@@ -369,7 +370,7 @@ const RegenerateConfirmDialog = ({ open, onOpenChange, onSuccess }: RegeneratePr
             }
             onSubmit={async ({ currentPassword }, { setSubmitting, setStatus }) => {
               try {
-                const res = await fetch(`${ENTRYPOINT}/me/2fa/recovery-codes`, {
+                const res = await fetchWithTimeout(`${ENTRYPOINT}/me/2fa/recovery-codes`, {
                   method: "POST",
                   credentials: "include",
                   headers: { "Content-Type": "application/json" },
@@ -444,7 +445,7 @@ const RevealConfirmDialog = ({ open, onOpenChange, onRevealed }: RevealProps) =>
         }
         onSubmit={async ({ currentPassword }, { setSubmitting, setStatus, resetForm }) => {
           try {
-            const res = await fetch(`${ENTRYPOINT}/me/2fa/recovery-codes/reveal`, {
+            const res = await fetchWithTimeout(`${ENTRYPOINT}/me/2fa/recovery-codes/reveal`, {
               method: "POST",
               credentials: "include",
               headers: { "Content-Type": "application/json" },

--- a/pwa/components/account/TwoFactorSetupDialog.tsx
+++ b/pwa/components/account/TwoFactorSetupDialog.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useState } from "react";
 import { Formik, Form } from "formik";
-import QRCode from "qrcode";
+// Force the browser bundle: Turbopack doesn't honor qrcode's `browser`
+// field swap, so a plain `from "qrcode"` import drags in the Node entry
+// which hangs in the browser and leaves the QR spinner forever.
+// @ts-expect-error — @types/qrcode only ships types for the package root.
+import QRCode from "qrcode/lib/browser";
 import { Check, Copy, Download, Loader2, ShieldCheck } from "lucide-react";
 import { ENTRYPOINT } from "@/config/entrypoint";
 import { Alert, AlertDescription } from "@/components/ui/alert";

--- a/pwa/components/account/TwoFactorSetupDialog.tsx
+++ b/pwa/components/account/TwoFactorSetupDialog.tsx
@@ -7,6 +7,7 @@ import { Formik, Form } from "formik";
 import QRCode from "qrcode/lib/browser";
 import { Check, Copy, Download, Loader2, ShieldCheck } from "lucide-react";
 import { ENTRYPOINT } from "@/config/entrypoint";
+import { fetchWithTimeout } from "@/lib/fetchWithTimeout";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import {
@@ -60,7 +61,7 @@ const TwoFactorSetupDialog = ({ open, onOpenChange, onEnabled }: Props) => {
     let cancelled = false;
     (async () => {
       try {
-        const res = await fetch(`${ENTRYPOINT}/me/2fa/setup`, {
+        const res = await fetchWithTimeout(`${ENTRYPOINT}/me/2fa/setup`, {
           method: "POST",
           credentials: "include",
         });
@@ -176,7 +177,7 @@ const ScanStep = ({ qrDataUri, secret, onVerified }: ScanStepProps) => (
       validate={({ code }) => (code.trim() ? {} : { code: "Enter the code from your app." })}
       onSubmit={async ({ code }, { setSubmitting, setStatus }) => {
         try {
-          const res = await fetch(`${ENTRYPOINT}/me/2fa/verify`, {
+          const res = await fetchWithTimeout(`${ENTRYPOINT}/me/2fa/verify`, {
             method: "POST",
             credentials: "include",
             headers: { "Content-Type": "application/json" },

--- a/pwa/components/auth/AuthCard.tsx
+++ b/pwa/components/auth/AuthCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useAuth } from "@/contexts/AuthContext";
@@ -13,12 +13,29 @@ import {
 import AuraWordmark from "./AuraWordmark";
 import SignInForm from "./SignInForm";
 import SignUpForm from "./SignUpForm";
+import TwoFactorChallengeForm, {
+  type TwoFactorMode,
+} from "./TwoFactorChallengeForm";
 
 type Tab = "signin" | "signup";
 
 interface Props {
   /** Which form this page entry point renders. */
   defaultTab: Tab;
+}
+
+/**
+ * Current step of the sign-in/up flow. The 2FA modes are reached only via
+ * the credentials step — they're tracked here (not inside SignInForm) so
+ * the footer can swap in lockstep with the form body.
+ */
+type AuthStep = "credentials" | "signup" | "totp" | "backup";
+
+interface CopyEntry {
+  title: string;
+  subtitle: string;
+  switchLabel: string;
+  switchCta: string;
 }
 
 const COPY: Record<Tab, { title: string; subtitle: string; switchLabel: string; switchCta: string; switchPath: string }> = {
@@ -38,9 +55,29 @@ const COPY: Record<Tab, { title: string; subtitle: string; switchLabel: string; 
   },
 };
 
+const TWO_FACTOR_COPY: Record<TwoFactorMode, CopyEntry> = {
+  totp: {
+    title: "Two-factor verification",
+    subtitle: "Open your authenticator app and enter the 6-digit code.",
+    switchLabel: "Lost your authenticator?",
+    switchCta: "Use a backup code instead",
+  },
+  backup: {
+    title: "Use a backup code",
+    subtitle: "Enter one of the recovery codes you saved at setup.",
+    switchLabel: "Have your authenticator?",
+    switchCta: "Use your authenticator app instead",
+  },
+};
+
 const AuthCard = ({ defaultTab }: Props) => {
   const router = useRouter();
   const { isAuthenticated, isLoading } = useAuth();
+  // The credentials step keeps the form's existing two-tab feel; the
+  // 2FA steps are reachable only from a successful password submission.
+  const [step, setStep] = useState<AuthStep>(
+    defaultTab === "signup" ? "signup" : "credentials",
+  );
 
   const next = typeof router.query.next === "string" ? router.query.next : undefined;
   const inviteToken =
@@ -57,31 +94,69 @@ const AuthCard = ({ defaultTab }: Props) => {
     }
   }, [isLoading, isAuthenticated, next, router]);
 
-  const copy = COPY[defaultTab];
   const queryIndex = router.asPath.indexOf("?");
   const search = queryIndex >= 0 ? router.asPath.slice(queryIndex) : "";
-  const switchHref = `${copy.switchPath}${search}`;
+
+  // Pick the title/subtitle/footer copy for the current step. The
+  // signin/signup tabs share the COPY map shape; the 2FA steps come from
+  // TWO_FACTOR_COPY and don't have a switchPath (their toggle is a
+  // setStep call, not a route).
+  const tabCopy = COPY[step === "signup" ? "signup" : "signin"];
+  const isTwoFactor = step === "totp" || step === "backup";
+  const cardCopy = isTwoFactor
+    ? TWO_FACTOR_COPY[step]
+    : { title: tabCopy.title, subtitle: tabCopy.subtitle };
 
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-background px-4 py-10 gap-8">
       <AuraWordmark />
       <Card className="w-full max-w-lg overflow-hidden p-0">
         <CardHeader className="p-8 pb-6">
-          <CardTitle className="text-3xl font-bold">{copy.title}</CardTitle>
-          <CardDescription className="text-base">{copy.subtitle}</CardDescription>
+          <CardTitle className="text-3xl font-bold">{cardCopy.title}</CardTitle>
+          <CardDescription className="text-base">{cardCopy.subtitle}</CardDescription>
         </CardHeader>
         <CardContent className="p-8 pt-2">
-          {defaultTab === "signin" ? (
-            <SignInForm next={next} registered={registered} reset={reset} />
-          ) : (
+          {step === "signup" ? (
             <SignUpForm inviteToken={inviteToken} next={next} />
+          ) : step === "credentials" ? (
+            <SignInForm
+              next={next}
+              registered={registered}
+              reset={reset}
+              onTwoFactorRequired={() => setStep("totp")}
+            />
+          ) : (
+            <TwoFactorChallengeForm
+              next={next}
+              mode={step}
+              onCancel={() => setStep("credentials")}
+            />
           )}
         </CardContent>
         <div className="border-t border-border bg-background px-8 py-5 text-center text-sm text-muted-foreground">
-          {copy.switchLabel}{" "}
-          <Link href={switchHref} className="text-primary font-semibold hover:text-foreground">
-            {copy.switchCta}
-          </Link>
+          {isTwoFactor ? (
+            <>
+              {TWO_FACTOR_COPY[step].switchLabel}{" "}
+              <button
+                type="button"
+                onClick={() => setStep(step === "totp" ? "backup" : "totp")}
+                className="text-primary font-semibold hover:text-foreground"
+                data-testid="2fa-mode-toggle"
+              >
+                {TWO_FACTOR_COPY[step].switchCta}
+              </button>
+            </>
+          ) : (
+            <>
+              {tabCopy.switchLabel}{" "}
+              <Link
+                href={`${tabCopy.switchPath}${search}`}
+                className="text-primary font-semibold hover:text-foreground"
+              >
+                {tabCopy.switchCta}
+              </Link>
+            </>
+          )}
         </div>
       </Card>
       <p className="text-xs text-muted-foreground tracking-wide">

--- a/pwa/components/auth/AuthCard.tsx
+++ b/pwa/components/auth/AuthCard.tsx
@@ -55,19 +55,27 @@ const COPY: Record<Tab, { title: string; subtitle: string; switchLabel: string; 
   },
 };
 
-const TWO_FACTOR_COPY: Record<TwoFactorMode, CopyEntry> = {
-  totp: {
-    title: "Two-factor verification",
-    subtitle: "Open your authenticator app and enter the 6-digit code.",
-    switchLabel: "Lost your authenticator?",
-    switchCta: "Use a backup code instead",
-  },
-  backup: {
+/**
+ * 2FA copy is built per-render because the subtitle weaves in the
+ * caller's email — easier to keep here as one small function than to
+ * thread template tokens through the COPY map.
+ */
+const twoFactorCopy = (mode: TwoFactorMode, email: string | null): CopyEntry => {
+  const forEmail = email ? ` for ${email}` : "";
+  if (mode === "totp") {
+    return {
+      title: "Two-factor authentication",
+      subtitle: `Enter the 6-digit code from your authenticator app${forEmail}.`,
+      switchLabel: "",
+      switchCta: "Use a backup code instead",
+    };
+  }
+  return {
     title: "Use a backup code",
-    subtitle: "Enter one of the recovery codes you saved at setup.",
-    switchLabel: "Have your authenticator?",
-    switchCta: "Use your authenticator app instead",
-  },
+    subtitle: "One of the backup codes you saved when you enabled 2FA. Each can be used once.",
+    switchLabel: "",
+    switchCta: "Back to authenticator code",
+  };
 };
 
 const AuthCard = ({ defaultTab }: Props) => {
@@ -78,6 +86,10 @@ const AuthCard = ({ defaultTab }: Props) => {
   const [step, setStep] = useState<AuthStep>(
     defaultTab === "signup" ? "signup" : "credentials",
   );
+  // Email captured at the password step so the 2FA challenge can show
+  // "Signing in as X · not you?" without the server having to include
+  // identity fields in the half-auth response.
+  const [twoFactorEmail, setTwoFactorEmail] = useState<string | null>(null);
 
   const next = typeof router.query.next === "string" ? router.query.next : undefined;
   const inviteToken =
@@ -99,13 +111,12 @@ const AuthCard = ({ defaultTab }: Props) => {
 
   // Pick the title/subtitle/footer copy for the current step. The
   // signin/signup tabs share the COPY map shape; the 2FA steps come from
-  // TWO_FACTOR_COPY and don't have a switchPath (their toggle is a
-  // setStep call, not a route).
+  // twoFactorCopy() (built per render because the subtitle includes the
+  // captured email).
   const tabCopy = COPY[step === "signup" ? "signup" : "signin"];
   const isTwoFactor = step === "totp" || step === "backup";
-  const cardCopy = isTwoFactor
-    ? TWO_FACTOR_COPY[step]
-    : { title: tabCopy.title, subtitle: tabCopy.subtitle };
+  const tfCopy = isTwoFactor ? twoFactorCopy(step, twoFactorEmail) : null;
+  const cardCopy = tfCopy ?? { title: tabCopy.title, subtitle: tabCopy.subtitle };
 
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-background px-4 py-10 gap-8">
@@ -123,29 +134,33 @@ const AuthCard = ({ defaultTab }: Props) => {
               next={next}
               registered={registered}
               reset={reset}
-              onTwoFactorRequired={() => setStep("totp")}
+              onTwoFactorRequired={(email) => {
+                setTwoFactorEmail(email);
+                setStep("totp");
+              }}
             />
           ) : (
             <TwoFactorChallengeForm
               next={next}
               mode={step}
-              onCancel={() => setStep("credentials")}
+              email={twoFactorEmail}
+              onCancel={() => {
+                setTwoFactorEmail(null);
+                setStep("credentials");
+              }}
             />
           )}
         </CardContent>
         <div className="border-t border-border bg-background px-8 py-5 text-center text-sm text-muted-foreground">
-          {isTwoFactor ? (
-            <>
-              {TWO_FACTOR_COPY[step].switchLabel}{" "}
-              <button
-                type="button"
-                onClick={() => setStep(step === "totp" ? "backup" : "totp")}
-                className="text-primary font-semibold hover:text-foreground"
-                data-testid="2fa-mode-toggle"
-              >
-                {TWO_FACTOR_COPY[step].switchCta}
-              </button>
-            </>
+          {isTwoFactor && tfCopy ? (
+            <button
+              type="button"
+              onClick={() => setStep(step === "totp" ? "backup" : "totp")}
+              className="text-primary font-semibold hover:text-foreground"
+              data-testid="2fa-mode-toggle"
+            >
+              {tfCopy.switchCta}
+            </button>
           ) : (
             <>
               {tabCopy.switchLabel}{" "}

--- a/pwa/components/auth/SignInForm.tsx
+++ b/pwa/components/auth/SignInForm.tsx
@@ -7,7 +7,6 @@ import { safeNextPath } from "@/lib/authRedirect";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { FormikField } from "@/components/ui/formik-field";
-import TwoFactorChallengeForm from "./TwoFactorChallengeForm";
 
 interface SignInValues {
   email: string;
@@ -28,25 +27,18 @@ interface Props {
   registered?: boolean;
   /** True when the user just reset their password. */
   reset?: boolean;
+  /**
+   * Called when `/auth/login` responds `requiresTwoFactor`. The parent
+   * (AuthCard) swaps the form body + footer copy in lockstep — keeping the
+   * mode here would force the footer to live inside this form too.
+   */
+  onTwoFactorRequired: () => void;
 }
 
-const SignInForm = ({ next, registered, reset }: Props) => {
+const SignInForm = ({ next, registered, reset, onTwoFactorRequired }: Props) => {
   const { login } = useAuth();
   const router = useRouter();
-  // Local state vs. URL state because the half-authenticated session is
-  // already on a server cookie — there's nothing useful to put in the URL,
-  // and a back-button to /signin should restart, not resume.
-  const [twoFactorPrompt, setTwoFactorPrompt] = useState(false);
   const [ssoNotice, setSsoNotice] = useState<string | null>(null);
-
-  if (twoFactorPrompt) {
-    return (
-      <TwoFactorChallengeForm
-        next={next}
-        onCancel={() => setTwoFactorPrompt(false)}
-      />
-    );
-  }
 
   return (
     <div className="space-y-4">
@@ -79,7 +71,7 @@ const SignInForm = ({ next, registered, reset }: Props) => {
           try {
             const result = await login(values.email, values.password);
             if (result.requiresTwoFactor) {
-              setTwoFactorPrompt(true);
+              onTwoFactorRequired();
               return;
             }
             router.push(safeNextPath(next));

--- a/pwa/components/auth/SignInForm.tsx
+++ b/pwa/components/auth/SignInForm.tsx
@@ -30,9 +30,11 @@ interface Props {
   /**
    * Called when `/auth/login` responds `requiresTwoFactor`. The parent
    * (AuthCard) swaps the form body + footer copy in lockstep — keeping the
-   * mode here would force the footer to live inside this form too.
+   * mode here would force the footer to live inside this form too. The
+   * email is forwarded so the challenge form can show a "Signing in as
+   * X" line without an extra round-trip.
    */
-  onTwoFactorRequired: () => void;
+  onTwoFactorRequired: (email: string) => void;
 }
 
 const SignInForm = ({ next, registered, reset, onTwoFactorRequired }: Props) => {
@@ -71,7 +73,7 @@ const SignInForm = ({ next, registered, reset, onTwoFactorRequired }: Props) => 
           try {
             const result = await login(values.email, values.password);
             if (result.requiresTwoFactor) {
-              onTwoFactorRequired();
+              onTwoFactorRequired(values.email);
               return;
             }
             router.push(safeNextPath(next));

--- a/pwa/components/auth/TwoFactorChallengeForm.tsx
+++ b/pwa/components/auth/TwoFactorChallengeForm.tsx
@@ -6,9 +6,20 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { FormikField } from "@/components/ui/formik-field";
 
+/**
+ * Which credential the user is presenting for the second factor. Both
+ * paths hit the same `/auth/2fa-check` endpoint — the server distinguishes
+ * by checking the input against the TOTP secret first, then the recovery
+ * code hashes — so this is purely UX: input shape, helper copy, validation
+ * threshold. The toggle between modes lives in AuthCard's footer.
+ */
+export type TwoFactorMode = "totp" | "backup";
+
 interface Props {
   /** `?next=` from the URL — caller forwards it from the sign-in page. */
   next?: string;
+  /** Whether the form prompts for a TOTP code or a backup recovery code. */
+  mode: TwoFactorMode;
   /**
    * Lets the user back out of the half-authenticated state — they'll need
    * to log in again from the start. The sign-in form re-mounts and the
@@ -22,30 +33,47 @@ interface Values {
   code: string;
 }
 
-const validate = ({ code }: Values) => {
-  const errors: Partial<Values> = {};
-  const trimmed = code.trim();
-  if (!trimmed) errors.code = "Enter a code from your authenticator app.";
-  return errors;
+const COPY: Record<TwoFactorMode, {
+  field: { label: string; placeholder: string; autoComplete: string };
+  emptyError: string;
+}> = {
+  totp: {
+    field: {
+      label: "Authentication code",
+      placeholder: "123 456",
+      autoComplete: "one-time-code",
+    },
+    emptyError: "Enter a code from your authenticator app.",
+  },
+  backup: {
+    field: {
+      label: "Backup code",
+      placeholder: "xxxx-xxxx-xxxx",
+      autoComplete: "off",
+    },
+    emptyError: "Enter one of your saved backup codes.",
+  },
 };
 
-const TwoFactorChallengeForm = ({ next, onCancel }: Props) => {
+const TwoFactorChallengeForm = ({ next, mode, onCancel }: Props) => {
   const { submitTwoFactorCode } = useAuth();
   const router = useRouter();
+  const copy = COPY[mode];
 
   return (
     <div className="space-y-4">
-      <div>
-        <h2 className="text-lg font-semibold">Two-factor verification</h2>
-        <p className="text-sm text-muted-foreground">
-          Open your authenticator app and enter the 6-digit code, or use one
-          of your saved recovery codes.
-        </p>
-      </div>
-
       <Formik<Values>
+        // Key by mode so switching between TOTP / backup wipes the input
+        // (otherwise a half-typed TOTP would linger when the user clicks
+        // "Use a backup code instead", and the validation message would
+        // be misleading).
+        key={mode}
         initialValues={{ code: "" }}
-        validate={validate}
+        validate={({ code }) => {
+          const errors: Partial<Values> = {};
+          if (!code.trim()) errors.code = copy.emptyError;
+          return errors;
+        }}
         onSubmit={async ({ code }, { setSubmitting, setStatus }) => {
           try {
             await submitTwoFactorCode(code.trim());
@@ -67,9 +95,9 @@ const TwoFactorChallengeForm = ({ next, onCancel }: Props) => {
 
             <FormikField
               name="code"
-              label="Authentication code"
-              placeholder="123 456"
-              autoComplete="one-time-code"
+              label={copy.field.label}
+              placeholder={copy.field.placeholder}
+              autoComplete={copy.field.autoComplete}
               inputMode="text"
               autoFocus
               data-testid="2fa-code"

--- a/pwa/components/auth/TwoFactorChallengeForm.tsx
+++ b/pwa/components/auth/TwoFactorChallengeForm.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import { Formik, Form, useFormikContext } from "formik";
 import { Clock3, ShieldAlert } from "lucide-react";
-import { useAuth } from "@/contexts/AuthContext";
+import { TwoFactorRateLimitError, useAuth } from "@/contexts/AuthContext";
 import { safeNextPath } from "@/lib/authRedirect";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -49,6 +49,25 @@ const TOTP_WINDOW_SECONDS = 30;
 const TwoFactorChallengeForm = ({ next, mode, email, onCancel }: Props) => {
   const { submitTwoFactorCode } = useAuth();
   const router = useRouter();
+  // Wall-clock instant when the rate-limit bucket refills enough for
+  // another attempt — null whenever we're not currently throttled. We
+  // store the deadline (vs. seconds-remaining) so the countdown stays
+  // accurate even if the browser tab goes inactive and rejoins.
+  const [rateLimitedUntil, setRateLimitedUntil] = useState<number | null>(null);
+  const rateLimitSecondsLeft = useCountdownTo(rateLimitedUntil);
+  // Clear the throttle once the bucket has refilled. Check the
+  // wall-clock deadline (not the derived seconds-left) because the
+  // countdown's initial state is 0 on the very render where
+  // `rateLimitedUntil` was just set — a `seconds <= 0` check would
+  // immediately clear the throttle on that render before the countdown
+  // effect catches up.
+  useEffect(() => {
+    if (rateLimitedUntil !== null && Date.now() >= rateLimitedUntil) {
+      setRateLimitedUntil(null);
+    }
+  }, [rateLimitedUntil, rateLimitSecondsLeft]);
+
+  const isRateLimited = rateLimitedUntil !== null;
 
   return (
     <div className="space-y-5">
@@ -73,6 +92,9 @@ const TwoFactorChallengeForm = ({ next, mode, email, onCancel }: Props) => {
             await submitTwoFactorCode(code.trim());
             router.push(safeNextPath(next));
           } catch (err) {
+            if (err instanceof TwoFactorRateLimitError) {
+              setRateLimitedUntil(Date.now() + err.retryAfterSeconds * 1000);
+            }
             setStatus(err instanceof Error ? err.message : "Verification failed.");
           } finally {
             setSubmitting(false);
@@ -81,10 +103,15 @@ const TwoFactorChallengeForm = ({ next, mode, email, onCancel }: Props) => {
       >
         {({ isSubmitting, status, values }) => (
           <Form className="space-y-5" noValidate>
-            <FormStatusAlert status={status} mode={mode} hasInput={Boolean(values.code.trim())} />
+            <FormStatusAlert
+              status={status}
+              mode={mode}
+              hasInput={Boolean(values.code.trim())}
+              rateLimitSecondsLeft={isRateLimited ? rateLimitSecondsLeft : null}
+            />
 
             {mode === "totp" ? (
-              <TotpField hasError={Boolean(status)} />
+              <TotpField hasError={Boolean(status)} disabled={isRateLimited} />
             ) : (
               <FormikField
                 name="code"
@@ -94,6 +121,7 @@ const TwoFactorChallengeForm = ({ next, mode, email, onCancel }: Props) => {
                 inputMode="text"
                 autoFocus
                 inputClassName="font-mono"
+                disabled={isRateLimited}
                 data-testid="2fa-code"
               />
             )}
@@ -102,11 +130,15 @@ const TwoFactorChallengeForm = ({ next, mode, email, onCancel }: Props) => {
 
             <Button
               type="submit"
-              disabled={isSubmitting}
+              disabled={isSubmitting || isRateLimited}
               className="w-full"
               data-testid="2fa-submit"
             >
-              {isSubmitting ? "Verifying..." : "Verify"}
+              {isRateLimited
+                ? `Verify (${rateLimitSecondsLeft}s)`
+                : isSubmitting
+                ? "Verifying..."
+                : "Verify"}
             </Button>
 
             {mode === "backup" && <BackupCodeNote />}
@@ -139,7 +171,7 @@ const TwoFactorChallengeForm = ({ next, mode, email, onCancel }: Props) => {
  * input can shovel digits into the `code` field without us threading
  * the form's bag through every wrapper.
  */
-const TotpField = ({ hasError }: { hasError: boolean }) => {
+const TotpField = ({ hasError, disabled }: { hasError: boolean; disabled: boolean }) => {
   const { values, setFieldValue, submitForm } = useFormikContext<Values>();
 
   return (
@@ -157,6 +189,7 @@ const TotpField = ({ hasError }: { hasError: boolean }) => {
           }
         }}
         autoFocus
+        disabled={disabled}
         data-testid="2fa-code"
         containerClassName="justify-center gap-2"
       >
@@ -173,6 +206,31 @@ const TotpField = ({ hasError }: { hasError: boolean }) => {
       </InputOTP>
     </div>
   );
+};
+
+/**
+ * Recomputes the seconds remaining until `deadlineMs` every 250ms.
+ * Pure derivation, so flipping the deadline to null pauses the timer.
+ * Returns 0 when the deadline has passed (or when deadline is null).
+ */
+const useCountdownTo = (deadlineMs: number | null): number => {
+  const compute = () =>
+    deadlineMs === null ? 0 : Math.max(0, Math.ceil((deadlineMs - Date.now()) / 1000));
+  const [secondsLeft, setSecondsLeft] = useState(compute);
+
+  useEffect(() => {
+    setSecondsLeft(compute());
+    if (deadlineMs === null) return;
+    const id = window.setInterval(() => {
+      setSecondsLeft(Math.max(0, Math.ceil((deadlineMs - Date.now()) / 1000)));
+    }, 250);
+    return () => window.clearInterval(id);
+    // compute is intentionally re-defined per render and not memoized —
+    // it closes over deadlineMs which is the only signal that matters.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deadlineMs]);
+
+  return secondsLeft;
 };
 
 /**
@@ -207,33 +265,38 @@ const secondsUntilNextWindow = (): number => {
 /**
  * Inline alert for the various error states. Wrong-code copy spells out
  * the 30-second rotation so users who hit a stale code understand why
- * a "correct" looking entry didn't match. Rate-limit copy is wired up
- * for when the backend starts returning 429 on /auth/2fa-check —
- * harmless if it never does.
+ * a "correct" looking entry didn't match. Rate-limit copy uses the
+ * live `rateLimitSecondsLeft` countdown so the user sees the wait
+ * tick down without re-querying anything.
  */
 const FormStatusAlert = ({
   status,
   mode,
   hasInput,
+  rateLimitSecondsLeft,
 }: {
   status: string | undefined;
   mode: TwoFactorMode;
   hasInput: boolean;
+  /** Seconds until the rate-limit bucket has a token again; null when not throttled. */
+  rateLimitSecondsLeft: number | null;
 }) => {
-  if (!status) return null;
+  const isRateLimited = rateLimitSecondsLeft !== null;
+  if (!status && !isRateLimited) return null;
   // Don't shout "enter a code" right after the user clears the input —
   // they're presumably about to start typing. The button-disabled
   // state already conveys that nothing's submittable yet.
-  if (!hasInput && /enter (the|a|one of)/i.test(status)) return null;
+  if (!isRateLimited && !hasInput && status && /enter (the|a|one of)/i.test(status)) {
+    return null;
+  }
 
-  const isRateLimited = /too many/i.test(status);
   const title = isRateLimited
     ? "Too many attempts"
     : mode === "totp"
     ? "That code didn't match"
     : "That backup code didn't work";
   const description = isRateLimited
-    ? status
+    ? `We allow 5 codes per minute. Try again in ${rateLimitSecondsLeft}s, or use a backup code.`
     : mode === "totp"
     ? "Enter the current code from your authenticator. Codes rotate every 30s."
     : "Each backup code can only be used once. Try a different one.";

--- a/pwa/components/auth/TwoFactorChallengeForm.tsx
+++ b/pwa/components/auth/TwoFactorChallengeForm.tsx
@@ -1,17 +1,23 @@
+import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
-import { Formik, Form } from "formik";
+import { Formik, Form, useFormikContext } from "formik";
+import { Clock3, ShieldAlert } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { safeNextPath } from "@/lib/authRedirect";
-import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { FormikField } from "@/components/ui/formik-field";
+import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSlot,
+} from "@/components/ui/input-otp";
 
 /**
  * Which credential the user is presenting for the second factor. Both
- * paths hit the same `/auth/2fa-check` endpoint — the server distinguishes
- * by checking the input against the TOTP secret first, then the recovery
- * code hashes — so this is purely UX: input shape, helper copy, validation
- * threshold. The toggle between modes lives in AuthCard's footer.
+ * paths hit the same `/auth/2fa-check` endpoint — the server
+ * distinguishes by checking the input against the TOTP secret first,
+ * then the recovery code hashes — so this is purely UX.
  */
 export type TwoFactorMode = "totp" | "backup";
 
@@ -21,10 +27,14 @@ interface Props {
   /** Whether the form prompts for a TOTP code or a backup recovery code. */
   mode: TwoFactorMode;
   /**
-   * Lets the user back out of the half-authenticated state — they'll need
-   * to log in again from the start. The sign-in form re-mounts and the
-   * server-side TwoFactorToken is harmless on its own (it can't be used
-   * for anything until the right code is submitted).
+   * Email captured at the password step — surfaced in the "Signing in
+   * as X · not you?" line so the user can confirm whose account they're
+   * unlocking before they spend a TOTP / backup code on the wrong one.
+   */
+  email: string | null;
+  /**
+   * Lets the user back out of the half-authenticated state — they'll
+   * need to log in again from the start.
    */
   onCancel: () => void;
 }
@@ -33,45 +43,29 @@ interface Values {
   code: string;
 }
 
-const COPY: Record<TwoFactorMode, {
-  field: { label: string; placeholder: string; autoComplete: string };
-  emptyError: string;
-}> = {
-  totp: {
-    field: {
-      label: "Authentication code",
-      placeholder: "123 456",
-      autoComplete: "one-time-code",
-    },
-    emptyError: "Enter a code from your authenticator app.",
-  },
-  backup: {
-    field: {
-      label: "Backup code",
-      placeholder: "xxxx-xxxx-xxxx",
-      autoComplete: "off",
-    },
-    emptyError: "Enter one of your saved backup codes.",
-  },
-};
+/** RFC 6238 default — codes roll every 30 seconds. */
+const TOTP_WINDOW_SECONDS = 30;
 
-const TwoFactorChallengeForm = ({ next, mode, onCancel }: Props) => {
+const TwoFactorChallengeForm = ({ next, mode, email, onCancel }: Props) => {
   const { submitTwoFactorCode } = useAuth();
   const router = useRouter();
-  const copy = COPY[mode];
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-5">
       <Formik<Values>
-        // Key by mode so switching between TOTP / backup wipes the input
-        // (otherwise a half-typed TOTP would linger when the user clicks
-        // "Use a backup code instead", and the validation message would
-        // be misleading).
+        // Key by mode so switching wipes the input; otherwise a half-typed
+        // TOTP would linger when the user clicks "Use a backup code
+        // instead" and the validation message would be misleading.
         key={mode}
         initialValues={{ code: "" }}
         validate={({ code }) => {
           const errors: Partial<Values> = {};
-          if (!code.trim()) errors.code = copy.emptyError;
+          if (!code.trim()) {
+            errors.code =
+              mode === "totp"
+                ? "Enter the 6-digit code from your authenticator."
+                : "Enter one of your saved backup codes.";
+          }
           return errors;
         }}
         onSubmit={async ({ code }, { setSubmitting, setStatus }) => {
@@ -85,23 +79,26 @@ const TwoFactorChallengeForm = ({ next, mode, onCancel }: Props) => {
           }
         }}
       >
-        {({ isSubmitting, status }) => (
-          <Form className="space-y-4" noValidate>
-            {status && (
-              <Alert variant="destructive" data-testid="2fa-error">
-                <AlertDescription>{status}</AlertDescription>
-              </Alert>
+        {({ isSubmitting, status, values }) => (
+          <Form className="space-y-5" noValidate>
+            <FormStatusAlert status={status} mode={mode} hasInput={Boolean(values.code.trim())} />
+
+            {mode === "totp" ? (
+              <TotpField hasError={Boolean(status)} />
+            ) : (
+              <FormikField
+                name="code"
+                label="Backup code"
+                placeholder="xxxx-xxxx-xxxx"
+                autoComplete="off"
+                inputMode="text"
+                autoFocus
+                inputClassName="font-mono"
+                data-testid="2fa-code"
+              />
             )}
 
-            <FormikField
-              name="code"
-              label={copy.field.label}
-              placeholder={copy.field.placeholder}
-              autoComplete={copy.field.autoComplete}
-              inputMode="text"
-              autoFocus
-              data-testid="2fa-code"
-            />
+            {mode === "totp" && <TotpCountdown />}
 
             <Button
               type="submit"
@@ -112,20 +109,162 @@ const TwoFactorChallengeForm = ({ next, mode, onCancel }: Props) => {
               {isSubmitting ? "Verifying..." : "Verify"}
             </Button>
 
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={onCancel}
-              className="w-full"
-            >
-              Cancel and start over
-            </Button>
+            {mode === "backup" && <BackupCodeNote />}
+
+            <p className="text-center text-sm text-muted-foreground">
+              {email ? (
+                <>
+                  Signing in as <span className="text-foreground">{email}</span>
+                  <span className="mx-1.5 opacity-50">·</span>
+                </>
+              ) : null}
+              <button
+                type="button"
+                onClick={onCancel}
+                className="text-primary font-semibold hover:text-foreground"
+                data-testid="2fa-cancel"
+              >
+                not you?
+              </button>
+            </p>
           </Form>
         )}
       </Formik>
     </div>
   );
 };
+
+/**
+ * Lifts Formik's `setFieldValue` out of render-prop land so the OTP
+ * input can shovel digits into the `code` field without us threading
+ * the form's bag through every wrapper.
+ */
+const TotpField = ({ hasError }: { hasError: boolean }) => {
+  const { values, setFieldValue, submitForm } = useFormikContext<Values>();
+
+  return (
+    <div className="space-y-2">
+      <InputOTP
+        maxLength={6}
+        value={values.code}
+        onChange={(value) => {
+          setFieldValue("code", value);
+          // Auto-submit when the user finishes typing the 6th digit —
+          // matches the rhythm of every other TOTP UX (you stop after
+          // 6, you don't also reach for the Verify button).
+          if (value.length === 6) {
+            void submitForm();
+          }
+        }}
+        autoFocus
+        data-testid="2fa-code"
+        containerClassName="justify-center gap-2"
+      >
+        <InputOTPGroup className="gap-2">
+          {[0, 1, 2, 3, 4, 5].map((idx) => (
+            <InputOTPSlot
+              key={idx}
+              index={idx}
+              aria-invalid={hasError ? "true" : "false"}
+              className="h-12 w-12 rounded-md border text-xl font-semibold tabular-nums"
+            />
+          ))}
+        </InputOTPGroup>
+      </InputOTP>
+    </div>
+  );
+};
+
+/**
+ * Live "code refreshes in Ns" indicator. TOTP windows are absolute
+ * (`floor(now / 30)`), so seconds-remaining is `30 - (now % 30)`.
+ * Re-renders every 250ms so the readout never lags more than a quarter
+ * second; cleaning up on unmount avoids the classic "still ticking
+ * after the route changed" leak.
+ */
+const TotpCountdown = () => {
+  const [secondsLeft, setSecondsLeft] = useState(() => secondsUntilNextWindow());
+
+  useEffect(() => {
+    const tick = () => setSecondsLeft(secondsUntilNextWindow());
+    const id = window.setInterval(tick, 250);
+    return () => window.clearInterval(id);
+  }, []);
+
+  return (
+    <p className="flex items-center justify-center gap-1.5 text-xs text-muted-foreground tabular-nums">
+      <Clock3 className="h-3 w-3" aria-hidden />
+      code refreshes in {secondsLeft}s
+    </p>
+  );
+};
+
+const secondsUntilNextWindow = (): number => {
+  const now = Math.floor(Date.now() / 1000);
+  return TOTP_WINDOW_SECONDS - (now % TOTP_WINDOW_SECONDS);
+};
+
+/**
+ * Inline alert for the various error states. Wrong-code copy spells out
+ * the 30-second rotation so users who hit a stale code understand why
+ * a "correct" looking entry didn't match. Rate-limit copy is wired up
+ * for when the backend starts returning 429 on /auth/2fa-check —
+ * harmless if it never does.
+ */
+const FormStatusAlert = ({
+  status,
+  mode,
+  hasInput,
+}: {
+  status: string | undefined;
+  mode: TwoFactorMode;
+  hasInput: boolean;
+}) => {
+  if (!status) return null;
+  // Don't shout "enter a code" right after the user clears the input —
+  // they're presumably about to start typing. The button-disabled
+  // state already conveys that nothing's submittable yet.
+  if (!hasInput && /enter (the|a|one of)/i.test(status)) return null;
+
+  const isRateLimited = /too many/i.test(status);
+  const title = isRateLimited
+    ? "Too many attempts"
+    : mode === "totp"
+    ? "That code didn't match"
+    : "That backup code didn't work";
+  const description = isRateLimited
+    ? status
+    : mode === "totp"
+    ? "Enter the current code from your authenticator. Codes rotate every 30s."
+    : "Each backup code can only be used once. Try a different one.";
+
+  return (
+    <Alert
+      variant="destructive"
+      data-testid="2fa-error"
+      data-error-kind={isRateLimited ? "rate-limit" : "wrong-code"}
+    >
+      <ShieldAlert className="h-4 w-4" aria-hidden />
+      <AlertTitle>{title}</AlertTitle>
+      <AlertDescription>{description}</AlertDescription>
+    </Alert>
+  );
+};
+
+/**
+ * Small NOTE box explaining that consuming a backup code doesn't burn
+ * the others — mirrors the mockup's tooltip-style box. Phrased without
+ * the exact remaining-count because we don't know it at challenge time
+ * (the count is gated behind full auth).
+ */
+const BackupCodeNote = () => (
+  <div className="rounded-md border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+    <p className="font-semibold uppercase tracking-wider text-foreground">Note</p>
+    <p className="mt-1">
+      Each backup code works once. The rest stay valid — you can regenerate the
+      whole set from Account → Security after you sign in.
+    </p>
+  </div>
+);
 
 export default TwoFactorChallengeForm;

--- a/pwa/components/ui/input-otp.tsx
+++ b/pwa/components/ui/input-otp.tsx
@@ -1,0 +1,75 @@
+import * as React from "react"
+import { OTPInput, OTPInputContext } from "input-otp"
+import { MinusIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function InputOTP({
+  className,
+  containerClassName,
+  ...props
+}: React.ComponentProps<typeof OTPInput> & {
+  containerClassName?: string
+}) {
+  return (
+    <OTPInput
+      data-slot="input-otp"
+      containerClassName={cn(
+        "flex items-center gap-2 has-disabled:opacity-50",
+        containerClassName
+      )}
+      className={cn("disabled:cursor-not-allowed", className)}
+      {...props}
+    />
+  )
+}
+
+function InputOTPGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="input-otp-group"
+      className={cn("flex items-center", className)}
+      {...props}
+    />
+  )
+}
+
+function InputOTPSlot({
+  index,
+  className,
+  ...props
+}: React.ComponentProps<"div"> & {
+  index: number
+}) {
+  const inputOTPContext = React.useContext(OTPInputContext)
+  const { char, hasFakeCaret, isActive } = inputOTPContext?.slots[index] ?? {}
+
+  return (
+    <div
+      data-slot="input-otp-slot"
+      data-active={isActive}
+      className={cn(
+        "relative flex h-9 w-9 items-center justify-center border-y border-r border-input text-sm shadow-xs transition-all outline-none first:rounded-l-md first:border-l last:rounded-r-md aria-invalid:border-destructive data-[active=true]:z-10 data-[active=true]:border-ring data-[active=true]:ring-[3px] data-[active=true]:ring-ring/50 data-[active=true]:aria-invalid:border-destructive data-[active=true]:aria-invalid:ring-destructive/20 dark:bg-input/30 dark:data-[active=true]:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    >
+      {char}
+      {hasFakeCaret && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <div className="h-4 w-px animate-caret-blink bg-foreground duration-1000" />
+        </div>
+      )}
+    </div>
+  )
+}
+
+function InputOTPSeparator({ ...props }: React.ComponentProps<"div">) {
+  return (
+    <div data-slot="input-otp-separator" role="separator" {...props}>
+      <MinusIcon />
+    </div>
+  )
+}
+
+export { InputOTP, InputOTPGroup, InputOTPSlot, InputOTPSeparator }

--- a/pwa/contexts/AuthContext.tsx
+++ b/pwa/contexts/AuthContext.tsx
@@ -79,6 +79,18 @@ interface AuthContextType {
   clearError: () => void;
 }
 
+/**
+ * Thrown by `submitTwoFactorCode` when the backend returns 429. Carries
+ * the retry-after window so the challenge form can disable Verify and
+ * drive a live countdown.
+ */
+export class TwoFactorRateLimitError extends Error {
+  constructor(message: string, public readonly retryAfterSeconds: number) {
+    super(message);
+    this.name = "TwoFactorRateLimitError";
+  }
+}
+
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
@@ -158,6 +170,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     if (!res.ok) {
       const data = await res.json().catch(() => ({}));
+      // 429 from the rate-limit subscriber carries a structured
+      // retryAfter (and a Retry-After header) — surface it as a typed
+      // error so the form can drive a countdown without parsing the
+      // message string.
+      if (res.status === 429) {
+        throw new TwoFactorRateLimitError(
+          data.error || "Too many attempts.",
+          typeof data.retryAfter === "number" ? data.retryAfter : 60,
+        );
+      }
       throw new Error(data.error || "Invalid authentication code.");
     }
 

--- a/pwa/contexts/AuthContext.tsx
+++ b/pwa/contexts/AuthContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useState, useEffect, useCallback, ReactNode } from "react";
 import { useTheme } from "next-themes";
 import { ENTRYPOINT } from "../config/entrypoint";
+import { fetchWithTimeout } from "../lib/fetchWithTimeout";
 
 export type ThemePreference = "light" | "dark" | "system";
 export type NotificationFrequency = "realtime" | "hourly" | "daily";
@@ -112,7 +113,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const fetchMe = useCallback(async () => {
     try {
-      const res = await fetch(`${ENTRYPOINT}/api/me`, { credentials: "include" });
+      const res = await fetchWithTimeout(`${ENTRYPOINT}/api/me`, { credentials: "include" });
       if (res.ok) {
         const data = await res.json();
         setUser(data);
@@ -132,7 +133,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const login = useCallback(async (email: string, password: string): Promise<LoginResult> => {
     setError(null);
-    const res = await fetch(`${ENTRYPOINT}/auth/login`, {
+    const res = await fetchWithTimeout(`${ENTRYPOINT}/auth/login`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       credentials: "include",
@@ -161,7 +162,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const submitTwoFactorCode = useCallback(async (code: string) => {
-    const res = await fetch(`${ENTRYPOINT}/auth/2fa-check`, {
+    const res = await fetchWithTimeout(`${ENTRYPOINT}/auth/2fa-check`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       credentials: "include",
@@ -189,7 +190,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const register = useCallback(async (input: RegisterInput) => {
     setError(null);
-    const res = await fetch(`${ENTRYPOINT}/users`, {
+    const res = await fetchWithTimeout(`${ENTRYPOINT}/users`, {
       method: "POST",
       headers: { "Content-Type": "application/ld+json" },
       credentials: "include",
@@ -211,7 +212,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const changePassword = useCallback(async (currentPassword: string, newPassword: string) => {
-    const res = await fetch(`${ENTRYPOINT}/auth/change-password`, {
+    const res = await fetchWithTimeout(`${ENTRYPOINT}/auth/change-password`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       credentials: "include",
@@ -225,7 +226,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const requestPasswordReset = useCallback(async (email: string) => {
-    const res = await fetch(`${ENTRYPOINT}/auth/forgot-password`, {
+    const res = await fetchWithTimeout(`${ENTRYPOINT}/auth/forgot-password`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       credentials: "include",
@@ -238,7 +239,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const resetPassword = useCallback(async (token: string, newPassword: string) => {
-    const res = await fetch(`${ENTRYPOINT}/auth/reset-password`, {
+    const res = await fetchWithTimeout(`${ENTRYPOINT}/auth/reset-password`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       credentials: "include",
@@ -257,7 +258,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const logout = useCallback(() => {
     setUser(null);
-    fetch(`${ENTRYPOINT}/auth/logout`, {
+    fetchWithTimeout(`${ENTRYPOINT}/auth/logout`, {
       method: "POST",
       credentials: "include",
     }).catch(() => {});

--- a/pwa/lib/fetchWithTimeout.ts
+++ b/pwa/lib/fetchWithTimeout.ts
@@ -1,0 +1,38 @@
+/**
+ * Default deadline for auth + 2FA fetches in milliseconds. Long enough to
+ * tolerate a normal slow round-trip; short enough that a wedged port
+ * forward or stalled connection surfaces as a real error instead of a
+ * spinner that sits forever (the failure mode that bit us on the
+ * Reveal-codes button when Docker Desktop dropped its host↔WSL2 forward).
+ */
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+/**
+ * Thin `fetch` wrapper that wires an `AbortSignal.timeout()` deadline
+ * onto the request and re-throws DOMException("TimeoutError") as a
+ * human-readable `Error("Network timeout. Please try again.")`. Any
+ * caller-provided `signal` is honored as-is — pass your own when you
+ * need a longer (or shorter) cap.
+ *
+ * Only used from the auth / 2FA UI for now where a hung fetch leaves
+ * the form stuck in its submitting state; we can broaden the use
+ * elsewhere if the same symptom shows up.
+ */
+export async function fetchWithTimeout(
+  input: RequestInfo | URL,
+  init: RequestInit & { timeoutMs?: number } = {},
+): Promise<Response> {
+  const { timeoutMs = DEFAULT_TIMEOUT_MS, signal, ...rest } = init;
+  const effectiveSignal = signal ?? AbortSignal.timeout(timeoutMs);
+  try {
+    return await fetch(input, { ...rest, signal: effectiveSignal });
+  } catch (err) {
+    if (
+      err instanceof DOMException &&
+      (err.name === "TimeoutError" || err.name === "AbortError")
+    ) {
+      throw new Error("Network timeout. Please try again.");
+    }
+    throw err;
+  }
+}

--- a/pwa/next-env.d.ts
+++ b/pwa/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -33,6 +33,7 @@
     "cmdk": "^1.1.1",
     "date-fns": "^4.2.1",
     "formik": "^2.4.9",
+    "input-otp": "^1.4.2",
     "isomorphic-unfetch": "^4.0.2",
     "lucide-react": "^1.16.0",
     "next": "^16.2.6",

--- a/pwa/pnpm-lock.yaml
+++ b/pwa/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       formik:
         specifier: ^2.4.9
         version: 2.4.9(@types/react@19.2.15)(react@19.2.6)
+      input-otp:
+        specifier: ^1.4.2
+        version: 1.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       isomorphic-unfetch:
         specifier: ^4.0.2
         version: 4.0.2
@@ -2727,6 +2730,12 @@ packages:
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  input-otp@1.4.2:
+    resolution: {integrity: sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -7072,6 +7081,11 @@ snapshots:
   inflection@3.0.2: {}
 
   inline-style-parser@0.2.7: {}
+
+  input-otp@1.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
 
   internal-slot@1.1.0:
     dependencies:


### PR DESCRIPTION
## Summary

End-to-end rework of the 2FA experience driven from a design mockup, plus a few security improvements that came up along the way.

**Sign-in challenge step**
- Redesigned to match the mockup: 6-digit OTP boxes (shadcn `input-otp`), email-anchored subtitle, 30-second TOTP rotation countdown, "Signing in as X · not you?" footer.
- New "Use a backup code instead" / "Back to authenticator code" toggle in the card footer, both modes hit the same `/auth/2fa-check` endpoint.
- Inline error states styled per mockup: "That code didn't match" with rotation hint vs. amber "Too many attempts — Try again in Ns, or use a backup code".
- New `POST /auth/2fa-check` rate-limit: 5/min per user, shared bucket with `/me/2fa/verify`. Returns 429 + `Retry-After` + structured `retryAfter` body. PWA drives a live countdown, disables Verify and the input boxes, and auto-clears when the bucket refills.

**Recovery codes**
- Structural change: `user.totp_recovery_code_hashes` → `user.totp_recovery_codes` ([{hash, consumedAt, encrypted?}]). Consumed codes stay on the row so the security panel can show them struck-through alongside the still-spendable ones.
- New password-gated "Reveal codes" flow in the security panel (GitHub-style step-up). Codes are envelope-encrypted at generation via the existing `TwoFactorSecretCipher`; the `/me/2fa/recovery-codes/reveal` endpoint requires `currentPassword` to decrypt.
- Consumed codes display their actual plaintext (struck-through) on the masked list — spent codes can't re-authenticate so surfacing them is harmless.

**Setup flow fixes**
- `qrcode@1.5.4` import switched to `qrcode/lib/browser` — Next 16 Turbopack doesn't honor the `browser` field swap, so the Node entry was getting bundled into the client and `QRCode.toDataURL()` hung forever, leaving the setup-dialog spinner stuck.
- `TwoFactorJsonHandler::serializeUser()` was missing the `twoFactor` block that `AuthController` includes — the user object came back from the 2fa-check path without `.twoFactor`, crashing the security panel's new recovery-code fetch.

**Fixtures**
- Uma (`user@aura.test` / `user123`) is now seeded with TOTP 2FA enabled, a stable base-32 secret, and 10 known recovery codes so the challenge flow is exercised on every fixture reload without manual pairing. See the `FIXTURE_TOTP_SECRET` and `FIXTURE_RECOVERY_CODES` constants in `UserFixtures.php`.

## Test plan
- [x] PHPUnit: 464 tests, 1481 assertions, all green
- [x] PHPStan level 10 + strict-rules: no errors
- [x] PHP_CodeSniffer: no errors
- [x] Doctrine schema: mapping correct
- [x] PWA typecheck: clean
- [x] Manual: sign in → 6-digit OTP → success
- [x] Manual: sign in → wrong code → "That code didn't match" alert + red-bordered boxes
- [x] Manual: 5 wrong codes → 6th submission rate-limited with countdown ticking down to refill
- [x] Manual: "Use a backup code instead" → backup mode → consume a backup code → /account renders the strikethrough
- [x] Manual: Account → Security → consumed codes show plaintext struck-through, unused stay masked
- [x] Manual: Account → Security → Reveal codes → password prompt → wrong password rejected, correct password reveals all 10 plaintexts
- [x] Manual: 2FA setup dialog renders QR code (fix for the Turbopack hang)