### PR TITLE
fix(signup): silence CodeQL XSS + open-redirect on invite re-mount

### DIFF
--- a/pwa/components/auth/InviteSignup.tsx
+++ b/pwa/components/auth/InviteSignup.tsx
@@ -192,10 +192,20 @@ const InviteSignup = ({ token, next }: Props) => {
         signedInEmail={user?.email ?? ""}
         onSignOutAndAccept={async () => {
           await logout();
-          // Re-render the page once the auth context clears; the URL
-          // stays put so the same token re-fetches as pending instead
-          // of mismatch.
-          router.replace(router.asPath);
+          // Re-mount the signup page so the auth context clears and the
+          // invite re-fetches as `pending` instead of `mismatch`. Built
+          // from known-safe inputs — literal pathname, the `token` prop
+          // we already validated above, and the same `next` we
+          // sanitize through `isSafeNextPath` everywhere else — rather
+          // than re-issuing `router.asPath`, which CodeQL traces back
+          // to the URL bar and treats as untrusted (CWE-79 / CWE-601).
+          router.replace({
+            pathname: "/signup",
+            query: {
+              invite: token,
+              ...(isSafeNextPath(next) ? { next } : {}),
+            },
+          });
         }}
         onIgnore={() => {
           // safeNextPath returns either `next` or "/account" — same


### PR DESCRIPTION
## Summary

Two GitHub Advanced Security alerts opened against #309 after merge:

- [#12 — Client-side cross-site scripting](https://github.com/roboparker/Aura/security/code-scanning/12)
- [#13 — Client-side URL redirect](https://github.com/roboparker/Aura/security/code-scanning/13)

Both fired on the same line: `router.replace(router.asPath)` inside the "Sign out & accept invite" handler on the email-mismatch screen. CodeQL traces `router.asPath` back to the URL bar without recognizing any sanitizer in its path and treats it as an untrusted destination string (CWE-79 / CWE-601).

The data-flow is harmless in practice — Next.js parses `asPath` against the existing route table, and the URL was just written by Next.js itself when the user followed the invite link. Chasing CodeQL-recognized sanitization barriers around `router.asPath` is fiddly though; cheaper to rebuild the destination from known-safe inputs.

After this PR, the handler builds a navigation object from:
- literal `pathname: '/signup'`
- the `token` prop we already validated upstream (the lookup endpoint either resolved it or fell back to the expired screen)
- the same `next` we already sanitize through `isSafeNextPath` everywhere else

Both alerts close as a result.

## Test plan
- [x] PWA typecheck clean
- [x] Manual: signed-in user (admin) visits `/signup?invite=pending-invite-fixture` → mismatch card → "Sign out & accept invite" → lands back on `/signup?invite=pending-invite-fixture` as unauthenticated, signs up flow renders