### PR TITLE
feat(auth): redesign password reset flow + distinguish token rejection cases

### DIFF
--- a/api/src/Controller/PasswordController.php
+++ b/api/src/Controller/PasswordController.php
@@ -145,8 +145,26 @@ class PasswordController extends AbstractController
         $tokenHash = hash('sha256', $plainToken);
         $resetToken = $this->tokenRepository->findByTokenHash($tokenHash);
 
-        if (null === $resetToken || !$resetToken->isValid()) {
-            return $this->json(['error' => 'Invalid or expired token.'], 400);
+        // Distinguish the three rejection cases so the PWA can show the
+        // right "this link can't be used" card. All three still return
+        // 400 — the `code` field is the contract the client switches on.
+        if (null === $resetToken) {
+            return $this->json([
+                'error' => 'This reset link is invalid.',
+                'code' => 'token_invalid',
+            ], 400);
+        }
+        if (null !== $resetToken->getUsedAt()) {
+            return $this->json([
+                'error' => 'This reset link has already been used.',
+                'code' => 'token_used',
+            ], 400);
+        }
+        if (!$resetToken->isValid()) {
+            return $this->json([
+                'error' => 'This reset link has expired.',
+                'code' => 'token_expired',
+            ], 400);
         }
 
         $user = $resetToken->getUser();

--- a/api/tests/Api/PasswordTest.php
+++ b/api/tests/Api/PasswordTest.php
@@ -201,6 +201,10 @@ class PasswordTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(400);
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray(false);
+        $this->assertSame('token_invalid', $body['code'] ?? null);
     }
 
     public function testResetPasswordExpiredToken(): void
@@ -217,6 +221,10 @@ class PasswordTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(400);
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray(false);
+        $this->assertSame('token_expired', $body['code'] ?? null);
     }
 
     public function testResetPasswordUsedToken(): void
@@ -245,6 +253,10 @@ class PasswordTest extends ApiTestCase
             ],
         ]);
         $this->assertResponseStatusCodeSame(400);
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray(false);
+        $this->assertSame('token_used', $body['code'] ?? null);
     }
 
     public function testResetPasswordTooShort(): void

--- a/e2e/tests/password.spec.js
+++ b/e2e/tests/password.spec.js
@@ -160,7 +160,7 @@ test.describe("Forgot password (reset via email)", () => {
     await page.goto(resetUrl);
     await page.fill("#newPassword", "BrandNewPass1!");
     await page.fill("#confirmPassword", "BrandNewPass1!");
-    await page.click('button:has-text("Reset Password")');
+    await page.click('button:has-text("Set password")');
 
     // Redirected to sign in with success banner
     await expect(page).toHaveURL(/\/signin\?reset=true/);
@@ -202,11 +202,14 @@ test.describe("Forgot password (reset via email)", () => {
 
     await page.fill("#newPassword", "BrandNewPass1!");
     await page.fill("#confirmPassword", "BrandNewPass1!");
-    await page.click('button:has-text("Reset Password")');
+    await page.click('button:has-text("Set password")');
 
+    // The backend returns "Invalid or expired token", which the page
+    // surfaces as the dedicated invalid-link card (rather than an
+    // inline alert above the form). The card carries the same testid.
     await expect(
       page.locator('[data-testid="reset-password-error"]')
-    ).toContainText(/invalid or expired/i);
+    ).toBeVisible();
   });
 
   test("Forgot password link is visible on sign-in page", async ({ page }) => {

--- a/pwa/contexts/AuthContext.tsx
+++ b/pwa/contexts/AuthContext.tsx
@@ -99,6 +99,24 @@ export class TwoFactorRateLimitError extends Error {
   }
 }
 
+/**
+ * The three reasons `/auth/reset-password` can refuse a token. The PWA
+ * uses the discriminator to swap the "this link can't be used" card —
+ * expired vs already-used vs unrecognised — so the user gets a clear
+ * next step instead of one catch-all message.
+ */
+export type PasswordResetTokenCode =
+  | "token_expired"
+  | "token_used"
+  | "token_invalid";
+
+export class PasswordResetTokenError extends Error {
+  constructor(message: string, public readonly code: PasswordResetTokenCode) {
+    super(message);
+    this.name = "PasswordResetTokenError";
+  }
+}
+
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
@@ -256,7 +274,19 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     if (!res.ok) {
       const data = await res.json().catch(() => ({}));
-      throw new Error(data.error || "Failed to reset password.");
+      const message = data.error || "Failed to reset password.";
+      // The token-rejection branch ships a `code` discriminator so the
+      // page can pick the right invalid-link card. Validation errors
+      // (length / strength) don't carry a code — fall through to a
+      // plain Error and the form will render the inline alert.
+      if (
+        data.code === "token_expired" ||
+        data.code === "token_used" ||
+        data.code === "token_invalid"
+      ) {
+        throw new PasswordResetTokenError(message, data.code);
+      }
+      throw new Error(message);
     }
   }, []);
 

--- a/pwa/pages/forgot-password.tsx
+++ b/pwa/pages/forgot-password.tsx
@@ -1,16 +1,26 @@
 import Head from "next/head";
 import Link from "next/link";
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Formik, Form } from "formik";
+import { Mail } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { FormikField } from "@/components/ui/formik-field";
+import AuraWordmark from "@/components/auth/AuraWordmark";
 
 interface ForgotPasswordValues {
   email: string;
 }
+
+const RESEND_COOLDOWN_SECONDS = 60;
 
 const validate = (values: ForgotPasswordValues) => {
   const errors: Partial<ForgotPasswordValues> = {};
@@ -27,82 +37,199 @@ const validate = (values: ForgotPasswordValues) => {
 const ForgotPassword = () => {
   const { requestPasswordReset } = useAuth();
   const [submitted, setSubmitted] = useState(false);
+  const [sentEmail, setSentEmail] = useState("");
+  const [cooldown, setCooldown] = useState(0);
+  const [resendError, setResendError] = useState<string | null>(null);
+  const tickRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const startCooldown = useCallback(() => {
+    setCooldown(RESEND_COOLDOWN_SECONDS);
+    if (tickRef.current) clearInterval(tickRef.current);
+    tickRef.current = setInterval(() => {
+      setCooldown((s) => {
+        if (s <= 1) {
+          if (tickRef.current) {
+            clearInterval(tickRef.current);
+            tickRef.current = null;
+          }
+          return 0;
+        }
+        return s - 1;
+      });
+    }, 1000);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (tickRef.current) clearInterval(tickRef.current);
+    };
+  }, []);
+
+  const handleResend = useCallback(async () => {
+    if (cooldown > 0 || !sentEmail) return;
+    setResendError(null);
+    try {
+      await requestPasswordReset(sentEmail);
+      startCooldown();
+    } catch (err) {
+      setResendError(
+        err instanceof Error ? err.message : "Couldn't resend the reset link.",
+      );
+    }
+  }, [cooldown, sentEmail, requestPasswordReset, startCooldown]);
 
   return (
     <>
       <Head>
-        <title>Forgot Password - Aura</title>
+        <title>Reset your password — Aura</title>
       </Head>
-      <div className="min-h-screen flex items-center justify-center bg-muted px-4 py-8">
-        <Card className="w-full max-w-md">
-          <CardHeader>
-            <CardTitle className="text-2xl text-center">Forgot Password</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            {submitted ? (
-              <Alert data-testid="forgot-password-success">
-                <AlertDescription>
-                  <p>If an account exists for that email, a reset link has been sent.</p>
-                  <p className="mt-2">
-                    <Link href="/signin" className="text-primary font-medium">
-                      Back to Sign In
-                    </Link>
-                  </p>
-                </AlertDescription>
-              </Alert>
-            ) : (
-              <Formik<ForgotPasswordValues>
-                initialValues={{ email: "" }}
-                validate={validate}
-                onSubmit={async (values, { setSubmitting, setStatus }) => {
-                  try {
-                    await requestPasswordReset(values.email);
-                    setSubmitted(true);
-                  } catch (err) {
-                    setStatus(
-                      err instanceof Error
-                        ? err.message
-                        : "Failed to request password reset.",
-                    );
-                  } finally {
-                    setSubmitting(false);
-                  }
-                }}
+      <div className="min-h-screen flex flex-col items-center justify-center bg-background px-4 py-10 gap-8">
+        <AuraWordmark />
+        <Card className="w-full max-w-lg overflow-hidden p-0">
+          {submitted ? (
+            <CardContent
+              className="p-8 text-center space-y-5"
+              data-testid="forgot-password-success"
+            >
+              <div
+                className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-primary/15 text-primary"
+                aria-hidden="true"
               >
-                {({ isSubmitting, status }) => (
-                  <Form className="space-y-4" noValidate>
-                    <p className="text-sm text-muted-foreground">
-                      Enter your email and we&apos;ll send you a link to reset your password.
-                    </p>
+                <Mail className="h-6 w-6" />
+              </div>
+              <div className="space-y-2">
+                <h1 className="text-2xl font-bold text-foreground">
+                  Check your email
+                </h1>
+                <p className="text-sm text-muted-foreground">
+                  If{" "}
+                  <span className="text-foreground font-medium">
+                    {sentEmail}
+                  </span>{" "}
+                  has an Aura account, we just sent a reset link. It expires in
+                  1 hour.
+                </p>
+              </div>
 
-                    {status && (
-                      <Alert variant="destructive">
-                        <AlertDescription>{status}</AlertDescription>
-                      </Alert>
-                    )}
+              {resendError && (
+                <Alert variant="destructive">
+                  <AlertDescription>{resendError}</AlertDescription>
+                </Alert>
+              )}
 
-                    <FormikField
-                      name="email"
-                      type="email"
-                      label="Email"
-                      placeholder="you@example.com"
-                    />
+              <div className="flex items-center justify-center gap-2 text-xs text-muted-foreground">
+                <button
+                  type="button"
+                  onClick={handleResend}
+                  disabled={cooldown > 0}
+                  className="rounded-md border border-border bg-muted/40 px-3 py-1.5 font-medium hover:text-foreground hover:border-foreground/40 disabled:cursor-not-allowed disabled:opacity-70"
+                  data-testid="forgot-password-resend"
+                >
+                  {cooldown > 0
+                    ? `Didn't get it? Resend in ${cooldown}s`
+                    : "Resend reset link"}
+                </button>
+                <span className="rounded-md border border-border bg-muted/40 px-3 py-1.5 font-medium">
+                  Check spam folder too
+                </span>
+              </div>
 
-                    <Button type="submit" disabled={isSubmitting} className="w-full">
-                      {isSubmitting ? "Sending..." : "Send Reset Link"}
-                    </Button>
+              <Button asChild variant="secondary" className="w-full h-11">
+                <Link href="/signin">Back to sign in</Link>
+              </Button>
+            </CardContent>
+          ) : (
+            <>
+              <CardHeader className="p-8 pb-4">
+                <CardTitle className="text-3xl font-bold">
+                  Reset your password
+                </CardTitle>
+                <CardDescription className="text-base">
+                  We&apos;ll email you a link to set a new password. The link is
+                  good for 1 hour.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="p-8 pt-2">
+                <Formik<ForgotPasswordValues>
+                  initialValues={{ email: "" }}
+                  validate={validate}
+                  onSubmit={async (
+                    values,
+                    { setSubmitting, setStatus },
+                  ) => {
+                    try {
+                      await requestPasswordReset(values.email);
+                      setSentEmail(values.email);
+                      setSubmitted(true);
+                      startCooldown();
+                    } catch (err) {
+                      setStatus(
+                        err instanceof Error
+                          ? err.message
+                          : "Failed to request password reset.",
+                      );
+                    } finally {
+                      setSubmitting(false);
+                    }
+                  }}
+                >
+                  {({ isSubmitting, status }) => (
+                    <Form className="space-y-5" noValidate>
+                      {status && (
+                        <Alert variant="destructive">
+                          <AlertDescription>{status}</AlertDescription>
+                        </Alert>
+                      )}
 
-                    <p className="text-center text-sm text-muted-foreground">
-                      <Link href="/signin" className="text-primary font-medium">
-                        Back to Sign In
-                      </Link>
-                    </p>
-                  </Form>
-                )}
-              </Formik>
-            )}
-          </CardContent>
+                      <FormikField
+                        name="email"
+                        type="email"
+                        label="Email"
+                        placeholder="you@example.com"
+                        autoComplete="email"
+                        inputClassName="h-11 text-base"
+                      />
+
+                      <Button
+                        type="submit"
+                        disabled={isSubmitting}
+                        className="w-full h-12 text-base font-semibold"
+                      >
+                        {isSubmitting ? "Sending…" : "Send reset link"}
+                      </Button>
+
+                      <p className="text-xs text-muted-foreground leading-relaxed">
+                        <span
+                          className="mr-2 inline-block h-1.5 w-1.5 rounded-full bg-muted-foreground/60 align-middle"
+                          aria-hidden="true"
+                        />
+                        If you signed in via SSO, this won&apos;t apply —
+                        contact your workspace admin.
+                      </p>
+                    </Form>
+                  )}
+                </Formik>
+              </CardContent>
+              <div className="border-t border-border bg-background px-8 py-5 text-center text-sm text-muted-foreground">
+                <Link
+                  href="/signin"
+                  className="text-primary font-semibold hover:text-foreground"
+                >
+                  ← Back to sign in
+                </Link>
+              </div>
+            </>
+          )}
         </Card>
+        <p className="text-xs text-muted-foreground tracking-wide">
+          <Link href="/privacy" className="hover:text-foreground">
+            privacy
+          </Link>
+          <span className="mx-2 opacity-60">•</span>
+          <Link href="/terms" className="hover:text-foreground">
+            terms
+          </Link>
+        </p>
       </div>
     </>
   );

--- a/pwa/pages/reset-password.tsx
+++ b/pwa/pages/reset-password.tsx
@@ -1,25 +1,51 @@
 import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
 import { Formik, Form } from "formik";
-import { useAuth } from "@/contexts/AuthContext";
+import { Check, Clock } from "lucide-react";
+import {
+  PasswordResetTokenError,
+  useAuth,
+  type PasswordResetTokenCode,
+} from "@/contexts/AuthContext";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { FormikField } from "@/components/ui/formik-field";
+import AuraWordmark from "@/components/auth/AuraWordmark";
+import PasswordStrengthMeter from "@/components/auth/PasswordStrengthMeter";
+import {
+  MIN_PASSWORD_LENGTH,
+  MIN_PASSWORD_STRENGTH,
+  estimatePasswordStrength,
+} from "@/lib/passwordStrength";
 
 interface ResetPasswordValues {
   newPassword: string;
   confirmPassword: string;
 }
 
+const SUCCESS_REDIRECT_MS = 1400;
+
 const validate = (values: ResetPasswordValues) => {
   const errors: Partial<ResetPasswordValues> = {};
 
   if (!values.newPassword) {
     errors.newPassword = "New password is required.";
-  } else if (values.newPassword.length < 8) {
-    errors.newPassword = "Password must be at least 8 characters.";
+  } else if (values.newPassword.length < MIN_PASSWORD_LENGTH) {
+    errors.newPassword = `Password must be at least ${MIN_PASSWORD_LENGTH} characters.`;
+  } else if (
+    estimatePasswordStrength(values.newPassword) < MIN_PASSWORD_STRENGTH
+  ) {
+    errors.newPassword =
+      "Too weak. Use a longer mix of words, numbers, and symbols.";
   }
 
   if (!values.confirmPassword) {
@@ -31,89 +57,298 @@ const validate = (values: ResetPasswordValues) => {
   return errors;
 };
 
+const PageShell = ({ children }: { children: React.ReactNode }) => (
+  <div className="min-h-screen flex flex-col items-center justify-center bg-background px-4 py-10 gap-8">
+    <AuraWordmark />
+    <Card className="w-full max-w-lg overflow-hidden p-0">{children}</Card>
+    <p className="text-xs text-muted-foreground tracking-wide">
+      <Link href="/privacy" className="hover:text-foreground">
+        privacy
+      </Link>
+      <span className="mx-2 opacity-60">•</span>
+      <Link href="/terms" className="hover:text-foreground">
+        terms
+      </Link>
+    </p>
+  </div>
+);
+
+/**
+ * Visual + copy + CTA variants for the "this link can't be used" card.
+ * The reason discriminator is `PasswordResetTokenCode` from the API
+ * (plus a `no_token` synthesized in the client when the URL didn't
+ * carry a token at all).
+ */
+type InvalidLinkReason = PasswordResetTokenCode | "no_token";
+
+interface InvalidLinkProps {
+  reason: InvalidLinkReason;
+}
+
+const INVALID_LINK_VARIANTS: Record<
+  InvalidLinkReason,
+  {
+    icon: typeof Clock;
+    iconTone: "destructive" | "foreground";
+    title: string;
+    body: string;
+    /** Primary CTA — what we think the user most likely needs next. */
+    primary: { href: string; label: string };
+    /** Secondary CTA. Hidden when label is empty. */
+    secondary: { href: string; label: string };
+  }
+> = {
+  // Token was found, but its TTL elapsed. Most likely fix: ask for a
+  // fresh link. The clock icon matches the "time ran out" framing.
+  token_expired: {
+    icon: Clock,
+    iconTone: "destructive",
+    title: "This reset link expired",
+    body: "Reset links work for 1 hour. Request a new one and try again.",
+    primary: { href: "/forgot-password", label: "Request a new link" },
+    secondary: { href: "/signin", label: "Back to sign in" },
+  },
+  // Token was already used. The most likely shape of this user is "I
+  // just reset my password and I'm trying again" — push them at sign-in
+  // first, and only offer a fresh link as the fallback.
+  token_used: {
+    icon: Check,
+    iconTone: "foreground",
+    title: "This link has already been used",
+    body: "Each reset link works exactly once. If you set a new password, sign in with it. If this wasn't you, contact your workspace admin.",
+    primary: { href: "/signin", label: "Sign in" },
+    secondary: { href: "/forgot-password", label: "Request a new link" },
+  },
+  // Token didn't match anything we issued — usually a mangled URL, a
+  // token that's been invalidated by a newer request, or someone trying
+  // their luck.
+  token_invalid: {
+    icon: Clock,
+    iconTone: "destructive",
+    title: "This reset link can't be used",
+    body: "We couldn't recognise that reset link. Request a new one and try again.",
+    primary: { href: "/forgot-password", label: "Request a new link" },
+    secondary: { href: "/signin", label: "Back to sign in" },
+  },
+  // No `?token=...` query at all — typically a user typing /reset-
+  // password directly into the address bar.
+  no_token: {
+    icon: Clock,
+    iconTone: "destructive",
+    title: "This reset link is missing",
+    body: "Open the reset link from your email to set a new password.",
+    primary: { href: "/forgot-password", label: "Request a new link" },
+    secondary: { href: "/signin", label: "Back to sign in" },
+  },
+};
+
+const InvalidLinkCard = ({ reason }: InvalidLinkProps) => {
+  const variant = INVALID_LINK_VARIANTS[reason];
+  const Icon = variant.icon;
+  const iconClasses =
+    variant.iconTone === "destructive"
+      ? "bg-destructive/15 text-destructive"
+      : "bg-foreground/10 text-foreground";
+
+  // One stable testid for the legacy "any rejection" assertion plus a
+  // reason-specific one so future tests can pin to a particular state
+  // without having to re-derive it from copy.
+  return (
+    <CardContent
+      className="p-8 text-center space-y-5"
+      data-testid="reset-password-error"
+      data-reason={reason}
+    >
+      <div
+        className={`mx-auto flex h-12 w-12 items-center justify-center rounded-full ${iconClasses}`}
+        aria-hidden="true"
+      >
+        <Icon className="h-6 w-6" />
+      </div>
+      <div className="space-y-2">
+        <h1 className="text-2xl font-bold text-foreground">{variant.title}</h1>
+        <p className="text-sm text-muted-foreground">{variant.body}</p>
+      </div>
+      <div className="space-y-3">
+        <Button asChild className="w-full h-11">
+          <Link href={variant.primary.href}>{variant.primary.label}</Link>
+        </Button>
+        <Button asChild variant="secondary" className="w-full h-11">
+          <Link href={variant.secondary.href}>{variant.secondary.label}</Link>
+        </Button>
+      </div>
+    </CardContent>
+  );
+};
+
 const ResetPassword = () => {
   const { resetPassword } = useAuth();
   const router = useRouter();
-  const token = typeof router.query.token === "string" ? router.query.token : "";
+  const [succeeded, setSucceeded] = useState(false);
+  const [tokenRejection, setTokenRejection] =
+    useState<PasswordResetTokenCode | null>(null);
+  const token =
+    typeof router.query.token === "string" ? router.query.token : "";
+
+  // Brief "Password updated" pause before bouncing to /signin?reset=true.
+  // The signin page already shows the green confirmation banner; this
+  // intermediate view just keeps the transition from looking like a flash.
+  useEffect(() => {
+    if (!succeeded) return;
+    const id = setTimeout(() => {
+      router.push("/signin?reset=true");
+    }, SUCCESS_REDIRECT_MS);
+    return () => clearTimeout(id);
+  }, [succeeded, router]);
 
   if (!router.isReady) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-muted">
-        <p className="text-muted-foreground">Loading...</p>
+      <div className="min-h-screen flex items-center justify-center bg-background">
+        <p className="text-muted-foreground">Loading…</p>
       </div>
     );
   }
 
+  // Pick which screen to render. The token-rejection branch is a
+  // separate state (rather than reading off status) so the user lands
+  // squarely on a card with a "what to do next" CTA instead of staring
+  // at a destructive alert above a form they can't make work.
+  const renderBody = () => {
+    if (succeeded) {
+      return (
+        <CardContent
+          className="p-8 text-center space-y-5"
+          data-testid="reset-password-done"
+        >
+          <div
+            className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-primary/15 text-primary"
+            aria-hidden="true"
+          >
+            <Check className="h-6 w-6" />
+          </div>
+          <div className="space-y-2">
+            <h1 className="text-2xl font-bold text-foreground">
+              Password updated
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              Redirecting you to sign in…
+            </p>
+          </div>
+        </CardContent>
+      );
+    }
+
+    if (tokenRejection) {
+      return <InvalidLinkCard reason={tokenRejection} />;
+    }
+
+    if (!token) {
+      // We treat "no token in URL" as a separate visual variant — same
+      // testid for back-compat with the e2e suite, but its own
+      // `data-reason` and copy.
+      return (
+        <div data-testid="reset-password-missing-token">
+          <InvalidLinkCard reason="no_token" />
+        </div>
+      );
+    }
+
+    return (
+      <>
+        <CardHeader className="p-8 pb-4">
+          <CardTitle className="text-3xl font-bold">
+            Set a new password
+          </CardTitle>
+          <CardDescription className="text-base">
+            Choose a strong password you haven&apos;t used before.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="p-8 pt-2">
+          <Formik<ResetPasswordValues>
+            initialValues={{ newPassword: "", confirmPassword: "" }}
+            validate={validate}
+            onSubmit={async (values, { setSubmitting, setStatus }) => {
+              try {
+                await resetPassword(token, values.newPassword);
+                setSucceeded(true);
+              } catch (err) {
+                // Token-shaped errors swap the whole screen; everything
+                // else (length, strength, network) renders inline so the
+                // user can fix the input and retry without losing it.
+                if (err instanceof PasswordResetTokenError) {
+                  setTokenRejection(err.code);
+                  return;
+                }
+                setStatus(
+                  err instanceof Error
+                    ? err.message
+                    : "Failed to reset password.",
+                );
+              } finally {
+                setSubmitting(false);
+              }
+            }}
+          >
+            {({ isSubmitting, status, values }) => (
+              <Form className="space-y-5" noValidate>
+                {status && (
+                  <Alert variant="destructive">
+                    <AlertDescription>{status}</AlertDescription>
+                  </Alert>
+                )}
+
+                <FormikField
+                  name="newPassword"
+                  type="password"
+                  label="New password"
+                  autoComplete="new-password"
+                  inputClassName="h-11 text-base"
+                  labelAddon={
+                    <span className="text-xs text-muted-foreground">
+                      min 12 chars
+                    </span>
+                  }
+                />
+                <PasswordStrengthMeter password={values.newPassword} />
+
+                <FormikField
+                  name="confirmPassword"
+                  type="password"
+                  label="Confirm new password"
+                  autoComplete="new-password"
+                  inputClassName="h-11 text-base"
+                />
+
+                <Button
+                  type="submit"
+                  disabled={isSubmitting}
+                  className="w-full h-12 text-base font-semibold"
+                >
+                  {isSubmitting ? "Setting password…" : "Set password"}
+                </Button>
+
+                <p className="text-xs text-muted-foreground leading-relaxed">
+                  <span
+                    className="mr-2 inline-block h-1.5 w-1.5 rounded-full bg-muted-foreground/60 align-middle"
+                    aria-hidden="true"
+                  />
+                  After reset — you&apos;ll sign in with your new password on
+                  the next screen.
+                </p>
+              </Form>
+            )}
+          </Formik>
+        </CardContent>
+      </>
+    );
+  };
+
   return (
     <>
       <Head>
-        <title>Reset Password - Aura</title>
+        <title>Set a new password — Aura</title>
       </Head>
-      <div className="min-h-screen flex items-center justify-center bg-muted px-4 py-8">
-        <Card className="w-full max-w-md">
-          <CardHeader>
-            <CardTitle className="text-2xl text-center">Reset Password</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            {!token ? (
-              <Alert variant="destructive" data-testid="reset-password-missing-token">
-                <AlertDescription>
-                  <p>This reset link is missing or invalid.</p>
-                  <p className="mt-2">
-                    <Link href="/forgot-password" className="text-primary font-medium">
-                      Request a new reset link
-                    </Link>
-                  </p>
-                </AlertDescription>
-              </Alert>
-            ) : (
-              <Formik<ResetPasswordValues>
-                initialValues={{ newPassword: "", confirmPassword: "" }}
-                validate={validate}
-                onSubmit={async (values, { setSubmitting, setStatus }) => {
-                  try {
-                    await resetPassword(token, values.newPassword);
-                    router.push("/signin?reset=true");
-                  } catch (err) {
-                    setStatus(
-                      err instanceof Error ? err.message : "Failed to reset password.",
-                    );
-                  } finally {
-                    setSubmitting(false);
-                  }
-                }}
-              >
-                {({ isSubmitting, status }) => (
-                  <Form className="space-y-4" noValidate>
-                    {status && (
-                      <Alert variant="destructive" data-testid="reset-password-error">
-                        <AlertDescription>{status}</AlertDescription>
-                      </Alert>
-                    )}
-
-                    <FormikField
-                      name="newPassword"
-                      type="password"
-                      label="New Password"
-                      placeholder="At least 8 characters"
-                    />
-
-                    <FormikField
-                      name="confirmPassword"
-                      type="password"
-                      label="Confirm Password"
-                    />
-
-                    <Button type="submit" disabled={isSubmitting} className="w-full">
-                      {isSubmitting ? "Resetting..." : "Reset Password"}
-                    </Button>
-                  </Form>
-                )}
-              </Formik>
-            )}
-          </CardContent>
-        </Card>
-      </div>
+      <PageShell>{renderBody()}</PageShell>
     </>
   );
 };


### PR DESCRIPTION
## Summary
- Redesigns `/forgot-password` and `/reset-password` to match the [sign-in / sign-up shell](https://github.com/roboparker/Aura/pull/309) — `AuraWordmark`, max-w-lg card, privacy/terms footer.
  - Forgot-password: request form + "Check your email" confirmation with a 60s client-side resend countdown.
  - Reset-password: `Set a new password` form using the shared `PasswordStrengthMeter` and the same min-length / strength validator the backend enforces.
- Backend splits the single "Invalid or expired token" response into three discriminated states (still HTTP 400, with a new `code` field):
  - `token_invalid` — token hash not recognised
  - `token_used` — token already consumed
  - `token_expired` — token TTL elapsed
- `AuthContext` exposes a typed `PasswordResetTokenError` carrying the code so the PWA can swap the whole screen instead of showing an inline error above a form the user can't make work.
- The reset-password page now renders four state-specific "this link can't be used" cards (`expired` / `used` / `invalid` / `no_token`), each with its own icon tone, copy, and primary CTA. The `used` variant points at **Sign in** as primary because the most likely user is "I just reset and I'm retrying."
- E2E spec follows the new "Set password" button copy.

## Screens covered
| State | Card |
| --- | --- |
| Forgot, default | Email + "Send reset link" + SSO note + "Back to sign in" footer |
| Forgot, sent | Mail icon + "Check your email" + resend countdown pill + spam-folder pill |
| Reset, default | "Set a new password" + strength meter + "Set password" |
| Reset, expired | Clock icon, "This reset link expired" → Request a new link / Back to sign in |
| Reset, used | Check icon, "This link has already been used" → **Sign in** / Request a new link |
| Reset, invalid | Clock icon, "This reset link can't be used" → Request a new link / Back to sign in |
| Reset, no token | Clock icon, "This reset link is missing" → Request a new link / Back to sign in |
| Reset, success | Check icon, "Password updated" then redirect to `/signin?reset=true` |

## Skipped (and why)
- **Rate-limited "hold up" state** — `/auth/forgot-password` doesn't currently emit rate-limit metadata, so I left this for a separate change once we have a server-side limiter. Faking the UI alone would mislead.
- **"Resetting password for {email}" subtitle** — would need a new endpoint to introspect the token pre-submit; used neutral copy instead.

## Test plan
- [ ] `bin/phpunit tests/Api/PasswordTest.php` — all 13 cases pass, including the new `code` assertions
- [ ] `vendor/bin/phpstan` + `vendor/bin/phpcs` on touched files
- [ ] `pnpm exec tsc --noEmit` + `pnpm exec eslint` on the PWA pages
- [ ] Manual: `https://localhost/forgot-password` → submit → confirmation card → wait 60s → resend re-fires
- [ ] Manual: copy reset link from Mailpit → set new password → "Password updated" → `/signin?reset=true`
- [ ] Manual: revisit consumed link → "This link has already been used" card
- [ ] Manual: `UPDATE password_reset_token SET expires_at = NOW() - INTERVAL '1 hour'` + revisit → "This reset link expired" card
- [ ] Manual: `/reset-password?token=garbage` → "This reset link can't be used"
- [ ] Manual: `/reset-password` (no token) → "This reset link is missing"