### PR TITLE
feat(pwa): browse docs/*.md at /guides with theme-switchable code blocks

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -64,6 +64,9 @@ services:
       # See note on `/app/vendor` above — keeps pnpm's symlinked store
       # off the host filesystem so installs don't corrupt the WSL share.
       - pwa_node_modules:/srv/app/node_modules
+      # Repo-root docs/ surfaced inside the container so scripts/sync-docs.mjs
+      # can find a source when predev / prebuild runs from /srv/app.
+      - ./docs:/srv/docs:ro
     environment:
       API_PLATFORM_CREATE_CLIENT_ENTRYPOINT: http://php
       API_PLATFORM_CREATE_CLIENT_OUTPUT: .

--- a/pwa/.dockerignore
+++ b/pwa/.dockerignore
@@ -1,5 +1,6 @@
 **/*.log
 **/*.md
+!.content/docs/**/*.md
 **/._*
 **/.dockerignore
 **/.DS_Store

--- a/pwa/.gitignore
+++ b/pwa/.gitignore
@@ -12,6 +12,9 @@
 /.next/
 /out/
 
+# Mirrored by scripts/sync-docs.mjs from the repo-root docs/ tree
+/.content/
+
 # production
 /build
 

--- a/pwa/components/common/Footer.tsx
+++ b/pwa/components/common/Footer.tsx
@@ -1,0 +1,114 @@
+import Link from "next/link";
+
+const Footer = () => (
+  <footer className="mt-12 border-t bg-background">
+    <div className="mx-auto max-w-6xl px-4 py-8">
+      <div className="grid grid-cols-2 gap-6 sm:grid-cols-3">
+        <div>
+          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Product
+          </h3>
+          <ul className="space-y-1.5 text-sm">
+            <li>
+              <Link href="/" className="text-foreground hover:underline">
+                Home
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/guides"
+                className="text-foreground hover:underline"
+              >
+                Guides
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/privacy"
+                className="text-foreground hover:underline"
+              >
+                Privacy
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/terms"
+                className="text-foreground hover:underline"
+              >
+                Terms
+              </Link>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Developers
+          </h3>
+          <ul className="space-y-1.5 text-sm">
+            <li>
+              <a href="/docs" className="text-foreground hover:underline">
+                API reference
+              </a>
+            </li>
+            <li>
+              <Link
+                href="/guides/developer/api-guide"
+                className="text-foreground hover:underline"
+              >
+                API guide
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/guides/developer/architecture"
+                className="text-foreground hover:underline"
+              >
+                Architecture
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/dev/components"
+                className="text-foreground hover:underline"
+              >
+                Component library
+              </Link>
+            </li>
+          </ul>
+        </div>
+        <div className="col-span-2 sm:col-span-1">
+          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Project
+          </h3>
+          <ul className="space-y-1.5 text-sm">
+            <li>
+              <a
+                href="https://github.com/roboparker/Aura"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-foreground hover:underline"
+              >
+                GitHub
+              </a>
+            </li>
+            <li>
+              <a
+                href="https://github.com/roboparker/Aura/issues"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-foreground hover:underline"
+              >
+                Report an issue
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <p className="mt-8 text-xs text-muted-foreground">
+        Aura — built on API Platform. Licensed MIT.
+      </p>
+    </div>
+  </footer>
+);
+
+export default Footer;

--- a/pwa/components/common/Layout.tsx
+++ b/pwa/components/common/Layout.tsx
@@ -9,6 +9,7 @@ import { ThemeProvider } from "next-themes";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { ActiveSpaceProvider } from "@/contexts/ActiveSpaceContext";
 import TwoFactorRecoveryInterstitial from "@/components/auth/TwoFactorRecoveryInterstitial";
+import Footer from "./Footer";
 import Navbar from "./Navbar";
 import Sidebar from "./Sidebar";
 
@@ -35,15 +36,18 @@ const Layout = ({
         <HydrationBoundary state={dehydratedState}>
           <AuthProvider>
             <ActiveSpaceProvider>
-              <Navbar />
-              {/* Persistent left sidebar (`md:` and up) when signed
-                  in; the navbar's mobile Sheet handles the small-
-                  screen case. Sidebar renders nothing for
-                  unauthenticated visitors so the marketing/auth
-                  screens keep their original full-width layout. */}
-              <div className="flex">
-                <Sidebar />
-                <div className="flex-1 min-w-0">{children}</div>
+              <div className="flex min-h-screen flex-col">
+                <Navbar />
+                {/* Persistent left sidebar (`md:` and up) when signed
+                    in; the navbar's mobile Sheet handles the small-
+                    screen case. Sidebar renders nothing for
+                    unauthenticated visitors so the marketing/auth
+                    screens keep their original full-width layout. */}
+                <div className="flex flex-1">
+                  <Sidebar />
+                  <div className="flex-1 min-w-0">{children}</div>
+                </div>
+                <Footer />
               </div>
               {/* Forced modal that appears the moment the API signals
                   this session signed in with a backup code. See

--- a/pwa/components/common/Navbar.tsx
+++ b/pwa/components/common/Navbar.tsx
@@ -1,13 +1,7 @@
 import Link from "next/link";
-import { ChevronDown, Menu } from "lucide-react";
+import { Menu } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import {
   Sheet,
   SheetClose,
@@ -35,22 +29,9 @@ const Navbar = () => {
           >
             Aura
           </Link>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="sm" className="gap-1">
-                Docs
-                <ChevronDown className="h-3.5 w-3.5" aria-hidden />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start">
-              <DropdownMenuItem asChild>
-                <a href="/docs">API</a>
-              </DropdownMenuItem>
-              <DropdownMenuItem asChild>
-                <Link href="/dev/components">Components</Link>
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          {/* Developer-facing doc links (API reference, component
+              library, guides) live in the page Footer to keep the navbar
+              focused on the active session. */}
         </div>
 
         {/* SearchBar stretches into the empty space between the

--- a/pwa/components/editor/CodeFence.tsx
+++ b/pwa/components/editor/CodeFence.tsx
@@ -7,6 +7,7 @@ import {
 import { Check, Copy } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { CODE_THEME_PRESETS } from "@/lib/codeThemes";
+import CodeThemeSwitcher from "./CodeThemeSwitcher";
 
 interface CodeFenceProps {
   code: string;
@@ -100,18 +101,21 @@ const CodeFence = ({ code, language, className }: CodeFenceProps) => {
         <span className="font-mono uppercase tracking-wide text-muted-foreground">
           {language || "code"}
         </span>
-        <button
-          type="button"
-          onClick={handleCopy}
-          aria-label="Copy code"
-          className="inline-flex h-6 w-6 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
-        >
-          {copied ? (
-            <Check className="h-3.5 w-3.5" />
-          ) : (
-            <Copy className="h-3.5 w-3.5" />
-          )}
-        </button>
+        <div className="flex items-center gap-1">
+          <CodeThemeSwitcher variant="compact" />
+          <button
+            type="button"
+            onClick={handleCopy}
+            aria-label="Copy code"
+            className="inline-flex h-6 w-6 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
+          >
+            {copied ? (
+              <Check className="h-3.5 w-3.5" />
+            ) : (
+              <Copy className="h-3.5 w-3.5" />
+            )}
+          </button>
+        </div>
       </div>
       {prismLanguage ? (
         CODE_THEME_PRESETS.map((preset) => (

--- a/pwa/components/editor/CodeFence.tsx
+++ b/pwa/components/editor/CodeFence.tsx
@@ -1,0 +1,111 @@
+import { useState } from "react";
+import { Highlight, themes, type Language } from "prism-react-renderer";
+import { useTheme } from "next-themes";
+import { Check, Copy } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface CodeFenceProps {
+  code: string;
+  language: string;
+  className?: string;
+}
+
+// Languages prism-react-renderer's `Language` union accepts. Anything
+// outside this set falls through to plain monospace styling rather than
+// throwing inside Highlight.
+const KNOWN_LANGUAGES = new Set<Language>([
+  "markup", "bash", "clike", "c", "cpp", "css", "javascript", "jsx",
+  "coffeescript", "actionscript", "css-extr", "diff", "git", "go",
+  "graphql", "handlebars", "json", "less", "makefile", "markdown",
+  "objectivec", "ocaml", "python", "reason", "sass", "scss", "sql",
+  "stylus", "tsx", "typescript", "wasm", "yaml",
+]);
+
+const normalise = (raw: string): Language | null => {
+  const k = raw.toLowerCase();
+  if (k === "ts") return "typescript";
+  if (k === "js") return "javascript";
+  if (k === "sh" || k === "shell" || k === "zsh") return "bash";
+  if (k === "yml") return "yaml";
+  if (k === "html") return "markup";
+  if (k === "php") return "clike";
+  return KNOWN_LANGUAGES.has(k as Language) ? (k as Language) : null;
+};
+
+// Code fence renderer for the `/guides` markdown pages. Mirrors the
+// component-library CodeBlock (theme-aware, copy button), but takes its
+// code + language as plain strings so it can be slotted in as react-
+// markdown's `<pre>` override.
+const CodeFence = ({ code, language, className }: CodeFenceProps) => {
+  const { resolvedTheme } = useTheme();
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // clipboard API blocked (insecure context, denied permission) —
+      // swallow silently rather than blowing up the page.
+    }
+  };
+
+  const prismLanguage = normalise(language);
+  const prismTheme = resolvedTheme === "dark" ? themes.vsDark : themes.github;
+
+  return (
+    <div
+      className={cn(
+        "group relative my-4 overflow-hidden rounded-md border border-input bg-muted/30",
+        className,
+      )}
+    >
+      <div className="flex items-center justify-between border-b border-input/60 bg-muted/40 px-3 py-1 text-xs">
+        <span className="font-mono uppercase tracking-wide text-muted-foreground">
+          {language || "code"}
+        </span>
+        <button
+          type="button"
+          onClick={handleCopy}
+          aria-label="Copy code"
+          className="inline-flex h-6 w-6 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
+        >
+          {copied ? (
+            <Check className="h-3.5 w-3.5" />
+          ) : (
+            <Copy className="h-3.5 w-3.5" />
+          )}
+        </button>
+      </div>
+      {prismLanguage ? (
+        <Highlight code={code} language={prismLanguage} theme={prismTheme}>
+          {({ className: hlClass, style, tokens, getLineProps, getTokenProps }) => (
+            <pre
+              className={cn(hlClass, "overflow-x-auto p-4 text-sm leading-relaxed")}
+              style={style}
+            >
+              {tokens.map((line, i) => {
+                const lineProps = getLineProps({ line });
+                return (
+                  <div key={i} {...lineProps}>
+                    {line.map((token, key) => {
+                      const tokenProps = getTokenProps({ token });
+                      return <span key={key} {...tokenProps} />;
+                    })}
+                  </div>
+                );
+              })}
+            </pre>
+          )}
+        </Highlight>
+      ) : (
+        <pre className="overflow-x-auto bg-muted p-4 text-sm leading-relaxed">
+          <code>{code}</code>
+        </pre>
+      )}
+    </div>
+  );
+};
+
+export default CodeFence;

--- a/pwa/components/editor/CodeFence.tsx
+++ b/pwa/components/editor/CodeFence.tsx
@@ -1,6 +1,10 @@
 import { useState } from "react";
-import { Highlight, themes, type Language } from "prism-react-renderer";
-import { useTheme } from "next-themes";
+import {
+  Highlight,
+  themes,
+  type Language,
+  type PrismTheme,
+} from "prism-react-renderer";
 import { Check, Copy } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -32,12 +36,42 @@ const normalise = (raw: string): Language | null => {
   return KNOWN_LANGUAGES.has(k as Language) ? (k as Language) : null;
 };
 
-// Code fence renderer for the `/guides` markdown pages. Mirrors the
-// component-library CodeBlock (theme-aware, copy button), but takes its
-// code + language as plain strings so it can be slotted in as react-
-// markdown's `<pre>` override.
+interface HighlightedProps {
+  code: string;
+  language: Language;
+  theme: PrismTheme;
+}
+
+const Highlighted = ({ code, language, theme }: HighlightedProps) => (
+  <Highlight code={code} language={language} theme={theme}>
+    {({ className: hlClass, style, tokens, getLineProps, getTokenProps }) => (
+      <pre
+        className={cn(hlClass, "m-0 overflow-x-auto p-4 text-sm leading-relaxed")}
+        style={style}
+      >
+        {tokens.map((line, i) => {
+          const lineProps = getLineProps({ line });
+          return (
+            <div key={i} {...lineProps}>
+              {line.map((token, key) => {
+                const tokenProps = getTokenProps({ token });
+                return <span key={key} {...tokenProps} />;
+              })}
+            </div>
+          );
+        })}
+      </pre>
+    )}
+  </Highlight>
+);
+
+// Code fence renderer for the `/guides` markdown pages. Renders BOTH
+// light + dark Prism outputs server-side and lets CSS show the right
+// one based on the `dark` class next-themes paints onto <html> before
+// hydration. Reading the theme via `useTheme()` would race the
+// hydration cycle and produce a brief flash of the wrong palette on
+// every refresh, since `resolvedTheme` is undefined during SSR.
 const CodeFence = ({ code, language, className }: CodeFenceProps) => {
-  const { resolvedTheme } = useTheme();
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
@@ -52,7 +86,6 @@ const CodeFence = ({ code, language, className }: CodeFenceProps) => {
   };
 
   const prismLanguage = normalise(language);
-  const prismTheme = resolvedTheme === "dark" ? themes.vsDark : themes.github;
 
   return (
     <div
@@ -79,28 +112,16 @@ const CodeFence = ({ code, language, className }: CodeFenceProps) => {
         </button>
       </div>
       {prismLanguage ? (
-        <Highlight code={code} language={prismLanguage} theme={prismTheme}>
-          {({ className: hlClass, style, tokens, getLineProps, getTokenProps }) => (
-            <pre
-              className={cn(hlClass, "overflow-x-auto p-4 text-sm leading-relaxed")}
-              style={style}
-            >
-              {tokens.map((line, i) => {
-                const lineProps = getLineProps({ line });
-                return (
-                  <div key={i} {...lineProps}>
-                    {line.map((token, key) => {
-                      const tokenProps = getTokenProps({ token });
-                      return <span key={key} {...tokenProps} />;
-                    })}
-                  </div>
-                );
-              })}
-            </pre>
-          )}
-        </Highlight>
+        <>
+          <div className="dark:hidden">
+            <Highlighted code={code} language={prismLanguage} theme={themes.github} />
+          </div>
+          <div className="hidden dark:block">
+            <Highlighted code={code} language={prismLanguage} theme={themes.vsDark} />
+          </div>
+        </>
       ) : (
-        <pre className="overflow-x-auto bg-muted p-4 text-sm leading-relaxed">
+        <pre className="m-0 overflow-x-auto bg-muted p-4 text-sm leading-relaxed">
           <code>{code}</code>
         </pre>
       )}

--- a/pwa/components/editor/CodeFence.tsx
+++ b/pwa/components/editor/CodeFence.tsx
@@ -1,12 +1,12 @@
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import {
   Highlight,
-  themes,
   type Language,
   type PrismTheme,
 } from "prism-react-renderer";
 import { Check, Copy } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { CODE_THEME_PRESETS } from "@/lib/codeThemes";
 
 interface CodeFenceProps {
   code: string;
@@ -65,12 +65,14 @@ const Highlighted = ({ code, language, theme }: HighlightedProps) => (
   </Highlight>
 );
 
-// Code fence renderer for the `/guides` markdown pages. Renders BOTH
-// light + dark Prism outputs server-side and lets CSS show the right
-// one based on the `dark` class next-themes paints onto <html> before
-// hydration. Reading the theme via `useTheme()` would race the
-// hydration cycle and produce a brief flash of the wrong palette on
-// every refresh, since `resolvedTheme` is undefined during SSR.
+// Renders every preset's light + dark variants up-front and tags each
+// pane with `data-pane-theme` + `data-pane-mode`. CSS in globals.css
+// (.cf-pane rules) shows only the pane that matches the active
+// combination of `html[data-code-theme]` and `html.dark`. Doing it
+// statically — rather than reading the active preset via React state —
+// means SSR-rendered HTML already contains the right pane for every
+// possible (preset, mode) combination, so a refresh paints the user's
+// saved choice with zero flash.
 const CodeFence = ({ code, language, className }: CodeFenceProps) => {
   const [copied, setCopied] = useState(false);
 
@@ -112,14 +114,24 @@ const CodeFence = ({ code, language, className }: CodeFenceProps) => {
         </button>
       </div>
       {prismLanguage ? (
-        <>
-          <div className="dark:hidden">
-            <Highlighted code={code} language={prismLanguage} theme={themes.github} />
-          </div>
-          <div className="hidden dark:block">
-            <Highlighted code={code} language={prismLanguage} theme={themes.vsDark} />
-          </div>
-        </>
+        CODE_THEME_PRESETS.map((preset) => (
+          <Fragment key={preset.id}>
+            <div
+              className="cf-pane"
+              data-pane-theme={preset.id}
+              data-pane-mode="light"
+            >
+              <Highlighted code={code} language={prismLanguage} theme={preset.light} />
+            </div>
+            <div
+              className="cf-pane"
+              data-pane-theme={preset.id}
+              data-pane-mode="dark"
+            >
+              <Highlighted code={code} language={prismLanguage} theme={preset.dark} />
+            </div>
+          </Fragment>
+        ))
       ) : (
         <pre className="m-0 overflow-x-auto bg-muted p-4 text-sm leading-relaxed">
           <code>{code}</code>

--- a/pwa/components/editor/CodeThemeSwitcher.tsx
+++ b/pwa/components/editor/CodeThemeSwitcher.tsx
@@ -1,0 +1,82 @@
+import { useCallback, useEffect, useState } from "react";
+import { Check, Palette } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  CODE_THEME_PRESETS,
+  CODE_THEME_STORAGE_KEY,
+  DEFAULT_CODE_THEME_ID,
+  isKnownCodeThemeId,
+} from "@/lib/codeThemes";
+
+const readActive = (): string => {
+  if (typeof document === "undefined") return DEFAULT_CODE_THEME_ID;
+  const attr = document.documentElement.dataset.codeTheme;
+  return isKnownCodeThemeId(attr) ? (attr as string) : DEFAULT_CODE_THEME_ID;
+};
+
+// Lets the reader pick which Prism palette renders every code fence on
+// the page. The choice is applied by mutating `html[data-code-theme]`
+// (the CSS rules in globals.css handle the rest) and persisted to
+// localStorage so the inline bootstrap script in `_document.tsx` can
+// restore it on the next page load.
+const CodeThemeSwitcher = () => {
+  const [active, setActive] = useState<string>(DEFAULT_CODE_THEME_ID);
+
+  // Sync from the DOM after mount — the inline bootstrap script has
+  // already stamped the saved value onto <html> by the time React
+  // renders the first frame.
+  useEffect(() => {
+    setActive(readActive());
+  }, []);
+
+  const handlePick = useCallback((id: string) => {
+    document.documentElement.setAttribute("data-code-theme", id);
+    try {
+      localStorage.setItem(CODE_THEME_STORAGE_KEY, id);
+    } catch {
+      // localStorage may be unavailable (private mode) — silently
+      // accept the in-page change.
+    }
+    setActive(id);
+  }, []);
+
+  const activeLabel =
+    CODE_THEME_PRESETS.find((p) => p.id === active)?.label ?? "Code theme";
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm" className="gap-2">
+          <Palette className="h-4 w-4" aria-hidden />
+          <span>{activeLabel}</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-48">
+        <DropdownMenuLabel>Code theme</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {CODE_THEME_PRESETS.map((preset) => (
+          <DropdownMenuItem
+            key={preset.id}
+            onSelect={() => handlePick(preset.id)}
+            className="flex items-center justify-between"
+          >
+            <span>{preset.label}</span>
+            {preset.id === active ? (
+              <Check className="h-4 w-4" aria-hidden />
+            ) : null}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+export default CodeThemeSwitcher;

--- a/pwa/components/editor/CodeThemeSwitcher.tsx
+++ b/pwa/components/editor/CodeThemeSwitcher.tsx
@@ -16,6 +16,15 @@ import {
   isKnownCodeThemeId,
 } from "@/lib/codeThemes";
 
+interface CodeThemeSwitcherProps {
+  /**
+   * `full` — labelled outline button (page-level use).
+   * `compact` — icon-only trigger sized to sit inside the CodeFence
+   * header bar next to the copy button.
+   */
+  variant?: "full" | "compact";
+}
+
 const readActive = (): string => {
   if (typeof document === "undefined") return DEFAULT_CODE_THEME_ID;
   const attr = document.documentElement.dataset.codeTheme;
@@ -27,7 +36,7 @@ const readActive = (): string => {
 // (the CSS rules in globals.css handle the rest) and persisted to
 // localStorage so the inline bootstrap script in `_document.tsx` can
 // restore it on the next page load.
-const CodeThemeSwitcher = () => {
+const CodeThemeSwitcher = ({ variant = "full" }: CodeThemeSwitcherProps) => {
   const [active, setActive] = useState<string>(DEFAULT_CODE_THEME_ID);
 
   // Sync from the DOM after mount — the inline bootstrap script has
@@ -54,10 +63,21 @@ const CodeThemeSwitcher = () => {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="sm" className="gap-2">
-          <Palette className="h-4 w-4" aria-hidden />
-          <span>{activeLabel}</span>
-        </Button>
+        {variant === "compact" ? (
+          <button
+            type="button"
+            aria-label={`Code theme: ${activeLabel}`}
+            title={`Code theme: ${activeLabel}`}
+            className="inline-flex h-6 w-6 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
+          >
+            <Palette className="h-3.5 w-3.5" aria-hidden />
+          </button>
+        ) : (
+          <Button variant="outline" size="sm" className="gap-2">
+            <Palette className="h-4 w-4" aria-hidden />
+            <span>{activeLabel}</span>
+          </Button>
+        )}
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-48">
         <DropdownMenuLabel>Code theme</DropdownMenuLabel>

--- a/pwa/lib/codeThemes.ts
+++ b/pwa/lib/codeThemes.ts
@@ -1,0 +1,31 @@
+import { themes, type PrismTheme } from "prism-react-renderer";
+
+export interface CodeThemePreset {
+  id: string;
+  label: string;
+  light: PrismTheme;
+  dark: PrismTheme;
+}
+
+// Curated pairs — each preset ships a `light` and `dark` palette so the
+// page can paint the right one for whichever mode the user picks. The
+// id is the persisted value (localStorage + `html[data-code-theme]`).
+export const CODE_THEME_PRESETS: readonly CodeThemePreset[] = [
+  { id: "vs", label: "VS Code", light: themes.vsLight, dark: themes.vsDark },
+  { id: "github", label: "GitHub", light: themes.github, dark: themes.vsDark },
+  {
+    id: "nightowl",
+    label: "Night Owl",
+    light: themes.nightOwlLight,
+    dark: themes.nightOwl,
+  },
+  { id: "dracula", label: "Dracula", light: themes.dracula, dark: themes.dracula },
+  { id: "palenight", label: "Palenight", light: themes.palenight, dark: themes.palenight },
+  { id: "oceanic", label: "Oceanic Next", light: themes.oceanicNext, dark: themes.oceanicNext },
+];
+
+export const DEFAULT_CODE_THEME_ID = "vs";
+export const CODE_THEME_STORAGE_KEY = "aura.codeTheme";
+
+export const isKnownCodeThemeId = (id: string | null | undefined): boolean =>
+  typeof id === "string" && CODE_THEME_PRESETS.some((p) => p.id === id);

--- a/pwa/lib/docs.ts
+++ b/pwa/lib/docs.ts
@@ -1,0 +1,116 @@
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join, resolve, sep } from "node:path";
+
+// Server-only — only imported from getStaticPaths / getStaticProps. The
+// markdown tree is mirrored into `pwa/.content/docs/` by
+// `scripts/sync-docs.mjs`, which runs as a predev/prebuild hook.
+const DOCS_ROOT = resolve(process.cwd(), ".content", "docs");
+
+export interface DocSection {
+  slug: string;
+  title: string;
+  entries: DocEntry[];
+}
+
+export interface DocEntry {
+  slug: string[];
+  href: string;
+  title: string;
+  section: string;
+}
+
+const SECTION_LABELS: Record<string, string> = {
+  developer: "Developer",
+  user: "User",
+};
+
+const titleFromFilename = (filename: string): string => {
+  const base = filename.replace(/\.md$/, "");
+  return base
+    .split("-")
+    .map((part) => (part.length > 0 ? part[0].toUpperCase() + part.slice(1) : part))
+    .join(" ");
+};
+
+// First `# heading` line wins, otherwise prettify the filename.
+const titleFromMarkdown = (body: string, filename: string): string => {
+  const match = body.match(/^#\s+(.+?)\s*$/m);
+  if (match) return match[1].trim();
+  return titleFromFilename(filename);
+};
+
+const isMarkdown = (name: string): boolean => name.endsWith(".md");
+
+const walk = async (dir: string, prefix: string[] = []): Promise<DocEntry[]> => {
+  let dirents: string[];
+  try {
+    dirents = await readdir(dir);
+  } catch {
+    return [];
+  }
+  const out: DocEntry[] = [];
+  for (const name of dirents) {
+    const full = join(dir, name);
+    const s = await stat(full);
+    if (s.isDirectory()) {
+      out.push(...(await walk(full, [...prefix, name])));
+    } else if (isMarkdown(name)) {
+      const body = await readFile(full, "utf8");
+      const slug = [...prefix, name.replace(/\.md$/, "")];
+      out.push({
+        slug,
+        href: `/guides/${slug.join("/")}`,
+        title: titleFromMarkdown(body, name),
+        section: prefix[0] ?? "",
+      });
+    }
+  }
+  return out;
+};
+
+export const getAllDocs = async (): Promise<DocEntry[]> => walk(DOCS_ROOT);
+
+export const getDocSections = async (): Promise<DocSection[]> => {
+  const all = await getAllDocs();
+  const bySection = new Map<string, DocEntry[]>();
+  for (const entry of all) {
+    const list = bySection.get(entry.section) ?? [];
+    list.push(entry);
+    bySection.set(entry.section, list);
+  }
+  return Array.from(bySection.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([slug, entries]) => ({
+      slug,
+      title: SECTION_LABELS[slug] ?? titleFromFilename(slug),
+      entries: entries.sort((a, b) => a.title.localeCompare(b.title)),
+    }));
+};
+
+export interface LoadedDoc {
+  slug: string[];
+  title: string;
+  body: string;
+  section: string;
+}
+
+export const loadDoc = async (slug: string[]): Promise<LoadedDoc | null> => {
+  // Defence in depth — Next.js already normalises route params, but we're
+  // joining user-influenced strings onto a filesystem path.
+  if (slug.some((segment) => segment.includes("..") || segment.includes(sep))) {
+    return null;
+  }
+  const path = join(DOCS_ROOT, ...slug) + ".md";
+  let body: string;
+  try {
+    body = await readFile(path, "utf8");
+  } catch {
+    return null;
+  }
+  return {
+    slug,
+    title: titleFromMarkdown(body, slug[slug.length - 1] + ".md"),
+    body,
+    section: slug[0] ?? "",
+  };
+};

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "sync:docs": "node scripts/sync-docs.mjs",
+    "predev": "node scripts/sync-docs.mjs",
+    "prebuild": "node scripts/sync-docs.mjs",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",

--- a/pwa/pages/_document.tsx
+++ b/pwa/pages/_document.tsx
@@ -1,0 +1,45 @@
+import { Html, Head, Main, NextScript } from "next/document";
+import {
+  CODE_THEME_PRESETS,
+  CODE_THEME_STORAGE_KEY,
+  DEFAULT_CODE_THEME_ID,
+} from "@/lib/codeThemes";
+
+// Runs BEFORE React hydrates. Reads the persisted code-theme id from
+// localStorage and stamps it onto `<html data-code-theme="...">`, which
+// the CSS rules in globals.css use to show only the matching code-fence
+// pane. Doing this synchronously before paint is what keeps refreshes
+// flash-free even when the user has picked a non-default theme.
+const codeThemeBootstrap = `
+(function() {
+  try {
+    var ids = ${JSON.stringify(CODE_THEME_PRESETS.map((p) => p.id))};
+    var saved = localStorage.getItem(${JSON.stringify(CODE_THEME_STORAGE_KEY)});
+    var id = saved && ids.indexOf(saved) !== -1 ? saved : ${JSON.stringify(DEFAULT_CODE_THEME_ID)};
+    document.documentElement.setAttribute('data-code-theme', id);
+  } catch (e) {
+    document.documentElement.setAttribute('data-code-theme', ${JSON.stringify(DEFAULT_CODE_THEME_ID)});
+  }
+})();
+`.trim();
+
+const Document = () => (
+  <Html
+    lang="en"
+    data-code-theme={DEFAULT_CODE_THEME_ID}
+    suppressHydrationWarning
+  >
+    <Head>
+      <script
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{ __html: codeThemeBootstrap }}
+      />
+    </Head>
+    <body>
+      <Main />
+      <NextScript />
+    </body>
+  </Html>
+);
+
+export default Document;

--- a/pwa/pages/guides/[...slug].tsx
+++ b/pwa/pages/guides/[...slug].tsx
@@ -1,11 +1,32 @@
+import { Children, isValidElement, type ReactElement } from "react";
 import type { GetStaticPaths, GetStaticProps } from "next";
 import Head from "next/head";
 import Link from "next/link";
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { ChevronLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import CodeFence from "@/components/editor/CodeFence";
 import { getAllDocs, loadDoc, type LoadedDoc } from "@/lib/docs";
+
+// `<pre>` override: react-markdown wraps a fenced code block as
+// `<pre><code className="language-xxx">{code}</code></pre>`. Unwrap it
+// to extract the language + raw source and hand off to CodeFence, which
+// runs Prism. Plain `<pre>` (no language) falls back to default styling.
+const renderPre: Components["pre"] = ({ children }) => {
+  const only = Children.toArray(children).find(isValidElement) as
+    | ReactElement<{ className?: string; children?: unknown }>
+    | undefined;
+  const className = only?.props.className ?? "";
+  const match = /language-([\w+-]+)/.exec(className);
+  if (only && match) {
+    const code = String(only.props.children ?? "").replace(/\n$/, "");
+    return <CodeFence code={code} language={match[1]} />;
+  }
+  return <pre>{children}</pre>;
+};
+
+const MARKDOWN_COMPONENTS: Components = { pre: renderPre };
 
 interface Props {
   doc: LoadedDoc;
@@ -45,7 +66,12 @@ const GuidePage = ({ doc, sectionLabel }: Props) => (
         </header>
 
         <article className="doc-content">
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>{doc.body}</ReactMarkdown>
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
+            components={MARKDOWN_COMPONENTS}
+          >
+            {doc.body}
+          </ReactMarkdown>
         </article>
       </div>
     </main>

--- a/pwa/pages/guides/[...slug].tsx
+++ b/pwa/pages/guides/[...slug].tsx
@@ -1,0 +1,76 @@
+import type { GetStaticPaths, GetStaticProps } from "next";
+import Head from "next/head";
+import Link from "next/link";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { ChevronLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { getAllDocs, loadDoc, type LoadedDoc } from "@/lib/docs";
+
+interface Props {
+  doc: LoadedDoc;
+  sectionLabel: string;
+}
+
+const SECTION_LABELS: Record<string, string> = {
+  developer: "Developer",
+  user: "User",
+};
+
+const GuidePage = ({ doc, sectionLabel }: Props) => (
+  <>
+    <Head>
+      <title>{`${doc.title} — Aura guides`}</title>
+      <meta
+        name="description"
+        content={`${doc.title} — ${sectionLabel} documentation for Aura.`}
+      />
+    </Head>
+    <main className="bg-background">
+      <div className="mx-auto max-w-3xl px-6 py-10 md:py-16">
+        <Button asChild variant="ghost" size="sm" className="mb-6 -ml-2 gap-1">
+          <Link href="/guides">
+            <ChevronLeft className="h-4 w-4" aria-hidden />
+            All guides
+          </Link>
+        </Button>
+
+        <header className="mb-8 border-b pb-6">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">
+            {sectionLabel}
+          </p>
+          <h1 className="mt-1 text-3xl md:text-4xl font-bold tracking-tight">
+            {doc.title}
+          </h1>
+        </header>
+
+        <article className="doc-content">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{doc.body}</ReactMarkdown>
+        </article>
+      </div>
+    </main>
+  </>
+);
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const docs = await getAllDocs();
+  return {
+    paths: docs.map((d) => ({ params: { slug: d.slug } })),
+    fallback: false,
+  };
+};
+
+export const getStaticProps: GetStaticProps<Props> = async (context) => {
+  const raw = context.params?.slug;
+  const slug = Array.isArray(raw) ? raw : raw ? [raw] : [];
+  const doc = await loadDoc(slug);
+  if (!doc) return { notFound: true };
+  return {
+    props: {
+      doc,
+      sectionLabel: SECTION_LABELS[doc.section] ?? doc.section,
+    },
+  };
+};
+
+export default GuidePage;

--- a/pwa/pages/guides/[...slug].tsx
+++ b/pwa/pages/guides/[...slug].tsx
@@ -7,7 +7,6 @@ import remarkGfm from "remark-gfm";
 import { ChevronLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import CodeFence from "@/components/editor/CodeFence";
-import CodeThemeSwitcher from "@/components/editor/CodeThemeSwitcher";
 import { getAllDocs, loadDoc, type LoadedDoc } from "@/lib/docs";
 
 // `<pre>` override: react-markdown wraps a fenced code block as
@@ -50,15 +49,12 @@ const GuidePage = ({ doc, sectionLabel }: Props) => (
     </Head>
     <main className="bg-background">
       <div className="mx-auto max-w-3xl px-6 py-10 md:py-16">
-        <div className="mb-6 flex items-center justify-between">
-          <Button asChild variant="ghost" size="sm" className="-ml-2 gap-1">
-            <Link href="/guides">
-              <ChevronLeft className="h-4 w-4" aria-hidden />
-              All guides
-            </Link>
-          </Button>
-          <CodeThemeSwitcher />
-        </div>
+        <Button asChild variant="ghost" size="sm" className="mb-6 -ml-2 gap-1">
+          <Link href="/guides">
+            <ChevronLeft className="h-4 w-4" aria-hidden />
+            All guides
+          </Link>
+        </Button>
 
         <header className="mb-8 border-b pb-6">
           <p className="text-xs uppercase tracking-wide text-muted-foreground">

--- a/pwa/pages/guides/[...slug].tsx
+++ b/pwa/pages/guides/[...slug].tsx
@@ -7,6 +7,7 @@ import remarkGfm from "remark-gfm";
 import { ChevronLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import CodeFence from "@/components/editor/CodeFence";
+import CodeThemeSwitcher from "@/components/editor/CodeThemeSwitcher";
 import { getAllDocs, loadDoc, type LoadedDoc } from "@/lib/docs";
 
 // `<pre>` override: react-markdown wraps a fenced code block as
@@ -49,12 +50,15 @@ const GuidePage = ({ doc, sectionLabel }: Props) => (
     </Head>
     <main className="bg-background">
       <div className="mx-auto max-w-3xl px-6 py-10 md:py-16">
-        <Button asChild variant="ghost" size="sm" className="mb-6 -ml-2 gap-1">
-          <Link href="/guides">
-            <ChevronLeft className="h-4 w-4" aria-hidden />
-            All guides
-          </Link>
-        </Button>
+        <div className="mb-6 flex items-center justify-between">
+          <Button asChild variant="ghost" size="sm" className="-ml-2 gap-1">
+            <Link href="/guides">
+              <ChevronLeft className="h-4 w-4" aria-hidden />
+              All guides
+            </Link>
+          </Button>
+          <CodeThemeSwitcher />
+        </div>
 
         <header className="mb-8 border-b pb-6">
           <p className="text-xs uppercase tracking-wide text-muted-foreground">

--- a/pwa/pages/guides/index.tsx
+++ b/pwa/pages/guides/index.tsx
@@ -1,0 +1,76 @@
+import type { GetStaticProps } from "next";
+import Head from "next/head";
+import Link from "next/link";
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { getDocSections, type DocSection } from "@/lib/docs";
+
+interface Props {
+  sections: DocSection[];
+}
+
+const GuidesIndex = ({ sections }: Props) => (
+  <>
+    <Head>
+      <title>Guides — Aura</title>
+      <meta
+        name="description"
+        content="User and developer documentation for Aura."
+      />
+    </Head>
+    <main className="bg-background">
+      <div className="mx-auto max-w-5xl px-6 py-10 md:py-16">
+        <header className="mb-10">
+          <h1 className="text-3xl md:text-4xl font-bold tracking-tight">
+            Guides
+          </h1>
+          <p className="mt-2 max-w-2xl text-muted-foreground">
+            User-facing how-tos and developer reference, rendered from the
+            project&apos;s markdown docs.
+          </p>
+        </header>
+
+        {sections.length === 0 ? (
+          <p className="text-muted-foreground">
+            No documentation pages have been published yet.
+          </p>
+        ) : (
+          sections.map((section) => (
+            <section key={section.slug} className="mb-10">
+              <div className="mb-3 flex items-baseline gap-3">
+                <h2 className="text-xl font-medium">{section.title}</h2>
+                <Badge variant="secondary">{section.entries.length}</Badge>
+              </div>
+              <div className="grid gap-3 sm:grid-cols-2">
+                {section.entries.map((entry) => (
+                  <Link
+                    key={entry.href}
+                    href={entry.href}
+                    className="no-underline"
+                  >
+                    <Card className="h-full transition-colors hover:border-primary">
+                      <CardHeader>
+                        <CardTitle className="text-base">
+                          {entry.title}
+                        </CardTitle>
+                        <CardDescription className="font-mono text-xs">
+                          {entry.slug.join("/")}.md
+                        </CardDescription>
+                      </CardHeader>
+                    </Card>
+                  </Link>
+                ))}
+              </div>
+            </section>
+          ))
+        )}
+      </div>
+    </main>
+  </>
+);
+
+export const getStaticProps: GetStaticProps<Props> = async () => ({
+  props: { sections: await getDocSections() },
+});
+
+export default GuidesIndex;

--- a/pwa/scripts/sync-docs.mjs
+++ b/pwa/scripts/sync-docs.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+// Copies the repo-root `docs/` tree into `pwa/.content/docs/` so the
+// markdown viewer routes can read it via `fs` at build time without
+// reaching outside the package. Idempotent and tolerant of a missing
+// source — Docker prod builds run this against the already-staged copy.
+import { cp, stat, mkdir, rm } from "node:fs/promises";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const dst = resolve(here, "..", ".content", "docs");
+
+// Source candidates, in priority order:
+//  1. `../../docs` — repo root when running on the host (`pnpm dev` /
+//     `pnpm build` from `pwa/`) or inside the Docker dev container with
+//     the `./docs:/srv/docs` bind mount in compose.override.yaml.
+//  2. `/srv/docs` — same Docker dev bind mount, addressed absolutely.
+const candidates = [
+  resolve(here, "..", "..", "docs"),
+  "/srv/docs",
+];
+
+let src = null;
+for (const c of candidates) {
+  try {
+    const s = await stat(c);
+    if (s.isDirectory()) {
+      src = c;
+      break;
+    }
+  } catch {
+    // not found — try the next candidate
+  }
+}
+
+if (!src) {
+  // Likely running inside the Docker prod build context where the docs
+  // were already staged by an earlier step (or just not available). The
+  // page reads from `.content/docs/` and renders an empty list if absent.
+  console.warn(
+    "[sync-docs] No source `docs/` directory found; leaving .content/docs/ as-is.",
+  );
+  process.exit(0);
+}
+
+// `cp({ recursive, force })` overwrites existing entries but won't remove
+// files the source no longer has — wipe first to keep deletions in sync.
+await rm(dst, { recursive: true, force: true });
+await mkdir(dst, { recursive: true });
+await cp(src, dst, { recursive: true });
+console.log(`[sync-docs] Synced ${src} -> ${dst}`);

--- a/pwa/styles/globals.css
+++ b/pwa/styles/globals.css
@@ -226,6 +226,27 @@
  * inside the body when it duplicates the filename-derived title. */
 .doc-content > h1:first-child { @apply hidden; }
 
+/* Code-fence theme switching — all preset variants are SSR'd by
+ * CodeFence; CSS keeps only the one matching the active
+ * `html[data-code-theme]` + `html.dark` combination visible. The
+ * inline script in `_document.tsx` stamps `data-code-theme` before
+ * React hydrates, so refreshes paint the right pane without flash. */
+.cf-pane { display: none; }
+html:not(.dark)[data-code-theme="vs"] .cf-pane[data-pane-theme="vs"][data-pane-mode="light"],
+html.dark[data-code-theme="vs"] .cf-pane[data-pane-theme="vs"][data-pane-mode="dark"],
+html:not(.dark)[data-code-theme="github"] .cf-pane[data-pane-theme="github"][data-pane-mode="light"],
+html.dark[data-code-theme="github"] .cf-pane[data-pane-theme="github"][data-pane-mode="dark"],
+html:not(.dark)[data-code-theme="nightowl"] .cf-pane[data-pane-theme="nightowl"][data-pane-mode="light"],
+html.dark[data-code-theme="nightowl"] .cf-pane[data-pane-theme="nightowl"][data-pane-mode="dark"],
+html:not(.dark)[data-code-theme="dracula"] .cf-pane[data-pane-theme="dracula"][data-pane-mode="light"],
+html.dark[data-code-theme="dracula"] .cf-pane[data-pane-theme="dracula"][data-pane-mode="dark"],
+html:not(.dark)[data-code-theme="palenight"] .cf-pane[data-pane-theme="palenight"][data-pane-mode="light"],
+html.dark[data-code-theme="palenight"] .cf-pane[data-pane-theme="palenight"][data-pane-mode="dark"],
+html:not(.dark)[data-code-theme="oceanic"] .cf-pane[data-pane-theme="oceanic"][data-pane-mode="light"],
+html.dark[data-code-theme="oceanic"] .cf-pane[data-pane-theme="oceanic"][data-pane-mode="dark"] {
+    display: block;
+}
+
 /* BlockNote owns its own background; just round the outer container. */
 .bn-container {
     @apply rounded-md;

--- a/pwa/styles/globals.css
+++ b/pwa/styles/globals.css
@@ -194,6 +194,36 @@
 .markdown-view th { @apply bg-muted font-semibold text-left; }
 .markdown-view input[type="checkbox"] { @apply mr-1 align-middle; }
 
+/* Long-form rendered markdown — sized for full doc pages (/guides). */
+.doc-content {
+    @apply text-base text-foreground leading-7 break-words;
+}
+.doc-content h1 { @apply text-2xl font-semibold mt-8 mb-3; }
+.doc-content h2 { @apply text-xl font-semibold mt-8 mb-3 pt-2 border-t; }
+.doc-content h3 { @apply text-lg font-semibold mt-6 mb-2; }
+.doc-content h4, .doc-content h5, .doc-content h6 { @apply text-base font-semibold mt-4 mb-2; }
+.doc-content p { @apply my-3; }
+.doc-content ul { @apply list-disc pl-6 my-3; }
+.doc-content ol { @apply list-decimal pl-6 my-3; }
+.doc-content li { @apply my-1; }
+.doc-content li > p { @apply my-1; }
+.doc-content a { @apply text-primary underline underline-offset-4; }
+.doc-content strong { @apply font-semibold; }
+.doc-content em { @apply italic; }
+.doc-content blockquote { @apply border-l-4 border-border pl-4 my-4 text-muted-foreground italic; }
+.doc-content code { @apply bg-muted rounded px-1.5 py-0.5 text-[0.875em] font-mono; }
+.doc-content pre { @apply bg-muted rounded-md p-4 my-4 overflow-x-auto; }
+.doc-content pre code { @apply bg-transparent p-0 text-sm; }
+.doc-content hr { @apply my-6 border-border; }
+.doc-content table { @apply border-collapse my-4 w-full text-sm; }
+.doc-content th, .doc-content td { @apply border border-border px-3 py-2 align-top; }
+.doc-content th { @apply bg-muted font-semibold text-left; }
+.doc-content input[type="checkbox"] { @apply mr-1 align-middle; }
+.doc-content > :first-child { @apply mt-0; }
+/* The page header already renders the doc title, so suppress a leading H1
+ * inside the body when it duplicates the filename-derived title. */
+.doc-content > h1:first-child { @apply hidden; }
+
 /* BlockNote owns its own background; just round the outer container. */
 .bn-container {
     @apply rounded-md;

--- a/pwa/styles/globals.css
+++ b/pwa/styles/globals.css
@@ -212,8 +212,10 @@
 .doc-content em { @apply italic; }
 .doc-content blockquote { @apply border-l-4 border-border pl-4 my-4 text-muted-foreground italic; }
 .doc-content code { @apply bg-muted rounded px-1.5 py-0.5 text-[0.875em] font-mono; }
-.doc-content pre { @apply bg-muted rounded-md p-4 my-4 overflow-x-auto; }
-.doc-content pre code { @apply bg-transparent p-0 text-sm; }
+/* `>` selectors so CodeFence's own <pre> (wrapped in a styled <div>)
+ * isn't doubled up with default padding / background. */
+.doc-content > pre { @apply bg-muted rounded-md p-4 my-4 overflow-x-auto; }
+.doc-content > pre > code { @apply bg-transparent p-0 text-sm; }
 .doc-content hr { @apply my-6 border-border; }
 .doc-content table { @apply border-collapse my-4 w-full text-sm; }
 .doc-content th, .doc-content td { @apply border border-border px-3 py-2 align-top; }


### PR DESCRIPTION
## Summary

- Adds a public `/guides` route that renders the repo-root `docs/` tree (developer + user markdown) as styled pages — index groups by section, catch-all `[...slug]` renders each `.md` via `react-markdown` + `remark-gfm`.
- Drops the **Docs** dropdown from the navbar and adds a site-wide **Footer** carrying the developer-facing links (API reference, API guide, architecture, component library).
- Syntax-highlights fenced code blocks via `prism-react-renderer` (already in the tree from the component-library docs) with a per-fence language label and copy button.
- Ships a **flash-free code-theme switcher** in the fence header bar: six curated Prism palettes (VS Code, GitHub, Night Owl, Dracula, Palenight, Oceanic Next), persisted to localStorage, applied before React hydrates by an inline bootstrap script in `_document.tsx`. CSS shows only the active `(preset, mode)` pane out of the variants SSR'd up front, so a refresh paints the saved palette with zero flash.
- Markdown is mirrored into `pwa/.content/docs/` by `scripts/sync-docs.mjs`, hooked to `predev` / `prebuild`. Docker dev mounts `./docs:/srv/docs:ro` so the script finds a source in-container; `.dockerignore` re-includes `.content/docs/**/*.md` for prod builds.

## Test plan

- [ ] `pnpm typecheck` green
- [ ] `/guides` index lists all docs grouped by Developer / User
- [ ] Each `/guides/<section>/<slug>` page renders the matching `.md` with headings, lists, tables, and code blocks
- [ ] Footer shows on every page; navbar no longer has the Docs dropdown
- [ ] Code blocks: syntax-highlighted in both light and dark mode; refreshing in dark mode does not flash to the light palette
- [ ] Palette dropdown in any code fence header swaps every code block on the page; choice persists across refresh with no flash
- [ ] Copy button copies the raw source for that block
- [ ] Docker prod build still produces a working PWA image (`.dockerignore` allow rule + sync script)