### PR TITLE
security: prevent request forgery via tainted fetch URLs

### DIFF
--- a/pwa/lib/fetchWithTimeout.ts
+++ b/pwa/lib/fetchWithTimeout.ts
@@ -8,6 +8,32 @@
 const DEFAULT_TIMEOUT_MS = 10_000;
 
 /**
+ * Resolve the request target and refuse anything that isn't same-origin
+ * with the app. Every caller talks to our own API (`ENTRYPOINT`, which is
+ * `window.origin` in the browser), so a cross-origin target can only be the
+ * result of a tainted URL — block it before the request leaves the browser
+ * with the user's session cookies attached (request-forgery defense).
+ */
+function assertSameOrigin(input: RequestInfo | URL): void {
+  if (typeof window === "undefined") return;
+  const raw =
+    typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.href
+        : input.url;
+  let resolved: URL;
+  try {
+    resolved = new URL(raw, window.location.href);
+  } catch {
+    throw new Error("Refusing to fetch an invalid URL.");
+  }
+  if (resolved.origin !== window.location.origin) {
+    throw new Error("Refusing to fetch a cross-origin URL.");
+  }
+}
+
+/**
  * Thin `fetch` wrapper that wires an `AbortSignal.timeout()` deadline
  * onto the request and re-throws DOMException("TimeoutError") as a
  * human-readable `Error("Network timeout. Please try again.")`. Any
@@ -22,6 +48,7 @@ export async function fetchWithTimeout(
   input: RequestInfo | URL,
   init: RequestInit & { timeoutMs?: number } = {},
 ): Promise<Response> {
+  assertSameOrigin(input);
   const { timeoutMs = DEFAULT_TIMEOUT_MS, signal, ...rest } = init;
   const effectiveSignal = signal ?? AbortSignal.timeout(timeoutMs);
   try {

--- a/pwa/pages/admin/segments/[id].tsx
+++ b/pwa/pages/admin/segments/[id].tsx
@@ -76,10 +76,13 @@ const AdminSegmentDetail: NextPage = () => {
   const load = useCallback(async () => {
     if (!id) return;
     try {
-      const res = await fetchWithTimeout(`${ENTRYPOINT}/segments/${id}`, {
-        credentials: "include",
-        headers: { Accept: "application/ld+json" },
-      });
+      const res = await fetchWithTimeout(
+        `${ENTRYPOINT}/segments/${encodeURIComponent(id)}`,
+        {
+          credentials: "include",
+          headers: { Accept: "application/ld+json" },
+        },
+      );
       if (res.status === 404) {
         setNotFound(true);
         return;


### PR DESCRIPTION
## What

Resolves the open **critical CodeQL alert [#14](https://github.com/roboparker/Aura/security/code-scanning/14) (`js/request-forgery`)** — "The URL of this request depends on a user-provided value" — at `pwa/lib/fetchWithTimeout.ts`.

## Why

`fetchWithTimeout` is the flagged sink. Its one caller that fed a **user-controlled value straight into the URL path** is the admin segment detail page, where `id = router.query.id` was interpolated unescaped into `` `${ENTRYPOINT}/segments/${id}` ``. Without encoding, a crafted `id` (e.g. `../something`) could redirect the authenticated, cookie-bearing request to a different API endpoint — request forgery.

Other dynamic-route callers were checked and are safe: invite tokens were already `encodeURIComponent`-wrapped, and email-change / reset tokens travel in the request body, not the URL.

## Changes

1. **Root-cause fix** — wrap the tainted path segment in `encodeURIComponent(id)` at `pwa/pages/admin/segments/[id].tsx`, the precise CodeQL-recognized remediation that breaks the traced flow.
2. **Defense-in-depth** — add an `assertSameOrigin` guard inside `fetchWithTimeout` that resolves the target URL and throws if it isn't same-origin with the app. Every caller targets `ENTRYPOINT` (= `window.origin`), so this is a no-op for legitimate traffic but blocks any future tainted URL from leaving the browser with the user's session cookies. No-op during SSR.

## Notes

- Couldn't run the PWA typecheck locally (no Node toolchain in the dev environment); CI's **PWA Typecheck** check will validate.
- Separate open **Dependabot alert #104** (high, `react-router`) is a dependency bump, out of scope for this code fix.
