### PR TITLE
docs: sync developer docs + component library with current code

### DIFF
--- a/docs/developer/deployment.md
+++ b/docs/developer/deployment.md
@@ -101,13 +101,14 @@ Ensure all secrets are set to strong, unique values in production.
 
 ### Deploy
 ```bash
+cd helm
 skaffold run
 ```
 
 ### Configuration
 - Helm chart: `helm/api-platform/`
-- Skaffold config: `skaffold.yaml`
-- Values override: `skaffold-values.yaml`
+- Skaffold config: `helm/skaffold.yaml`
+- Values override: `helm/skaffold-values.yaml`
 
 ## CI/CD
 

--- a/docs/developer/mcp-server.md
+++ b/docs/developer/mcp-server.md
@@ -37,7 +37,7 @@ curl -X POST https://your-aura/api-tokens \
 
 The response includes a one-shot `plainToken` field — copy it; subsequent `GET /api-tokens` calls do not return it again. The persisted database row stores only the sha256 hash.
 
-`scopes` is an array of MCP tool names. The empty array (default) means "all tools." Narrow tokens to e.g. `["get_task", "list_tasks"]` for read-only access.
+`scopes` is an array drawn from a fixed **resource vocabulary** (`ApiToken::SCOPE_VOCABULARY`), `Assert\Choice`-validated: `read:tasks`, `write:tasks`, `read:projects`, `write:projects`, `read:pages`, `admin`. The empty array (default) means "all tools." Each registered tool maps to a required scope via `App\Mcp\ScopeMap`, with `write:*` implying the matching `read:*` and `admin` acting as a superset — so e.g. `["read:tasks", "read:projects"]` yields a read-only token. (Raw tool names like `get_task` are **not** valid scope values and will be rejected.)
 
 `POST /api-tokens` and `GET /api-tokens` use the cookie-based PWA session (firewall: `main`); the `/mcp` firewall is independent and accepts only Bearer tokens.
 
@@ -58,7 +58,7 @@ The response includes a one-shot `plainToken` field — copy it; subsequent `GET
 
 Call `tools/list` to inspect each tool's JSON Schema. Tools execute as the user that owns the bearer token; visibility, edit, and delete rules mirror the existing API Platform `security:` expressions on each entity.
 
-> **Custom field values** — `set_custom_field` is intentionally not yet exposed: the underlying `CustomFieldValue` entity isn't built (only definitions, from #84). `get_custom_fields` returns the project's defined fields so MCP callers can prepare for the value-write surface once it lands.
+> **Custom field values** — `get_custom_fields` returns a project's defined fields (`CustomFieldDefinition`). Per-task values (`CustomFieldValue`, #227) are written through the REST Task `customFieldValues` array; a dedicated `set_custom_field` MCP tool is not yet exposed.
 
 ## Errors
 

--- a/pwa/components/dev/registry.ts
+++ b/pwa/components/dev/registry.ts
@@ -8,7 +8,6 @@ export type RegistryEntry = {
     | "Data"
     | "Editor"
     | "User"
-    | "Theme"
     | "Layout"
     | "Discussions"
     | "Custom fields"
@@ -34,20 +33,28 @@ export const componentRegistry: RegistryEntry[] = [
   { slug: "formik-field", name: "FormikField", category: "Form", description: "Formik-aware label + input + error wrapper." },
   { slug: "input", name: "Input", category: "Form", description: "Single-line text input." },
   { slug: "input-group", name: "InputGroup", category: "Form", description: "Compose an input with leading/trailing addons." },
+  { slug: "input-otp", name: "InputOTP", category: "Form", description: "Segmented one-time-code input (slots + separator) built on input-otp." },
+  { slug: "color-swatch-picker", name: "ColorSwatchPicker", category: "Form", description: "Stateless radiogroup row of color swatches with a saving pulse state." },
+  { slug: "email-chip-input", name: "EmailChipInput", category: "Form", description: "Controlled multi-email chip input with paste-split, validation ring, and colored tiles." },
   { slug: "label", name: "Label", category: "Form", description: "Accessible label associated to a form control." },
   { slug: "popover", name: "Popover", category: "Overlay", description: "Floating content anchored to a trigger." },
   { slug: "separator", name: "Separator", category: "Primitive", description: "Horizontal or vertical divider." },
   { slug: "sheet", name: "Sheet", category: "Overlay", description: "Side-anchored drawer." },
   { slug: "switch", name: "Switch", category: "Form", description: "On/off toggle built on @base-ui/react." },
   { slug: "table", name: "Table", category: "Data", description: "Styled HTML table primitives." },
+  { slug: "comments-panel", name: "CommentsPanel", category: "Data", description: "Flat chronological comment thread with composer, inline edit/delete, and a lockable composer." },
   { slug: "tabs", name: "Tabs", category: "Primitive", description: "Tab list + panels." },
   { slug: "textarea", name: "Textarea", category: "Form", description: "Multi-line text input." },
   { slug: "markdown-editor", name: "MarkdownEditor", category: "Editor", description: "BlockNote-backed WYSIWYG markdown editor." },
   { slug: "markdown-view", name: "MarkdownView", category: "Editor", description: "Read-only markdown renderer." },
+  { slug: "code-fence", name: "CodeFence", category: "Editor", description: "Syntax-highlighted code block with copy button and per-page theme switcher." },
+  { slug: "code-theme-switcher", name: "CodeThemeSwitcher", category: "Editor", description: "Dropdown to pick the Prism palette for code fences; persisted to localStorage." },
   { slug: "user-avatar", name: "UserAvatar", category: "User", description: "Avatar with image fallback to personalized initials." },
   { slug: "avatar-stack", name: "AvatarStack", category: "User", description: "Overlapping avatar cluster with a +N overflow chip." },
-  { slug: "layout", name: "Layout", category: "Layout", description: "App-shell wrapper: providers + persistent Navbar and Sidebar." },
-  { slug: "navbar", name: "Navbar", category: "Layout", description: "Top app bar with wordmark, search, badges, and mobile sheet." },
+  { slug: "layout", name: "Layout", category: "Layout", description: "App-shell wrapper: providers + persistent Sidebar, Navbar, and Footer." },
+  { slug: "navbar", name: "Navbar", category: "Layout", description: "Top app bar with breadcrumbs/wordmark, search, badges, and mobile sheet." },
+  { slug: "breadcrumbs", name: "Breadcrumbs", category: "Layout", description: "URL-derived navbar breadcrumb trail; lazy-fetches entity names for UUID segments." },
+  { slug: "footer", name: "Footer", category: "Layout", description: "Static site footer with product, developer, and project link columns." },
   { slug: "sidebar", name: "Sidebar", category: "Layout", description: "Persistent left navigation column (md and up, authenticated only)." },
   { slug: "sidebar-nav", name: "SidebarNav", category: "Layout", description: "Shared nav contents used by the persistent sidebar and the mobile sheet." },
   { slug: "search-bar", name: "SearchBar", category: "Layout", description: "Navbar task search with debounced autocomplete; ⌘K opens the SearchOverlay palette." },

--- a/pwa/pages/dev/components/breadcrumbs.tsx
+++ b/pwa/pages/dev/components/breadcrumbs.tsx
@@ -1,0 +1,21 @@
+import Breadcrumbs from "@/components/common/Breadcrumbs";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const BreadcrumbsPage = () => (
+  <ComponentDoc
+    name="Breadcrumbs"
+    description="URL-derived breadcrumb trail for the navbar. Top-level segments come from a static label registry; UUID segments are treated as entity ids — the previous segment names the resource and the display name is lazy-fetched (`/{resource}/{id}`) and cached via react-query. The last crumb is the current page and isn't a link. Renders nothing on the home page and auth screens (it stands in for the Aura wordmark on every other authenticated route). Only prop is `className`."
+    importPath={`import Breadcrumbs from "@/components/common/Breadcrumbs";`}
+    examples={[
+      {
+        title: "Derived from the current path",
+        description:
+          "Rendered live below — the trail reflects this page's own URL (Home / Dev / Components / Breadcrumbs).",
+        code: `<Breadcrumbs className="hidden md:flex flex-1 min-w-0" />`,
+        preview: <Breadcrumbs />,
+      },
+    ]}
+  />
+);
+
+export default BreadcrumbsPage;

--- a/pwa/pages/dev/components/code-fence.tsx
+++ b/pwa/pages/dev/components/code-fence.tsx
@@ -1,0 +1,32 @@
+import CodeFence from "@/components/editor/CodeFence";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const TS_SAMPLE = `export function greet(name: string): string {
+  return \`Hello, \${name}!\`;
+}`;
+
+const CodeFencePage = () => (
+  <ComponentDoc
+    name="CodeFence"
+    description="Syntax-highlighted code block (prism-react-renderer) with a copy button and a per-page CodeThemeSwitcher in the header bar. `language` is normalised (ts→typescript, sh→bash, etc.); an unknown language falls through to plain monospace rather than throwing. Every preset's palette is rendered up-front and CSS shows only the active one, so a saved theme paints with no flash on load. Used to render fenced code in the guides."
+    importPath={`import CodeFence from "@/components/editor/CodeFence";`}
+    examples={[
+      {
+        title: "TypeScript",
+        code: `<CodeFence language="ts" code={tsSource} />`,
+        preview: <CodeFence language="ts" code={TS_SAMPLE} />,
+      },
+      {
+        title: "Unknown language (plain fallback)",
+        description:
+          "A language outside Prism's set renders as plain monospace — the header still shows the label and copy button.",
+        code: `<CodeFence language="brainfuck" code="++++++++[>++++++++<-]>+." />`,
+        preview: (
+          <CodeFence language="brainfuck" code="++++++++[>++++++++<-]>+." />
+        ),
+      },
+    ]}
+  />
+);
+
+export default CodeFencePage;

--- a/pwa/pages/dev/components/code-theme-switcher.tsx
+++ b/pwa/pages/dev/components/code-theme-switcher.tsx
@@ -1,0 +1,28 @@
+import CodeThemeSwitcher from "@/components/editor/CodeThemeSwitcher";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const CodeThemeSwitcherPage = () => (
+  <ComponentDoc
+    name="CodeThemeSwitcher"
+    description="Dropdown that picks which Prism palette renders every CodeFence on the page. The choice mutates `html[data-code-theme]` (CSS in globals.css does the rest) and persists to localStorage so the inline bootstrap script in _document.tsx restores it on the next load. The `full` variant is a labelled outline button for page-level use; the `compact` variant is the icon-only trigger embedded in the CodeFence header bar."
+    importPath={`import CodeThemeSwitcher from "@/components/editor/CodeThemeSwitcher";`}
+    examples={[
+      {
+        title: "Full (labelled button)",
+        description:
+          "Page-level control showing the active preset's name. Picking a theme re-paints every code fence on the page.",
+        code: `<CodeThemeSwitcher variant="full" />`,
+        preview: <CodeThemeSwitcher variant="full" />,
+      },
+      {
+        title: "Compact (icon-only)",
+        description:
+          "The trigger used inside the CodeFence header next to the copy button.",
+        code: `<CodeThemeSwitcher variant="compact" />`,
+        preview: <CodeThemeSwitcher variant="compact" />,
+      },
+    ]}
+  />
+);
+
+export default CodeThemeSwitcherPage;

--- a/pwa/pages/dev/components/color-swatch-picker.tsx
+++ b/pwa/pages/dev/components/color-swatch-picker.tsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+import ColorSwatchPicker from "@/components/common/ColorSwatchPicker";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const Basic = () => {
+  const [color, setColor] = useState("#0e7490");
+  return (
+    <ColorSwatchPicker
+      value={color}
+      onChange={setColor}
+      ariaLabel="Avatar color"
+    />
+  );
+};
+
+const Saving = () => {
+  const [color, setColor] = useState("#9333ea");
+  return (
+    <ColorSwatchPicker
+      value={color}
+      onChange={setColor}
+      savingColor={color}
+      ariaLabel="Avatar color (saving)"
+    />
+  );
+};
+
+const ColorSwatchPickerPage = () => (
+  <ComponentDoc
+    name="ColorSwatchPicker"
+    description="Stateless `radiogroup` row of round color swatches — the picker shape used for avatar color in account settings and reused on the create/edit space + group surfaces. The caller owns `value` and is notified via `onChange`. Defaults to `AVATAR_PALETTE`; pass `options` to override. `savingColor` pulses the in-flight swatch and `disabled` short-circuits all interaction so a form can stop the user racing an async save."
+    importPath={`import ColorSwatchPicker from "@/components/common/ColorSwatchPicker";`}
+    examples={[
+      {
+        title: "Default palette",
+        description:
+          "The selected swatch scales up with a ring. Click another to change the controlled value.",
+        code: `const [color, setColor] = useState("#0e7490");
+
+<ColorSwatchPicker
+  value={color}
+  onChange={setColor}
+  ariaLabel="Avatar color"
+/>`,
+        preview: <Basic />,
+      },
+      {
+        title: "Saving state",
+        description:
+          "Pass the in-flight color to `savingColor` to pulse it while an async save resolves.",
+        code: `<ColorSwatchPicker
+  value={color}
+  onChange={setColor}
+  savingColor={color}
+  ariaLabel="Avatar color"
+/>`,
+        preview: <Saving />,
+      },
+    ]}
+  />
+);
+
+export default ColorSwatchPickerPage;

--- a/pwa/pages/dev/components/comments-panel.tsx
+++ b/pwa/pages/dev/components/comments-panel.tsx
@@ -1,0 +1,119 @@
+import CommentsPanel, { type Comment } from "@/components/common/CommentsPanel";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const ada = {
+  "@id": "/users/1",
+  id: "1",
+  givenName: "Ada",
+  familyName: "Lovelace",
+  personalizedColor: "#0e7490",
+};
+
+const lin = {
+  "@id": "/users/2",
+  id: "2",
+  givenName: "Lin",
+  familyName: "Mei",
+  personalizedColor: "#9333ea",
+};
+
+const sampleComments: Comment[] = [
+  {
+    "@id": "/comments/1",
+    id: "1",
+    body: "First pass looks great — let's ship it.",
+    author: ada,
+    createdAt: "2026-06-05T09:00:00Z",
+    updatedAt: null,
+  },
+  {
+    "@id": "/comments/2",
+    id: "2",
+    body: "Thanks! I'll clean up the edge cases first.",
+    author: lin,
+    createdAt: "2026-06-05T10:30:00Z",
+    updatedAt: null,
+  },
+];
+
+const noop = async () => {};
+
+const CommentsPanelPage = () => (
+  <ComponentDoc
+    name="CommentsPanel"
+    description="Flat chronological comment thread (#228) shared across task, page, and discussion parents — the surrounding page owns the create/edit/delete handlers and passes a `parentLabel`; the panel knows nothing about the parent type. Comments render in `createdAt` order with author avatars; `@mention` tokens render as inline markdown (notifications fire server-side). `currentUserIri` + `canModerate` gate the inline edit/delete affordances. Setting `canCompose={false}` (with a `composerNotice`) hides the composer for a locked thread while existing comments stay visible."
+    importPath={`import CommentsPanel, { type Comment } from "@/components/common/CommentsPanel";`}
+    examples={[
+      {
+        title: "Open thread",
+        description:
+          "Two comments with an active composer. `currentUserIri` matches the second author, so its edit/delete actions appear on hover.",
+        code: `<CommentsPanel
+  parentLabel="task"
+  comments={comments}
+  isLoading={false}
+  currentUserIri="/users/2"
+  canModerate={false}
+  onCreate={handleCreate}
+  onEdit={handleEdit}
+  onDelete={handleDelete}
+/>`,
+        preview: (
+          <CommentsPanel
+            parentLabel="task"
+            comments={sampleComments}
+            isLoading={false}
+            currentUserIri="/users/2"
+            canModerate={false}
+            onCreate={noop}
+            onEdit={noop}
+            onDelete={noop}
+          />
+        ),
+      },
+      {
+        title: "Locked thread (no composer)",
+        description:
+          "Discussions pass `canCompose={false}` on a locked thread; existing comments stay readable and `composerNotice` replaces the composer.",
+        code: `<CommentsPanel
+  parentLabel="discussion"
+  comments={comments}
+  isLoading={false}
+  currentUserIri="/users/2"
+  canModerate={false}
+  canCompose={false}
+  composerNotice={
+    <Alert>
+      <AlertDescription>
+        This discussion is locked — new replies are turned away.
+      </AlertDescription>
+    </Alert>
+  }
+  onCreate={handleCreate}
+  onEdit={handleEdit}
+  onDelete={handleDelete}
+/>`,
+        preview: (
+          <CommentsPanel
+            parentLabel="discussion"
+            comments={sampleComments}
+            isLoading={false}
+            currentUserIri="/users/2"
+            canModerate={false}
+            canCompose={false}
+            composerNotice={
+              <p className="text-sm text-muted-foreground">
+                This discussion is locked — new replies are turned away.
+              </p>
+            }
+            onCreate={noop}
+            onEdit={noop}
+            onDelete={noop}
+          />
+        ),
+      },
+    ]}
+  />
+);
+
+export default CommentsPanelPage;

--- a/pwa/pages/dev/components/email-chip-input.tsx
+++ b/pwa/pages/dev/components/email-chip-input.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import EmailChipInput from "@/components/common/EmailChipInput";
+import { Label } from "@/components/ui/label";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const Basic = () => {
+  const [emails, setEmails] = useState<string[]>(["ada@example.com"]);
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor="invite-emails">Invite by email</Label>
+      <EmailChipInput
+        inputId="invite-emails"
+        value={emails}
+        onChange={setEmails}
+        placeholder="Type an email…"
+      />
+    </div>
+  );
+};
+
+const EmailChipInputPage = () => (
+  <ComponentDoc
+    name="EmailChipInput"
+    description="Controlled multi-email chip input backed by an external `value` array, so the caller owns state and can submit the list directly. Enter, comma, or Tab chips the draft; Backspace on an empty input removes the last chip; pasting a comma/whitespace-separated list splits into chips. Invalid emails keep focus and flash a red ring without blocking the form. Each chip shows a deterministic colored letter tile (no `/users` lookup). Used on the create-space and create-group flows."
+    importPath={`import EmailChipInput from "@/components/common/EmailChipInput";`}
+    examples={[
+      {
+        title: "Controlled with a Label",
+        description:
+          "Pair `inputId` with an external `<Label htmlFor>`. Type an address and press Enter (or comma) to chip it.",
+        code: `const [emails, setEmails] = useState<string[]>(["ada@example.com"]);
+
+<Label htmlFor="invite-emails">Invite by email</Label>
+<EmailChipInput
+  inputId="invite-emails"
+  value={emails}
+  onChange={setEmails}
+  placeholder="Type an email…"
+/>`,
+        preview: <Basic />,
+      },
+    ]}
+  />
+);
+
+export default EmailChipInputPage;

--- a/pwa/pages/dev/components/footer.tsx
+++ b/pwa/pages/dev/components/footer.tsx
@@ -1,0 +1,19 @@
+import Footer from "@/components/common/Footer";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const FooterPage = () => (
+  <ComponentDoc
+    name="Footer"
+    description="Static site footer rendered at the bottom of the app shell by Layout. Three link columns — Product (Home, Guides, Privacy, Terms), Developers (API reference, API guide, Architecture, Component library), and Project (GitHub, Report an issue) — over a MIT-license line. No props."
+    importPath={`import Footer from "@/components/common/Footer";`}
+    examples={[
+      {
+        title: "Default",
+        code: `<Footer />`,
+        preview: <Footer />,
+      },
+    ]}
+  />
+);
+
+export default FooterPage;

--- a/pwa/pages/dev/components/index.tsx
+++ b/pwa/pages/dev/components/index.tsx
@@ -11,10 +11,11 @@ const categories = [
   "Data",
   "Editor",
   "User",
-  "Theme",
   "Layout",
   "Discussions",
   "Custom fields",
+  "Groups",
+  "Notifications",
 ] as const;
 
 const ComponentsIndex = () => (

--- a/pwa/pages/dev/components/input-otp.tsx
+++ b/pwa/pages/dev/components/input-otp.tsx
@@ -1,0 +1,65 @@
+import { useState } from "react";
+import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSeparator,
+  InputOTPSlot,
+} from "@/components/ui/input-otp";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const SixDigit = () => {
+  const [value, setValue] = useState("");
+  return (
+    <InputOTP maxLength={6} value={value} onChange={setValue}>
+      <InputOTPGroup>
+        <InputOTPSlot index={0} />
+        <InputOTPSlot index={1} />
+        <InputOTPSlot index={2} />
+      </InputOTPGroup>
+      <InputOTPSeparator />
+      <InputOTPGroup>
+        <InputOTPSlot index={3} />
+        <InputOTPSlot index={4} />
+        <InputOTPSlot index={5} />
+      </InputOTPGroup>
+    </InputOTP>
+  );
+};
+
+const InputOtpPage = () => (
+  <ComponentDoc
+    name="InputOTP"
+    description="Segmented one-time-code input built on the `input-otp` package. Compose `InputOTPGroup` + `InputOTPSlot` (indexed) and optional `InputOTPSeparator` to lay out the boxes; the parent owns the value via `value`/`onChange` and caps the length with `maxLength`. Used by the 2FA challenge form."
+    importPath={`import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSeparator,
+  InputOTPSlot,
+} from "@/components/ui/input-otp";`}
+    examples={[
+      {
+        title: "Six digits, grouped 3 + 3",
+        description:
+          "A separator splits the code into two groups. Type to fill the slots left-to-right; the active slot gets a caret and ring.",
+        code: `const [value, setValue] = useState("");
+
+<InputOTP maxLength={6} value={value} onChange={setValue}>
+  <InputOTPGroup>
+    <InputOTPSlot index={0} />
+    <InputOTPSlot index={1} />
+    <InputOTPSlot index={2} />
+  </InputOTPGroup>
+  <InputOTPSeparator />
+  <InputOTPGroup>
+    <InputOTPSlot index={3} />
+    <InputOTPSlot index={4} />
+    <InputOTPSlot index={5} />
+  </InputOTPGroup>
+</InputOTP>`,
+        preview: <SixDigit />,
+      },
+    ]}
+  />
+);
+
+export default InputOtpPage;

--- a/pwa/pages/dev/components/layout.tsx
+++ b/pwa/pages/dev/components/layout.tsx
@@ -4,7 +4,7 @@ import ComponentDoc from "@/components/dev/ComponentDoc";
 const LayoutPage = () => (
   <ComponentDoc
     name="Layout"
-    description="App-shell wrapper used by _app.tsx. Mounts ThemeProvider, QueryClientProvider, HydrationBoundary, AuthProvider, and ActiveSpaceProvider, then renders the persistent Navbar + Sidebar around page content. Sidebar collapses to nothing for unauthenticated visitors so marketing and auth screens keep their full-width chrome."
+    description="App-shell wrapper used by _app.tsx. Mounts QueryClientProvider, HydrationBoundary, AuthProvider, and ActiveSpaceProvider, then renders the persistent Sidebar + Navbar + Footer around page content. Sidebar collapses to nothing for unauthenticated visitors so marketing and auth screens keep their full-width chrome; waitlisted accounts render chrome-free. The app is dark-only — there is no theme provider."
     importPath={`import Layout from "@/components/common/Layout";`}
     examples={[
       {

--- a/pwa/pages/dev/components/navbar.tsx
+++ b/pwa/pages/dev/components/navbar.tsx
@@ -4,7 +4,7 @@ import ComponentDoc from "@/components/dev/ComponentDoc";
 const NavbarPage = () => (
   <ComponentDoc
     name="Navbar"
-    description="Top app bar: Aura wordmark + Docs dropdown on the left, SearchBar in the middle (auth-only), OverdueBadge + NotificationBell on the right, and a mobile Sheet trigger that mounts SidebarNav inside a slide-over. Signed-out visitors see Sign In / Sign Up buttons instead of the badges and bell."
+    description="Top app bar. Signed-out visitors get the Aura wordmark as the home anchor plus Sign In / Sign Up buttons. Signed-in viewers get the Breadcrumbs trail (replacing the wordmark) + SearchBar in the flexible middle, OverdueBadge + NotificationBell on the right, and a mobile-only Sheet trigger that mounts SidebarNav inside a slide-over. Developer doc links live in the Footer, not the navbar."
     importPath={`import Navbar from "@/components/common/Navbar";`}
     examples={[
       {

--- a/pwa/pages/dev/components/search-bar.tsx
+++ b/pwa/pages/dev/components/search-bar.tsx
@@ -4,7 +4,7 @@ import ComponentDoc from "@/components/dev/ComponentDoc";
 const SearchBarPage = () => (
   <ComponentDoc
     name="SearchBar"
-    description="Always-visible task search input mounted in the navbar with a debounced live autocomplete dropdown (max 6 hits). Submitting Enter or clicking 'View all results' navigates to /search; clicking a single result jumps there with the result's IRI in the hash so the page can scroll/highlight it in context. ⌘/Ctrl+K focuses the input from anywhere in the app. Pre-fills from ?q= and the legacy ?search= so deep links feel continuous."
+    description="Always-visible task search input mounted in the navbar with a debounced live autocomplete dropdown (max 6 hits). Submitting Enter or clicking 'View all results' navigates to /search; clicking a single result jumps there with the result's IRI in the hash so the page can scroll/highlight it in context. ⌘/Ctrl+K is owned by the SearchOverlay command palette (not this bar). Pre-fills from ?q= and the legacy ?search= so deep links feel continuous."
     importPath={`import SearchBar from "@/components/common/SearchBar";`}
     examples={[
       {
@@ -13,11 +13,11 @@ const SearchBarPage = () => (
         preview: (
           <p className="text-sm text-muted-foreground">
             Mounted by <code className="mx-1">Navbar</code> for authenticated
-            users. The bar is already visible at the top of this page — try{" "}
+            users. The bar is already visible at the top of this page; press{" "}
             <kbd className="rounded border bg-muted px-1.5 py-0.5 text-xs">
               ⌘K
             </kbd>{" "}
-            to focus it.
+            to open the SearchOverlay palette.
           </p>
         ),
       },

--- a/pwa/pages/dev/components/sidebar-nav.tsx
+++ b/pwa/pages/dev/components/sidebar-nav.tsx
@@ -4,7 +4,7 @@ import ComponentDoc from "@/components/dev/ComponentDoc";
 const SidebarNavPage = () => (
   <ComponentDoc
     name="SidebarNav"
-    description="Shared navigation surface used by both the persistent Sidebar (md and up) and the mobile Sheet variant in the Navbar. Renders the signed-in user header, personal links (My Tasks, Groups, Account, Settings), the active-space list (with a lock icon for personal spaces), an Admin section for ROLE_ADMIN users, and a Sign Out button anchored to the bottom."
+    description="Shared navigation surface used by both the persistent Sidebar (md and up) and the mobile Sheet variant in the Navbar. Renders the signed-in user header, the SpaceSwitcher, personal links (My Tasks, Notifications, Groups, Settings), an Admin section for ROLE_ADMIN users (Admin, Waitlist, Segments, and the external Mercure debugger), and a Sign Out button anchored to the bottom."
     importPath={`import SidebarNav from "@/components/common/SidebarNav";`}
     examples={[
       {

--- a/pwa/pages/dev/components/space-switcher.tsx
+++ b/pwa/pages/dev/components/space-switcher.tsx
@@ -4,17 +4,17 @@ import ComponentDoc from "@/components/dev/ComponentDoc";
 const SpaceSwitcherPage = () => (
   <ComponentDoc
     name="SpaceSwitcher"
-    description="Active-space dropdown surfaced next to the Aura wordmark in the navbar. Picks the user's current space and persists the choice via ActiveSpaceContext (localStorage key `aura.activeSpaceId`), so listing pages (`/projects`, `/discussions`) scope to it. Personal spaces wear a lock icon. Renders 'Loading…' until the space list resolves and nothing if the user has no spaces."
+    description="Active-space dropdown rendered at the top of SidebarNav (under the user header, above the personal links). Picks the user's current space and persists the choice via ActiveSpaceContext (localStorage key `aura.activeSpaceId`), so listing pages (`/projects`, `/discussions`) scope to it. The dropdown lists spaces by recency, selecting one navigates to `/spaces/{id}`, and a divider adds shortcuts to All spaces (/spaces) and Create space (/spaces/new). Personal spaces wear a lock icon. Renders 'Loading…' until the space list resolves and nothing if the user has no active space."
     importPath={`import SpaceSwitcher from "@/components/common/SpaceSwitcher";`}
     examples={[
       {
-        title: "Default (in navbar)",
+        title: "Default (in the sidebar)",
         code: `<SpaceSwitcher />`,
         preview: (
           <p className="text-sm text-muted-foreground">
-            Mounted by <code className="mx-1">Navbar</code> for authenticated
-            users with at least one space loaded. The dropdown is already
-            visible in the navbar at the top of this page.
+            Mounted by <code className="mx-1">SidebarNav</code> for
+            authenticated users with at least one space loaded. The switcher is
+            already visible at the top of the sidebar on the left of this page.
           </p>
         ),
       },

--- a/pwa/pages/dev/components/user-avatar.tsx
+++ b/pwa/pages/dev/components/user-avatar.tsx
@@ -2,16 +2,14 @@ import UserAvatar from "@/components/user/UserAvatar";
 import ComponentDoc from "@/components/dev/ComponentDoc";
 
 const ada = {
-  username: "ada-lovelace",
-  firstName: "Ada",
-  lastName: "Lovelace",
+  givenName: "Ada",
+  familyName: "Lovelace",
   personalizedColor: "#0e7490",
 };
 
 const lin = {
-  username: "lin-mei",
-  firstName: "Lin",
-  lastName: "Mei",
+  givenName: "Lin",
+  familyName: "Mei",
   personalizedColor: "#9333ea",
 };
 
@@ -25,9 +23,8 @@ const UserAvatarPage = () => (
         title: "Initials fallback (no avatarUrls)",
         code: `<UserAvatar
   user={{
-    username: "ada-lovelace",
-    firstName: "Ada",
-    lastName: "Lovelace",
+    givenName: "Ada",
+    familyName: "Lovelace",
     personalizedColor: "#0e7490",
   }}
 />`,


### PR DESCRIPTION
## Description

An audit pass to bring documentation back in line with the codebase after the recent segments / waitlist / settings-shell / dark-only / task-drawer work. No runtime behavior changes — docs and the `/dev/components` library only.

**Fixes to existing dev component pages** (`pwa/pages/dev/components/`):
- **layout** — drop the removed `ThemeProvider` (dark-only now); shell is Sidebar + Navbar + Footer.
- **navbar** — remove the gone "Docs dropdown"; the Aura wordmark is signed-out-only and Breadcrumbs replace it when signed in.
- **space-switcher** — it's rendered in `SidebarNav`, not next to the navbar wordmark; documented the recency list + All spaces / Create space shortcuts.
- **search-bar** — ⌘K opens the `SearchOverlay` palette; it does not focus this input.
- **sidebar-nav** — correct the personal links (My Tasks, Notifications, Groups, Settings — no "Account") and the admin section (Admin, Waitlist, Segments, Mercure).
- **user-avatar** — example used non-existent `username`/`firstName`/`lastName`; switched to the real `givenName`/`familyName`.

**Fixes to `docs/`:**
- **mcp-server.md** — token `scopes` are the resource vocabulary (`read:tasks`…`admin`) reconciled via `ScopeMap`, not raw tool names; removed the stale "`CustomFieldValue` isn't built" note (shipped in #227).
- **deployment.md** — Skaffold config/values live under `helm/`; `skaffold run` now `cd helm` first.

**Component library completeness:**
- The index `categories` array listed the dead "Theme" category and was **missing "Groups" and "Notifications"**, so the existing `group-tile` and `notification-row` cards never rendered. Fixed, and removed "Theme" from the registry union.
- Added doc pages + registry entries for 8 reusable components that had none: `input-otp`, `color-swatch-picker`, `email-chip-input`, `code-fence`, `code-theme-switcher`, `footer`, `breadcrumbs`, `comments-panel`.

## Type of Change

- [x] Documentation

## Component

- [x] PWA (Next.js)
- [x] Documentation

## How Has This Been Tested?

Ran the PWA CI checks against all changed/new files in a throwaway `app-pwa` container:
- `pnpm typecheck` (`tsc --noEmit`) — passes clean.
- `npx eslint <changed files>` — passes clean.

## Checklist

- [x] My code follows the project's conventions
- [ ] I have added tests that prove my fix or feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed