### PR TITLE
security: bump react-router to 7.17.0 (GHSA-8x6r-g9mw-2r78)

### DIFF
--- a/pwa/pnpm-lock.yaml
+++ b/pwa/pnpm-lock.yaml
@@ -155,7 +155,7 @@ importers:
         specifier: ^16.2.7
         version: 16.2.7(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       eslint-plugin-react-hooks:
-        specifier: ^7.0.0
+        specifier: ^7.1.1
         version: 7.1.1(eslint@9.39.4(jiti@2.7.0))
       typescript:
         specifier: ^6.0.3
@@ -3687,15 +3687,15 @@ packages:
       '@types/react':
         optional: true
 
-  react-router-dom@7.14.2:
-    resolution: {integrity: sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==}
+  react-router-dom@7.17.0:
+    resolution: {integrity: sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
 
-  react-router@7.14.2:
-    resolution: {integrity: sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==}
+  react-router@7.17.0:
+    resolution: {integrity: sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -8104,7 +8104,7 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  ra-core@5.14.6(@tanstack/react-query@5.101.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.74.0(react@19.2.7))(react-router-dom@7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
+  ra-core@5.14.6(@tanstack/react-query@5.101.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.74.0(react@19.2.7))(react-router-dom@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
     dependencies:
       '@tanstack/react-query': 5.101.0(react@19.2.7)
       date-fns: 3.6.0
@@ -8118,13 +8118,13 @@ snapshots:
       react-error-boundary: 4.1.2(react@19.2.7)
       react-hook-form: 7.74.0(react@19.2.7)
       react-is: 19.2.7
-      react-router: 7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react-router-dom: 7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react-router: 7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react-router-dom: 7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
-  ra-i18n-polyglot@5.14.6(@tanstack/react-query@5.101.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.74.0(react@19.2.7))(react-router-dom@7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
+  ra-i18n-polyglot@5.14.6(@tanstack/react-query@5.101.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.74.0(react@19.2.7))(react-router-dom@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
     dependencies:
       node-polyglot: 2.6.0
-      ra-core: 5.14.6(@tanstack/react-query@5.101.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.74.0(react@19.2.7))(react-router-dom@7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      ra-core: 5.14.6(@tanstack/react-query@5.101.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.74.0(react@19.2.7))(react-router-dom@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
     transitivePeerDependencies:
       - '@tanstack/react-query'
       - react
@@ -8133,9 +8133,9 @@ snapshots:
       - react-router
       - react-router-dom
 
-  ra-language-english@5.14.6(@tanstack/react-query@5.101.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.74.0(react@19.2.7))(react-router-dom@7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
+  ra-language-english@5.14.6(@tanstack/react-query@5.101.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.74.0(react@19.2.7))(react-router-dom@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
     dependencies:
-      ra-core: 5.14.6(@tanstack/react-query@5.101.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.74.0(react@19.2.7))(react-router-dom@7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      ra-core: 5.14.6(@tanstack/react-query@5.101.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.74.0(react@19.2.7))(react-router-dom@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
     transitivePeerDependencies:
       - '@tanstack/react-query'
       - react
@@ -8144,7 +8144,7 @@ snapshots:
       - react-router
       - react-router-dom
 
-  ? ra-ui-materialui@5.14.6(@mui/icons-material@7.3.10(@mui/material@7.3.10(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.16)(react@19.2.7))(@mui/material@7.3.10(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@7.3.10(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react@19.2.7))(@mui/utils@7.3.10(@types/react@19.2.16)(react@19.2.7))(@tanstack/react-query@5.101.0(react@19.2.7))(csstype@3.2.3)(ra-core@5.14.6(@tanstack/react-query@5.101.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.74.0(react@19.2.7))(react-router-dom@7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.74.0(react@19.2.7))(react-is@19.2.7)(react-router-dom@7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+  ? ra-ui-materialui@5.14.6(@mui/icons-material@7.3.10(@mui/material@7.3.10(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.16)(react@19.2.7))(@mui/material@7.3.10(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@7.3.10(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react@19.2.7))(@mui/utils@7.3.10(@types/react@19.2.16)(react@19.2.7))(@tanstack/react-query@5.101.0(react@19.2.7))(csstype@3.2.3)(ra-core@5.14.6(@tanstack/react-query@5.101.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.74.0(react@19.2.7))(react-router-dom@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.74.0(react@19.2.7))(react-is@19.2.7)(react-router-dom@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
   : dependencies:
       '@mui/icons-material': 7.3.10(@mui/material@7.3.10(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.16)(react@19.2.7)
       '@mui/material': 7.3.10(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -8161,7 +8161,7 @@ snapshots:
       jsonexport: 3.2.0
       lodash: 4.18.1
       query-string: 7.1.3
-      ra-core: 5.14.6(@tanstack/react-query@5.101.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.74.0(react@19.2.7))(react-router-dom@7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      ra-core: 5.14.6(@tanstack/react-query@5.101.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.74.0(react@19.2.7))(react-router-dom@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       react-dropzone: 14.4.1(react@19.2.7)
@@ -8169,8 +8169,8 @@ snapshots:
       react-hook-form: 7.74.0(react@19.2.7)
       react-hotkeys-hook: 5.2.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react-is: 19.2.7
-      react-router: 7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react-router-dom: 7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react-router: 7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react-router-dom: 7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react-transition-group: 4.4.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
   radix-ui@1.4.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
@@ -8247,15 +8247,15 @@ snapshots:
       '@mui/icons-material': 7.3.10(@mui/material@7.3.10(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.16)(react@19.2.7)
       '@mui/material': 7.3.10(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-query': 5.101.0(react@19.2.7)
-      ra-core: 5.14.6(@tanstack/react-query@5.101.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.74.0(react@19.2.7))(react-router-dom@7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
-      ra-i18n-polyglot: 5.14.6(@tanstack/react-query@5.101.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.74.0(react@19.2.7))(react-router-dom@7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
-      ra-language-english: 5.14.6(@tanstack/react-query@5.101.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.74.0(react@19.2.7))(react-router-dom@7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
-      ra-ui-materialui: 5.14.6(@mui/icons-material@7.3.10(@mui/material@7.3.10(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.16)(react@19.2.7))(@mui/material@7.3.10(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@7.3.10(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react@19.2.7))(@mui/utils@7.3.10(@types/react@19.2.16)(react@19.2.7))(@tanstack/react-query@5.101.0(react@19.2.7))(csstype@3.2.3)(ra-core@5.14.6(@tanstack/react-query@5.101.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.74.0(react@19.2.7))(react-router-dom@7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.74.0(react@19.2.7))(react-is@19.2.7)(react-router-dom@7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      ra-core: 5.14.6(@tanstack/react-query@5.101.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.74.0(react@19.2.7))(react-router-dom@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      ra-i18n-polyglot: 5.14.6(@tanstack/react-query@5.101.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.74.0(react@19.2.7))(react-router-dom@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      ra-language-english: 5.14.6(@tanstack/react-query@5.101.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.74.0(react@19.2.7))(react-router-dom@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      ra-ui-materialui: 5.14.6(@mui/icons-material@7.3.10(@mui/material@7.3.10(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.16)(react@19.2.7))(@mui/material@7.3.10(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@7.3.10(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react@19.2.7))(@types/react@19.2.16)(react@19.2.7))(@mui/utils@7.3.10(@types/react@19.2.16)(react@19.2.7))(@tanstack/react-query@5.101.0(react@19.2.7))(csstype@3.2.3)(ra-core@5.14.6(@tanstack/react-query@5.101.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.74.0(react@19.2.7))(react-router-dom@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-hook-form@7.74.0(react@19.2.7))(react-is@19.2.7)(react-router-dom@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       react-hook-form: 7.74.0(react@19.2.7)
-      react-router: 7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react-router-dom: 7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react-router: 7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react-router-dom: 7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     transitivePeerDependencies:
       - '@mui/material-pigment-css'
       - '@mui/system'
@@ -8351,13 +8351,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.16
 
-  react-router-dom@7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  react-router-dom@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      react-router: 7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react-router: 7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
-  react-router@7.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       cookie: 1.1.1
       react: 19.2.7

--- a/pwa/pnpm-lock.yaml
+++ b/pwa/pnpm-lock.yaml
@@ -155,7 +155,7 @@ importers:
         specifier: ^16.2.7
         version: 16.2.7(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       eslint-plugin-react-hooks:
-        specifier: ^7.1.1
+        specifier: ^7.0.0
         version: 7.1.1(eslint@9.39.4(jiti@2.7.0))
       typescript:
         specifier: ^6.0.3


### PR DESCRIPTION
## What

Bumps the transitive `react-router` / `react-router-dom` from **7.14.2 → 7.17.0** in `pwa/pnpm-lock.yaml` (lockfile-only).

## Why

Dependabot alert [#104](https://github.com/roboparker/Aura/security/dependabot/104) — [GHSA-8x6r-g9mw-2r78](https://github.com/advisories/GHSA-8x6r-g9mw-2r78) / CVE-2026-42342 (high, 7.5, CWE-400): DoS via unbounded path expansion in React Router's `__manifest` endpoint. Vulnerable range `>= 7.0.0, < 7.15.0`; patched in 7.15.0.

`react-router` is pulled in transitively via `@api-platform/admin` → `react-admin` (`ra-core`), which mounts at `/admin`.

## Exploitability note

The advisory states the issue only affects **React Router Framework Mode** apps — not Declarative (`<BrowserRouter>`) or Data Mode (`createBrowserRouter`/`<RouterProvider>`). react-admin uses Data Mode and the PWA is Next.js, so the practical attack surface here is effectively nil. This bump clears the alert and keeps us on a patched line regardless.

## Scope

- Only `pwa/pnpm-lock.yaml` changes; `package.json` is untouched (the dep was never a direct one).
- Regenerated via `pnpm update react-router react-router-dom --depth Infinity --lockfile-only` on the repo-pinned pnpm 9.1.3.

Closes Dependabot alert #104.