### PR TITLE
fix: align privacy policy with actual deletion behavior; add governing law to terms

### DIFF
--- a/pwa/pages/privacy.tsx
+++ b/pwa/pages/privacy.tsx
@@ -1,7 +1,7 @@
 import Head from "next/head";
 import Link from "next/link";
 
-const LAST_UPDATED = "May 17, 2026";
+const LAST_UPDATED = "June 9, 2026";
 
 const Privacy = () => (
   <>
@@ -27,9 +27,10 @@ const Privacy = () => (
         <div className="space-y-8 text-foreground leading-relaxed">
           <section>
             <p className="text-muted-foreground">
-              This Privacy Policy describes how Aura (the &quot;Service&quot;)
-              collects, uses, and protects your personal data when you use it.
-              By using the Service, you agree to the practices described here.
+              This Privacy Policy describes how Aura (the &quot;Service&quot;),
+              operated by Robert Parker (&quot;we&quot;, &quot;us&quot;), collects,
+              uses, and protects your personal data when you use it. By using
+              the Service, you agree to the practices described here.
             </p>
           </section>
 
@@ -49,7 +50,14 @@ const Privacy = () => (
               <li>
                 <strong className="text-foreground">Authentication data.</strong>{" "}
                 A hashed password and, if you enable two-factor authentication,
-                an encrypted TOTP secret and one-time backup codes.
+                an encrypted TOTP secret and one-time backup codes. If you
+                create API tokens, we store them in hashed form.
+              </li>
+              <li>
+                <strong className="text-foreground">Push subscriptions.</strong>{" "}
+                If you enable push notifications, we store a per-device
+                subscription endpoint so we can deliver notifications to that
+                device.
               </li>
               <li>
                 <strong className="text-foreground">Usage data.</strong>{" "}
@@ -78,8 +86,10 @@ const Privacy = () => (
               We do not sell your personal data. Content you create is visible
               only to you and the collaborators you share it with (for example,
               members of a space). We may share data with infrastructure
-              providers strictly to operate the Service, and we may disclose
-              information if required by law.
+              providers strictly to operate the Service — for example, push
+              notifications are delivered through your browser vendor&apos;s
+              push service (such as those operated by Google, Mozilla, or
+              Apple) — and we may disclose information if required by law.
             </p>
           </section>
 
@@ -87,10 +97,14 @@ const Privacy = () => (
             <h2 className="text-xl font-semibold mb-2">4. Data retention</h2>
             <p className="text-muted-foreground">
               We retain your account data and content for as long as your
-              account is active. When you delete your account, we delete the
-              associated personal data within a reasonable period, except where
+              account is active. When you delete your account, we delete your
+              personal data — your profile, credentials, sessions, tokens, and
+              notifications — within a reasonable period, except where
               retention is required for legal, security, or fraud-prevention
-              purposes.
+              purposes. Content you contributed to shared spaces (such as
+              tasks, pages, discussions, comments, and attachments) may remain
+              available to the other members of those spaces, disassociated
+              from your identity.
             </p>
           </section>
 
@@ -127,8 +141,9 @@ const Privacy = () => (
             <p className="text-muted-foreground">
               We use cookies and browser local storage for essential
               functionality such as keeping you signed in and remembering your
-              active space and theme preferences. We do not use third-party
-              advertising or tracking cookies.
+              active space, theme preferences, and recent searches (stored
+              only on your device). We do not use third-party advertising or
+              tracking cookies.
             </p>
           </section>
 

--- a/pwa/pages/terms.tsx
+++ b/pwa/pages/terms.tsx
@@ -1,7 +1,7 @@
 import Head from "next/head";
 import Link from "next/link";
 
-const LAST_UPDATED = "May 17, 2026";
+const LAST_UPDATED = "June 9, 2026";
 
 const Terms = () => (
   <>
@@ -28,9 +28,10 @@ const Terms = () => (
           <section>
             <p className="text-muted-foreground">
               These Terms and Conditions (&quot;Terms&quot;) govern your access
-              to and use of Aura (the &quot;Service&quot;). By creating an
-              account or using the Service, you agree to be bound by these
-              Terms. If you do not agree, do not use the Service.
+              to and use of Aura (the &quot;Service&quot;), operated by Robert
+              Parker (&quot;we&quot;, &quot;us&quot;). By creating an account or
+              using the Service, you agree to be bound by these Terms. If you
+              do not agree, do not use the Service.
             </p>
           </section>
 
@@ -105,7 +106,21 @@ const Terms = () => (
           </section>
 
           <section>
-            <h2 className="text-xl font-semibold mb-2">7. Changes to these Terms</h2>
+            <h2 className="text-xl font-semibold mb-2">7. Governing law</h2>
+            <p className="text-muted-foreground">
+              These Terms are governed by the laws of the State of Oregon,
+              United States, without regard to its conflict-of-law provisions.
+              Any dispute arising out of or relating to these Terms or the
+              Service will be brought exclusively in the state or federal
+              courts located in Oregon, and you consent to the jurisdiction of
+              those courts. Nothing in this section limits any rights you may
+              have under the mandatory consumer-protection laws of the place
+              where you live.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold mb-2">8. Changes to these Terms</h2>
             <p className="text-muted-foreground">
               We may update these Terms from time to time. When we do, we
               will revise the &quot;Last updated&quot; date above. If the
@@ -116,7 +131,7 @@ const Terms = () => (
           </section>
 
           <section>
-            <h2 className="text-xl font-semibold mb-2">8. Contact</h2>
+            <h2 className="text-xl font-semibold mb-2">9. Contact</h2>
             <p className="text-muted-foreground">
               Questions about these Terms? Reach out via the project&apos;s{" "}
               <Link


### PR DESCRIPTION
## Description

Review pass over the `/privacy` and `/terms` pages to bring them in line with what the product actually does, and to fill two legal gaps ahead of a hosted launch.

**Privacy policy**
- **Corrects the data-retention claim**: the policy said account deletion deletes "the associated personal data", but `AccountDeletionService` reassigns shared-space content (tasks, pages, discussions, comments, attachments) to the "Former member" sentinel rather than deleting it. The policy now says personal data (profile, credentials, sessions, tokens, notifications) is deleted while shared-space content may remain, disassociated from the user's identity.
- Discloses push-notification subscription storage (§1) and delivery through browser-vendor push services (§3).
- Mentions hashed API tokens (§1) and on-device recent-search storage (§7).

**Terms**
- New §7 governing-law clause (State of Oregon, exclusive Oregon venue) with a carve-out preserving users' mandatory local consumer-protection rights; subsequent sections renumbered.
- Names the operator ("operated by Robert Parker") in both documents' intros.

Both "Last updated" dates bumped to June 9, 2026.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation

## Component

- [ ] API (PHP/Symfony)
- [x] PWA (Next.js)
- [ ] Infrastructure (Docker/Helm)
- [ ] E2E Tests
- [ ] Documentation

## How Has This Been Tested?

Content-only JSX edits to two static pages, matching the existing markup patterns (escaped entities, same section structure). No local Node toolchain available in this environment, so relying on the PWA Typecheck CI check.

## Checklist

- [x] My code follows the project's conventions
- [ ] I have added tests that prove my fix or feature works (content-only change)
- [ ] New and existing tests pass locally (no local toolchain; CI verifies)
- [x] I have updated documentation if needed

**Reviewer notes**: Oregon was chosen over Washington as marginally more operator-friendly (WA's Consumer Protection Act carries treble damages + fee-shifting); it's a two-word swap if Washington is preferred. The reverse-engineering clause in §2 of the terms (which sits oddly next to the MIT license) was deliberately left untouched. Not legal advice — worth a real lawyer's pass before a hosted launch.