### PR TITLE
feat: add backup/restore scripts and security headers for droplet deploys

### DIFF
--- a/api/config/packages/framework.yaml
+++ b/api/config/packages/framework.yaml
@@ -7,8 +7,15 @@ framework:
     # See https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#headers
     trusted_headers: [ 'x-forwarded-for', 'x-forwarded-proto' ]
 
-    # Session is needed for json_login authentication
-    session: true
+    # Session is needed for json_login authentication.
+    # Cookie hardening: `secure` follows the request scheme (auto), the
+    # cookie is invisible to JS, and Lax same-site blocks cross-site POSTs
+    # from carrying it. The PWA and API are same-origin behind Caddy, so
+    # Lax doesn't affect the auth flow.
+    session:
+        cookie_secure: auto
+        cookie_httponly: true
+        cookie_samesite: lax
 
     # UUIDv7 is time-ordered, which keeps B-tree index locality good.
     # Configured globally so `doctrine.uuid_generator` emits v7.

--- a/api/frankenphp/Caddyfile
+++ b/api/frankenphp/Caddyfile
@@ -55,6 +55,19 @@
 	# Disable Topics tracking if not enabled explicitly: https://github.com/jkarlin/topics
 	header ?Permissions-Policy "browsing-topics=()"
 
+	# Security headers, applied to every response (PWA, API, /media/*, and
+	# the Mercure SSE endpoint — headers are sent once when the stream
+	# opens, so they don't interfere with event delivery). Browsers only
+	# honor HSTS over a trusted HTTPS connection, so the self-signed dev
+	# cert on localhost is unaffected. Nothing in the app is iframed, so
+	# DENY is safe.
+	header {
+		Strict-Transport-Security "max-age=31536000"
+		X-Content-Type-Options "nosniff"
+		X-Frame-Options "DENY"
+		Referrer-Policy "strict-origin-when-cross-origin"
+	}
+
 	route {
 		# Serve user-uploaded media (avatars, attachments) directly from disk
 		handle_path /media/* {

--- a/docs/developer/deployment.md
+++ b/docs/developer/deployment.md
@@ -92,6 +92,71 @@ docker compose -f compose.yaml -f compose.prod.yaml up -d
 
 Ensure all secrets are set to strong, unique values in production.
 
+## Backups
+
+The compose stack has two stateful pieces: the PostgreSQL database (volume
+`database_data`) and user-uploaded media (volume `media_data`, mounted at
+`/app/var/media` in the `php` container). `scripts/backup.sh` snapshots
+both into timestamped files and prunes old ones:
+
+```bash
+scripts/backup.sh
+# -> backups/db-20260609-031500.sql.gz      (pg_dump | gzip)
+# -> backups/media-20260609-031500.tar.gz   (tar of the media volume)
+```
+
+The stack must be running — the dump goes through `docker compose exec`.
+Configuration via env vars:
+
+| Variable         | Default                          | Description |
+|------------------|----------------------------------|-------------|
+| `BACKUP_DIR`     | `./backups`                      | Where backup files are written |
+| `RETENTION_DAYS` | `14`                             | Delete backups older than N days (`0` disables pruning) |
+| `COMPOSE_FILES`  | `compose.yaml compose.prod.yaml` | Compose files passed as `-f` flags |
+| `POSTGRES_USER`  | `app`                            | Database user for `pg_dump`/`psql` |
+| `POSTGRES_DB`    | `app`                            | Database name |
+
+### Restoring
+
+`scripts/restore.sh` is the inverse. It is **destructive** — it stops
+`php`/`worker`, drops and recreates the database, replays the dump, and
+(optionally) replaces the media volume contents — so it prompts for a
+literal `yes` unless `--force` is passed:
+
+```bash
+scripts/restore.sh backups/db-20260609-031500.sql.gz
+scripts/restore.sh --media backups/media-20260609-031500.tar.gz backups/db-20260609-031500.sql.gz
+scripts/restore.sh --force backups/db-20260609-031500.sql.gz   # no prompt (for scripted recovery)
+```
+
+Restore into a fresh droplet by starting the stack first
+(`docker compose -f compose.yaml -f compose.prod.yaml up -d`), then
+running the restore — the migration step on boot is harmless since the
+dump replays the full schema over the recreated database.
+
+### Scheduling with cron
+
+Nightly at 03:10, keeping 14 days, logging to a file:
+
+```cron
+10 3 * * * cd /opt/aura && BACKUP_DIR=/var/backups/aura scripts/backup.sh >> /var/log/aura-backup.log 2>&1
+```
+
+Backups written to the droplet's own disk don't survive the droplet
+dying — copy them off-box (e.g. `rclone`/`s3cmd` to DigitalOcean Spaces,
+or `scp` to another machine) as a second cron step.
+
+### DigitalOcean droplet snapshots
+
+Enable [droplet snapshots/backups](https://docs.digitalocean.com/products/images/snapshots/)
+as a belt-and-braces layer: they capture the whole disk (including the
+Docker volumes) and make whole-droplet recovery trivial. They are **not**
+a substitute for `pg_dump`, though — a snapshot of a running Postgres
+data directory is only crash-consistent, and snapshots can't restore a
+single database or be replayed into a different environment. Run both:
+snapshots for disaster recovery, `scripts/backup.sh` for clean,
+portable, point-in-time database dumps.
+
 ## Kubernetes (Helm + Skaffold)
 
 ### Prerequisites

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Back up the two stateful pieces of the compose stack: a gzipped pg_dump
+# of the PostgreSQL database and a gzipped tar of the media volume (user
+# uploads), written to timestamped files with simple age-based retention.
+#
+# Usage:
+#   scripts/backup.sh
+#   BACKUP_DIR=/var/backups/aura RETENTION_DAYS=30 scripts/backup.sh
+#
+# Configuration (env vars):
+#   BACKUP_DIR      Where backups are written (default: ./backups)
+#   RETENTION_DAYS  Delete backups older than N days (default: 14; 0 disables)
+#   COMPOSE_FILES   Space-separated compose files (default: "compose.yaml compose.prod.yaml")
+#   POSTGRES_USER   Database user (default: app)
+#   POSTGRES_DB     Database name (default: app)
+#
+# The stack must be running (the dump goes through `docker compose exec`).
+# Intended to run from cron on the droplet — see docs/developer/deployment.md.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+BACKUP_DIR="${BACKUP_DIR:-$ROOT/backups}"
+RETENTION_DAYS="${RETENTION_DAYS:-14}"
+COMPOSE_FILES="${COMPOSE_FILES:-compose.yaml compose.prod.yaml}"
+POSTGRES_USER="${POSTGRES_USER:-app}"
+POSTGRES_DB="${POSTGRES_DB:-app}"
+
+log() {
+  printf '[backup %s] %s\n' "$(date -Iseconds 2>/dev/null || date)" "$*"
+}
+
+compose() {
+  local args=() f
+  for f in $COMPOSE_FILES; do
+    args+=(-f "$f")
+  done
+  docker compose "${args[@]}" "$@"
+}
+
+# Resolve BACKUP_DIR to an absolute path before cd-ing to the repo root,
+# so a relative BACKUP_DIR stays relative to the caller's cwd.
+mkdir -p "$BACKUP_DIR"
+BACKUP_DIR="$(cd "$BACKUP_DIR" && pwd)"
+cd "$ROOT"
+
+timestamp="$(date +%Y%m%d-%H%M%S)"
+
+# Database dump. Write to a .tmp first and rename only on success, so a
+# failed dump (set -o pipefail catches pg_dump errors through the gzip
+# pipe) never leaves a truncated file that looks like a valid backup.
+db_file="$BACKUP_DIR/db-$timestamp.sql.gz"
+log "dumping database '$POSTGRES_DB' to $db_file"
+compose exec -T database pg_dump -U "$POSTGRES_USER" "$POSTGRES_DB" | gzip > "$db_file.tmp"
+mv "$db_file.tmp" "$db_file"
+
+# Media volume (user uploads). The volume is mounted in the php container
+# at /app/var/media, so tar it from there rather than guessing the
+# project-prefixed volume name.
+media_file="$BACKUP_DIR/media-$timestamp.tar.gz"
+log "archiving media volume to $media_file"
+compose exec -T php tar -cf - -C /app/var media | gzip > "$media_file.tmp"
+mv "$media_file.tmp" "$media_file"
+
+# Retention: drop backups older than RETENTION_DAYS. Only touches files
+# matching our own naming pattern, so anything else in BACKUP_DIR is safe.
+if [ "$RETENTION_DAYS" -gt 0 ]; then
+  log "pruning backups older than $RETENTION_DAYS day(s)"
+  find "$BACKUP_DIR" -maxdepth 1 -type f \
+    \( -name 'db-*.sql.gz' -o -name 'media-*.tar.gz' \) \
+    -mtime +"$RETENTION_DAYS" -print -delete
+fi
+
+log "done: $db_file ($(du -h "$db_file" | cut -f1)), $media_file ($(du -h "$media_file" | cut -f1))"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# Restore a backup created by scripts/backup.sh.
+#
+# DESTRUCTIVE: drops and recreates the database, and (with --media)
+# replaces the contents of the media volume. Prompts for confirmation
+# unless --force is passed.
+#
+# Usage:
+#   scripts/restore.sh backups/db-20260609-031500.sql.gz
+#   scripts/restore.sh --media backups/media-20260609-031500.tar.gz backups/db-20260609-031500.sql.gz
+#   scripts/restore.sh --force backups/db-20260609-031500.sql.gz
+#
+# Configuration (env vars):
+#   COMPOSE_FILES   Space-separated compose files (default: "compose.yaml compose.prod.yaml")
+#   POSTGRES_USER   Database user (default: app)
+#   POSTGRES_DB     Database name (default: app)
+#
+# The stack must be running. php and worker are stopped for the duration
+# of the restore so nothing writes mid-restore, then started again.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+COMPOSE_FILES="${COMPOSE_FILES:-compose.yaml compose.prod.yaml}"
+POSTGRES_USER="${POSTGRES_USER:-app}"
+POSTGRES_DB="${POSTGRES_DB:-app}"
+
+log() {
+  printf '[restore %s] %s\n' "$(date -Iseconds 2>/dev/null || date)" "$*"
+}
+
+compose() {
+  local args=() f
+  for f in $COMPOSE_FILES; do
+    args+=(-f "$f")
+  done
+  docker compose "${args[@]}" "$@"
+}
+
+db_dump=""
+media_archive=""
+force=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --force) force=1 ;;
+    --media)
+      shift
+      [ $# -gt 0 ] || { echo "--media needs a file argument" >&2; exit 2; }
+      media_archive="$1"
+      ;;
+    -h|--help)
+      sed -n '2,21p' "$0"
+      exit 0
+      ;;
+    -*) echo "unknown arg: $1" >&2; exit 2 ;;
+    *)
+      [ -z "$db_dump" ] || { echo "unexpected extra argument: $1" >&2; exit 2; }
+      db_dump="$1"
+      ;;
+  esac
+  shift
+done
+
+if [ -z "$db_dump" ]; then
+  echo "usage: scripts/restore.sh [--force] [--media <media-*.tar.gz>] <db-*.sql.gz>" >&2
+  exit 2
+fi
+[ -f "$db_dump" ] || { echo "no such file: $db_dump" >&2; exit 1; }
+if [ -n "$media_archive" ]; then
+  [ -f "$media_archive" ] || { echo "no such file: $media_archive" >&2; exit 1; }
+fi
+
+# Resolve backup paths to absolute before cd-ing to the repo root.
+db_dump="$(cd "$(dirname "$db_dump")" && pwd)/$(basename "$db_dump")"
+if [ -n "$media_archive" ]; then
+  media_archive="$(cd "$(dirname "$media_archive")" && pwd)/$(basename "$media_archive")"
+fi
+cd "$ROOT"
+
+if [ "$force" = "0" ]; then
+  echo "This will DROP and recreate database '$POSTGRES_DB' from:"
+  echo "  $db_dump"
+  if [ -n "$media_archive" ]; then
+    echo "and REPLACE the media volume contents from:"
+    echo "  $media_archive"
+  fi
+  printf 'Type "yes" to continue: '
+  read -r answer
+  if [ "$answer" != "yes" ]; then
+    echo "aborted." >&2
+    exit 1
+  fi
+fi
+
+log "stopping php and worker so nothing writes during the restore"
+compose stop php worker
+
+log "dropping and recreating database '$POSTGRES_DB'"
+compose exec -T database psql -U "$POSTGRES_USER" -d postgres -v ON_ERROR_STOP=1 <<SQL
+DROP DATABASE IF EXISTS "$POSTGRES_DB" WITH (FORCE);
+CREATE DATABASE "$POSTGRES_DB" OWNER "$POSTGRES_USER";
+SQL
+
+log "restoring database from $db_dump"
+gunzip -c "$db_dump" | compose exec -T database psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 --quiet
+
+if [ -n "$media_archive" ]; then
+  # php is stopped, so untar through a throwaway container on the same
+  # volumes (--no-deps: don't restart anything; entrypoint bypassed so
+  # the image's DB-wait/migrate logic doesn't run). Existing media is
+  # cleared first so the volume matches the archive exactly.
+  log "restoring media volume from $media_archive"
+  gunzip -c "$media_archive" | compose run --rm --no-deps -T --entrypoint sh php \
+    -c 'rm -rf /app/var/media/* && tar -xf - -C /app/var'
+fi
+
+log "starting php and worker"
+compose up -d php worker
+
+log "done"


### PR DESCRIPTION
## Description

Closes two operational gaps ahead of deploying to a single DigitalOcean droplet:

**Backups (none existed).** `scripts/backup.sh` snapshots the two stateful pieces of the compose stack — a gzipped `pg_dump` of the database and a tar of the `media_data` volume (streamed out of the `php` container, so no guessing the project-prefixed volume name) — into timestamped files with age-based retention (default 14 days, `0` disables). Safe under `set -euo pipefail`; dumps write to `.tmp` and rename only on success so a failed dump can't masquerade as a valid backup. Configurable via `BACKUP_DIR`, `RETENTION_DAYS`, `COMPOSE_FILES`, `POSTGRES_USER`, `POSTGRES_DB`.

`scripts/restore.sh` is the destructive inverse: stops `php`/`worker` so nothing writes mid-restore, `DROP DATABASE … WITH (FORCE)` + recreate, replays the dump with `psql -v ON_ERROR_STOP=1`, optionally restores media via `--media` (throwaway `compose run --no-deps` container, entrypoint bypassed, volume cleared first). Requires a typed `yes` unless `--force`.

`docs/developer/deployment.md` gains a **Backups** section: usage, env-var table, restore walkthrough, a sample crontab line, an off-box copy note, and DigitalOcean snapshot guidance (snapshots are only crash-consistent for Postgres — run both).

**Security headers (Caddyfile set none).** Adds `Strict-Transport-Security: max-age=31536000`, `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, and `Referrer-Policy: strict-origin-when-cross-origin` on every response. Grepped the repo for `iframe`/`frame-ancestors` — nothing is framed, so DENY is safe. Mercure SSE and `/media/*` are unaffected (headers go out once when the response opens), and browsers ignore HSTS on the untrusted dev cert.

Session cookies are now explicit in `framework.yaml`: `cookie_secure: auto`, `cookie_httponly: true`, `cookie_samesite: lax`. The PWA and API are same-origin behind Caddy, so Lax doesn't touch the auth flow; `auto` follows the request scheme, so the in-process test client keeps working.

## Type of Change

- [x] New feature
- [x] Documentation

## Component

- [x] API (PHP/Symfony)
- [x] Infrastructure (Docker/Helm)
- [x] Documentation

## How Has This Been Tested?

- `frankenphp validate --config frankenphp/Caddyfile` → valid configuration.
- `bin/console -e test cache:warmup` + `debug:config framework session` → cookie params resolve and merge correctly with the test mock-file session storage.
- Migrated a fresh `app_test` (48 migrations) and ran the cookie-auth test files: `UserSessionTest` OK (6 tests), `TwoFactorTest` OK (11), `TwoFactorRecoveryTest` OK (6) — together these exercise login → session cookie → authenticated requests → step-up actions.
- Both scripts pass `bash -n` and shellcheck (zero findings); confirmed GNU tar exists in the app-php image.
- No PHP source changed, so PHPStan/phpcs are unaffected; CI runs the full suite.

## Checklist

- [x] My code follows the project's conventions
- [ ] I have added tests that prove my fix or feature works (config + ops scripts; covered by the existing suite)
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed