### PR TITLE
fix: add symfony/process to production dependencies

### DIFF
--- a/api/composer.json
+++ b/api/composer.json
@@ -34,6 +34,7 @@
         "symfony/mercure-bundle": "^0.4.2",
         "symfony/messenger": "7.4.*",
         "symfony/monolog-bundle": "^4.0",
+        "symfony/process": "8.0.*",
         "symfony/property-access": "7.4.*",
         "symfony/property-info": "7.4.*",
         "symfony/rate-limiter": "7.4.*",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "200c09176a9ae1c8d3271c745becdd6a",
+    "content-hash": "a181838e682966019578a6fa2d09d710",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -8229,6 +8229,71 @@
             "time": "2026-04-10T16:19:22+00:00"
         },
         {
+            "name": "symfony/process",
+            "version": "v8.0.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "4f23d9c7637ead9ed19f697fe93cb87fd9b379d4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/4f23d9c7637ead9ed19f697fe93cb87fd9b379d4",
+                "reference": "4f23d9c7637ead9ed19f697fe93cb87fd9b379d4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Executes commands in sub-processes",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v8.0.13"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-23T18:05:53+00:00"
+        },
+        {
             "name": "symfony/property-access",
             "version": "v7.4.8",
             "source": {
@@ -15052,71 +15117,6 @@
                 }
             ],
             "time": "2026-03-24T13:12:05+00:00"
-        },
-        {
-            "name": "symfony/process",
-            "version": "v8.0.13",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "4f23d9c7637ead9ed19f697fe93cb87fd9b379d4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/4f23d9c7637ead9ed19f697fe93cb87fd9b379d4",
-                "reference": "4f23d9c7637ead9ed19f697fe93cb87fd9b379d4",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Process\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Executes commands in sub-processes",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/process/tree/v8.0.13"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-05-23T18:05:53+00:00"
         },
         {
             "name": "symfony/web-profiler-bundle",


### PR DESCRIPTION
## Problem

The first automated production deploy (#407 pipeline) failed at the **pre-deploy backup** step:

```
In BackupRunner.php line 105:
  Attempted to load class "Process" from namespace "Symfony\Component\Process".
```

`App\Service\BackupRunner` (behind `app:backup:run` — used by both the pre-deploy backup in `scripts/deploy.sh` and the nightly scheduled backup) shells out to `pg_dump` via `Symfony\Component\Process\Process`. But `symfony/process` was only present **transitively, in the dev dependency tree**. The production image is built `--no-dev`, so the class was pruned and the command crashed at runtime.

CI didn't catch it because the test suite installs **with** dev dependencies, where `symfony/process` resolves transitively — the gap only exists in the `--no-dev` production image.

## Fix

Promote `symfony/process` to an explicit production `require`, **at its already-locked version (v8.0.13)** — no version drift:

- `composer.json`: `+ "symfony/process": "8.0.*"` (matches the 8.0.x line `http-kernel`/`dependency-injection` already sit on in the lock).
- `composer.lock`: `symfony/process` moves from `packages-dev` into `packages`; content-hash updated. No other package changes.

Regenerated by running `composer require` inside the actual production image (PHP 8.4) so the resolution matches the deploy target exactly.

## Follow-up (not in this PR)

CI smoke-test that runs `app:backup:run` (or `--dry-run`) against the built `--no-dev` production image would catch this class of "missing-in-prod-only" dependency bug before it reaches a deploy.