### PR TITLE
feat: enable Umami analytics with the production website ID

### DIFF
--- a/pwa/.env.production
+++ b/pwa/.env.production
@@ -5,4 +5,4 @@
 # in the Umami dashboard (Settings → Websites → Add website), then committed
 # here — the ID ships in the page source anyway, it is not a secret. While
 # unset, the tracker script is never rendered and analytics is fully off.
-# NEXT_PUBLIC_UMAMI_WEBSITE_ID=
+NEXT_PUBLIC_UMAMI_WEBSITE_ID=0217ffc5-83a0-4640-8ea3-79e4b4f75840


### PR DESCRIPTION
Sets `NEXT_PUBLIC_UMAMI_WEBSITE_ID` in `pwa/.env.production` to the website created in the production Umami dashboard (`madori` / madori.app). The ID is public — it ships in the page source — so committing it is safe.

With this baked into the PWA build, the tracker script renders and pageview + product-event tracking goes live on the next deploy. Follow-up to [#410](https://github.com/roboparker/Aura/pull/410).