### PR TITLE
fix: let waitlisted users deactivate, export and delete their accounts

### DIFF
--- a/api/config/packages/security.yaml
+++ b/api/config/packages/security.yaml
@@ -71,7 +71,12 @@ security:
         - { path: ^/api/me$, roles: IS_AUTHENTICATED_FULLY }
         - { path: ^/me/2fa, roles: ROLE_USER }
         - { path: ^/me/sessions, roles: ROLE_USER }
-        - { path: ^/me/(deactivate|export|delete)$, roles: ROLE_USER }
+        # Account lifecycle (GDPR/CCPA): any fully-authenticated account —
+        # including a waitlisted ROLE_WAITLISTED one, which holds no ROLE_USER
+        # — must be able to deactivate, export, and delete itself. The
+        # controller only operates on the current user and every action is
+        # step-up protected via SensitiveActionVerifier.
+        - { path: ^/me/(deactivate|export|delete)$, roles: IS_AUTHENTICATED_FULLY }
         # Waitlist mode toggle — platform admins only.
         - { path: ^/admin/waitlist, roles: ROLE_ADMIN }
         # User segments (A/B tests, beta gating, rollouts) — platform admins

--- a/api/tests/Api/AccountLifecycleTest.php
+++ b/api/tests/Api/AccountLifecycleTest.php
@@ -110,6 +110,72 @@ class AccountLifecycleTest extends ApiTestCase
         );
     }
 
+    /**
+     * A waitlisted account holds no ROLE_USER, but the lifecycle endpoints
+     * are gated on IS_AUTHENTICATED_FULLY so the GDPR self-service actions
+     * (deactivate / export / delete) stay reachable while waiting.
+     */
+    public function testWaitlistedUserCanDeactivateAccount(): void
+    {
+        $waiter = $this->createWaitlistedUser('waiter@example.com');
+        $client = static::createClient();
+        $client->loginUser($waiter);
+
+        $client->request('POST', '/me/deactivate', [
+            'json' => ['currentPassword' => 'Password123!@#'],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $this->entityManager->clear();
+        $refreshed = $this->entityManager->getRepository(User::class)->find($waiter->getId());
+        $this->assertNotNull($refreshed);
+        $this->assertTrue($refreshed->isDeactivated());
+    }
+
+    public function testWaitlistedUserCanExportOwnData(): void
+    {
+        $waiter = $this->createWaitlistedUser('waiter@example.com');
+        $client = static::createClient();
+        $client->loginUser($waiter);
+
+        $client->request('POST', '/me/export', [
+            'json' => ['currentPassword' => 'Password123!@#'],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $profile = $this->arrayField($response->toArray(), 'profile');
+        $this->assertSame('waiter@example.com', $profile['email']);
+    }
+
+    public function testWaitlistedUserCanDeleteAccount(): void
+    {
+        $waiter = $this->createWaitlistedUser('waiter@example.com');
+        $client = static::createClient();
+        $client->loginUser($waiter);
+
+        $client->request('POST', '/me/delete', [
+            'json' => ['confirmEmail' => 'waiter@example.com', 'currentPassword' => 'Password123!@#'],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(204);
+
+        $this->entityManager->clear();
+        $this->assertNull(
+            $this->entityManager->getRepository(User::class)->findOneBy(['email' => 'waiter@example.com']),
+        );
+    }
+
+    private function createWaitlistedUser(string $email): User
+    {
+        $user = $this->createUser($email);
+        $user->setWaitlisted(true);
+        $this->entityManager->flush();
+        return $user;
+    }
+
     private function makeTask(User $owner, string $title): Task
     {
         $task = new Task();

--- a/api/tests/Api/WaitlistTest.php
+++ b/api/tests/Api/WaitlistTest.php
@@ -4,6 +4,7 @@ namespace App\Tests\Api;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Entity\Space;
 use App\Entity\User;
 use App\Service\WaitlistSettings;
 use Doctrine\ORM\EntityManagerInterface;
@@ -100,6 +101,61 @@ class WaitlistTest extends ApiTestCase
         // …but a ROLE_USER-gated endpoint is forbidden (no ROLE_USER).
         $client->request('GET', '/api-tokens');
         $this->assertResponseStatusCodeSame(403);
+    }
+
+    /**
+     * GDPR/CCPA: a waitlisted signup must still be able to export and delete
+     * its own data, even though it holds no ROLE_USER. Goes through the real
+     * signup path so the account carries the personal space created by
+     * UserPasswordHasherProcessor, and asserts deletion reaps it.
+     */
+    public function testWaitlistedSignupCanExportAndDeleteItself(): void
+    {
+        $this->setWaitlist(true);
+        $client = static::createClient();
+
+        $client->request('POST', '/users', [
+            'json' => [
+                'email' => 'leaver@example.com',
+                'plainPassword' => 'Password123!@#',
+                'givenName' => 'Wait',
+                'familyName' => 'Leaver',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+
+        $user = $this->reloadUser('leaver@example.com');
+        $this->assertTrue($user->isWaitlisted());
+
+        $space = $this->entityManager->getRepository(Space::class)
+            ->findOneBy(['createdBy' => $user, 'isPersonal' => true]);
+        $this->assertNotNull($space);
+        $spaceId = (string) $space->getId();
+
+        $client->loginUser($user);
+
+        // Export works despite the missing ROLE_USER.
+        $client->request('POST', '/me/export', [
+            'json' => ['currentPassword' => 'Password123!@#'],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseIsSuccessful();
+        $profile = $this->arrayField($this->body($client), 'profile');
+        $this->assertSame('leaver@example.com', $profile['email']);
+
+        // Delete works too, and reaps the personal space with the account.
+        $client->request('POST', '/me/delete', [
+            'json' => ['confirmEmail' => 'leaver@example.com', 'currentPassword' => 'Password123!@#'],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(204);
+
+        $em = static::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $em->clear();
+        $this->assertNull($em->getRepository(User::class)->findOneBy(['email' => 'leaver@example.com']));
+        $this->assertNull($em->find(Space::class, $spaceId));
     }
 
     public function testAdminEndpointsRequireAdmin(): void

--- a/pwa/components/settings/AccountLifecycleDialogs.tsx
+++ b/pwa/components/settings/AccountLifecycleDialogs.tsx
@@ -1,0 +1,213 @@
+import { useState } from "react";
+import { Loader2 } from "lucide-react";
+import { ENTRYPOINT } from "@/config/entrypoint";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+/**
+ * Step-up confirmation dialogs for the account lifecycle endpoints
+ * (`/me/export`, `/me/delete`). Shared between the Settings danger zone and
+ * the waitlist gate page — waitlisted accounts must still be able to export
+ * and delete their data (GDPR/CCPA) even though the rest of the app is
+ * closed to them.
+ */
+
+/** Shared credential input — TOTP code when 2FA is on, else password. */
+export const StepUpField = ({
+  twoFactorEnabled,
+  value,
+  onChange,
+}: {
+  twoFactorEnabled: boolean;
+  value: string;
+  onChange: (v: string) => void;
+}) => (
+  <div className="space-y-1.5">
+    <Label htmlFor="danger-stepup">
+      {twoFactorEnabled ? "Authentication code" : "Current password"}
+    </Label>
+    <Input
+      id="danger-stepup"
+      type={twoFactorEnabled ? "text" : "password"}
+      inputMode={twoFactorEnabled ? "numeric" : undefined}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      autoComplete={twoFactorEnabled ? "one-time-code" : "current-password"}
+      data-testid="danger-stepup-input"
+    />
+  </div>
+);
+
+export const stepUpBody = (twoFactorEnabled: boolean, value: string) =>
+  twoFactorEnabled ? { totpCode: value } : { currentPassword: value };
+
+export const ExportDataDialog = ({
+  open,
+  onOpenChange,
+  twoFactorEnabled,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  twoFactorEnabled: boolean;
+}) => {
+  const [value, setValue] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(`${ENTRYPOINT}/me/export`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(stepUpBody(twoFactorEnabled, value)),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || "Failed to export.");
+      }
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "aura-export.json";
+      a.click();
+      URL.revokeObjectURL(url);
+      onOpenChange(false);
+      setValue("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Export your data</DialogTitle>
+          <DialogDescription>Confirm to download your data.</DialogDescription>
+        </DialogHeader>
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+        <StepUpField twoFactorEnabled={twoFactorEnabled} value={value} onChange={setValue} />
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={() => void submit()}
+            disabled={submitting || value.trim() === ""}
+            data-testid="export-confirm"
+          >
+            {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : "Download"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export const DeleteAccountDialog = ({
+  open,
+  onOpenChange,
+  twoFactorEnabled,
+  email,
+  onDeleted,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  twoFactorEnabled: boolean;
+  email: string;
+  onDeleted: () => void;
+}) => {
+  const [confirmEmail, setConfirmEmail] = useState("");
+  const [value, setValue] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const emailMatches = confirmEmail.trim().toLowerCase() === email.toLowerCase();
+
+  const submit = async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(`${ENTRYPOINT}/me/delete`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ confirmEmail, ...stepUpBody(twoFactorEnabled, value) }),
+      });
+      if (!res.ok && res.status !== 204) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || "Failed to delete account.");
+      }
+      onDeleted();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="text-destructive">Delete your account</DialogTitle>
+          <DialogDescription>
+            This permanently deletes {email}. Type your email and confirm.
+          </DialogDescription>
+        </DialogHeader>
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+        <div className="space-y-1.5">
+          <Label htmlFor="delete-confirm-email">Type {email} to confirm</Label>
+          <Input
+            id="delete-confirm-email"
+            type="email"
+            value={confirmEmail}
+            onChange={(e) => setConfirmEmail(e.target.value)}
+            autoComplete="off"
+            data-testid="delete-confirm-email"
+          />
+        </div>
+        <StepUpField twoFactorEnabled={twoFactorEnabled} value={value} onChange={setValue} />
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={() => void submit()}
+            disabled={submitting || !emailMatches || value.trim() === ""}
+            data-testid="delete-confirm"
+          >
+            {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : "Delete my account"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/pwa/pages/settings/danger.tsx
+++ b/pwa/pages/settings/danger.tsx
@@ -4,6 +4,12 @@ import { Download, Loader2 } from "lucide-react";
 import { ENTRYPOINT } from "@/config/entrypoint";
 import { useAuth } from "@/contexts/AuthContext";
 import SettingsShell from "@/components/settings/SettingsShell";
+import {
+  DeleteAccountDialog,
+  ExportDataDialog,
+  StepUpField,
+  stepUpBody,
+} from "@/components/settings/AccountLifecycleDialogs";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -15,8 +21,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 
 const DELETE_CONSEQUENCES = [
   "Spaces you solely admin are transferred to another member, or archived if empty.",
@@ -42,35 +46,6 @@ const DangerPage = () => {
     </SettingsShell>
   );
 };
-
-/** Shared credential input — TOTP code when 2FA is on, else password. */
-const StepUpField = ({
-  twoFactorEnabled,
-  value,
-  onChange,
-}: {
-  twoFactorEnabled: boolean;
-  value: string;
-  onChange: (v: string) => void;
-}) => (
-  <div className="space-y-1.5">
-    <Label htmlFor="danger-stepup">
-      {twoFactorEnabled ? "Authentication code" : "Current password"}
-    </Label>
-    <Input
-      id="danger-stepup"
-      type={twoFactorEnabled ? "text" : "password"}
-      inputMode={twoFactorEnabled ? "numeric" : undefined}
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      autoComplete={twoFactorEnabled ? "one-time-code" : "current-password"}
-      data-testid="danger-stepup-input"
-    />
-  </div>
-);
-
-const stepUpBody = (twoFactorEnabled: boolean, value: string) =>
-  twoFactorEnabled ? { totpCode: value } : { currentPassword: value };
 
 const DeactivateCard = ({
   twoFactorEnabled,
@@ -163,39 +138,6 @@ const DeactivateCard = ({
 
 const ExportCard = ({ twoFactorEnabled }: { twoFactorEnabled: boolean }) => {
   const [open, setOpen] = useState(false);
-  const [value, setValue] = useState("");
-  const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const submit = async () => {
-    setSubmitting(true);
-    setError(null);
-    try {
-      const res = await fetch(`${ENTRYPOINT}/me/export`, {
-        method: "POST",
-        credentials: "include",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(stepUpBody(twoFactorEnabled, value)),
-      });
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(data.error || "Failed to export.");
-      }
-      const blob = await res.blob();
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = "aura-export.json";
-      a.click();
-      URL.revokeObjectURL(url);
-      setOpen(false);
-      setValue("");
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed.");
-    } finally {
-      setSubmitting(false);
-    }
-  };
 
   return (
     <Card>
@@ -212,33 +154,7 @@ const ExportCard = ({ twoFactorEnabled }: { twoFactorEnabled: boolean }) => {
         </Button>
       </CardContent>
 
-      <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Export your data</DialogTitle>
-            <DialogDescription>Confirm to download your data.</DialogDescription>
-          </DialogHeader>
-          {error && (
-            <Alert variant="destructive">
-              <AlertDescription>{error}</AlertDescription>
-            </Alert>
-          )}
-          <StepUpField twoFactorEnabled={twoFactorEnabled} value={value} onChange={setValue} />
-          <DialogFooter>
-            <Button type="button" variant="outline" onClick={() => setOpen(false)} disabled={submitting}>
-              Cancel
-            </Button>
-            <Button
-              type="button"
-              onClick={() => void submit()}
-              disabled={submitting || value.trim() === ""}
-              data-testid="export-confirm"
-            >
-              {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : "Download"}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <ExportDataDialog open={open} onOpenChange={setOpen} twoFactorEnabled={twoFactorEnabled} />
     </Card>
   );
 };
@@ -253,34 +169,10 @@ const DeleteCard = ({
   const { logout } = useAuth();
   const router = useRouter();
   const [open, setOpen] = useState(false);
-  const [confirmEmail, setConfirmEmail] = useState("");
-  const [value, setValue] = useState("");
-  const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
-  const emailMatches = confirmEmail.trim().toLowerCase() === email.toLowerCase();
-
-  const submit = async () => {
-    setSubmitting(true);
-    setError(null);
-    try {
-      const res = await fetch(`${ENTRYPOINT}/me/delete`, {
-        method: "POST",
-        credentials: "include",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ confirmEmail, ...stepUpBody(twoFactorEnabled, value) }),
-      });
-      if (!res.ok && res.status !== 204) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(data.error || "Failed to delete account.");
-      }
-      logout();
-      void router.replace("/signin");
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed.");
-    } finally {
-      setSubmitting(false);
-    }
+  const handleDeleted = () => {
+    logout();
+    void router.replace("/signin");
   };
 
   return (
@@ -307,47 +199,13 @@ const DeleteCard = ({
         </Button>
       </CardContent>
 
-      <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle className="text-destructive">Delete your account</DialogTitle>
-            <DialogDescription>
-              This permanently deletes {email}. Type your email and confirm.
-            </DialogDescription>
-          </DialogHeader>
-          {error && (
-            <Alert variant="destructive">
-              <AlertDescription>{error}</AlertDescription>
-            </Alert>
-          )}
-          <div className="space-y-1.5">
-            <Label htmlFor="delete-confirm-email">Type {email} to confirm</Label>
-            <Input
-              id="delete-confirm-email"
-              type="email"
-              value={confirmEmail}
-              onChange={(e) => setConfirmEmail(e.target.value)}
-              autoComplete="off"
-              data-testid="delete-confirm-email"
-            />
-          </div>
-          <StepUpField twoFactorEnabled={twoFactorEnabled} value={value} onChange={setValue} />
-          <DialogFooter>
-            <Button type="button" variant="outline" onClick={() => setOpen(false)} disabled={submitting}>
-              Cancel
-            </Button>
-            <Button
-              type="button"
-              variant="destructive"
-              onClick={() => void submit()}
-              disabled={submitting || !emailMatches || value.trim() === ""}
-              data-testid="delete-confirm"
-            >
-              {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : "Delete my account"}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <DeleteAccountDialog
+        open={open}
+        onOpenChange={setOpen}
+        twoFactorEnabled={twoFactorEnabled}
+        email={email}
+        onDeleted={handleDeleted}
+      />
     </Card>
   );
 };

--- a/pwa/pages/waitlist.tsx
+++ b/pwa/pages/waitlist.tsx
@@ -1,11 +1,15 @@
 import type { NextPage } from "next";
 import Head from "next/head";
 import { useRouter } from "next/router";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Clock } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { signinHrefForCurrent } from "@/lib/authRedirect";
 import AuraWordmark from "@/components/auth/AuraWordmark";
+import {
+  DeleteAccountDialog,
+  ExportDataDialog,
+} from "@/components/settings/AccountLifecycleDialogs";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -18,11 +22,17 @@ import {
 /**
  * Landing page for waitlisted accounts. The WaitlistGate (mounted in Layout)
  * routes every waitlisted user here; this page is the one screen they can see
- * until an admin opens signups and promotes them.
+ * until an admin opens signups and promotes them. Because the Settings shell
+ * is unreachable while waitlisted, the GDPR self-service actions (export +
+ * delete) get a small affordance here.
  */
 const Waitlist: NextPage = () => {
   const { user, isAuthenticated, isLoading, logout } = useAuth();
   const router = useRouter();
+  const [exportOpen, setExportOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  const twoFactorEnabled = Boolean(user?.twoFactor.enabled);
 
   useEffect(() => {
     if (isLoading) return;
@@ -39,6 +49,11 @@ const Waitlist: NextPage = () => {
   const handleSignOut = () => {
     logout();
     router.replace("/signin");
+  };
+
+  const handleDeleted = () => {
+    logout();
+    void router.replace("/signin");
   };
 
   if (isLoading || !isAuthenticated || (user && !user.waitlisted)) {
@@ -77,9 +92,43 @@ const Waitlist: NextPage = () => {
             <Button variant="outline" onClick={handleSignOut} className="w-full">
               Sign out
             </Button>
+            <p className="text-xs text-muted-foreground">
+              Changed your mind?{" "}
+              <button
+                type="button"
+                className="underline underline-offset-2 hover:text-foreground"
+                onClick={() => setExportOpen(true)}
+                data-testid="waitlist-export-open"
+              >
+                Download my data
+              </button>{" "}
+              or{" "}
+              <button
+                type="button"
+                className="underline underline-offset-2 hover:text-destructive"
+                onClick={() => setDeleteOpen(true)}
+                data-testid="waitlist-delete-open"
+              >
+                delete my account
+              </button>
+              .
+            </p>
           </CardContent>
         </Card>
       </div>
+
+      <ExportDataDialog
+        open={exportOpen}
+        onOpenChange={setExportOpen}
+        twoFactorEnabled={twoFactorEnabled}
+      />
+      <DeleteAccountDialog
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        twoFactorEnabled={twoFactorEnabled}
+        email={user?.email ?? ""}
+        onDeleted={handleDeleted}
+      />
     </>
   );
 };


### PR DESCRIPTION
## Problem

The account-lifecycle endpoints were gated by `ROLE_USER` in `security.yaml`. A waitlisted account holds only `ROLE_WAITLISTED` (`User::getRoles()` withholds `ROLE_USER` while `waitlisted` is true), so waitlisted users got 403 on `POST /me/delete` and `/me/export`. Since production launched with waitlist mode on, most new signups could neither self-delete nor export their data — contradicting the privacy policy's deletion promise and GDPR/CCPA expectations.

## Fix

**API**
- Relax `^/me/(deactivate|export|delete)$` to `IS_AUTHENTICATED_FULLY`. The controller only ever operates on the current user, and every action stays step-up protected via `SensitiveActionVerifier` (TOTP when 2FA is on, else `currentPassword`).
- `AccountDeletionService` needs no change: the personal space created at signup is reaped in `handleSpaces`, and the “Former member” sentinel is persisted directly through the EM so it can never be flagged waitlisted.

**PWA**
- Extracted the export/delete step-up dialogs from the danger zone page into `pwa/components/settings/AccountLifecycleDialogs.tsx` (no behavior change on `/settings/danger`).
- The waitlist gate page (`/waitlist`) — the only screen a waitlisted user can reach — now offers “Download my data” / “delete my account” links that open those dialogs.

## Tests

- `AccountLifecycleTest`: a waitlisted user can deactivate, export, and delete (previously 403).
- `WaitlistTest::testWaitlistedSignupCanExportAndDeleteItself`: full path through real signup with waitlist mode on, so the account carries its personal space — asserts export works and deletion removes both the user and the personal space.