### PR TITLE
chore: support Cloudflare Origin Certificate for origin TLS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.env
 /backups/
+/certs/
 /helm/api-platform/charts/*
 !/helm/api-platform/charts/.gitignore

--- a/api/frankenphp/Caddyfile
+++ b/api/frankenphp/Caddyfile
@@ -17,6 +17,15 @@
 {$CADDY_EXTRA_CONFIG}
 
 {$SERVER_NAME:localhost} {
+	# Optional explicit TLS cert (Cloudflare Origin Certificate in prod). When
+	# TLS_DIRECTIVE is unset (dev, and prod before the origin-cert cutover) this
+	# expands to nothing and Caddy keeps its automatic HTTPS (Let's Encrypt for a
+	# public SERVER_NAME, internal cert for localhost). In prod behind the
+	# Cloudflare proxy, set it to `tls /etc/caddy/origin/cert.pem /etc/caddy/origin/key.pem`
+	# so the origin no longer depends on ACME renewal that the proxy can break.
+	# See docs/developer/deployment.md § Origin TLS behind Cloudflare.
+	{$TLS_DIRECTIVE}
+
 	log {
 		# Redact the authorization query parameter that can be set by Mercure
 		format filter {
@@ -155,6 +164,11 @@
 # strong, this is internet-reachable in prod. The loopback-published port
 # on the umami service remains as an SSH-tunnel fallback.
 {$UMAMI_SERVER_NAME:analytics.localhost} {
+	# Same optional explicit TLS as the main block — the Cloudflare Origin
+	# Certificate's *.madori.app wildcard covers analytics.madori.app too, so the
+	# analytics host stops depending on ACME renewal once TLS_DIRECTIVE is set.
+	{$TLS_DIRECTIVE}
+
 	encode zstd br gzip
 
 	header {

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -8,6 +8,17 @@ services:
       APP_SECRET: ${APP_SECRET}
       MERCURE_PUBLISHER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET}
       MERCURE_SUBSCRIBER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET}
+      # Optional explicit TLS for the Caddy site blocks. Empty by default so the
+      # stack keeps automatic HTTPS; set in the server .env to
+      #   TLS_DIRECTIVE=tls /etc/caddy/origin/cert.pem /etc/caddy/origin/key.pem
+      # to serve a Cloudflare Origin Certificate (no ACME renewal). The cert/key
+      # are mounted read-only from ./certs below — place them there first.
+      TLS_DIRECTIVE: ${TLS_DIRECTIVE:-}
+    volumes:
+      # Cloudflare Origin Certificate (and key) for the origin, read-only. The
+      # host ./certs dir is untracked (gitignored) and survives `git reset
+      # --hard` on deploy. Inert until TLS_DIRECTIVE references these paths.
+      - ./certs:/etc/caddy/origin:ro
 
   # Reuses the prod php image (source + vendor baked in, no bind-mount).
   worker:

--- a/docs/developer/deployment.md
+++ b/docs/developer/deployment.md
@@ -94,6 +94,65 @@ docker compose -f compose.yaml -f compose.prod.yaml up -d
 
 Ensure all secrets are set to strong, unique values in production.
 
+## Origin TLS behind Cloudflare
+
+Production (`madori.app`) sits behind the Cloudflare proxy (orange cloud) with
+the SSL/TLS mode set to **Full (strict)**: Cloudflare presents its edge
+certificate to browsers and re-encrypts to the origin, validating the origin's
+certificate. By default Caddy/FrankenPHP auto-provisions a Let's Encrypt
+certificate for the origin, but **ACME renewal can fail behind the proxy** — the
+HTTP-01 / TLS-ALPN-01 challenges are intercepted by Cloudflare — so a renewal
+that silently fails would eventually lapse the origin cert and Full (strict)
+would start returning **HTTP 526** errors.
+
+The durable fix is a **Cloudflare Origin Certificate** (a long-lived cert, up to
+15 years, trusted only by Cloudflare's edge — exactly what a proxied origin
+needs). Caddy serves it via an explicit `tls` directive instead of ACME.
+
+This is wired up but **gated** so it has zero effect until switched on:
+
+- `api/frankenphp/Caddyfile` — both site blocks contain `{$TLS_DIRECTIVE}`,
+  which expands to nothing when the env var is unset (dev and pre-cutover prod
+  keep automatic HTTPS).
+- `compose.prod.yaml` — the `php` service passes `TLS_DIRECTIVE` through and
+  mounts the host `./certs` dir read-only at `/etc/caddy/origin`. `./certs` is
+  gitignored and survives the deploy's `git reset --hard`.
+
+### One-time cutover
+
+1. **Create the Origin Certificate.** In the Cloudflare dashboard:
+   *SSL/TLS → Origin Server → Create Certificate* (let Cloudflare generate the
+   key; hostnames `madori.app` + `*.madori.app`; 15-year validity). Copy the
+   **Origin Certificate** and **Private Key** PEM blocks.
+2. **Place the files on the server** (key readable only by root):
+   ```bash
+   mkdir -p /opt/aura/certs
+   # paste the cert into cert.pem and the key into key.pem
+   chmod 600 /opt/aura/certs/key.pem
+   ```
+3. **Enable it** in `/opt/aura/.env`:
+   ```
+   TLS_DIRECTIVE=tls /etc/caddy/origin/cert.pem /etc/caddy/origin/key.pem
+   ```
+4. **Recreate the `php` container** to pick up the new env + Caddyfile:
+   ```bash
+   docker compose -f compose.yaml -f compose.prod.yaml up -d php
+   ```
+5. **Verify** the origin now serves the Cloudflare Origin CA cert and the site
+   is still healthy through the proxy:
+   ```bash
+   echo | openssl s_client -connect 5.78.210.192:443 -servername madori.app 2>/dev/null \
+     | openssl x509 -noout -issuer -subject        # issuer: Cloudflare, Inc.
+   curl -sS -o /dev/null -w '%{http_code}\n' https://madori.app/   # 200
+   ```
+
+> The Caddyfile change ships in the `app-php` image, so the cutover requires the
+> image built from a commit that contains `{$TLS_DIRECTIVE}` to be deployed
+> first. Until step 3 sets the var, that deploy is a no-op for TLS.
+
+**Rollback:** remove the `TLS_DIRECTIVE` line from `.env` and
+`up -d php` again — Caddy reverts to automatic Let's Encrypt.
+
 ## Backups
 
 The compose stack has two stateful pieces: the PostgreSQL database (volume


### PR DESCRIPTION
## What

Adds a **gated** way to serve a **Cloudflare Origin Certificate** for the origin's TLS, instead of relying on Caddy's Let's Encrypt auto-renewal.

## Why

`madori.app` runs behind the Cloudflare proxy (orange cloud) with SSL/TLS mode **Full (strict)**. Caddy/FrankenPHP auto-provisions a Let's Encrypt cert for the origin, but **ACME renewal can fail behind the proxy** (the HTTP-01 / TLS-ALPN-01 challenges get intercepted by Cloudflare). If a renewal silently fails, the origin cert lapses and Full (strict) starts returning **HTTP 526**. A long-lived Cloudflare Origin Certificate removes the ACME dependency entirely.

## Changes

- **`api/frankenphp/Caddyfile`** — both site blocks gain `{$TLS_DIRECTIVE}`. Unset (dev + prod before cutover) → expands to nothing → automatic HTTPS unchanged.
- **`compose.prod.yaml`** — `php` passes `TLS_DIRECTIVE` through and mounts the untracked host `./certs` dir read-only at `/etc/caddy/origin`.
- **`.gitignore`** — ignore `/certs/`.
- **`docs/developer/deployment.md`** — new "Origin TLS behind Cloudflare" section with the one-time cutover steps + rollback.

## Safety

**No behavior change until `TLS_DIRECTIVE` is set in the server `.env`.** Merging + deploying this is a no-op for TLS; the actual cutover (generate origin cert → place in `/opt/aura/certs` → set `TLS_DIRECTIVE` → `up -d php`) is a separate, documented manual step. Rollback = remove the env line and recreate the container (reverts to Let's Encrypt).
