### PR TITLE
fix: clear signup consent error immediately when the box is checked

### DIFF
--- a/pwa/components/auth/TermsConsentField.tsx
+++ b/pwa/components/auth/TermsConsentField.tsx
@@ -25,8 +25,13 @@ const TermsConsentField = ({ name = "acceptTerms" }: { name?: string }) => {
           id={id}
           checked={field.value}
           onCheckedChange={(checked) => {
+            // Mark touched without validating against the stale snapshot, then
+            // let setValue run the single validation pass that sees the new
+            // value. Validating on the touched update can re-assert the error
+            // using the previous (still-false) values, leaving the error shown
+            // under an already-checked box.
+            helpers.setTouched(true, false);
             helpers.setValue(checked === true);
-            helpers.setTouched(true);
           }}
           aria-invalid={showError}
           aria-describedby={showError ? `${id}-error` : undefined}


### PR DESCRIPTION
## Summary

Fixes #403 — the consent validation error *"Please agree to the Terms and Privacy Policy to continue."* stayed visible in red even after the *I agree to Aura's Terms and Privacy Policy* checkbox was checked.

## Root cause

`TermsConsentField` drives the Radix checkbox by hand:

```ts
onCheckedChange={(checked) => {
  helpers.setValue(checked === true);
  helpers.setTouched(true);
}}
```

This is the classic Formik stale-validation race. `setValue` and `setTouched(true)` each kick off an async validation pass; the one started by `setTouched(true)` can run against the **previous** values snapshot (where `acceptTerms` is still `false`), re-asserting the error after the `setValue` pass cleared it. The error then renders because `touched` is now true while `field.value === true`.

## Fix

Mark touched **without** validating, then let `setValue` run the single validation pass that sees the new value:

```ts
helpers.setTouched(true, false); // no validation against stale values
helpers.setValue(checked === true); // validates with the new value
```

## Affected surfaces

The fix lands in the shared `TermsConsentField` clickwrap component, so all three account-creation surfaces are covered:
- Standard + waitlist signup (`SignUpForm.tsx`)
- Invite acceptance (`InviteSignup.tsx`)

Introduced with the consent gate in #393; observed live on madori.app 2026-06-10.