### PR TITLE
feat: waitlist confirmation email at signup

### DIFF
--- a/api/src/Service/WaitlistJoinedMailer.php
+++ b/api/src/Service/WaitlistJoinedMailer.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\User;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Mailer\MailerInterface;
+
+/**
+ * Sends the "you're on the waitlist" confirmation email at signup time while
+ * waitlist mode is on. Purely informational — it sets the expectation that we
+ * email when access opens and closes the loop on a signup that otherwise gets
+ * only the in-app confirmation screen (#404).
+ *
+ * Reads as a pair with {@see WaitlistAccessMailer} (same MAILER_FROM fallback);
+ * carries no token and nothing actionable. Sending is best-effort at the call
+ * site ({@see \App\State\UserPasswordHasherProcessor}) — a dead SMTP server
+ * must not roll back the signup that already landed in the database.
+ */
+final class WaitlistJoinedMailer
+{
+    public function __construct(
+        private MailerInterface $mailer,
+        #[Autowire('%env(default::MAILER_FROM)%')]
+        private ?string $mailerFrom = null,
+    ) {
+    }
+
+    public function sendJoinedConfirmation(User $user): void
+    {
+        $from = (null !== $this->mailerFrom && '' !== $this->mailerFrom) ? $this->mailerFrom : 'no-reply@aura.test';
+
+        $email = (new TemplatedEmail())
+            ->from($from)
+            ->to($user->getEmail())
+            ->subject("You're on the Aura waitlist")
+            ->htmlTemplate('emails/waitlist_joined.html.twig')
+            ->textTemplate('emails/waitlist_joined.txt.twig')
+            ->context([
+                'recipient' => $user,
+            ]);
+
+        $this->mailer->send($email);
+    }
+}

--- a/api/src/State/UserPasswordHasherProcessor.php
+++ b/api/src/State/UserPasswordHasherProcessor.php
@@ -10,11 +10,14 @@ use App\Entity\SpaceMembership;
 use App\Entity\User;
 use App\Repository\UserInviteRepository;
 use App\Service\AvatarColorService;
+use App\Service\WaitlistJoinedMailer;
 use App\Service\WaitlistSettings;
 use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
 
@@ -34,6 +37,8 @@ final class UserPasswordHasherProcessor implements ProcessorInterface
         private UserInviteRepository $inviteRepository,
         private EntityManagerInterface $em,
         private WaitlistSettings $waitlistSettings,
+        private WaitlistJoinedMailer $waitlistJoinedMailer,
+        private LoggerInterface $logger,
         #[Autowire(service: 'limiter.signup_ip')]
         private RateLimiterFactoryInterface $signupLimiter,
         private RequestStack $requestStack,
@@ -96,6 +101,15 @@ final class UserPasswordHasherProcessor implements ProcessorInterface
             $this->acceptInvite($user, $inviteToken);
         }
 
+        // Confirm the signup with a "you're on the list" email (#404). Gated on
+        // the persisted waitlisted flag, not the setting, so an invite-token
+        // signup that ever bypasses the gate (lands un-waitlisted) won't get it.
+        // Best-effort after the flush, mirroring the access email — a dead SMTP
+        // server logs a warning but can't undo the signup that already landed.
+        if ($operation instanceof Post && $user->isWaitlisted()) {
+            $this->sendWaitlistJoined($user);
+        }
+
         return $user;
     }
 
@@ -125,6 +139,18 @@ final class UserPasswordHasherProcessor implements ProcessorInterface
             $retryAfter,
             'Too many accounts created from this network. Please try again later.',
         );
+    }
+
+    private function sendWaitlistJoined(User $user): void
+    {
+        try {
+            $this->waitlistJoinedMailer->sendJoinedConfirmation($user);
+        } catch (TransportExceptionInterface $e) {
+            $this->logger->warning('Failed to send waitlist confirmation email to {email}: {error}', [
+                'email' => $user->getEmail(),
+                'error' => $e->getMessage(),
+            ]);
+        }
     }
 
     /**

--- a/api/templates/emails/waitlist_joined.html.twig
+++ b/api/templates/emails/waitlist_joined.html.twig
@@ -1,0 +1,10 @@
+{# @var recipient \App\Entity\User #}
+<p>Hi {{ recipient.givenName ?: recipient.email }},</p>
+
+<p>Thanks for joining the Aura waitlist — you're on the list.</p>
+
+<p>We're opening access in batches. When your spot comes up, we'll email you a
+link to sign in with the email and password you just chose. There's nothing
+you need to do until then.</p>
+
+<p>&mdash; Aura</p>

--- a/api/templates/emails/waitlist_joined.txt.twig
+++ b/api/templates/emails/waitlist_joined.txt.twig
@@ -1,0 +1,10 @@
+{# @var recipient \App\Entity\User #}
+Hi {{ recipient.givenName ?: recipient.email }},
+
+Thanks for joining the Aura waitlist — you're on the list.
+
+We're opening access in batches. When your spot comes up, we'll email you a link
+to sign in with the email and password you just chose. There's nothing you need
+to do until then.
+
+— Aura

--- a/api/tests/Api/WaitlistTest.php
+++ b/api/tests/Api/WaitlistTest.php
@@ -58,6 +58,15 @@ class WaitlistTest extends ApiTestCase
         ]);
         $this->assertResponseStatusCodeSame(201);
 
+        // Exactly one "you're on the waitlist" confirmation goes to the signup
+        // address (#404). Asserted before any further request — the mailer
+        // profiler reflects only the most recent request.
+        $this->assertEmailCount(1);
+        $email = $this->getMailerMessage();
+        self::assertNotNull($email);
+        $this->assertEmailAddressContains($email, 'To', 'waiter@example.com');
+        $this->assertEmailHeaderSame($email, 'Subject', "You're on the Aura waitlist");
+
         $user = $this->reloadUser('waiter@example.com');
         $this->assertTrue($user->isWaitlisted());
         $this->assertSame(['ROLE_WAITLISTED'], $user->getRoles());
@@ -78,6 +87,9 @@ class WaitlistTest extends ApiTestCase
             'headers' => ['Content-Type' => 'application/ld+json'],
         ]);
         $this->assertResponseStatusCodeSame(201);
+
+        // Open signups get no waitlist confirmation email.
+        $this->assertEmailCount(0);
 
         $user = $this->reloadUser('open@example.com');
         $this->assertFalse($user->isWaitlisted());

--- a/pwa/components/auth/AuthCard.tsx
+++ b/pwa/components/auth/AuthCard.tsx
@@ -3,8 +3,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { CheckCircle2, Loader2 } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
-import { ENTRYPOINT } from "@/config/entrypoint";
-import { fetchWithTimeout } from "@/lib/fetchWithTimeout";
+import { useSignupStatus } from "@/lib/useSignupStatus";
 import { isSafeNextPath, safeNextPath } from "@/lib/authRedirect";
 import { AVATAR_PALETTE } from "@/lib/avatarPalette";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -127,10 +126,6 @@ const AuthCard = ({ defaultTab }: Props) => {
     defaultTab === "signup" ? "signup-form" : "credentials",
   );
   const [twoFactorEmail, setTwoFactorEmail] = useState<string | null>(null);
-  // Whether the instance is in waitlist mode — drives the signup copy and
-  // flow. Defaults to false (open signups); the /signup-status fetch below
-  // flips it on. Invite signups always run the normal flow.
-  const [waitlistMode, setWaitlistMode] = useState(false);
 
   // Sign-up multi-step state. The form payload is captured on step 1
   // and held here so step 2 can POST it with the chosen color; the
@@ -152,6 +147,13 @@ const AuthCard = ({ defaultTab }: Props) => {
   const registered = router.query.registered === "true";
   const reset = router.query.reset === "true";
 
+  // Whether the instance is in waitlist mode — drives the signup copy/flow and
+  // the footer CTA on both entry points. Invite signups always run the normal
+  // flow (they bypass the gate), so an invite token forces it off. Errors fall
+  // back to open signups; the server still enforces the real gate.
+  const { waitlistEnabled } = useSignupStatus();
+  const waitlistMode = waitlistEnabled && !inviteToken;
+
   useEffect(() => {
     // Authenticated users normally don't need /signin or /signup, so
     // we bounce them to wherever `next` points. The one exception is
@@ -163,28 +165,6 @@ const AuthCard = ({ defaultTab }: Props) => {
       router.replace(safeNextPath(next));
     }
   }, [isLoading, isAuthenticated, next, router, inviteToken]);
-
-  // Resolve whether signups are open or gated behind the waitlist. Only the
-  // signup entry point needs to know (the sign-in side is unaffected), and
-  // invite signups always bypass the waitlist. Errors fall back to open
-  // signups — the server still enforces the real gate.
-  useEffect(() => {
-    if (defaultTab !== "signup" || inviteToken) return;
-    let cancelled = false;
-    (async () => {
-      try {
-        const res = await fetchWithTimeout(`${ENTRYPOINT}/signup-status`);
-        if (!res.ok) return;
-        const data = await res.json();
-        if (!cancelled) setWaitlistMode(Boolean(data.waitlistEnabled));
-      } catch {
-        /* keep the open-signup default */
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [defaultTab, inviteToken]);
 
   const queryIndex = router.asPath.indexOf("?");
   const search = queryIndex >= 0 ? router.asPath.slice(queryIndex) : "";
@@ -204,6 +184,14 @@ const AuthCard = ({ defaultTab }: Props) => {
   const tabCopy = COPY[step === "credentials" ? "signin" : "signup"];
   const isTwoFactor = step === "totp" || step === "backup";
   const tfCopy = isTwoFactor ? twoFactorCopy(step, twoFactorEmail) : null;
+
+  // The footer's "switch" CTA points either at signup or signin. When it leads
+  // to signup and the instance is waitlisted, label it "Join the waitlist" so
+  // the signin page's footer reads the same as every other public CTA.
+  const switchCta =
+    waitlistMode && tabCopy.switchPath === "/signup"
+      ? "Join the waitlist"
+      : tabCopy.switchCta;
 
   const cardCopy: { title: string; subtitle: string } | null = (() => {
     if (tfCopy) return { title: tfCopy.title, subtitle: tfCopy.subtitle };
@@ -414,7 +402,7 @@ const AuthCard = ({ defaultTab }: Props) => {
                   href={`${tabCopy.switchPath}${search}`}
                   className="text-primary font-semibold hover:text-foreground"
                 >
-                  {tabCopy.switchCta}
+                  {switchCta}
                 </Link>
               </>
             )}

--- a/pwa/components/common/Navbar.tsx
+++ b/pwa/components/common/Navbar.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { Menu } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
+import { useSignupStatus } from "@/lib/useSignupStatus";
 import { Button } from "@/components/ui/button";
 import {
   Sheet,
@@ -19,6 +20,7 @@ import SidebarNav from "./SidebarNav";
 
 const Navbar = () => {
   const { isAuthenticated } = useAuth();
+  const { waitlistEnabled } = useSignupStatus();
 
   return (
     <nav className="border-b bg-background">
@@ -89,7 +91,9 @@ const Navbar = () => {
                 <Link href="/signin">Sign In</Link>
               </Button>
               <Button asChild size="sm">
-                <Link href="/signup">Sign Up</Link>
+                <Link href="/signup">
+                  {waitlistEnabled ? "Join the waitlist" : "Sign Up"}
+                </Link>
               </Button>
             </>
           )}

--- a/pwa/lib/useSignupStatus.ts
+++ b/pwa/lib/useSignupStatus.ts
@@ -1,0 +1,28 @@
+import { useQuery } from "@tanstack/react-query";
+import { ENTRYPOINT } from "@/config/entrypoint";
+import { fetchWithTimeout } from "@/lib/fetchWithTimeout";
+
+/**
+ * Public signup gate. Mirrors the API's `GET /signup-status` — `true` means the
+ * instance is in waitlist mode, so the public CTAs ("Sign up" / "Get started")
+ * read as "Join the waitlist" instead. Unauthenticated and cheap; cached across
+ * the navbar + landing page + auth card so the label stays consistent.
+ *
+ * Errors fall back to open signups — the server still enforces the real gate,
+ * and a stray "Sign up" label on a waitlisted instance just lands the visitor
+ * on the signup page, which swaps to the waitlist flow on its own.
+ */
+export function useSignupStatus(): { waitlistEnabled: boolean; isLoading: boolean } {
+  const query = useQuery({
+    queryKey: ["signup-status"],
+    queryFn: async (): Promise<boolean> => {
+      const res = await fetchWithTimeout(`${ENTRYPOINT}/signup-status`);
+      if (!res.ok) return false;
+      const data = await res.json();
+      return Boolean(data.waitlistEnabled);
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+
+  return { waitlistEnabled: query.data ?? false, isLoading: query.isLoading };
+}

--- a/pwa/pages/index.tsx
+++ b/pwa/pages/index.tsx
@@ -25,6 +25,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
+import { useSignupStatus } from "@/lib/useSignupStatus";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -544,6 +545,8 @@ const WRAP = "mx-auto w-full max-w-[1180px] px-6";
 
 const Home = () => {
   const { isAuthenticated } = useAuth();
+  const { waitlistEnabled } = useSignupStatus();
+  const signupCta = waitlistEnabled ? "Join the waitlist" : "Get started — free";
 
   return (
     <>
@@ -608,7 +611,7 @@ const Home = () => {
                 ) : (
                   <>
                     <Button asChild size="lg" className={GLOW}>
-                      <Link href="/signup">Get started — free</Link>
+                      <Link href="/signup">{signupCta}</Link>
                     </Button>
                     <Button asChild size="lg" variant="secondary">
                       <Link href="/signin">Sign in</Link>
@@ -778,7 +781,7 @@ const Home = () => {
                   </Button>
                 ) : (
                   <Button asChild size="lg" className={GLOW}>
-                    <Link href="/signup">Get started — free</Link>
+                    <Link href="/signup">{signupCta}</Link>
                   </Button>
                 )}
               </div>


### PR DESCRIPTION
Closes #404

## Backend — waitlist confirmation email (#404)

When waitlist mode is on, a fresh signup now receives a **"You're on the Aura waitlist"** confirmation email. Previously the only email in the flow was the *access* email sent later, at promotion — a new signup got the in-app "you're on the list" screen and then silence.

- **`App\Service\WaitlistJoinedMailer`** — mirrors `WaitlistAccessMailer` (same `MAILER_FROM` fallback). Purely informational: no token, no links that require an active account.
- **`emails/waitlist_joined.{html,txt}.twig`** — "you're on the list / we'll email when access opens" copy.
- **`UserPasswordHasherProcessor`** — sends best-effort post-flush, gated on the **persisted `waitlisted` flag** (not the setting), so open signups and any future invite-token bypass don't get it. SMTP errors log a warning but can't roll back the signup.
- Tests in `WaitlistTest`: waitlist-on signup asserts one email (right recipient + subject); open signup asserts none. Inline since `when@test` routes Messenger to `sync://`.

## Frontend — "Join the waitlist" CTA copy

While the instance is gated, the public sign-up CTAs now read **"Join the waitlist"** instead of "Sign Up" / "Get started":

- New shared **`useSignupStatus()`** hook (react-query over `GET /signup-status`, cached) — replaces `AuthCard`'s one-off fetch so both the signin and signup entry points learn the gate.
- **Navbar** "Sign Up" button, **landing-page** hero + closing CTAs, and the **auth card's signin-footer** CTA all swap to "Join the waitlist" when waitlisted.
- Invite signups bypass the gate and keep the normal copy. Falls back to open-signup copy on error — the server still enforces the real gate, and the signup page already swaps to the waitlist flow on its own.