### PR TITLE
feat: land in Private space on sign-in by default

### DIFF
--- a/e2e/tests/auth-redirect.spec.js
+++ b/e2e/tests/auth-redirect.spec.js
@@ -127,9 +127,9 @@ test.describe("Auth redirect", () => {
   });
 
   // Each entry is a `?next=` value that should be rejected by `safeNextPath()`
-  // and fall back to /settings/profile. The list is the full set of attack
-  // vectors the helper guards against; if any of them ever land the user
-  // somewhere else, we want CI to scream.
+  // and fall back to /projects (the default post-login landing). The list is
+  // the full set of attack vectors the helper guards against; if any of them
+  // ever land the user somewhere else, we want CI to scream.
   const HOSTILE_NEXT_VALUES = [
     {
       label: "protocol-relative URL (`//host/...`)",
@@ -186,7 +186,7 @@ test.describe("Auth redirect", () => {
 
       // Falls back to the default landing page rather than wherever
       // the attacker tried to send us.
-      await expect(page).toHaveURL(/\/settings\/profile$/);
+      await expect(page).toHaveURL(/\/projects$/);
     });
   }
 });

--- a/e2e/tests/auth.spec.js
+++ b/e2e/tests/auth.spec.js
@@ -65,10 +65,14 @@ test.describe("Authentication", () => {
     await page.fill("#password", "Password123!@#");
     await page.click('button[type="submit"]');
 
-    // Should redirect to the Settings profile panel. The email now appears
-    // in two places after sign-in (sidebar header + profile identity form),
-    // so scope the assertion to the main panel.
-    await expect(page).toHaveURL(/\/settings\/profile/);
+    // A fresh sign-in with no redirect lands on the workspace home
+    // (/projects) with the user's Private space active (#405).
+    await expect(page).toHaveURL(/\/projects/);
+
+    // Confirm we're signed in as the right account. The email appears in
+    // two places (sidebar header + profile identity form), so open the
+    // profile panel and scope the assertion to the main panel.
+    await page.goto(`${BASE_URL}/settings/profile`);
     await expect(
       page.getByRole("main").getByText(email),
     ).toBeVisible();
@@ -90,7 +94,8 @@ test.describe("Authentication", () => {
     await page.fill("#password", "admin123");
     await page.click('button[type="submit"]');
 
-    await expect(page).toHaveURL(/\/settings\/profile/);
+    // Fresh sign-in lands on the workspace home (#405).
+    await expect(page).toHaveURL(/\/projects/);
 
     // Navigate to admin
     await page.goto(`${BASE_URL}/admin`);

--- a/e2e/tests/email-change.spec.js
+++ b/e2e/tests/email-change.spec.js
@@ -18,6 +18,10 @@ async function registerAndSignIn(page, request, email, password = "Password123!@
   await page.fill("#email", email);
   await page.fill("#password", password);
   await page.click('button[type="submit"]');
+  // A fresh sign-in lands on the workspace home (#405); the email-change
+  // form lives on the profile panel, so land callers there.
+  await expect(page).toHaveURL(/\/projects/);
+  await page.goto(`${BASE_URL}/settings/profile`);
   await expect(page).toHaveURL(/\/settings\/profile/);
 }
 
@@ -94,7 +98,8 @@ test.describe("Change email (authenticated)", () => {
     await page.fill("#email", newEmail);
     await page.fill("#password", "Password123!@#");
     await page.click('button[type="submit"]');
-    await expect(page).toHaveURL(/\/settings\/profile/);
+    // Fresh sign-in lands on the workspace home (#405).
+    await expect(page).toHaveURL(/\/projects/);
 
     // Now follow the revert link
     await page.goto(revertUrl);
@@ -106,7 +111,8 @@ test.describe("Change email (authenticated)", () => {
     await page.fill("#email", oldEmail);
     await page.fill("#password", "Password123!@#");
     await page.click('button[type="submit"]');
-    await expect(page).toHaveURL(/\/settings\/profile/);
+    // Fresh sign-in lands on the workspace home (#405).
+    await expect(page).toHaveURL(/\/projects/);
   });
 
   test("cannot request a change to an already-registered address", async ({

--- a/e2e/tests/helpers.js
+++ b/e2e/tests/helpers.js
@@ -21,7 +21,9 @@ async function registerAndSignIn(page, email, password = "Password123!@#", optio
   await page.fill("#email", email);
   await page.fill("#password", password);
   await page.click('button[type="submit"]');
-  await expect(page).toHaveURL(/\/settings\/profile/);
+  // A fresh sign-in with no `?next=` lands on the workspace home
+  // (/projects), with the user's Private space active (#405).
+  await expect(page).toHaveURL(/\/projects/);
 }
 
 /**

--- a/e2e/tests/notifications.spec.js
+++ b/e2e/tests/notifications.spec.js
@@ -11,7 +11,7 @@ const uniqueEmail = () => shared("notifications");
 test.describe("Notifications", () => {
   test("authenticated users see the notification bell with a zero state", async ({ page }) => {
     await registerAndSignIn(page, uniqueEmail());
-    // Land on the account page (registerAndSignIn redirects there) — the
+    // Land on the workspace home (registerAndSignIn redirects there) — the
     // bell is part of the navbar and is visible on every authenticated route.
     const bell = page.locator('[data-testid="notification-bell"]');
     await expect(bell).toBeVisible();

--- a/e2e/tests/password.spec.js
+++ b/e2e/tests/password.spec.js
@@ -65,7 +65,8 @@ test.describe("Change password (authenticated)", () => {
     await page.fill("#email", email);
     await page.fill("#password", "OriginalPass1!");
     await page.click('button[type="submit"]');
-    await expect(page).toHaveURL(/\/settings\/profile/);
+    // Fresh sign-in lands on the workspace home (#405).
+    await expect(page).toHaveURL(/\/projects/);
 
     // Change password — the form lives on the Security panel.
     await page.goto(`${BASE_URL}/settings/security`);
@@ -86,7 +87,8 @@ test.describe("Change password (authenticated)", () => {
     await page.fill("#email", email);
     await page.fill("#password", "BrandNewPass1!");
     await page.click('button[type="submit"]');
-    await expect(page).toHaveURL(/\/settings\/profile/);
+    // Fresh sign-in lands on the workspace home (#405).
+    await expect(page).toHaveURL(/\/projects/);
   });
 
   test("wrong current password shows error", async ({ page, request }) => {
@@ -97,7 +99,8 @@ test.describe("Change password (authenticated)", () => {
     await page.fill("#email", email);
     await page.fill("#password", "OriginalPass1!");
     await page.click('button[type="submit"]');
-    await expect(page).toHaveURL(/\/settings\/profile/);
+    // Fresh sign-in lands on the workspace home (#405).
+    await expect(page).toHaveURL(/\/projects/);
 
     await page.goto(`${BASE_URL}/settings/security`);
     await page.fill("#currentPassword", "wrongpass");
@@ -121,7 +124,8 @@ test.describe("Change password (authenticated)", () => {
     await page.fill("#email", email);
     await page.fill("#password", "OriginalPass1!");
     await page.click('button[type="submit"]');
-    await expect(page).toHaveURL(/\/settings\/profile/);
+    // Fresh sign-in lands on the workspace home (#405).
+    await expect(page).toHaveURL(/\/projects/);
 
     await page.goto(`${BASE_URL}/settings/security`);
     await page.fill("#currentPassword", "OriginalPass1!");
@@ -175,7 +179,8 @@ test.describe("Forgot password (reset via email)", () => {
     await page.fill("#email", email);
     await page.fill("#password", "BrandNewPass1!");
     await page.click('button[type="submit"]');
-    await expect(page).toHaveURL(/\/settings\/profile/);
+    // Fresh sign-in lands on the workspace home (#405).
+    await expect(page).toHaveURL(/\/projects/);
   });
 
   test("forgot-password returns success for unknown email (no enumeration)", async ({

--- a/pwa/components/auth/SignInForm.tsx
+++ b/pwa/components/auth/SignInForm.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 import { useState } from "react";
 import { Formik, Form } from "formik";
 import { useAuth } from "@/contexts/AuthContext";
+import { markActiveSpaceReset } from "@/contexts/ActiveSpaceContext";
 import { safeNextPath } from "@/lib/authRedirect";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -72,6 +73,11 @@ const SignInForm = ({ next, registered, reset, onTwoFactorRequired }: Props) => 
         onSubmit={async (values, { setSubmitting, setStatus }) => {
           try {
             const result = await login(values.email, values.password);
+            // Password accepted (login throws otherwise) — flag this as a
+            // fresh sign-in so the active space resets to Private. Set
+            // before the 2FA branch so it also covers the two-step path;
+            // the flag persists until the user fully authenticates.
+            markActiveSpaceReset();
             if (result.requiresTwoFactor) {
               onTwoFactorRequired(values.email);
               return;

--- a/pwa/contexts/ActiveSpaceContext.tsx
+++ b/pwa/contexts/ActiveSpaceContext.tsx
@@ -107,18 +107,47 @@ const ActiveSpaceContext = createContext<ActiveSpaceContextType | undefined>(
   undefined,
 );
 
-const STORAGE_KEY = "aura.activeSpaceId";
+// Per-user storage key — `aura.activeSpaceId.{userId}` — so two
+// accounts alternating on one browser never inherit each other's
+// selection. The legacy un-scoped key is dropped on sight (see below).
+const STORAGE_PREFIX = "aura.activeSpaceId";
+const LEGACY_STORAGE_KEY = "aura.activeSpaceId";
+const storageKeyFor = (userId: string) => `${STORAGE_PREFIX}.${userId}`;
+
+// sessionStorage flag set by the sign-in flow (see markActiveSpaceReset)
+// so the next active-space resolution starts in the personal space
+// rather than restoring whatever was last selected on this browser.
+const RESET_FLAG_KEY = "aura.activeSpaceReset";
+
+/**
+ * Called by the sign-in flow on a successful login so the post-login
+ * landing starts in the user's Private space instead of restoring the
+ * previous browser-local selection. Consumed once by ActiveSpaceContext
+ * when the authenticated user resolves; mid-session reloads (no flag)
+ * keep the currently selected space.
+ */
+export function markActiveSpaceReset() {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(RESET_FLAG_KEY, "1");
+  } catch {
+    // Private-mode / storage-disabled browsers: the worst case is that
+    // a fresh sign-in restores the last space instead of Private, which
+    // is the pre-#405 behavior — acceptable, not worth surfacing.
+  }
+}
 
 /**
  * Loads the user's space list from `GET /spaces` (already scoped to
  * the caller by SpaceAccessExtension) and tracks the active space —
  * the one whose content the listings should show.
  *
- * The active-space choice is persisted in localStorage under
- * `aura.activeSpaceId` so it sticks across reloads. On first load
- * (or when the previous selection is no longer accessible — left the
- * space, deleted it, etc.) we fall back to the personal "Private"
- * space, which is always present.
+ * The active-space choice is persisted in localStorage under a
+ * per-user key (`aura.activeSpaceId.{userId}`) so it sticks across
+ * reloads. On a fresh sign-in (flagged by `markActiveSpaceReset`), on
+ * first load, or when the previous selection is no longer accessible
+ * (left the space, deleted it, etc.), we fall back to the personal
+ * "Private" space, which is always present.
  *
  * Mounted INSIDE AuthProvider so it can react to login/logout: spaces
  * are re-fetched whenever the authenticated user changes, and cleared
@@ -132,15 +161,34 @@ export function ActiveSpaceProvider({ children }: { children: ReactNode }) {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Restore the persisted choice once on mount. We can't read
-  // localStorage during the initial render in Next.js (no `window`
-  // server-side), so the active-space stays null on first paint and
-  // settles after this effect runs.
+  // Resolve the persisted choice whenever the authenticated user
+  // settles. We can't read localStorage during the initial render in
+  // Next.js (no `window` server-side), so the active-space stays null
+  // on first paint and settles after this effect runs.
+  //
+  // On a fresh sign-in (RESET_FLAG_KEY set by markActiveSpaceReset) we
+  // discard any stored choice and start in the personal space; on a
+  // plain reload we restore the per-user selection so it survives.
   useEffect(() => {
     if (typeof window === "undefined") return;
-    const stored = window.localStorage.getItem(STORAGE_KEY);
-    if (stored) setActiveSpaceId(stored);
-  }, []);
+    // Drop the legacy un-scoped key so a selection can never bleed
+    // across accounts on a shared browser.
+    window.localStorage.removeItem(LEGACY_STORAGE_KEY);
+
+    if (!user?.id) {
+      setActiveSpaceId(null);
+      return;
+    }
+
+    if (window.sessionStorage.getItem(RESET_FLAG_KEY)) {
+      window.sessionStorage.removeItem(RESET_FLAG_KEY);
+      window.localStorage.removeItem(storageKeyFor(user.id));
+      setActiveSpaceId(null);
+      return;
+    }
+
+    setActiveSpaceId(window.localStorage.getItem(storageKeyFor(user.id)));
+  }, [user?.id]);
 
   const fetchSpaces = useCallback(async () => {
     setIsLoading(true);
@@ -186,12 +234,15 @@ export function ActiveSpaceProvider({ children }: { children: ReactNode }) {
     spaces[0] ??
     null;
 
-  const setActiveSpace = useCallback((space: Space) => {
-    setActiveSpaceId(space.id);
-    if (typeof window !== "undefined") {
-      window.localStorage.setItem(STORAGE_KEY, space.id);
-    }
-  }, []);
+  const setActiveSpace = useCallback(
+    (space: Space) => {
+      setActiveSpaceId(space.id);
+      if (typeof window !== "undefined" && user?.id) {
+        window.localStorage.setItem(storageKeyFor(user.id), space.id);
+      }
+    },
+    [user?.id],
+  );
 
   const isActiveSpaceAdmin = !!(
     activeSpace &&

--- a/pwa/contexts/ActiveSpaceContext.tsx
+++ b/pwa/contexts/ActiveSpaceContext.tsx
@@ -241,7 +241,7 @@ export function ActiveSpaceProvider({ children }: { children: ReactNode }) {
         window.localStorage.setItem(storageKeyFor(user.id), space.id);
       }
     },
-    [user?.id],
+    [user],
   );
 
   const isActiveSpaceAdmin = !!(

--- a/pwa/lib/authRedirect.ts
+++ b/pwa/lib/authRedirect.ts
@@ -12,7 +12,12 @@
  * redirector.
  */
 
-const FALLBACK_PATH = "/settings/profile";
+// Where a successful sign-in with no explicit `?next=` target lands —
+// and the safety fallback for an invalid/hostile `next` value. The
+// natural home is the user's workspace (their Private space is made
+// active on a fresh sign-in by ActiveSpaceContext), not the settings
+// shell.
+const FALLBACK_PATH = "/projects";
 
 // Arbitrary base used to round-trip user-supplied `next` through the
 // URL parser. The host/protocol are bogus so we can detect any value

--- a/pwa/pages/dev/components/space-switcher.tsx
+++ b/pwa/pages/dev/components/space-switcher.tsx
@@ -4,7 +4,7 @@ import ComponentDoc from "@/components/dev/ComponentDoc";
 const SpaceSwitcherPage = () => (
   <ComponentDoc
     name="SpaceSwitcher"
-    description="Active-space dropdown rendered at the top of SidebarNav (under the user header, above the personal links). Picks the user's current space and persists the choice via ActiveSpaceContext (localStorage key `aura.activeSpaceId`), so listing pages (`/projects`, `/discussions`) scope to it. The dropdown lists spaces by recency, selecting one navigates to `/spaces/{id}`, and a divider adds shortcuts to All spaces (/spaces) and Create space (/spaces/new). Personal spaces wear a lock icon. Renders 'Loading…' until the space list resolves and nothing if the user has no active space."
+    description="Active-space dropdown rendered at the top of SidebarNav (under the user header, above the personal links). Picks the user's current space and persists the choice via ActiveSpaceContext (per-user localStorage key `aura.activeSpaceId.{userId}`, reset to the Private space on a fresh sign-in), so listing pages (`/projects`, `/discussions`) scope to it. The dropdown lists spaces by recency, selecting one navigates to `/spaces/{id}`, and a divider adds shortcuts to All spaces (/spaces) and Create space (/spaces/new). Personal spaces wear a lock icon. Renders 'Loading…' until the space list resolves and nothing if the user has no active space."
     importPath={`import SpaceSwitcher from "@/components/common/SpaceSwitcher";`}
     examples={[
       {


### PR DESCRIPTION
## Summary

Fixes #405 — a fresh sign-in (no deep link) now lands on the workspace home (`/projects`) with the user's **Private** space active, instead of dropping on `/settings/profile` and restoring whatever space was last used on the browser.

## Changes

- **`pwa/lib/authRedirect.ts`** — `FALLBACK_PATH` changed from `/settings/profile` to `/projects`. This is both the post-login fallback (no `?next=`) and the safety fallback for an invalid/hostile `next` value.
- **`pwa/contexts/ActiveSpaceContext.tsx`**
  - Active-space selection is now persisted under a **per-user** key `aura.activeSpaceId.{userId}`, so two accounts alternating on one browser never inherit each other's selection. The legacy un-scoped `aura.activeSpaceId` key is removed on load.
  - New exported `markActiveSpaceReset()` sets a one-shot `sessionStorage` flag. When the authenticated user resolves with that flag set, the active space resets to **Private** (stored choice discarded); a plain reload (no flag) still restores the selected space.
- **`pwa/components/auth/SignInForm.tsx`** — calls `markActiveSpaceReset()` right after the password step succeeds (before the 2FA branch, so the two-step path is covered too; the flag persists until full authentication).
- **Tests + docs** — e2e fallback assertions (`auth-redirect.spec.js`) and the shared `registerAndSignIn` helper now expect `/projects`; the `space-switcher` dev doc notes the per-user key + Private-on-sign-in reset.

## Acceptance check

- ✅ Fresh sign-in (no redirect) → `/projects` with Private space active.
- ✅ Sign-in via a gated deep link → original destination via `?next=` (unchanged).
- ✅ Two accounts alternating on one browser never inherit each other's space (per-user key + reset-on-sign-in).
- ✅ Reloading mid-session keeps the currently selected space (no flag → restore from per-user key).

## Test plan

- Relies on CI (PWA Typecheck, E2E). The E2E `auth-redirect` suite and every spec using `registerAndSignIn` exercise the new landing path; the hostile-`next` cases pin the `/projects` fallback.
