### PR TITLE
fix: keep internal php host HTTP-only so origin-cert TLS can apply

### DIFF
--- a/api/frankenphp/Caddyfile
+++ b/api/frankenphp/Caddyfile
@@ -16,16 +16,14 @@
 
 {$CADDY_EXTRA_CONFIG}
 
-{$SERVER_NAME:localhost} {
-	# Optional explicit TLS cert (Cloudflare Origin Certificate in prod). When
-	# TLS_DIRECTIVE is unset (dev, and prod before the origin-cert cutover) this
-	# expands to nothing and Caddy keeps its automatic HTTPS (Let's Encrypt for a
-	# public SERVER_NAME, internal cert for localhost). In prod behind the
-	# Cloudflare proxy, set it to `tls /etc/caddy/origin/cert.pem /etc/caddy/origin/key.pem`
-	# so the origin no longer depends on ACME renewal that the proxy can break.
-	# See docs/developer/deployment.md § Origin TLS behind Cloudflare.
-	{$TLS_DIRECTIVE}
-
+# Shared site body for both the public host(s) and the internal `php` host.
+# Factored into a snippet so the two site blocks below don't duplicate the
+# routing. The split exists because the internal `http://php` site MUST stay
+# HTTP-only (service-to-service calls hit http://php), and Caddy refuses to put
+# an explicit TLS cert (TLS_DIRECTIVE) on a block that also serves an HTTP :80
+# address. Keeping `php` in its own HTTP block lets the public block carry the
+# Cloudflare Origin Certificate without conflict.
+(app) {
 	log {
 		# Redact the authorization query parameter that can be set by Mercure
 		format filter {
@@ -154,6 +152,30 @@
 			hide *.php
 		}
 	}
+}
+
+# Public host(s): the domain(s) in SERVER_NAME (e.g. `madori.app, localhost` in
+# prod, `localhost` in dev). Optional explicit TLS cert (Cloudflare Origin
+# Certificate in prod). When TLS_DIRECTIVE is unset (dev, and prod before the
+# origin-cert cutover) this expands to nothing and Caddy keeps its automatic
+# HTTPS (Let's Encrypt for a public SERVER_NAME, internal cert for localhost).
+# In prod behind the Cloudflare proxy, set it to
+# `tls /etc/caddy/origin/cert.pem /etc/caddy/origin/key.pem` so the origin no
+# longer depends on ACME renewal that the proxy can break.
+# See docs/developer/deployment.md § Origin TLS behind Cloudflare.
+{$SERVER_NAME:localhost} {
+	{$TLS_DIRECTIVE}
+
+	import app
+}
+
+# Internal service-to-service host. The PWA and worker reach the API at
+# http://php (NEXT_PUBLIC_ENTRYPOINT / MERCURE_URL), so this site is HTTP-only
+# on port 80 — it deliberately carries no TLS so the public block above can hold
+# the explicit origin certificate. Kept as its own block (rather than appended
+# to SERVER_NAME) for exactly that reason.
+http://php {
+	import app
 }
 
 # Umami analytics dashboard on its own hostname, TLS-terminated by the same

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,7 +6,10 @@ services:
     restart: unless-stopped
     environment:
       PWA_UPSTREAM: pwa:3000
-      SERVER_NAME: ${SERVER_NAME:-localhost}, php:80
+      # Public host(s) only. The internal `php` host has its own HTTP-only site
+      # block in api/frankenphp/Caddyfile (so the public block can carry an
+      # explicit TLS cert); it is no longer appended here.
+      SERVER_NAME: ${SERVER_NAME:-localhost}
       MERCURE_PUBLISHER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
       MERCURE_SUBSCRIBER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
       TRUSTED_PROXIES: ${TRUSTED_PROXIES:-127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16}

--- a/docs/developer/deployment.md
+++ b/docs/developer/deployment.md
@@ -111,9 +111,13 @@ needs). Caddy serves it via an explicit `tls` directive instead of ACME.
 
 This is wired up but **gated** so it has zero effect until switched on:
 
-- `api/frankenphp/Caddyfile` — both site blocks contain `{$TLS_DIRECTIVE}`,
-  which expands to nothing when the env var is unset (dev and pre-cutover prod
-  keep automatic HTTPS).
+- `api/frankenphp/Caddyfile` — the public host block and the analytics block
+  contain `{$TLS_DIRECTIVE}`, which expands to nothing when the env var is unset
+  (dev and pre-cutover prod keep automatic HTTPS). The internal `php` host is a
+  separate **HTTP-only** block (`http://php`) sharing the routing via the `(app)`
+  snippet — it must not carry the cert, because Caddy rejects a TLS policy on an
+  HTTP `:80` listener. For the same reason `php:80` was dropped from `SERVER_NAME`
+  in `compose.yaml`.
 - `compose.prod.yaml` — the `php` service passes `TLS_DIRECTIVE` through and
   mounts the host `./certs` dir read-only at `/etc/caddy/origin`. `./certs` is
   gitignored and survives the deploy's `git reset --hard`.


### PR DESCRIPTION
﻿## What

Fixes a defect in the origin-cert TLS support from #422 that crash-looped `php` when `TLS_DIRECTIVE` was set.

## Root cause

`#422` placed `{$TLS_DIRECTIVE}` in the main Caddy site block, but `compose.yaml` appends the internal `php:80` HTTP address to `SERVER_NAME`. Caddy refuses to attach a TLS connection policy to an HTTP `:80` listener:

```
Error: adapting config using caddyfile: server listening on [:80] is HTTP, but attempts to configure TLS connection policies
```

So enabling `TLS_DIRECTIVE` (the cutover) made the whole config fail to adapt and `php` crash-looped. (Found the hard way during the cutover; rolled back immediately — origin is back on Let's Encrypt and healthy.)

## Fix

- Factor the shared routing into a Caddy `(app)` snippet.
- Public host block (`SERVER_NAME`) imports it **and** carries the optional `{$TLS_DIRECTIVE}` cert.
- New dedicated **HTTP-only** `http://php` block imports the same snippet for service-to-service calls — no TLS, no conflict.
- Drop `php:80` from `SERVER_NAME` in `compose.yaml` (the internal host now has its own block).
- The analytics block had no `:80` address, so its `{$TLS_DIRECTIVE}` was always fine — unchanged.
- Docs updated.

## Safety

With `TLS_DIRECTIVE` unset (current prod + dev), this is behavior-neutral — the app is served on the same hosts as before. E2E covers the public + internal `http://php` paths. The TLS-on path will be validated on the server with `caddy validate` (TLS_DIRECTIVE set) **before** the live recreate, then the cutover proceeds.
