### PR TITLE
Promote to production: Caddyfile origin-cert fix + sign-in/waitlist updates

### DIFF
--- a/api/frankenphp/Caddyfile
+++ b/api/frankenphp/Caddyfile
@@ -16,16 +16,14 @@
 
 {$CADDY_EXTRA_CONFIG}
 
-{$SERVER_NAME:localhost} {
-	# Optional explicit TLS cert (Cloudflare Origin Certificate in prod). When
-	# TLS_DIRECTIVE is unset (dev, and prod before the origin-cert cutover) this
-	# expands to nothing and Caddy keeps its automatic HTTPS (Let's Encrypt for a
-	# public SERVER_NAME, internal cert for localhost). In prod behind the
-	# Cloudflare proxy, set it to `tls /etc/caddy/origin/cert.pem /etc/caddy/origin/key.pem`
-	# so the origin no longer depends on ACME renewal that the proxy can break.
-	# See docs/developer/deployment.md § Origin TLS behind Cloudflare.
-	{$TLS_DIRECTIVE}
-
+# Shared site body for both the public host(s) and the internal `php` host.
+# Factored into a snippet so the two site blocks below don't duplicate the
+# routing. The split exists because the internal `http://php` site MUST stay
+# HTTP-only (service-to-service calls hit http://php), and Caddy refuses to put
+# an explicit TLS cert (TLS_DIRECTIVE) on a block that also serves an HTTP :80
+# address. Keeping `php` in its own HTTP block lets the public block carry the
+# Cloudflare Origin Certificate without conflict.
+(app) {
 	log {
 		# Redact the authorization query parameter that can be set by Mercure
 		format filter {
@@ -154,6 +152,30 @@
 			hide *.php
 		}
 	}
+}
+
+# Public host(s): the domain(s) in SERVER_NAME (e.g. `madori.app, localhost` in
+# prod, `localhost` in dev). Optional explicit TLS cert (Cloudflare Origin
+# Certificate in prod). When TLS_DIRECTIVE is unset (dev, and prod before the
+# origin-cert cutover) this expands to nothing and Caddy keeps its automatic
+# HTTPS (Let's Encrypt for a public SERVER_NAME, internal cert for localhost).
+# In prod behind the Cloudflare proxy, set it to
+# `tls /etc/caddy/origin/cert.pem /etc/caddy/origin/key.pem` so the origin no
+# longer depends on ACME renewal that the proxy can break.
+# See docs/developer/deployment.md § Origin TLS behind Cloudflare.
+{$SERVER_NAME:localhost} {
+	{$TLS_DIRECTIVE}
+
+	import app
+}
+
+# Internal service-to-service host. The PWA and worker reach the API at
+# http://php (NEXT_PUBLIC_ENTRYPOINT / MERCURE_URL), so this site is HTTP-only
+# on port 80 — it deliberately carries no TLS so the public block above can hold
+# the explicit origin certificate. Kept as its own block (rather than appended
+# to SERVER_NAME) for exactly that reason.
+http://php {
+	import app
 }
 
 # Umami analytics dashboard on its own hostname, TLS-terminated by the same

--- a/api/src/Service/WaitlistJoinedMailer.php
+++ b/api/src/Service/WaitlistJoinedMailer.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\User;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Mailer\MailerInterface;
+
+/**
+ * Sends the "you're on the waitlist" confirmation email at signup time while
+ * waitlist mode is on. Purely informational — it sets the expectation that we
+ * email when access opens and closes the loop on a signup that otherwise gets
+ * only the in-app confirmation screen (#404).
+ *
+ * Reads as a pair with {@see WaitlistAccessMailer} (same MAILER_FROM fallback);
+ * carries no token and nothing actionable. Sending is best-effort at the call
+ * site ({@see \App\State\UserPasswordHasherProcessor}) — a dead SMTP server
+ * must not roll back the signup that already landed in the database.
+ */
+final class WaitlistJoinedMailer
+{
+    public function __construct(
+        private MailerInterface $mailer,
+        #[Autowire('%env(default::MAILER_FROM)%')]
+        private ?string $mailerFrom = null,
+    ) {
+    }
+
+    public function sendJoinedConfirmation(User $user): void
+    {
+        $from = (null !== $this->mailerFrom && '' !== $this->mailerFrom) ? $this->mailerFrom : 'no-reply@aura.test';
+
+        $email = (new TemplatedEmail())
+            ->from($from)
+            ->to($user->getEmail())
+            ->subject("You're on the Aura waitlist")
+            ->htmlTemplate('emails/waitlist_joined.html.twig')
+            ->textTemplate('emails/waitlist_joined.txt.twig')
+            ->context([
+                'recipient' => $user,
+            ]);
+
+        $this->mailer->send($email);
+    }
+}

--- a/api/src/State/UserPasswordHasherProcessor.php
+++ b/api/src/State/UserPasswordHasherProcessor.php
@@ -10,11 +10,14 @@ use App\Entity\SpaceMembership;
 use App\Entity\User;
 use App\Repository\UserInviteRepository;
 use App\Service\AvatarColorService;
+use App\Service\WaitlistJoinedMailer;
 use App\Service\WaitlistSettings;
 use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
 
@@ -34,6 +37,8 @@ final class UserPasswordHasherProcessor implements ProcessorInterface
         private UserInviteRepository $inviteRepository,
         private EntityManagerInterface $em,
         private WaitlistSettings $waitlistSettings,
+        private WaitlistJoinedMailer $waitlistJoinedMailer,
+        private LoggerInterface $logger,
         #[Autowire(service: 'limiter.signup_ip')]
         private RateLimiterFactoryInterface $signupLimiter,
         private RequestStack $requestStack,
@@ -96,6 +101,15 @@ final class UserPasswordHasherProcessor implements ProcessorInterface
             $this->acceptInvite($user, $inviteToken);
         }
 
+        // Confirm the signup with a "you're on the list" email (#404). Gated on
+        // the persisted waitlisted flag, not the setting, so an invite-token
+        // signup that ever bypasses the gate (lands un-waitlisted) won't get it.
+        // Best-effort after the flush, mirroring the access email — a dead SMTP
+        // server logs a warning but can't undo the signup that already landed.
+        if ($operation instanceof Post && $user->isWaitlisted()) {
+            $this->sendWaitlistJoined($user);
+        }
+
         return $user;
     }
 
@@ -125,6 +139,18 @@ final class UserPasswordHasherProcessor implements ProcessorInterface
             $retryAfter,
             'Too many accounts created from this network. Please try again later.',
         );
+    }
+
+    private function sendWaitlistJoined(User $user): void
+    {
+        try {
+            $this->waitlistJoinedMailer->sendJoinedConfirmation($user);
+        } catch (TransportExceptionInterface $e) {
+            $this->logger->warning('Failed to send waitlist confirmation email to {email}: {error}', [
+                'email' => $user->getEmail(),
+                'error' => $e->getMessage(),
+            ]);
+        }
     }
 
     /**

--- a/api/templates/emails/waitlist_joined.html.twig
+++ b/api/templates/emails/waitlist_joined.html.twig
@@ -1,0 +1,10 @@
+{# @var recipient \App\Entity\User #}
+<p>Hi {{ recipient.givenName ?: recipient.email }},</p>
+
+<p>Thanks for joining the Aura waitlist — you're on the list.</p>
+
+<p>We're opening access in batches. When your spot comes up, we'll email you a
+link to sign in with the email and password you just chose. There's nothing
+you need to do until then.</p>
+
+<p>&mdash; Aura</p>

--- a/api/templates/emails/waitlist_joined.txt.twig
+++ b/api/templates/emails/waitlist_joined.txt.twig
@@ -1,0 +1,10 @@
+{# @var recipient \App\Entity\User #}
+Hi {{ recipient.givenName ?: recipient.email }},
+
+Thanks for joining the Aura waitlist — you're on the list.
+
+We're opening access in batches. When your spot comes up, we'll email you a link
+to sign in with the email and password you just chose. There's nothing you need
+to do until then.
+
+— Aura

--- a/api/tests/Api/WaitlistTest.php
+++ b/api/tests/Api/WaitlistTest.php
@@ -58,6 +58,15 @@ class WaitlistTest extends ApiTestCase
         ]);
         $this->assertResponseStatusCodeSame(201);
 
+        // Exactly one "you're on the waitlist" confirmation goes to the signup
+        // address (#404). Asserted before any further request — the mailer
+        // profiler reflects only the most recent request.
+        $this->assertEmailCount(1);
+        $email = $this->getMailerMessage();
+        self::assertNotNull($email);
+        $this->assertEmailAddressContains($email, 'To', 'waiter@example.com');
+        $this->assertEmailHeaderSame($email, 'Subject', "You're on the Aura waitlist");
+
         $user = $this->reloadUser('waiter@example.com');
         $this->assertTrue($user->isWaitlisted());
         $this->assertSame(['ROLE_WAITLISTED'], $user->getRoles());
@@ -78,6 +87,9 @@ class WaitlistTest extends ApiTestCase
             'headers' => ['Content-Type' => 'application/ld+json'],
         ]);
         $this->assertResponseStatusCodeSame(201);
+
+        // Open signups get no waitlist confirmation email.
+        $this->assertEmailCount(0);
 
         $user = $this->reloadUser('open@example.com');
         $this->assertFalse($user->isWaitlisted());

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,7 +6,10 @@ services:
     restart: unless-stopped
     environment:
       PWA_UPSTREAM: pwa:3000
-      SERVER_NAME: ${SERVER_NAME:-localhost}, php:80
+      # Public host(s) only. The internal `php` host has its own HTTP-only site
+      # block in api/frankenphp/Caddyfile (so the public block can carry an
+      # explicit TLS cert); it is no longer appended here.
+      SERVER_NAME: ${SERVER_NAME:-localhost}
       MERCURE_PUBLISHER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
       MERCURE_SUBSCRIBER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
       TRUSTED_PROXIES: ${TRUSTED_PROXIES:-127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16}

--- a/docs/developer/deployment.md
+++ b/docs/developer/deployment.md
@@ -111,9 +111,13 @@ needs). Caddy serves it via an explicit `tls` directive instead of ACME.
 
 This is wired up but **gated** so it has zero effect until switched on:
 
-- `api/frankenphp/Caddyfile` — both site blocks contain `{$TLS_DIRECTIVE}`,
-  which expands to nothing when the env var is unset (dev and pre-cutover prod
-  keep automatic HTTPS).
+- `api/frankenphp/Caddyfile` — the public host block and the analytics block
+  contain `{$TLS_DIRECTIVE}`, which expands to nothing when the env var is unset
+  (dev and pre-cutover prod keep automatic HTTPS). The internal `php` host is a
+  separate **HTTP-only** block (`http://php`) sharing the routing via the `(app)`
+  snippet — it must not carry the cert, because Caddy rejects a TLS policy on an
+  HTTP `:80` listener. For the same reason `php:80` was dropped from `SERVER_NAME`
+  in `compose.yaml`.
 - `compose.prod.yaml` — the `php` service passes `TLS_DIRECTIVE` through and
   mounts the host `./certs` dir read-only at `/etc/caddy/origin`. `./certs` is
   gitignored and survives the deploy's `git reset --hard`.

--- a/e2e/tests/auth-redirect.spec.js
+++ b/e2e/tests/auth-redirect.spec.js
@@ -127,9 +127,9 @@ test.describe("Auth redirect", () => {
   });
 
   // Each entry is a `?next=` value that should be rejected by `safeNextPath()`
-  // and fall back to /settings/profile. The list is the full set of attack
-  // vectors the helper guards against; if any of them ever land the user
-  // somewhere else, we want CI to scream.
+  // and fall back to /projects (the default post-login landing). The list is
+  // the full set of attack vectors the helper guards against; if any of them
+  // ever land the user somewhere else, we want CI to scream.
   const HOSTILE_NEXT_VALUES = [
     {
       label: "protocol-relative URL (`//host/...`)",
@@ -186,7 +186,7 @@ test.describe("Auth redirect", () => {
 
       // Falls back to the default landing page rather than wherever
       // the attacker tried to send us.
-      await expect(page).toHaveURL(/\/settings\/profile$/);
+      await expect(page).toHaveURL(/\/projects$/);
     });
   }
 });

--- a/e2e/tests/auth.spec.js
+++ b/e2e/tests/auth.spec.js
@@ -65,10 +65,14 @@ test.describe("Authentication", () => {
     await page.fill("#password", "Password123!@#");
     await page.click('button[type="submit"]');
 
-    // Should redirect to the Settings profile panel. The email now appears
-    // in two places after sign-in (sidebar header + profile identity form),
-    // so scope the assertion to the main panel.
-    await expect(page).toHaveURL(/\/settings\/profile/);
+    // A fresh sign-in with no redirect lands on the workspace home
+    // (/projects) with the user's Private space active (#405).
+    await expect(page).toHaveURL(/\/projects/);
+
+    // Confirm we're signed in as the right account. The email appears in
+    // two places (sidebar header + profile identity form), so open the
+    // profile panel and scope the assertion to the main panel.
+    await page.goto(`${BASE_URL}/settings/profile`);
     await expect(
       page.getByRole("main").getByText(email),
     ).toBeVisible();
@@ -90,7 +94,8 @@ test.describe("Authentication", () => {
     await page.fill("#password", "admin123");
     await page.click('button[type="submit"]');
 
-    await expect(page).toHaveURL(/\/settings\/profile/);
+    // Fresh sign-in lands on the workspace home (#405).
+    await expect(page).toHaveURL(/\/projects/);
 
     // Navigate to admin
     await page.goto(`${BASE_URL}/admin`);

--- a/e2e/tests/email-change.spec.js
+++ b/e2e/tests/email-change.spec.js
@@ -18,6 +18,10 @@ async function registerAndSignIn(page, request, email, password = "Password123!@
   await page.fill("#email", email);
   await page.fill("#password", password);
   await page.click('button[type="submit"]');
+  // A fresh sign-in lands on the workspace home (#405); the email-change
+  // form lives on the profile panel, so land callers there.
+  await expect(page).toHaveURL(/\/projects/);
+  await page.goto(`${BASE_URL}/settings/profile`);
   await expect(page).toHaveURL(/\/settings\/profile/);
 }
 
@@ -94,7 +98,8 @@ test.describe("Change email (authenticated)", () => {
     await page.fill("#email", newEmail);
     await page.fill("#password", "Password123!@#");
     await page.click('button[type="submit"]');
-    await expect(page).toHaveURL(/\/settings\/profile/);
+    // Fresh sign-in lands on the workspace home (#405).
+    await expect(page).toHaveURL(/\/projects/);
 
     // Now follow the revert link
     await page.goto(revertUrl);
@@ -106,7 +111,8 @@ test.describe("Change email (authenticated)", () => {
     await page.fill("#email", oldEmail);
     await page.fill("#password", "Password123!@#");
     await page.click('button[type="submit"]');
-    await expect(page).toHaveURL(/\/settings\/profile/);
+    // Fresh sign-in lands on the workspace home (#405).
+    await expect(page).toHaveURL(/\/projects/);
   });
 
   test("cannot request a change to an already-registered address", async ({

--- a/e2e/tests/helpers.js
+++ b/e2e/tests/helpers.js
@@ -21,7 +21,9 @@ async function registerAndSignIn(page, email, password = "Password123!@#", optio
   await page.fill("#email", email);
   await page.fill("#password", password);
   await page.click('button[type="submit"]');
-  await expect(page).toHaveURL(/\/settings\/profile/);
+  // A fresh sign-in with no `?next=` lands on the workspace home
+  // (/projects), with the user's Private space active (#405).
+  await expect(page).toHaveURL(/\/projects/);
 }
 
 /**

--- a/e2e/tests/notifications.spec.js
+++ b/e2e/tests/notifications.spec.js
@@ -11,7 +11,7 @@ const uniqueEmail = () => shared("notifications");
 test.describe("Notifications", () => {
   test("authenticated users see the notification bell with a zero state", async ({ page }) => {
     await registerAndSignIn(page, uniqueEmail());
-    // Land on the account page (registerAndSignIn redirects there) — the
+    // Land on the workspace home (registerAndSignIn redirects there) — the
     // bell is part of the navbar and is visible on every authenticated route.
     const bell = page.locator('[data-testid="notification-bell"]');
     await expect(bell).toBeVisible();

--- a/e2e/tests/password.spec.js
+++ b/e2e/tests/password.spec.js
@@ -65,7 +65,8 @@ test.describe("Change password (authenticated)", () => {
     await page.fill("#email", email);
     await page.fill("#password", "OriginalPass1!");
     await page.click('button[type="submit"]');
-    await expect(page).toHaveURL(/\/settings\/profile/);
+    // Fresh sign-in lands on the workspace home (#405).
+    await expect(page).toHaveURL(/\/projects/);
 
     // Change password — the form lives on the Security panel.
     await page.goto(`${BASE_URL}/settings/security`);
@@ -86,7 +87,8 @@ test.describe("Change password (authenticated)", () => {
     await page.fill("#email", email);
     await page.fill("#password", "BrandNewPass1!");
     await page.click('button[type="submit"]');
-    await expect(page).toHaveURL(/\/settings\/profile/);
+    // Fresh sign-in lands on the workspace home (#405).
+    await expect(page).toHaveURL(/\/projects/);
   });
 
   test("wrong current password shows error", async ({ page, request }) => {
@@ -97,7 +99,8 @@ test.describe("Change password (authenticated)", () => {
     await page.fill("#email", email);
     await page.fill("#password", "OriginalPass1!");
     await page.click('button[type="submit"]');
-    await expect(page).toHaveURL(/\/settings\/profile/);
+    // Fresh sign-in lands on the workspace home (#405).
+    await expect(page).toHaveURL(/\/projects/);
 
     await page.goto(`${BASE_URL}/settings/security`);
     await page.fill("#currentPassword", "wrongpass");
@@ -121,7 +124,8 @@ test.describe("Change password (authenticated)", () => {
     await page.fill("#email", email);
     await page.fill("#password", "OriginalPass1!");
     await page.click('button[type="submit"]');
-    await expect(page).toHaveURL(/\/settings\/profile/);
+    // Fresh sign-in lands on the workspace home (#405).
+    await expect(page).toHaveURL(/\/projects/);
 
     await page.goto(`${BASE_URL}/settings/security`);
     await page.fill("#currentPassword", "OriginalPass1!");
@@ -175,7 +179,8 @@ test.describe("Forgot password (reset via email)", () => {
     await page.fill("#email", email);
     await page.fill("#password", "BrandNewPass1!");
     await page.click('button[type="submit"]');
-    await expect(page).toHaveURL(/\/settings\/profile/);
+    // Fresh sign-in lands on the workspace home (#405).
+    await expect(page).toHaveURL(/\/projects/);
   });
 
   test("forgot-password returns success for unknown email (no enumeration)", async ({

--- a/pwa/components/auth/AuthCard.tsx
+++ b/pwa/components/auth/AuthCard.tsx
@@ -3,8 +3,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { CheckCircle2, Loader2 } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
-import { ENTRYPOINT } from "@/config/entrypoint";
-import { fetchWithTimeout } from "@/lib/fetchWithTimeout";
+import { useSignupStatus } from "@/lib/useSignupStatus";
 import { isSafeNextPath, safeNextPath } from "@/lib/authRedirect";
 import { AVATAR_PALETTE } from "@/lib/avatarPalette";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -127,10 +126,6 @@ const AuthCard = ({ defaultTab }: Props) => {
     defaultTab === "signup" ? "signup-form" : "credentials",
   );
   const [twoFactorEmail, setTwoFactorEmail] = useState<string | null>(null);
-  // Whether the instance is in waitlist mode — drives the signup copy and
-  // flow. Defaults to false (open signups); the /signup-status fetch below
-  // flips it on. Invite signups always run the normal flow.
-  const [waitlistMode, setWaitlistMode] = useState(false);
 
   // Sign-up multi-step state. The form payload is captured on step 1
   // and held here so step 2 can POST it with the chosen color; the
@@ -152,6 +147,13 @@ const AuthCard = ({ defaultTab }: Props) => {
   const registered = router.query.registered === "true";
   const reset = router.query.reset === "true";
 
+  // Whether the instance is in waitlist mode — drives the signup copy/flow and
+  // the footer CTA on both entry points. Invite signups always run the normal
+  // flow (they bypass the gate), so an invite token forces it off. Errors fall
+  // back to open signups; the server still enforces the real gate.
+  const { waitlistEnabled } = useSignupStatus();
+  const waitlistMode = waitlistEnabled && !inviteToken;
+
   useEffect(() => {
     // Authenticated users normally don't need /signin or /signup, so
     // we bounce them to wherever `next` points. The one exception is
@@ -163,28 +165,6 @@ const AuthCard = ({ defaultTab }: Props) => {
       router.replace(safeNextPath(next));
     }
   }, [isLoading, isAuthenticated, next, router, inviteToken]);
-
-  // Resolve whether signups are open or gated behind the waitlist. Only the
-  // signup entry point needs to know (the sign-in side is unaffected), and
-  // invite signups always bypass the waitlist. Errors fall back to open
-  // signups — the server still enforces the real gate.
-  useEffect(() => {
-    if (defaultTab !== "signup" || inviteToken) return;
-    let cancelled = false;
-    (async () => {
-      try {
-        const res = await fetchWithTimeout(`${ENTRYPOINT}/signup-status`);
-        if (!res.ok) return;
-        const data = await res.json();
-        if (!cancelled) setWaitlistMode(Boolean(data.waitlistEnabled));
-      } catch {
-        /* keep the open-signup default */
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [defaultTab, inviteToken]);
 
   const queryIndex = router.asPath.indexOf("?");
   const search = queryIndex >= 0 ? router.asPath.slice(queryIndex) : "";
@@ -204,6 +184,14 @@ const AuthCard = ({ defaultTab }: Props) => {
   const tabCopy = COPY[step === "credentials" ? "signin" : "signup"];
   const isTwoFactor = step === "totp" || step === "backup";
   const tfCopy = isTwoFactor ? twoFactorCopy(step, twoFactorEmail) : null;
+
+  // The footer's "switch" CTA points either at signup or signin. When it leads
+  // to signup and the instance is waitlisted, label it "Join the waitlist" so
+  // the signin page's footer reads the same as every other public CTA.
+  const switchCta =
+    waitlistMode && tabCopy.switchPath === "/signup"
+      ? "Join the waitlist"
+      : tabCopy.switchCta;
 
   const cardCopy: { title: string; subtitle: string } | null = (() => {
     if (tfCopy) return { title: tfCopy.title, subtitle: tfCopy.subtitle };
@@ -414,7 +402,7 @@ const AuthCard = ({ defaultTab }: Props) => {
                   href={`${tabCopy.switchPath}${search}`}
                   className="text-primary font-semibold hover:text-foreground"
                 >
-                  {tabCopy.switchCta}
+                  {switchCta}
                 </Link>
               </>
             )}

--- a/pwa/components/auth/SignInForm.tsx
+++ b/pwa/components/auth/SignInForm.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 import { useState } from "react";
 import { Formik, Form } from "formik";
 import { useAuth } from "@/contexts/AuthContext";
+import { markActiveSpaceReset } from "@/contexts/ActiveSpaceContext";
 import { safeNextPath } from "@/lib/authRedirect";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -72,6 +73,11 @@ const SignInForm = ({ next, registered, reset, onTwoFactorRequired }: Props) => 
         onSubmit={async (values, { setSubmitting, setStatus }) => {
           try {
             const result = await login(values.email, values.password);
+            // Password accepted (login throws otherwise) — flag this as a
+            // fresh sign-in so the active space resets to Private. Set
+            // before the 2FA branch so it also covers the two-step path;
+            // the flag persists until the user fully authenticates.
+            markActiveSpaceReset();
             if (result.requiresTwoFactor) {
               onTwoFactorRequired(values.email);
               return;

--- a/pwa/components/auth/TermsConsentField.tsx
+++ b/pwa/components/auth/TermsConsentField.tsx
@@ -25,8 +25,13 @@ const TermsConsentField = ({ name = "acceptTerms" }: { name?: string }) => {
           id={id}
           checked={field.value}
           onCheckedChange={(checked) => {
+            // Mark touched without validating against the stale snapshot, then
+            // let setValue run the single validation pass that sees the new
+            // value. Validating on the touched update can re-assert the error
+            // using the previous (still-false) values, leaving the error shown
+            // under an already-checked box.
+            helpers.setTouched(true, false);
             helpers.setValue(checked === true);
-            helpers.setTouched(true);
           }}
           aria-invalid={showError}
           aria-describedby={showError ? `${id}-error` : undefined}

--- a/pwa/components/common/Navbar.tsx
+++ b/pwa/components/common/Navbar.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { Menu } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
+import { useSignupStatus } from "@/lib/useSignupStatus";
 import { Button } from "@/components/ui/button";
 import {
   Sheet,
@@ -19,6 +20,7 @@ import SidebarNav from "./SidebarNav";
 
 const Navbar = () => {
   const { isAuthenticated } = useAuth();
+  const { waitlistEnabled } = useSignupStatus();
 
   return (
     <nav className="border-b bg-background">
@@ -89,7 +91,9 @@ const Navbar = () => {
                 <Link href="/signin">Sign In</Link>
               </Button>
               <Button asChild size="sm">
-                <Link href="/signup">Sign Up</Link>
+                <Link href="/signup">
+                  {waitlistEnabled ? "Join the waitlist" : "Sign Up"}
+                </Link>
               </Button>
             </>
           )}

--- a/pwa/contexts/ActiveSpaceContext.tsx
+++ b/pwa/contexts/ActiveSpaceContext.tsx
@@ -107,18 +107,47 @@ const ActiveSpaceContext = createContext<ActiveSpaceContextType | undefined>(
   undefined,
 );
 
-const STORAGE_KEY = "aura.activeSpaceId";
+// Per-user storage key — `aura.activeSpaceId.{userId}` — so two
+// accounts alternating on one browser never inherit each other's
+// selection. The legacy un-scoped key is dropped on sight (see below).
+const STORAGE_PREFIX = "aura.activeSpaceId";
+const LEGACY_STORAGE_KEY = "aura.activeSpaceId";
+const storageKeyFor = (userId: string) => `${STORAGE_PREFIX}.${userId}`;
+
+// sessionStorage flag set by the sign-in flow (see markActiveSpaceReset)
+// so the next active-space resolution starts in the personal space
+// rather than restoring whatever was last selected on this browser.
+const RESET_FLAG_KEY = "aura.activeSpaceReset";
+
+/**
+ * Called by the sign-in flow on a successful login so the post-login
+ * landing starts in the user's Private space instead of restoring the
+ * previous browser-local selection. Consumed once by ActiveSpaceContext
+ * when the authenticated user resolves; mid-session reloads (no flag)
+ * keep the currently selected space.
+ */
+export function markActiveSpaceReset() {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(RESET_FLAG_KEY, "1");
+  } catch {
+    // Private-mode / storage-disabled browsers: the worst case is that
+    // a fresh sign-in restores the last space instead of Private, which
+    // is the pre-#405 behavior — acceptable, not worth surfacing.
+  }
+}
 
 /**
  * Loads the user's space list from `GET /spaces` (already scoped to
  * the caller by SpaceAccessExtension) and tracks the active space —
  * the one whose content the listings should show.
  *
- * The active-space choice is persisted in localStorage under
- * `aura.activeSpaceId` so it sticks across reloads. On first load
- * (or when the previous selection is no longer accessible — left the
- * space, deleted it, etc.) we fall back to the personal "Private"
- * space, which is always present.
+ * The active-space choice is persisted in localStorage under a
+ * per-user key (`aura.activeSpaceId.{userId}`) so it sticks across
+ * reloads. On a fresh sign-in (flagged by `markActiveSpaceReset`), on
+ * first load, or when the previous selection is no longer accessible
+ * (left the space, deleted it, etc.), we fall back to the personal
+ * "Private" space, which is always present.
  *
  * Mounted INSIDE AuthProvider so it can react to login/logout: spaces
  * are re-fetched whenever the authenticated user changes, and cleared
@@ -132,15 +161,34 @@ export function ActiveSpaceProvider({ children }: { children: ReactNode }) {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Restore the persisted choice once on mount. We can't read
-  // localStorage during the initial render in Next.js (no `window`
-  // server-side), so the active-space stays null on first paint and
-  // settles after this effect runs.
+  // Resolve the persisted choice whenever the authenticated user
+  // settles. We can't read localStorage during the initial render in
+  // Next.js (no `window` server-side), so the active-space stays null
+  // on first paint and settles after this effect runs.
+  //
+  // On a fresh sign-in (RESET_FLAG_KEY set by markActiveSpaceReset) we
+  // discard any stored choice and start in the personal space; on a
+  // plain reload we restore the per-user selection so it survives.
   useEffect(() => {
     if (typeof window === "undefined") return;
-    const stored = window.localStorage.getItem(STORAGE_KEY);
-    if (stored) setActiveSpaceId(stored);
-  }, []);
+    // Drop the legacy un-scoped key so a selection can never bleed
+    // across accounts on a shared browser.
+    window.localStorage.removeItem(LEGACY_STORAGE_KEY);
+
+    if (!user?.id) {
+      setActiveSpaceId(null);
+      return;
+    }
+
+    if (window.sessionStorage.getItem(RESET_FLAG_KEY)) {
+      window.sessionStorage.removeItem(RESET_FLAG_KEY);
+      window.localStorage.removeItem(storageKeyFor(user.id));
+      setActiveSpaceId(null);
+      return;
+    }
+
+    setActiveSpaceId(window.localStorage.getItem(storageKeyFor(user.id)));
+  }, [user?.id]);
 
   const fetchSpaces = useCallback(async () => {
     setIsLoading(true);
@@ -186,12 +234,15 @@ export function ActiveSpaceProvider({ children }: { children: ReactNode }) {
     spaces[0] ??
     null;
 
-  const setActiveSpace = useCallback((space: Space) => {
-    setActiveSpaceId(space.id);
-    if (typeof window !== "undefined") {
-      window.localStorage.setItem(STORAGE_KEY, space.id);
-    }
-  }, []);
+  const setActiveSpace = useCallback(
+    (space: Space) => {
+      setActiveSpaceId(space.id);
+      if (typeof window !== "undefined" && user?.id) {
+        window.localStorage.setItem(storageKeyFor(user.id), space.id);
+      }
+    },
+    [user?.id],
+  );
 
   const isActiveSpaceAdmin = !!(
     activeSpace &&

--- a/pwa/contexts/ActiveSpaceContext.tsx
+++ b/pwa/contexts/ActiveSpaceContext.tsx
@@ -241,7 +241,7 @@ export function ActiveSpaceProvider({ children }: { children: ReactNode }) {
         window.localStorage.setItem(storageKeyFor(user.id), space.id);
       }
     },
-    [user?.id],
+    [user],
   );
 
   const isActiveSpaceAdmin = !!(

--- a/pwa/lib/authRedirect.ts
+++ b/pwa/lib/authRedirect.ts
@@ -12,7 +12,12 @@
  * redirector.
  */
 
-const FALLBACK_PATH = "/settings/profile";
+// Where a successful sign-in with no explicit `?next=` target lands —
+// and the safety fallback for an invalid/hostile `next` value. The
+// natural home is the user's workspace (their Private space is made
+// active on a fresh sign-in by ActiveSpaceContext), not the settings
+// shell.
+const FALLBACK_PATH = "/projects";
 
 // Arbitrary base used to round-trip user-supplied `next` through the
 // URL parser. The host/protocol are bogus so we can detect any value

--- a/pwa/lib/useSignupStatus.ts
+++ b/pwa/lib/useSignupStatus.ts
@@ -1,0 +1,28 @@
+import { useQuery } from "@tanstack/react-query";
+import { ENTRYPOINT } from "@/config/entrypoint";
+import { fetchWithTimeout } from "@/lib/fetchWithTimeout";
+
+/**
+ * Public signup gate. Mirrors the API's `GET /signup-status` — `true` means the
+ * instance is in waitlist mode, so the public CTAs ("Sign up" / "Get started")
+ * read as "Join the waitlist" instead. Unauthenticated and cheap; cached across
+ * the navbar + landing page + auth card so the label stays consistent.
+ *
+ * Errors fall back to open signups — the server still enforces the real gate,
+ * and a stray "Sign up" label on a waitlisted instance just lands the visitor
+ * on the signup page, which swaps to the waitlist flow on its own.
+ */
+export function useSignupStatus(): { waitlistEnabled: boolean; isLoading: boolean } {
+  const query = useQuery({
+    queryKey: ["signup-status"],
+    queryFn: async (): Promise<boolean> => {
+      const res = await fetchWithTimeout(`${ENTRYPOINT}/signup-status`);
+      if (!res.ok) return false;
+      const data = await res.json();
+      return Boolean(data.waitlistEnabled);
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+
+  return { waitlistEnabled: query.data ?? false, isLoading: query.isLoading };
+}

--- a/pwa/pages/dev/components/space-switcher.tsx
+++ b/pwa/pages/dev/components/space-switcher.tsx
@@ -4,7 +4,7 @@ import ComponentDoc from "@/components/dev/ComponentDoc";
 const SpaceSwitcherPage = () => (
   <ComponentDoc
     name="SpaceSwitcher"
-    description="Active-space dropdown rendered at the top of SidebarNav (under the user header, above the personal links). Picks the user's current space and persists the choice via ActiveSpaceContext (localStorage key `aura.activeSpaceId`), so listing pages (`/projects`, `/discussions`) scope to it. The dropdown lists spaces by recency, selecting one navigates to `/spaces/{id}`, and a divider adds shortcuts to All spaces (/spaces) and Create space (/spaces/new). Personal spaces wear a lock icon. Renders 'Loading…' until the space list resolves and nothing if the user has no active space."
+    description="Active-space dropdown rendered at the top of SidebarNav (under the user header, above the personal links). Picks the user's current space and persists the choice via ActiveSpaceContext (per-user localStorage key `aura.activeSpaceId.{userId}`, reset to the Private space on a fresh sign-in), so listing pages (`/projects`, `/discussions`) scope to it. The dropdown lists spaces by recency, selecting one navigates to `/spaces/{id}`, and a divider adds shortcuts to All spaces (/spaces) and Create space (/spaces/new). Personal spaces wear a lock icon. Renders 'Loading…' until the space list resolves and nothing if the user has no active space."
     importPath={`import SpaceSwitcher from "@/components/common/SpaceSwitcher";`}
     examples={[
       {

--- a/pwa/pages/index.tsx
+++ b/pwa/pages/index.tsx
@@ -25,6 +25,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
+import { useSignupStatus } from "@/lib/useSignupStatus";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -544,6 +545,8 @@ const WRAP = "mx-auto w-full max-w-[1180px] px-6";
 
 const Home = () => {
   const { isAuthenticated } = useAuth();
+  const { waitlistEnabled } = useSignupStatus();
+  const signupCta = waitlistEnabled ? "Join the waitlist" : "Get started — free";
 
   return (
     <>
@@ -608,7 +611,7 @@ const Home = () => {
                 ) : (
                   <>
                     <Button asChild size="lg" className={GLOW}>
-                      <Link href="/signup">Get started — free</Link>
+                      <Link href="/signup">{signupCta}</Link>
                     </Button>
                     <Button asChild size="lg" variant="secondary">
                       <Link href="/signin">Sign in</Link>
@@ -778,7 +781,7 @@ const Home = () => {
                   </Button>
                 ) : (
                   <Button asChild size="lg" className={GLOW}>
-                    <Link href="/signup">Get started — free</Link>
+                    <Link href="/signup">{signupCta}</Link>
                   </Button>
                 )}
               </div>


### PR DESCRIPTION
﻿Promote `main` → `production` (merge commit, not squash).

## Primary purpose
- **fix: keep internal `php` host HTTP-only so origin-cert TLS can apply** (#428) — fixes the Caddyfile so `TLS_DIRECTIVE` can be enabled without crash-looping `php`. No-op until `TLS_DIRECTIVE` is set; unblocks the origin-cert cutover.

## Also riding along (already on main)
- feat: land in Private space on sign-in by default (#426)
- feat: swap public signup CTAs to "Join the waitlist" in waitlist mode; waitlist confirmation email at signup (#424/#425)
- fix: clear signup consent error when the box is checked; CI update for new sign-in landing

## Deploy
Standard pipeline (maintenance → backup → swap → health → page down). Behavior-neutral for TLS; the actual origin-cert cutover is a separate manual step performed after this deploy and after a `caddy validate` dry-run.
