### PR TITLE
feat: app:waitlist:grant CLI + shared WaitlistGrantService for UI and CLI

### DIFF
--- a/api/src/Command/WaitlistGrantCommand.php
+++ b/api/src/Command/WaitlistGrantCommand.php
@@ -72,7 +72,7 @@ final class WaitlistGrantCommand extends Command
         if ($all) {
             $candidates = $this->granter->findWaitlisted();
         } elseif (null !== $oldest) {
-            if (!is_string($oldest) || 1 !== preg_match('/^\d+$/', $oldest) || (int) $oldest < 1) {
+            if (1 !== preg_match('/^\d+$/', $oldest) || (int) $oldest < 1) {
                 $io->error('--oldest must be a positive integer.');
                 return Command::INVALID;
             }

--- a/api/src/Command/WaitlistGrantCommand.php
+++ b/api/src/Command/WaitlistGrantCommand.php
@@ -3,8 +3,7 @@
 namespace App\Command;
 
 use App\Entity\User;
-use App\Service\WaitlistPromoter;
-use Doctrine\ORM\EntityManagerInterface;
+use App\Service\WaitlistGrantService;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -12,13 +11,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\Uid\Uuid;
 
 /**
  * Grant waitlisted accounts full access from the CLI — the scriptable, SSH-able
- * companion to the /admin/waitlist "Grant access" button. Promotes each matched
- * user (flips the waitlist flag, restoring ROLE_USER) and emails them the same
- * "you're in" message the admin UI sends.
+ * companion to the /admin/waitlist "Grant access" button. Both surfaces share
+ * {@see WaitlistGrantService}, so selection + promotion behave identically.
  *
  *   bin/console app:waitlist:grant a@x.com b@x.com         # by email
  *   bin/console app:waitlist:grant 0190f3...               # by user id
@@ -37,10 +34,8 @@ use Symfony\Component\Uid\Uuid;
 )]
 final class WaitlistGrantCommand extends Command
 {
-    public function __construct(
-        private EntityManagerInterface $em,
-        private WaitlistPromoter $promoter,
-    ) {
+    public function __construct(private WaitlistGrantService $granter)
+    {
         parent::__construct();
     }
 
@@ -75,15 +70,19 @@ final class WaitlistGrantCommand extends Command
         }
 
         if ($all) {
-            $candidates = $this->waitlistedOldestFirst(null);
+            $candidates = $this->granter->findWaitlisted();
         } elseif (null !== $oldest) {
             if (!is_string($oldest) || 1 !== preg_match('/^\d+$/', $oldest) || (int) $oldest < 1) {
                 $io->error('--oldest must be a positive integer.');
                 return Command::INVALID;
             }
-            $candidates = $this->waitlistedOldestFirst((int) $oldest);
+            $candidates = $this->granter->findWaitlisted((int) $oldest);
         } else {
-            $candidates = $this->resolveSelectors($io, $selectors);
+            $resolved = $this->granter->resolveSelectors($selectors);
+            foreach ($resolved['notFound'] as $selector) {
+                $io->warning(sprintf('No user found for "%s" — skipped.', $selector));
+            }
+            $candidates = $resolved['users'];
         }
 
         if ([] === $candidates) {
@@ -91,78 +90,29 @@ final class WaitlistGrantCommand extends Command
             return Command::SUCCESS;
         }
 
-        $promoted = [];
-        foreach ($candidates as $user) {
-            if (!$user->isWaitlisted()) {
-                $io->writeln(sprintf('  <comment>skip</comment> %s — already has full access.', $user->getEmail()));
-                continue;
-            }
-            if (!$dryRun) {
-                // Flips the flag, flushes, and emails the user; a no-op if they
-                // were promoted between selection and now.
-                $this->promoter->promoteOne($user);
-            }
-            $promoted[] = $user;
+        $result = $this->granter->grant($candidates, $dryRun);
+
+        foreach ($result->skipped as $user) {
+            $io->writeln(sprintf('  <comment>skip</comment> %s — already has full access.', $user->getEmail()));
         }
 
-        if ([] === $promoted) {
+        if ([] === $result->promoted) {
             $io->warning('No waitlisted users in the selection — nothing changed.');
             return Command::SUCCESS;
         }
 
         $io->table(
             ['ID', 'Email'],
-            array_map(static fn (User $u): array => [(string) $u->getId(), $u->getEmail()], $promoted),
+            array_map(static fn (User $u): array => [(string) $u->getId(), $u->getEmail()], $result->promoted),
         );
 
         $io->success(sprintf(
             '%s %d user(s).%s',
             $dryRun ? 'Would promote' : 'Promoted',
-            count($promoted),
+            count($result->promoted),
             $dryRun ? ' Dry run — no changes made.' : '',
         ));
 
         return Command::SUCCESS;
-    }
-
-    /**
-     * Waitlisted users, oldest first. User has no createdOn column, but its id
-     * is a time-ordered UUIDv7 (see config/packages/framework.yaml), so ordering
-     * by id ASC is chronological — the longest-waiting accounts come first.
-     *
-     * @return list<User>
-     */
-    private function waitlistedOldestFirst(?int $limit): array
-    {
-        return $this->em->getRepository(User::class)
-            ->findBy(['waitlisted' => true], ['id' => 'ASC'], $limit);
-    }
-
-    /**
-     * Resolve each selector (a UUID or an email) to a user, deduping by id and
-     * warning on anything that doesn't match.
-     *
-     * @param list<string> $selectors
-     * @return list<User>
-     */
-    private function resolveSelectors(SymfonyStyle $io, array $selectors): array
-    {
-        $repo = $this->em->getRepository(User::class);
-
-        $found = [];
-        foreach ($selectors as $selector) {
-            $user = Uuid::isValid($selector)
-                ? $repo->find($selector)
-                : $repo->findOneBy(['email' => $selector]);
-
-            if (null === $user) {
-                $io->warning(sprintf('No user found for "%s" — skipped.', $selector));
-                continue;
-            }
-
-            $found[(string) $user->getId()] = $user;
-        }
-
-        return array_values($found);
     }
 }

--- a/api/src/Command/WaitlistGrantCommand.php
+++ b/api/src/Command/WaitlistGrantCommand.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\User;
+use App\Service\WaitlistPromoter;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Grant waitlisted accounts full access from the CLI — the scriptable, SSH-able
+ * companion to the /admin/waitlist "Grant access" button. Promotes each matched
+ * user (flips the waitlist flag, restoring ROLE_USER) and emails them the same
+ * "you're in" message the admin UI sends.
+ *
+ *   bin/console app:waitlist:grant a@x.com b@x.com         # by email
+ *   bin/console app:waitlist:grant 0190f3...               # by user id
+ *   bin/console app:waitlist:grant a@x.com 0190f3...       # ids and emails mixed
+ *   bin/console app:waitlist:grant --oldest=25             # the 25 longest-waiting
+ *   bin/console app:waitlist:grant --all                   # everyone on the list
+ *   bin/console app:waitlist:grant --all --dry-run         # preview, change nothing
+ *
+ * Exactly one selection mode per run: explicit ids/emails, --oldest=N, or --all.
+ * Selecting a user who already has full access is a harmless no-op (reported as
+ * skipped), so a stale list or a double-run never re-sends an email.
+ */
+#[AsCommand(
+    name: 'app:waitlist:grant',
+    description: 'Promote waitlisted users to full accounts (and email them) from the CLI.',
+)]
+final class WaitlistGrantCommand extends Command
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private WaitlistPromoter $promoter,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument(
+                'selectors',
+                InputArgument::IS_ARRAY,
+                'User ids and/or emails to grant access to',
+            )
+            ->addOption('all', null, InputOption::VALUE_NONE, 'Promote every waitlisted user')
+            ->addOption('oldest', null, InputOption::VALUE_REQUIRED, 'Promote the oldest N waitlisted users')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Show who would be promoted without changing anything');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        /** @var list<string> $selectors */
+        $selectors = $input->getArgument('selectors');
+        $all = true === $input->getOption('all');
+        $oldest = $input->getOption('oldest');
+        $dryRun = true === $input->getOption('dry-run');
+
+        // Exactly one selection mode — explicit selectors, --oldest, or --all.
+        $modes = ([] !== $selectors ? 1 : 0) + ($all ? 1 : 0) + (null !== $oldest ? 1 : 0);
+        if (1 !== $modes) {
+            $io->error('Choose exactly one of: <selectors>, --oldest=N, or --all.');
+            return Command::INVALID;
+        }
+
+        if ($all) {
+            $candidates = $this->waitlistedOldestFirst(null);
+        } elseif (null !== $oldest) {
+            if (!is_string($oldest) || 1 !== preg_match('/^\d+$/', $oldest) || (int) $oldest < 1) {
+                $io->error('--oldest must be a positive integer.');
+                return Command::INVALID;
+            }
+            $candidates = $this->waitlistedOldestFirst((int) $oldest);
+        } else {
+            $candidates = $this->resolveSelectors($io, $selectors);
+        }
+
+        if ([] === $candidates) {
+            $io->warning('No matching users — nothing to do.');
+            return Command::SUCCESS;
+        }
+
+        $promoted = [];
+        foreach ($candidates as $user) {
+            if (!$user->isWaitlisted()) {
+                $io->writeln(sprintf('  <comment>skip</comment> %s — already has full access.', $user->getEmail()));
+                continue;
+            }
+            if (!$dryRun) {
+                // Flips the flag, flushes, and emails the user; a no-op if they
+                // were promoted between selection and now.
+                $this->promoter->promoteOne($user);
+            }
+            $promoted[] = $user;
+        }
+
+        if ([] === $promoted) {
+            $io->warning('No waitlisted users in the selection — nothing changed.');
+            return Command::SUCCESS;
+        }
+
+        $io->table(
+            ['ID', 'Email'],
+            array_map(static fn (User $u): array => [(string) $u->getId(), $u->getEmail()], $promoted),
+        );
+
+        $io->success(sprintf(
+            '%s %d user(s).%s',
+            $dryRun ? 'Would promote' : 'Promoted',
+            count($promoted),
+            $dryRun ? ' Dry run — no changes made.' : '',
+        ));
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Waitlisted users, oldest first. User has no createdOn column, but its id
+     * is a time-ordered UUIDv7 (see config/packages/framework.yaml), so ordering
+     * by id ASC is chronological — the longest-waiting accounts come first.
+     *
+     * @return list<User>
+     */
+    private function waitlistedOldestFirst(?int $limit): array
+    {
+        return $this->em->getRepository(User::class)
+            ->findBy(['waitlisted' => true], ['id' => 'ASC'], $limit);
+    }
+
+    /**
+     * Resolve each selector (a UUID or an email) to a user, deduping by id and
+     * warning on anything that doesn't match.
+     *
+     * @param list<string> $selectors
+     * @return list<User>
+     */
+    private function resolveSelectors(SymfonyStyle $io, array $selectors): array
+    {
+        $repo = $this->em->getRepository(User::class);
+
+        $found = [];
+        foreach ($selectors as $selector) {
+            $user = Uuid::isValid($selector)
+                ? $repo->find($selector)
+                : $repo->findOneBy(['email' => $selector]);
+
+            if (null === $user) {
+                $io->warning(sprintf('No user found for "%s" — skipped.', $selector));
+                continue;
+            }
+
+            $found[(string) $user->getId()] = $user;
+        }
+
+        return array_values($found);
+    }
+}

--- a/api/src/Controller/WaitlistController.php
+++ b/api/src/Controller/WaitlistController.php
@@ -3,6 +3,7 @@
 namespace App\Controller;
 
 use App\Entity\User;
+use App\Service\WaitlistGrantService;
 use App\Service\WaitlistPromoter;
 use App\Service\WaitlistSettings;
 use Doctrine\ORM\EntityManagerInterface;
@@ -38,6 +39,7 @@ class WaitlistController extends AbstractController
     public function __construct(
         private WaitlistSettings $settings,
         private WaitlistPromoter $promoter,
+        private WaitlistGrantService $granter,
         private EntityManagerInterface $em,
     ) {
     }
@@ -107,11 +109,13 @@ class WaitlistController extends AbstractController
         if (null === $user) {
             return $this->json(['error' => 'User not found.'], 404);
         }
-        if (!$user->isWaitlisted()) {
+
+        // Same shared path as the CLI (app:waitlist:grant): a non-waitlisted
+        // user comes back as skipped rather than promoted.
+        $result = $this->granter->grant([$user]);
+        if ([] === $result->promoted) {
             return $this->json(['error' => 'User is not on the waitlist.'], 422);
         }
-
-        $this->promoter->promoteOne($user);
 
         return $this->json([
             'promoted' => true,

--- a/api/src/Service/WaitlistGrantResult.php
+++ b/api/src/Service/WaitlistGrantResult.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\User;
+
+/**
+ * Outcome of a {@see WaitlistGrantService::grant()} batch: who was actually
+ * promoted (was waitlisted, now a full member + emailed) versus who was a
+ * no-op (already had full access, so no flag flip and no email).
+ */
+final class WaitlistGrantResult
+{
+    /**
+     * @param list<User> $promoted users that were waitlisted and are now full members
+     * @param list<User> $skipped  users that already had full access (no-op, no email)
+     */
+    public function __construct(
+        public readonly array $promoted,
+        public readonly array $skipped,
+    ) {
+    }
+}

--- a/api/src/Service/WaitlistGrantService.php
+++ b/api/src/Service/WaitlistGrantService.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Targeted "grant waitlist access" orchestration, shared by the admin UI
+ * endpoint (POST /admin/waitlist/promote) and the CLI (app:waitlist:grant).
+ *
+ * It sits one level above {@see WaitlistPromoter}: the promoter is the low-level
+ * primitive that flips one account's flag and emails them, while this service
+ * knows how to *select* the accounts (by id/email, oldest-first, or the whole
+ * list) and how to promote a batch while reporting promoted-vs-skipped. Opening
+ * signups wholesale stays on WaitlistPromoter::promoteAll() — that path flips
+ * every flag in a single flush and isn't a targeted grant.
+ */
+final class WaitlistGrantService
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private WaitlistPromoter $promoter,
+    ) {
+    }
+
+    /**
+     * Promote each given user that is still waitlisted (flipping the flag,
+     * restoring ROLE_USER, and emailing them via the promoter). A user who
+     * already has full access is reported as skipped, never re-promoted or
+     * re-emailed — so a stale selection or a double-run is harmless.
+     *
+     * With $dryRun the same promoted/skipped split is computed but no flag is
+     * flipped and no email is sent — a single source of truth for what a real
+     * run would do.
+     *
+     * @param iterable<User> $users
+     */
+    public function grant(iterable $users, bool $dryRun = false): WaitlistGrantResult
+    {
+        $promoted = [];
+        $skipped = [];
+        foreach ($users as $user) {
+            if (!$user->isWaitlisted()) {
+                $skipped[] = $user;
+                continue;
+            }
+            if (!$dryRun) {
+                $this->promoter->promoteOne($user);
+            }
+            $promoted[] = $user;
+        }
+
+        return new WaitlistGrantResult($promoted, $skipped);
+    }
+
+    /**
+     * Waitlisted users, oldest first. User has no createdOn column, but its id
+     * is a time-ordered UUIDv7 (see config/packages/framework.yaml), so ordering
+     * by id ASC is chronological — the longest-waiting accounts come first.
+     *
+     * @return list<User>
+     */
+    public function findWaitlisted(?int $limit = null): array
+    {
+        return $this->em->getRepository(User::class)
+            ->findBy(['waitlisted' => true], ['id' => 'ASC'], $limit);
+    }
+
+    /**
+     * Resolve each selector (a UUID or an email) to a user, deduping by id.
+     * Selectors that match nothing are collected in `notFound` so the caller
+     * can report them however suits its surface.
+     *
+     * @param list<string> $selectors
+     * @return array{users: list<User>, notFound: list<string>}
+     */
+    public function resolveSelectors(array $selectors): array
+    {
+        $repo = $this->em->getRepository(User::class);
+
+        $users = [];
+        $notFound = [];
+        foreach ($selectors as $selector) {
+            $user = Uuid::isValid($selector)
+                ? $repo->find($selector)
+                : $repo->findOneBy(['email' => $selector]);
+
+            if (null === $user) {
+                $notFound[] = $selector;
+                continue;
+            }
+
+            $users[(string) $user->getId()] = $user;
+        }
+
+        return ['users' => array_values($users), 'notFound' => $notFound];
+    }
+}

--- a/api/tests/Command/WaitlistGrantCommandTest.php
+++ b/api/tests/Command/WaitlistGrantCommandTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace App\Tests\Command;
+
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+class WaitlistGrantCommandTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = self::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->em = $em;
+        $this->em->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testGrantsByEmail(): void
+    {
+        $this->makeWaitlisted('a@example.com');
+        $this->makeWaitlisted('b@example.com');
+
+        $tester = $this->invoke(['a@example.com']);
+        $tester->assertCommandIsSuccessful();
+
+        $this->assertFalse($this->reload('a@example.com')->isWaitlisted());
+        // The unselected user is untouched.
+        $this->assertTrue($this->reload('b@example.com')->isWaitlisted());
+    }
+
+    public function testGrantsByIdAndDedupesAcrossIdAndEmail(): void
+    {
+        $user = $this->makeWaitlisted('c@example.com');
+        $id = (string) $user->getId();
+
+        // Same user referenced twice (id + email) collapses to one promotion.
+        $tester = $this->invoke([$id, 'c@example.com']);
+        $tester->assertCommandIsSuccessful();
+
+        $this->assertFalse($this->reload('c@example.com')->isWaitlisted());
+    }
+
+    public function testAllPromotesEveryWaitlistedUser(): void
+    {
+        $this->makeWaitlisted('one@example.com');
+        $this->makeWaitlisted('two@example.com');
+        // A full account is left out of the waitlist entirely.
+        $this->makeWaitlisted('three@example.com', waitlisted: false);
+
+        $tester = $this->invoke([], ['--all' => true]);
+        $tester->assertCommandIsSuccessful();
+
+        $this->assertFalse($this->reload('one@example.com')->isWaitlisted());
+        $this->assertFalse($this->reload('two@example.com')->isWaitlisted());
+    }
+
+    public function testOldestPromotesTheLongestWaitingN(): void
+    {
+        // UUIDv7 ids are time-ordered, so creation order == oldest-first order.
+        $first = $this->makeWaitlisted('first@example.com');
+        $second = $this->makeWaitlisted('second@example.com');
+        $third = $this->makeWaitlisted('third@example.com');
+
+        $tester = $this->invoke([], ['--oldest' => '2']);
+        $tester->assertCommandIsSuccessful();
+
+        $this->assertFalse($this->reload('first@example.com')->isWaitlisted());
+        $this->assertFalse($this->reload('second@example.com')->isWaitlisted());
+        // The newest signup is still waiting.
+        $this->assertTrue($this->reload('third@example.com')->isWaitlisted());
+    }
+
+    public function testDryRunChangesNothing(): void
+    {
+        $this->makeWaitlisted('preview@example.com');
+
+        $tester = $this->invoke(['preview@example.com'], ['--dry-run' => true]);
+        $tester->assertCommandIsSuccessful();
+
+        $this->assertTrue($this->reload('preview@example.com')->isWaitlisted());
+    }
+
+    public function testRequiresExactlyOneMode(): void
+    {
+        $this->assertSame(Command::INVALID, $this->invoke([])->getStatusCode());
+        $this->assertSame(
+            Command::INVALID,
+            $this->invoke(['x@example.com'], ['--all' => true])->getStatusCode(),
+        );
+    }
+
+    public function testRejectsNonPositiveOldest(): void
+    {
+        $this->assertSame(Command::INVALID, $this->invoke([], ['--oldest' => '0'])->getStatusCode());
+        $this->assertSame(Command::INVALID, $this->invoke([], ['--oldest' => 'abc'])->getStatusCode());
+    }
+
+    public function testAlreadyFullAccountIsSkippedNotErrored(): void
+    {
+        $this->makeWaitlisted('full@example.com', waitlisted: false);
+
+        $tester = $this->invoke(['full@example.com']);
+        // No waitlisted users in the selection: a clean no-op, not a failure.
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $this->assertFalse($this->reload('full@example.com')->isWaitlisted());
+    }
+
+    /**
+     * @param list<string>         $selectors
+     * @param array<string, mixed> $options
+     */
+    private function invoke(array $selectors, array $options = []): CommandTester
+    {
+        $kernel = self::$kernel;
+        assert(null !== $kernel);
+        $application = new Application($kernel);
+        $tester = new CommandTester($application->find('app:waitlist:grant'));
+        $tester->execute(['selectors' => $selectors, ...$options]);
+        return $tester;
+    }
+
+    private function makeWaitlisted(string $email, bool $waitlisted = true): User
+    {
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $user->setWaitlisted($waitlisted);
+        $this->em->persist($user);
+        $this->em->flush();
+        return $user;
+    }
+
+    private function reload(string $email): User
+    {
+        $this->em->clear();
+        $user = $this->em->getRepository(User::class)->findOneBy(['email' => $email]);
+        assert($user instanceof User);
+        return $user;
+    }
+}

--- a/api/tests/Service/WaitlistGrantServiceTest.php
+++ b/api/tests/Service/WaitlistGrantServiceTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Entity\User;
+use App\Service\WaitlistGrantService;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+class WaitlistGrantServiceTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+    private WaitlistGrantService $granter;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = self::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->em = $em;
+        $this->em->createQuery('DELETE FROM App\Entity\User')->execute();
+
+        $granter = self::getContainer()->get(WaitlistGrantService::class);
+        assert($granter instanceof WaitlistGrantService);
+        $this->granter = $granter;
+    }
+
+    public function testGrantPromotesWaitlistedAndSkipsFullAccounts(): void
+    {
+        $waiting = $this->makeUser('waiting@example.com', waitlisted: true);
+        $full = $this->makeUser('full@example.com', waitlisted: false);
+
+        $result = $this->granter->grant([$waiting, $full]);
+
+        $this->assertSame([$waiting], $result->promoted);
+        $this->assertSame([$full], $result->skipped);
+        $this->assertFalse($this->reload('waiting@example.com')->isWaitlisted());
+    }
+
+    public function testGrantDryRunReportsButChangesNothing(): void
+    {
+        $waiting = $this->makeUser('dry@example.com', waitlisted: true);
+
+        $result = $this->granter->grant([$waiting], dryRun: true);
+
+        $this->assertSame([$waiting], $result->promoted);
+        // No flag flip — the split is computed without the side effects.
+        $this->assertTrue($this->reload('dry@example.com')->isWaitlisted());
+    }
+
+    public function testFindWaitlistedReturnsOldestFirstAndHonoursLimit(): void
+    {
+        // UUIDv7 ids are time-ordered, so creation order is oldest-first.
+        $first = $this->makeUser('first@example.com', waitlisted: true);
+        $second = $this->makeUser('second@example.com', waitlisted: true);
+        $this->makeUser('third@example.com', waitlisted: true);
+        $this->makeUser('full@example.com', waitlisted: false);
+
+        $oldestTwo = $this->granter->findWaitlisted(2);
+
+        $this->assertSame(
+            [(string) $first->getId(), (string) $second->getId()],
+            array_map(static fn (User $u): string => (string) $u->getId(), $oldestTwo),
+        );
+        $this->assertCount(3, $this->granter->findWaitlisted());
+    }
+
+    public function testResolveSelectorsMixesIdsAndEmailsDedupesAndReportsUnknown(): void
+    {
+        $user = $this->makeUser('hit@example.com', waitlisted: true);
+        $id = (string) $user->getId();
+
+        $resolved = $this->granter->resolveSelectors([$id, 'hit@example.com', 'missing@example.com']);
+
+        // The id + email referencing the same user collapse to one entry.
+        $this->assertSame([$user], $resolved['users']);
+        $this->assertSame(['missing@example.com'], $resolved['notFound']);
+    }
+
+    private function makeUser(string $email, bool $waitlisted): User
+    {
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $user->setWaitlisted($waitlisted);
+        $this->em->persist($user);
+        $this->em->flush();
+        return $user;
+    }
+
+    private function reload(string $email): User
+    {
+        $this->em->clear();
+        $user = $this->em->getRepository(User::class)->findOneBy(['email' => $email]);
+        assert($user instanceof User);
+        return $user;
+    }
+}

--- a/api/tests/Service/WaitlistGrantServiceTest.php
+++ b/api/tests/Service/WaitlistGrantServiceTest.php
@@ -21,9 +21,7 @@ class WaitlistGrantServiceTest extends KernelTestCase
         $this->em = $em;
         $this->em->createQuery('DELETE FROM App\Entity\User')->execute();
 
-        $granter = self::getContainer()->get(WaitlistGrantService::class);
-        assert($granter instanceof WaitlistGrantService);
-        $this->granter = $granter;
+        $this->granter = self::getContainer()->get(WaitlistGrantService::class);
     }
 
     public function testGrantPromotesWaitlistedAndSkipsFullAccounts(): void


### PR DESCRIPTION
## Summary

Adds an `app:waitlist:grant` console command so waitlisted users can be promoted from the CLI (e.g. over SSH on the prod box), and **extracts a shared `WaitlistGrantService` so the admin UI endpoint and the CLI run the exact same code path** — no behavioural drift between the two surfaces.

### Shared service

`WaitlistGrantService` is now the single place that selects + promotes waitlisted accounts, built on the existing `WaitlistPromoter::promoteOne()` primitive:

- `grant(iterable<User>, dryRun): WaitlistGrantResult` → `{promoted, skipped}` — promotes each still-waitlisted user (flag flip + "you're in" email); already-full accounts come back as `skipped` (no-op, no re-email). `dryRun` computes the same split with no side effects.
- `findWaitlisted(?limit)` — waitlisted users oldest-first (`id ASC`; ids are time-ordered UUIDv7, so that's chronological).
- `resolveSelectors(list<string>)` — ids and/or emails → users, deduped, with unknowns reported.

Both consumers delegate:
- `POST /admin/waitlist/promote` (admin UI "Grant access") → `grant([$user])`; a non-waitlisted user is now `skipped` → still returns 422.
- `app:waitlist:grant` (CLI) → `resolveSelectors`/`findWaitlisted` + `grant`.

Mass "open signups" (`POST /admin/waitlist` on→off) stays on `WaitlistPromoter::promoteAll()` — that path flips every flag in one flush and isn't a targeted grant.

## CLI selection modes (exactly one per run)

```bash
bin/console app:waitlist:grant a@x.com b@x.com      # by email
bin/console app:waitlist:grant 0190f3...            # by user id
bin/console app:waitlist:grant a@x.com 0190f3...    # ids + emails mixed (deduped)
bin/console app:waitlist:grant --oldest=25          # the 25 longest-waiting
bin/console app:waitlist:grant --all                # everyone on the waitlist
bin/console app:waitlist:grant --all --dry-run      # preview, change nothing
```

On prod:
```bash
docker compose -f compose.yaml -f compose.prod.yaml exec php \
  bin/console app:waitlist:grant --oldest=10
```

## Notes

- **Safe to re-run / idempotent.** A user who already has full access is reported as `skip`, never re-promoted or re-emailed.
- Unknown ids/emails are warned and skipped, not fatal.

## Test plan

- [ ] `WaitlistGrantServiceTest` — `grant` promoted/skipped split, dry-run no-op, `findWaitlisted` ordering + limit, `resolveSelectors` id/email dedupe + unknowns.
- [ ] `WaitlistGrantCommandTest` — by-email, by-id (+ dedupe), `--all`, `--oldest=N`, `--dry-run`, mode-exclusivity, bad `--oldest`, already-full skip.
- [ ] Existing `WaitlistTest` (admin endpoint) unchanged — same 404/422/200 + single email behaviour through the shared service.
- [ ] CI: Tests / PHPStan (level 10) / PHPCS.
