### PR TITLE
fix: inject MAILER_FROM into php + worker containers

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -19,6 +19,7 @@ services:
       MERCURE_PUBLIC_URL: ${CADDY_MERCURE_PUBLIC_URL:-https://${SERVER_NAME:-localhost}:${HTTPS_PORT:-443}/.well-known/mercure}
       MERCURE_JWT_SECRET: ${CADDY_MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
       MAILER_DSN: ${MAILER_DSN:-smtp://mailpit:1025}
+      MAILER_FROM: ${MAILER_FROM:-no-reply@aura.test}
       APP_FRONTEND_URL: ${APP_FRONTEND_URL:-https://localhost}
       MESSENGER_TRANSPORT_DSN: ${MESSENGER_TRANSPORT_DSN:-doctrine://default?auto_setup=false}
       # Hostname for the Umami dashboard site block in the Caddyfile.
@@ -91,6 +92,7 @@ services:
       SERVER_NAME: php-worker
       DATABASE_URL: postgresql://${POSTGRES_USER:-app}:${POSTGRES_PASSWORD:-!ChangeMe!}@database:5432/${POSTGRES_DB:-app}?serverVersion=${POSTGRES_VERSION:-16}&charset=${POSTGRES_CHARSET:-utf8}
       MAILER_DSN: ${MAILER_DSN:-smtp://mailpit:1025}
+      MAILER_FROM: ${MAILER_FROM:-no-reply@aura.test}
       APP_FRONTEND_URL: ${APP_FRONTEND_URL:-https://localhost}
       MESSENGER_TRANSPORT_DSN: ${MESSENGER_TRANSPORT_DSN:-doctrine://default?auto_setup=false}
       MERCURE_URL: ${CADDY_MERCURE_URL:-http://php/.well-known/mercure}


### PR DESCRIPTION
## Problem

`MAILER_FROM` is defined in the server `.env` (`no-reply@madori.app`) but was **never injected into the php/worker containers** — `compose.yaml` lists `MAILER_DSN` under each service''s `environment:` but not `MAILER_FROM`. So the app fell back to the hardcoded default `no-reply@aura.test` (see `WaitlistAccessMailer`, `InviteMailer`, etc.), and Resend rejected every send with:

```
403 This API key is not authorized to send emails from aura.test
```

This surfaced right after [#434](https://github.com/roboparker/Aura/pull/434) switched the transport to Resend''s HTTP API (the SMTP path had been failing earlier at the network layer, masking this second bug).

## Fix

Add `MAILER_FROM: ${MAILER_FROM:-no-reply@aura.test}` to the `environment:` block of both the `php` and `worker` services, mirroring how `MAILER_DSN` is wired. With the var present, the containers resolve it from `.env` and emails send from the verified `madori.app` domain.

## Verified in production

Applied the same change to the live server''s `compose.yaml` and recreated php+worker; both now report `MAILER_FROM=no-reply@madori.app`. A real grant email then delivered end-to-end (`POST https://api.resend.com/emails → 200`). This PR makes that durable through the deploy pipeline (the server checkout is `git reset --hard`-ed on each deploy, so the manual edit would otherwise be lost).