### PR TITLE
Promote: persist MAILER_FROM container env fix

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -19,6 +19,7 @@ services:
       MERCURE_PUBLIC_URL: ${CADDY_MERCURE_PUBLIC_URL:-https://${SERVER_NAME:-localhost}:${HTTPS_PORT:-443}/.well-known/mercure}
       MERCURE_JWT_SECRET: ${CADDY_MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
       MAILER_DSN: ${MAILER_DSN:-smtp://mailpit:1025}
+      MAILER_FROM: ${MAILER_FROM:-no-reply@aura.test}
       APP_FRONTEND_URL: ${APP_FRONTEND_URL:-https://localhost}
       MESSENGER_TRANSPORT_DSN: ${MESSENGER_TRANSPORT_DSN:-doctrine://default?auto_setup=false}
       # Hostname for the Umami dashboard site block in the Caddyfile.
@@ -91,6 +92,7 @@ services:
       SERVER_NAME: php-worker
       DATABASE_URL: postgresql://${POSTGRES_USER:-app}:${POSTGRES_PASSWORD:-!ChangeMe!}@database:5432/${POSTGRES_DB:-app}?serverVersion=${POSTGRES_VERSION:-16}&charset=${POSTGRES_CHARSET:-utf8}
       MAILER_DSN: ${MAILER_DSN:-smtp://mailpit:1025}
+      MAILER_FROM: ${MAILER_FROM:-no-reply@aura.test}
       APP_FRONTEND_URL: ${APP_FRONTEND_URL:-https://localhost}
       MESSENGER_TRANSPORT_DSN: ${MESSENGER_TRANSPORT_DSN:-doctrine://default?auto_setup=false}
       MERCURE_URL: ${CADDY_MERCURE_URL:-http://php/.well-known/mercure}


### PR DESCRIPTION
Promote `main` → `production`.

## Shipping

- **#437 — fix: inject `MAILER_FROM` into php + worker containers.** Without it, the containers fall back to `no-reply@aura.test` and Resend rejects every send with 403.

## Why this must land

The same change was applied manually to the live server and email is working now, but the deploy runs `git reset --hard origin/production` — so until this is on `production`, the next deploy would wipe the manual edit and break email again. This makes it durable.

## Post-deploy check

After deploy completes, php + worker should report `MAILER_FROM=no-reply@madori.app` and mail continues to send via `resend+api://`. No manual steps required (the `.env` already carries `MAILER_FROM` and the new `MAILER_DSN`).