### PR TITLE
fix: keep production deploy path at /opt/aura

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -117,7 +117,10 @@ jobs:
               -o StrictHostKeyChecking=yes \
               "${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}" \
               "set -euo pipefail
-               cd /opt/madori
+               # Server checkout dir stays /opt/aura even though the product is
+               # 'Madori': renaming it changes the Compose project name and would
+               # orphan the named volumes (Postgres data included).
+               cd /opt/aura
                git fetch -q origin production
                git checkout -q production
                git reset -q --hard origin/production

--- a/docs/developer/deployment.md
+++ b/docs/developer/deployment.md
@@ -128,13 +128,16 @@ This is wired up but **gated** so it has zero effect until switched on:
    *SSL/TLS → Origin Server → Create Certificate* (let Cloudflare generate the
    key; hostnames `madori.app` + `*.madori.app`; 15-year validity). Copy the
    **Origin Certificate** and **Private Key** PEM blocks.
-2. **Place the files on the server** (key readable only by root):
+2. **Place the files on the server** (key readable only by root). The server
+   checkout lives at `/opt/aura` — this directory name is intentionally kept
+   even though the product is "Madori", because renaming it changes the Docker
+   Compose project name and would orphan the named volumes (Postgres data):
    ```bash
-   mkdir -p /opt/madori/certs
+   mkdir -p /opt/aura/certs
    # paste the cert into cert.pem and the key into key.pem
-   chmod 600 /opt/madori/certs/key.pem
+   chmod 600 /opt/aura/certs/key.pem
    ```
-3. **Enable it** in `/opt/madori/.env`:
+3. **Enable it** in `/opt/aura/.env`:
    ```
    TLS_DIRECTIVE=tls /etc/caddy/origin/cert.pem /etc/caddy/origin/key.pem
    ```


### PR DESCRIPTION
Follow-up to the Madori rebrand ([#439](https://github.com/roboparker/Aura/pull/439)).

The rebrand renamed the server checkout path to `/opt/madori`, which broke the production deploy at:

```
bash: line 2: cd: /opt/madori: No such file or directory
```

It failed **fast — before any container swap or backup** — so production was untouched.

## Fix
Keep the deploy path as `/opt/aura`. It's physical infrastructure — the analog of the repo/folder name we deliberately left unchanged. Renaming the server directory would change the Docker Compose project name (defaults to the directory basename) and **orphan the named volumes** (`database_data` / `media_data` / `caddy_data`), starting Postgres on a fresh empty volume.

All user-facing Madori branding is unchanged. Comments added at both call sites (`deploy.yml`, `deployment.md`) so the path isn't "corrected" back later.

After this merges I'll promote `main` → `production` and confirm the deploy goes green.