### PR TITLE
Promote: fix deploy path (/opt/aura) to unblock Madori deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -117,7 +117,10 @@ jobs:
               -o StrictHostKeyChecking=yes \
               "${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}" \
               "set -euo pipefail
-               cd /opt/madori
+               # Server checkout dir stays /opt/aura even though the product is
+               # 'Madori': renaming it changes the Compose project name and would
+               # orphan the named volumes (Postgres data included).
+               cd /opt/aura
                git fetch -q origin production
                git checkout -q production
                git reset -q --hard origin/production

--- a/docs/developer/deployment.md
+++ b/docs/developer/deployment.md
@@ -128,13 +128,16 @@ This is wired up but **gated** so it has zero effect until switched on:
    *SSL/TLS → Origin Server → Create Certificate* (let Cloudflare generate the
    key; hostnames `madori.app` + `*.madori.app`; 15-year validity). Copy the
    **Origin Certificate** and **Private Key** PEM blocks.
-2. **Place the files on the server** (key readable only by root):
+2. **Place the files on the server** (key readable only by root). The server
+   checkout lives at `/opt/aura` — this directory name is intentionally kept
+   even though the product is "Madori", because renaming it changes the Docker
+   Compose project name and would orphan the named volumes (Postgres data):
    ```bash
-   mkdir -p /opt/madori/certs
+   mkdir -p /opt/aura/certs
    # paste the cert into cert.pem and the key into key.pem
-   chmod 600 /opt/madori/certs/key.pem
+   chmod 600 /opt/aura/certs/key.pem
    ```
-3. **Enable it** in `/opt/madori/.env`:
+3. **Enable it** in `/opt/aura/.env`:
    ```
    TLS_DIRECTIVE=tls /etc/caddy/origin/cert.pem /etc/caddy/origin/key.pem
    ```


### PR DESCRIPTION
Promote `main` → `production` to ship the deploy-path fix ([#441](https://github.com/roboparker/Aura/pull/441)) and finally land the Madori rebrand on production.

Merge with a **merge commit** (not squash), per the branching guide.

## Why
The previous promote ([#440](https://github.com/roboparker/Aura/pull/440)) advanced `production` to the rebrand but its deploy **failed fast** at `cd /opt/madori: No such file or directory` — before any container swap, so production was untouched. This promote brings the fix that keeps the server checkout path at `/opt/aura`.

## Delta over current production
- `fix: keep production deploy path at /opt/aura` — reverts only the deploy path (keeps all Madori branding). Renaming the server dir would change the Compose project name and orphan the named volumes (Postgres data), so the path stays `/opt/aura`.

## After merge
Merging triggers the auto-deploy. I'll watch the run and confirm madori.app comes back healthy.

⚠️ Runtime note (expected, already agreed): existing 2FA enrollments and API tokens stop working after this deploy (new TOTP key-derivation string + `madori_pat_` prefix) and must be re-created.