### PR TITLE
fix: hide dead Mercure debugger link in production sidebar

### DIFF
--- a/pwa/components/common/SidebarNav.tsx
+++ b/pwa/components/common/SidebarNav.tsx
@@ -32,9 +32,16 @@ const PERSONAL_NAV_LINKS = [
 // Backend tooling surfaced inside the PWA chrome. The Mercure debugger
 // is served by Caddy (FrankenPHP), not Next.js, so it's a regular <a>
 // link rather than a <Link>. Admin-only.
-const ADMIN_EXTERNAL_LINKS = [
-  { href: "/.well-known/mercure/ui/", label: "Mercure" },
-];
+//
+// The debugger UI only exists when Caddy is started with the `demo`
+// Mercure directive (MERCURE_EXTRA_DIRECTIVES=demo), which we set only
+// in dev + e2e. Production leaves it unset, so /.well-known/mercure/ui/
+// 404s there — hence we omit the link from production builds entirely
+// rather than surface a dead admin link.
+const ADMIN_EXTERNAL_LINKS =
+  process.env.NODE_ENV === "production"
+    ? []
+    : [{ href: "/.well-known/mercure/ui/", label: "Mercure" }];
 
 interface SidebarNavProps {
   /**


### PR DESCRIPTION
## What changed

The admin section of the PWA sidebar surfaced a **Mercure** link pointing at `/.well-known/mercure/ui/`. That debugger UI is only served when Caddy runs with the `demo` Mercure directive (`MERCURE_EXTRA_DIRECTIVES=demo`), which we set only in dev ([compose.override.yaml](compose.override.yaml)) and e2e ([compose.e2e.yaml](compose.e2e.yaml)). Production — both the Helm config and the Hetzner compose deploy — leaves it unset, so the link 404'd for admins.

This gates `ADMIN_EXTERNAL_LINKS` in [pwa/components/common/SidebarNav.tsx](pwa/components/common/SidebarNav.tsx) on `process.env.NODE_ENV`: the link is dropped from production builds and kept in dev/e2e where the UI actually exists.

## Why

A dead admin link in production is confusing. Rather than special-case the route or always-on the demo directive (which would expose an anonymous Mercure debugger publicly), we simply omit the link where its target doesn't exist.

## Notes for reviewer

- `process.env.NODE_ENV` is statically inlined by Next.js at build time, so the link is fully tree-shaken out of the production bundle — not just hidden at runtime.
- No behavior change in dev/e2e; the render loop just maps an empty array in prod.
