### PR TITLE
feat: admin user impersonation for testing/debugging

### DIFF
--- a/api/config/packages/security.yaml
+++ b/api/config/packages/security.yaml
@@ -8,6 +8,11 @@ security:
                 class: App\Entity\User
                 property: email
 
+    # Platform admins may impersonate any user for testing/debugging via the
+    # firewall's switch_user listener (see the `main` firewall below).
+    role_hierarchy:
+        ROLE_ADMIN: [ROLE_ALLOWED_TO_SWITCH]
+
     firewalls:
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
@@ -55,6 +60,12 @@ security:
                 failure_handler: App\Security\TwoFactorJsonHandler
             logout:
                 path: /auth/logout
+            # Admin impersonation. Gated on ROLE_ALLOWED_TO_SWITCH (granted to
+            # ROLE_ADMIN via role_hierarchy above). Start by hitting any
+            # main-firewall route with ?_switch_user=<email>; stop with
+            # ?_switch_user=_exit. The PWA drives both through /api/me so the
+            # same request returns the swapped user payload.
+            switch_user: true
 
     access_control:
         - { path: ^/users$, methods: [POST], roles: PUBLIC_ACCESS }

--- a/api/src/EventListener/SessionRegistryListener.php
+++ b/api/src/EventListener/SessionRegistryListener.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
 
 /**
  * Keeps the {@see UserSession} registry in sync with cookie/session-backed
@@ -64,6 +65,13 @@ final class SessionRegistryListener implements EventSubscriberInterface
             return;
         }
         if ($request->attributes->has(ApiTokenAuthenticator::TOKEN_ATTR)) {
+            return;
+        }
+
+        // While an admin is impersonating someone the underlying session row
+        // still belongs to the admin — don't rewrite it to the impersonated
+        // user or spawn a phantom session for them.
+        if ($this->tokenStorage->getToken() instanceof SwitchUserToken) {
             return;
         }
 

--- a/api/src/EventSubscriber/ImpersonationAuditSubscriber.php
+++ b/api/src/EventSubscriber/ImpersonationAuditSubscriber.php
@@ -35,22 +35,22 @@ final class ImpersonationAuditSubscriber implements EventSubscriberInterface
 
     public function onSwitchUser(SwitchUserEvent $event): void
     {
+        $token = $event->getToken();
         $target = $event->getTargetUser();
-        $current = $event->getToken()->getUser();
 
-        if ($event->getToken() instanceof SwitchUserToken) {
+        if ($token instanceof SwitchUserToken) {
             // Switch-out: target is the admin, current token holds the
             // impersonated account being unwrapped.
             $this->logger->info('Impersonation ended', [
                 'admin' => $this->ref($target),
-                'impersonated' => $this->ref($current),
+                'impersonated' => $this->ref($token->getUser()),
             ]);
 
             return;
         }
 
         $this->logger->info('Impersonation started', [
-            'admin' => $this->ref($current),
+            'admin' => $this->ref($token?->getUser()),
             'impersonated' => $this->ref($target),
         ]);
     }
@@ -58,7 +58,7 @@ final class ImpersonationAuditSubscriber implements EventSubscriberInterface
     private function ref(mixed $user): string
     {
         return $user instanceof User
-            ? sprintf('%s <%s>', (string) $user->getId(), (string) $user->getEmail())
+            ? sprintf('%s <%s>', (string) $user->getId(), $user->getEmail())
             : 'unknown';
     }
 }

--- a/api/src/EventSubscriber/ImpersonationAuditSubscriber.php
+++ b/api/src/EventSubscriber/ImpersonationAuditSubscriber.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use App\Entity\User;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
+use Symfony\Component\Security\Http\Event\SwitchUserEvent;
+
+/**
+ * Audit trail for admin impersonation (the firewall's switch_user feature).
+ *
+ * The event fires on both switch-in (?_switch_user=<email>) and switch-out
+ * (?_switch_user=_exit). They're told apart by the current token: on switch-in
+ * it's the admin's own token and the target is the impersonated user; on
+ * switch-out the current token is the SwitchUserToken being unwrapped and the
+ * target is the admin being restored.
+ */
+final class ImpersonationAuditSubscriber implements EventSubscriberInterface
+{
+    public function __construct(private LoggerInterface $logger)
+    {
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [SwitchUserEvent::class => 'onSwitchUser'];
+    }
+
+    public function onSwitchUser(SwitchUserEvent $event): void
+    {
+        $target = $event->getTargetUser();
+        $current = $event->getToken()->getUser();
+
+        if ($event->getToken() instanceof SwitchUserToken) {
+            // Switch-out: target is the admin, current token holds the
+            // impersonated account being unwrapped.
+            $this->logger->info('Impersonation ended', [
+                'admin' => $this->ref($target),
+                'impersonated' => $this->ref($current),
+            ]);
+
+            return;
+        }
+
+        $this->logger->info('Impersonation started', [
+            'admin' => $this->ref($current),
+            'impersonated' => $this->ref($target),
+        ]);
+    }
+
+    private function ref(mixed $user): string
+    {
+        return $user instanceof User
+            ? sprintf('%s <%s>', (string) $user->getId(), (string) $user->getEmail())
+            : 'unknown';
+    }
+}

--- a/api/src/Service/UserPayloadSerializer.php
+++ b/api/src/Service/UserPayloadSerializer.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Service;
 
 use App\Entity\User;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
 
 /**
  * Single source of truth for the `/api/me`-shaped user payload.
@@ -22,6 +24,7 @@ final class UserPayloadSerializer
     public function __construct(
         private TwoFactorRecoveryState $recoveryState,
         private SegmentEvaluator $segmentEvaluator,
+        private Security $security,
     ) {
     }
 
@@ -75,6 +78,32 @@ final class UserPayloadSerializer
                 // {@see \App\EventSubscriber\TwoFactorRecoveryListener}.
                 'recoveryPending' => $this->recoveryState->isPending(),
             ],
+            // When an admin is impersonating this user, surface who the real
+            // operator is so the PWA can show the impersonation banner +
+            // "Stop impersonation" control. Null in the normal case.
+            'impersonator' => $this->impersonator(),
+        ];
+    }
+
+    /**
+     * @return array{id: string, email: string, name: string}|null
+     */
+    private function impersonator(): ?array
+    {
+        $token = $this->security->getToken();
+        if (!$token instanceof SwitchUserToken) {
+            return null;
+        }
+
+        $admin = $token->getOriginalToken()->getUser();
+        if (!$admin instanceof User) {
+            return null;
+        }
+
+        return [
+            'id' => (string) $admin->getId(),
+            'email' => (string) $admin->getEmail(),
+            'name' => trim($admin->getGivenName() . ' ' . $admin->getFamilyName()),
         ];
     }
 }

--- a/api/src/Service/UserPayloadSerializer.php
+++ b/api/src/Service/UserPayloadSerializer.php
@@ -102,7 +102,7 @@ final class UserPayloadSerializer
 
         return [
             'id' => (string) $admin->getId(),
-            'email' => (string) $admin->getEmail(),
+            'email' => $admin->getEmail(),
             'name' => trim($admin->getGivenName() . ' ' . $admin->getFamilyName()),
         ];
     }

--- a/api/tests/Api/ImpersonationTest.php
+++ b/api/tests/Api/ImpersonationTest.php
@@ -37,6 +37,9 @@ class ImpersonationTest extends ApiTestCase
         $this->createTestUser('member@example.com');
 
         $client = static::createClient();
+        // switch_user replies with a 302 to the same URL minus ?_switch_user;
+        // follow it (as a real fetch would) to land on the swapped /api/me.
+        $client->followRedirects();
         $client->loginUser($admin);
 
         $client->request('GET', '/api/me?_switch_user=member@example.com');
@@ -56,6 +59,9 @@ class ImpersonationTest extends ApiTestCase
         $admin = $this->createTestUser('admin@example.com', 'Password123!@#', ['ROLE_ADMIN']);
 
         $client = static::createClient();
+        // switch_user replies with a 302 to the same URL minus ?_switch_user;
+        // follow it (as a real fetch would) to land on the swapped /api/me.
+        $client->followRedirects();
         $client->loginUser($admin);
 
         $client->request('GET', '/api/me');
@@ -69,6 +75,9 @@ class ImpersonationTest extends ApiTestCase
         $this->createTestUser('member@example.com');
 
         $client = static::createClient();
+        // switch_user replies with a 302 to the same URL minus ?_switch_user;
+        // follow it (as a real fetch would) to land on the swapped /api/me.
+        $client->followRedirects();
         $client->loginUser($admin);
 
         // Switch into the non-admin member...
@@ -87,6 +96,9 @@ class ImpersonationTest extends ApiTestCase
         $this->createTestUser('member@example.com');
 
         $client = static::createClient();
+        // switch_user replies with a 302 to the same URL minus ?_switch_user;
+        // follow it (as a real fetch would) to land on the swapped /api/me.
+        $client->followRedirects();
         $client->loginUser($admin);
 
         $client->request('GET', '/api/me?_switch_user=member@example.com');
@@ -110,6 +122,9 @@ class ImpersonationTest extends ApiTestCase
         $this->createTestUser('victim@example.com');
 
         $client = static::createClient();
+        // switch_user replies with a 302 to the same URL minus ?_switch_user;
+        // follow it (as a real fetch would) to land on the swapped /api/me.
+        $client->followRedirects();
         $client->loginUser($member);
 
         $client->request('GET', '/api/me?_switch_user=victim@example.com');

--- a/api/tests/Api/ImpersonationTest.php
+++ b/api/tests/Api/ImpersonationTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Admin impersonation via the firewall's switch_user feature.
+ *
+ * Start: any main-firewall request carrying ?_switch_user=<email>.
+ * Stop: ?_switch_user=_exit. The /api/me payload surfaces an `impersonator`
+ * block so the PWA can show the banner + "Stop impersonation" control.
+ */
+class ImpersonationTest extends ApiTestCase
+{
+    use JsonBodyAssertions;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testAdminCanImpersonateAndPayloadSurfacesImpersonator(): void
+    {
+        $admin = $this->createTestUser('admin@example.com', 'Password123!@#', ['ROLE_ADMIN']);
+        $this->createTestUser('member@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+
+        $client->request('GET', '/api/me?_switch_user=member@example.com');
+        $this->assertResponseIsSuccessful();
+
+        $body = $this->body($client);
+        $this->assertSame('member@example.com', $this->stringField($body, 'email'));
+
+        $impersonator = $body['impersonator'];
+        $this->assertIsArray($impersonator);
+        $this->assertSame('admin@example.com', $this->stringField($impersonator, 'email'));
+        $this->assertSame((string) $admin->getId(), $this->stringField($impersonator, 'id'));
+    }
+
+    public function testNormalSessionHasNullImpersonator(): void
+    {
+        $admin = $this->createTestUser('admin@example.com', 'Password123!@#', ['ROLE_ADMIN']);
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+
+        $client->request('GET', '/api/me');
+        $this->assertResponseIsSuccessful();
+        $this->assertNull($this->body($client)['impersonator']);
+    }
+
+    public function testImpersonatedSessionLosesAdminAccess(): void
+    {
+        $admin = $this->createTestUser('admin@example.com', 'Password123!@#', ['ROLE_ADMIN']);
+        $this->createTestUser('member@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+
+        // Switch into the non-admin member...
+        $client->request('GET', '/api/me?_switch_user=member@example.com');
+        $this->assertResponseIsSuccessful();
+
+        // ...and the impersonated session can no longer reach admin surfaces:
+        // the SwitchUserToken carries the member's roles, not ROLE_ADMIN.
+        $client->request('GET', '/admin/waitlist');
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testExitRestoresAdmin(): void
+    {
+        $admin = $this->createTestUser('admin@example.com', 'Password123!@#', ['ROLE_ADMIN']);
+        $this->createTestUser('member@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+
+        $client->request('GET', '/api/me?_switch_user=member@example.com');
+        $this->assertResponseIsSuccessful();
+
+        $client->request('GET', '/api/me?_switch_user=_exit');
+        $this->assertResponseIsSuccessful();
+
+        $body = $this->body($client);
+        $this->assertSame('admin@example.com', $this->stringField($body, 'email'));
+        $this->assertNull($body['impersonator']);
+
+        // And admin access is back.
+        $client->request('GET', '/admin/waitlist');
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testNonAdminCannotImpersonate(): void
+    {
+        $member = $this->createTestUser('member@example.com');
+        $this->createTestUser('victim@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($member);
+
+        $client->request('GET', '/api/me?_switch_user=victim@example.com');
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    /**
+     * @return array<int|string, mixed>
+     */
+    private function body(Client $client): array
+    {
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        return $response->toArray(false);
+    }
+
+    /**
+     * @param list<string> $roles
+     */
+    private function createTestUser(string $email, string $plainPassword = 'Password123!@#', array $roles = []): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles($roles);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, $plainPassword));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/api/tests/Api/ImpersonationTest.php
+++ b/api/tests/Api/ImpersonationTest.php
@@ -39,7 +39,7 @@ class ImpersonationTest extends ApiTestCase
         $client = static::createClient();
         // switch_user replies with a 302 to the same URL minus ?_switch_user;
         // follow it (as a real fetch would) to land on the swapped /api/me.
-        $client->followRedirects();
+        $client->getKernelBrowser()->followRedirects();
         $client->loginUser($admin);
 
         $client->request('GET', '/api/me?_switch_user=member@example.com');
@@ -61,7 +61,7 @@ class ImpersonationTest extends ApiTestCase
         $client = static::createClient();
         // switch_user replies with a 302 to the same URL minus ?_switch_user;
         // follow it (as a real fetch would) to land on the swapped /api/me.
-        $client->followRedirects();
+        $client->getKernelBrowser()->followRedirects();
         $client->loginUser($admin);
 
         $client->request('GET', '/api/me');
@@ -77,7 +77,7 @@ class ImpersonationTest extends ApiTestCase
         $client = static::createClient();
         // switch_user replies with a 302 to the same URL minus ?_switch_user;
         // follow it (as a real fetch would) to land on the swapped /api/me.
-        $client->followRedirects();
+        $client->getKernelBrowser()->followRedirects();
         $client->loginUser($admin);
 
         // Switch into the non-admin member...
@@ -98,7 +98,7 @@ class ImpersonationTest extends ApiTestCase
         $client = static::createClient();
         // switch_user replies with a 302 to the same URL minus ?_switch_user;
         // follow it (as a real fetch would) to land on the swapped /api/me.
-        $client->followRedirects();
+        $client->getKernelBrowser()->followRedirects();
         $client->loginUser($admin);
 
         $client->request('GET', '/api/me?_switch_user=member@example.com');
@@ -124,7 +124,7 @@ class ImpersonationTest extends ApiTestCase
         $client = static::createClient();
         // switch_user replies with a 302 to the same URL minus ?_switch_user;
         // follow it (as a real fetch would) to land on the swapped /api/me.
-        $client->followRedirects();
+        $client->getKernelBrowser()->followRedirects();
         $client->loginUser($member);
 
         $client->request('GET', '/api/me?_switch_user=victim@example.com');

--- a/pwa/components/common/ImpersonationBanner.tsx
+++ b/pwa/components/common/ImpersonationBanner.tsx
@@ -1,0 +1,52 @@
+import { useRouter } from "next/router";
+import { VenetianMask } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { displayName } from "@/lib/userDisplay";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Sticky bar shown across the top whenever an admin is impersonating another
+ * user (the firewall's switch_user). Keeps the operator aware they're acting
+ * as someone else and offers a one-click way back to their own session. The
+ * side menu carries the same "Stop impersonation" control.
+ *
+ * Renders nothing in the normal case, so it costs no layout when absent.
+ */
+const ImpersonationBanner = () => {
+  const { user, stopImpersonation } = useAuth();
+  const router = useRouter();
+
+  const impersonator = user?.impersonator;
+  if (!user || !impersonator) return null;
+
+  const handleStop = () => {
+    void stopImpersonation().then(() => router.push("/"));
+  };
+
+  return (
+    <div
+      className="sticky top-0 z-50 flex flex-wrap items-center justify-center gap-x-3 gap-y-1 border-b border-amber-300 bg-amber-100 px-4 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100"
+      role="status"
+      data-testid="impersonation-banner"
+    >
+      <span className="flex items-center gap-1.5">
+        <VenetianMask className="h-4 w-4 shrink-0" />
+        Impersonating <span className="font-semibold">{displayName(user)}</span>
+        <span className="hidden text-amber-700 dark:text-amber-300 sm:inline">
+          ({user.email})
+        </span>
+      </span>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={handleStop}
+        className="h-7 border-amber-400 bg-amber-50 text-amber-900 hover:bg-amber-200 dark:border-amber-700 dark:bg-amber-900 dark:text-amber-100"
+        data-testid="impersonation-banner-stop"
+      >
+        Stop impersonation
+      </Button>
+    </div>
+  );
+};
+
+export default ImpersonationBanner;

--- a/pwa/components/common/Layout.tsx
+++ b/pwa/components/common/Layout.tsx
@@ -10,6 +10,7 @@ import { ActiveSpaceProvider } from "@/contexts/ActiveSpaceContext";
 import TwoFactorRecoveryInterstitial from "@/components/auth/TwoFactorRecoveryInterstitial";
 import WaitlistGate from "@/components/auth/WaitlistGate";
 import Footer from "./Footer";
+import ImpersonationBanner from "./ImpersonationBanner";
 import Navbar from "./Navbar";
 import Sidebar from "./Sidebar";
 
@@ -34,6 +35,7 @@ const AppShell = ({ children }: { children: ReactNode }) => {
     <div className="flex min-h-screen">
       <Sidebar />
       <div className="flex-1 min-w-0 flex flex-col">
+        <ImpersonationBanner />
         <Navbar />
         <div className="flex-1">{children}</div>
         <Footer />

--- a/pwa/components/common/SidebarNav.tsx
+++ b/pwa/components/common/SidebarNav.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { useRouter } from "next/router";
 import type { ReactNode } from "react";
-import { LogOut } from "lucide-react";
+import { LogOut, VenetianMask } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { displayName } from "@/lib/userDisplay";
 import UserAvatar from "@/components/user/UserAvatar";
@@ -58,10 +58,15 @@ interface SidebarNavProps {
  * account quick-actions stay in sync across both surfaces.
  */
 const SidebarNav = ({ itemWrapper }: SidebarNavProps) => {
-  const { user, isAuthenticated, logout } = useAuth();
+  const { user, isAuthenticated, logout, stopImpersonation } = useAuth();
   const router = useRouter();
   const isAdmin = user?.roles?.includes("ROLE_ADMIN");
+  const impersonator = user?.impersonator ?? null;
   const wrap = itemWrapper ?? ((c) => c);
+
+  const handleStopImpersonation = () => {
+    void stopImpersonation().then(() => router.push("/"));
+  };
 
   if (!isAuthenticated || !user) return null;
 
@@ -146,6 +151,22 @@ const SidebarNav = ({ itemWrapper }: SidebarNavProps) => {
                   size="sm"
                   className={cn(
                     "justify-start w-full",
+                    router.pathname.startsWith("/admin/users") &&
+                      "bg-accent text-accent-foreground",
+                  )}
+                >
+                  <Link href="/admin/users">Users</Link>
+                </Button>,
+              )}
+            </span>
+            <span>
+              {wrap(
+                <Button
+                  asChild
+                  variant="ghost"
+                  size="sm"
+                  className={cn(
+                    "justify-start w-full",
                     router.pathname.startsWith("/admin/waitlist") &&
                       "bg-accent text-accent-foreground",
                   )}
@@ -186,6 +207,30 @@ const SidebarNav = ({ itemWrapper }: SidebarNavProps) => {
           </>
         )}
       </nav>
+
+      {/* While impersonating, a prominent way out lives at the bottom of
+          the side menu (mirrors the global top banner). Only the firewall's
+          switch_user exit restores the admin's own session. */}
+      {impersonator && (
+        <div className="border-t border-amber-300 bg-amber-50 px-3 py-2 dark:border-amber-900 dark:bg-amber-950/40">
+          <p className="px-1 pb-2 text-xs text-amber-800 dark:text-amber-200">
+            Impersonating{" "}
+            <span className="font-semibold">{displayName(user)}</span>
+          </p>
+          {wrap(
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleStopImpersonation}
+              className="w-full border-amber-400 text-amber-900 hover:bg-amber-100 dark:border-amber-700 dark:text-amber-100 dark:hover:bg-amber-900/40"
+              data-testid="stop-impersonation"
+            >
+              <VenetianMask className="mr-1.5 h-4 w-4" />
+              Stop impersonation
+            </Button>,
+          )}
+        </div>
+      )}
 
       {/* Sign Out is an action (handler), not a destination — keep it
           as a button anchored to the bottom of the sidebar so it

--- a/pwa/contexts/AuthContext.tsx
+++ b/pwa/contexts/AuthContext.tsx
@@ -92,6 +92,13 @@ export interface User {
   // Inlined so the security-card render doesn't have to chase a separate
   // /me/2fa/status request — the API merges defaults for legacy rows.
   twoFactor: TwoFactorStatus;
+  /**
+   * Set only while an admin is impersonating this account (the firewall's
+   * switch_user feature). Identifies the real operator so the PWA can show
+   * the impersonation banner + "Stop impersonation" control. Null/absent in
+   * the normal case.
+   */
+  impersonator?: { id: string; email: string; name: string } | null;
 }
 
 /**
@@ -140,6 +147,14 @@ interface AuthContextType {
   submitTwoFactorCode: (code: string) => Promise<User>;
   register: (input: RegisterInput) => Promise<void>;
   logout: () => void;
+  /**
+   * Admin-only: start impersonating the user with this email (the firewall's
+   * switch_user). Resolves once the session has swapped and the context holds
+   * the impersonated user. Throws on failure (e.g. not an admin).
+   */
+  impersonateUser: (email: string) => Promise<void>;
+  /** End an active impersonation, restoring the admin's own session. */
+  stopImpersonation: () => Promise<void>;
   /**
    * Confirms the current owner's identity (TOTP if 2FA is on, password
    * otherwise) and rotates the password. The PWA chooses the right
@@ -372,6 +387,34 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }).catch(() => {});
   }, []);
 
+  // Impersonation rides the firewall's switch_user listener: any main-firewall
+  // request carrying ?_switch_user swaps the token for that request. We route
+  // it through /api/me so the same call returns the swapped user payload.
+  const switchUser = useCallback(async (identifier: string): Promise<User> => {
+    const res = await fetchWithTimeout(
+      `${ENTRYPOINT}/api/me?_switch_user=${encodeURIComponent(identifier)}`,
+      { credentials: "include" },
+    );
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new Error(data.error || data.detail || "Couldn't switch user.");
+    }
+    const data = (await res.json()) as User;
+    setUser(data);
+    return data;
+  }, []);
+
+  const impersonateUser = useCallback(
+    async (email: string) => {
+      await switchUser(email);
+    },
+    [switchUser],
+  );
+
+  const stopImpersonation = useCallback(async () => {
+    await switchUser("_exit");
+  }, [switchUser]);
+
   return (
     <AuthContext.Provider
       value={{
@@ -382,6 +425,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         submitTwoFactorCode,
         register,
         logout,
+        impersonateUser,
+        stopImpersonation,
         changePassword,
         requestPasswordReset,
         resetPassword,

--- a/pwa/pages/admin/users.tsx
+++ b/pwa/pages/admin/users.tsx
@@ -1,0 +1,255 @@
+import type { NextPage } from "next";
+import Head from "next/head";
+import { useRouter } from "next/router";
+import { useCallback, useEffect, useState } from "react";
+import { VenetianMask } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { apiGetCollection } from "@/lib/apiClient";
+import { signinHrefForCurrent } from "@/lib/authRedirect";
+import { displayName } from "@/lib/userDisplay";
+import UserAvatar from "@/components/user/UserAvatar";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface AdminUser {
+  id: string;
+  email: string;
+  givenName: string;
+  familyName: string;
+  nickname: string | null;
+  personalizedColor: string;
+  avatarUrls?: { thumb?: string; profile?: string } | null;
+  roles?: string[];
+}
+
+const isAdminUser = (u: AdminUser): boolean =>
+  Array.isArray(u.roles) && u.roles.includes("ROLE_ADMIN");
+
+const AdminUsers: NextPage = () => {
+  const { user, isAuthenticated, isLoading, impersonateUser } = useAuth();
+  const router = useRouter();
+  const isAdmin = user?.roles?.includes("ROLE_ADMIN");
+
+  const [users, setUsers] = useState<AdminUser[]>([]);
+  const [query, setQuery] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  // The user a confirm dialog is currently asking about, or null.
+  const [target, setTarget] = useState<AdminUser | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated) {
+      router.replace(signinHrefForCurrent(router.asPath));
+    }
+  }, [isLoading, isAuthenticated, router]);
+
+  const load = useCallback(async () => {
+    try {
+      const data = await apiGetCollection<AdminUser>("/users", {
+        errorMessage: "Couldn't load users.",
+      });
+      setUsers(data);
+    } catch {
+      setError("Couldn't load users.");
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isAdmin) load();
+  }, [isAdmin, load]);
+
+  const confirmImpersonate = useCallback(async () => {
+    if (!target) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await impersonateUser(target.email);
+      // Land on the app home as the impersonated user; the auth + space
+      // contexts re-resolve off the new user id automatically.
+      router.push("/");
+    } catch (e) {
+      setError(
+        e instanceof Error ? e.message : `Couldn't impersonate ${target.email}.`,
+      );
+      setTarget(null);
+    } finally {
+      setBusy(false);
+    }
+  }, [target, impersonateUser, router]);
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-muted">
+        <p className="text-muted-foreground">Loading…</p>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return null;
+  }
+
+  if (!isAdmin) {
+    return (
+      <>
+        <Head>
+          <title>Access Denied - Madori</title>
+        </Head>
+        <div className="min-h-screen flex items-center justify-center bg-muted px-4">
+          <div className="text-center">
+            <h1 className="text-2xl font-bold text-foreground mb-2">Access Denied</h1>
+            <p className="text-muted-foreground">
+              You need administrator privileges to view this page.
+            </p>
+          </div>
+        </div>
+      </>
+    );
+  }
+
+  const needle = query.trim().toLowerCase();
+  const visible = needle
+    ? users.filter(
+        (u) =>
+          u.email.toLowerCase().includes(needle) ||
+          displayName(u).toLowerCase().includes(needle),
+      )
+    : users;
+
+  return (
+    <>
+      <Head>
+        <title>Users - Madori Admin</title>
+      </Head>
+      <div className="min-h-screen bg-muted px-4 py-12">
+        <div className="max-w-2xl mx-auto space-y-6">
+          <header>
+            <h1 className="text-2xl font-bold">Users</h1>
+            <p className="text-sm text-muted-foreground">
+              Sign in as another user to test or debug an issue from their
+              perspective. You can stop impersonating at any time.
+            </p>
+          </header>
+
+          {error && (
+            <Alert variant="destructive" data-testid="users-error">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          <Card data-testid="users-card">
+            <CardHeader>
+              <CardTitle>All users</CardTitle>
+              <CardDescription>
+                Click the mask icon to impersonate a user.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <Input
+                placeholder="Search by name or email…"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                aria-label="Search users"
+              />
+              <div className="space-y-2">
+                {visible.map((u) => {
+                  const isSelf = u.id === user?.id;
+                  return (
+                    <div
+                      key={u.id}
+                      className="flex items-center gap-3 rounded-md border p-3"
+                      data-testid="users-row"
+                    >
+                      <UserAvatar user={u} size="sm" />
+                      <div className="min-w-0 flex-1">
+                        <p className="text-sm font-medium truncate">
+                          {displayName(u)}
+                          {isAdminUser(u) && (
+                            <Badge variant="secondary" className="ml-2 align-middle">
+                              Admin
+                            </Badge>
+                          )}
+                        </p>
+                        <p className="text-xs text-muted-foreground truncate">
+                          {u.email}
+                        </p>
+                      </div>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        disabled={isSelf}
+                        onClick={() => setTarget(u)}
+                        aria-label={`Impersonate ${displayName(u)}`}
+                        title={isSelf ? "That's you" : "Impersonate"}
+                        data-testid="users-impersonate"
+                      >
+                        <VenetianMask className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  );
+                })}
+                {visible.length === 0 && (
+                  <p className="py-6 text-center text-sm text-muted-foreground">
+                    No users match “{query}”.
+                  </p>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      <Dialog open={target !== null} onOpenChange={(o) => !o && setTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Impersonate this user?</DialogTitle>
+            <DialogDescription>
+              You&apos;ll browse Madori as{" "}
+              <span className="font-medium">
+                {target ? displayName(target) : ""}
+              </span>{" "}
+              ({target?.email}). A banner stays on screen and a “Stop
+              impersonation” link sits at the bottom of the side menu until you
+              switch back.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="ghost"
+              onClick={() => setTarget(null)}
+              disabled={busy}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={() => void confirmImpersonate()}
+              disabled={busy}
+              data-testid="users-impersonate-confirm"
+            >
+              {busy ? "Switching…" : "Impersonate"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};
+
+export default AdminUsers;


### PR DESCRIPTION
## Description

Adds an admin-only **impersonate user** capability for testing/debugging, so support can reproduce issues from a specific user's perspective. Built on Symfony's native `switch_user` (stateful `main` firewall), so there's no custom token plumbing.

- **Start:** an admin clicks the mask icon on `/admin/users`, which hits `GET /api/me?_switch_user=<email>`; the firewall swaps the session token for that request and returns the impersonated user.
- **Stop:** `?_switch_user=_exit` restores the admin's own session — surfaced as a "Stop impersonation" link at the bottom of the side menu and a persistent top banner.

Per the requested behavior: **any user can be impersonated** (including other admins), and a **persistent banner** is shown in addition to the side-menu link.

## Type of Change

- [x] New feature

## Component

- [x] API (PHP/Symfony)
- [x] PWA (Next.js)

## What changed

**Backend**
- `security.yaml` — `switch_user: true` on the `main` firewall + `role_hierarchy` granting `ROLE_ADMIN → ROLE_ALLOWED_TO_SWITCH`.
- `UserPayloadSerializer` — adds an `impersonator: {id, email, name}` block to the `/api/me` payload while a `SwitchUserToken` is active (`null` otherwise). Single source of truth, so login + bootstrap + 2FA-success paths all carry it.
- `SessionRegistryListener` — skips the session-registry upsert during impersonation so the admin's "Active sessions" row isn't rewritten to the impersonated user.
- `ImpersonationAuditSubscriber` — logs impersonation start/stop (who impersonated whom).

**Frontend**
- `pwa/pages/admin/users.tsx` — new ROLE_ADMIN page listing users (`GET /users`) with a mask icon + confirm dialog; disabled for yourself.
- `SidebarNav` — "Users" admin link, plus a "Stop impersonation" link pinned to the bottom of the side menu while impersonating.
- `ImpersonationBanner` + `Layout` — persistent amber top banner while impersonating.
- `AuthContext` — `impersonator` field on `User` + `impersonateUser()` / `stopImpersonation()`.

## How Has This Been Tested?

`api/tests/Api/ImpersonationTest.php` covers:
- admin can switch and the payload surfaces the `impersonator` block
- a normal session reports `impersonator: null`
- an impersonated session **loses** admin access (`/admin/waitlist` → 403, since the `SwitchUserToken` carries the target's roles, not `ROLE_ADMIN`)
- `_exit` restores the admin and their access
- a non-admin attempting to switch gets 403

Not run on local Docker (WSL integration is off in this environment) — relying on CI for PHPUnit/PHPStan/PHPCS/typecheck.

## Notes for reviewers

- **2FA:** `SwitchUserToken` is not in scheb's `security_tokens` (matched by exact class), so impersonation correctly bypasses the 2FA challenge.
- **No DB migration** — `switch_user` adds no schema.
- **Deactivated targets:** `UserChecker` reactivates a soft-deactivated account on auth, so impersonating one would un-deactivate it. Not guarded here; easy to add a `SwitchUserEvent` refusal if desired.
- **CSRF posture:** the switch is a GET with a `samesite=lax` cookie, so a cross-site subresource can't trigger it. Can move behind a POST-only endpoint if preferred.

## Checklist

- [x] My code follows the project's conventions
- [x] I have added tests that prove my feature works
- [ ] New and existing tests pass locally (deferred to CI — local Docker unavailable)
- [ ] I have updated documentation if needed (no docs added; can add a developer doc if wanted)
