### PR TITLE
Move account menu to top bar, restyle sidebar nav

### DIFF
--- a/e2e/tests/avatar.spec.js
+++ b/e2e/tests/avatar.spec.js
@@ -20,11 +20,10 @@ test.describe("Avatar", () => {
       familyName: "Quinn",
     });
 
-    // Avatar now lives in the persistent sidebar header (the old
-    // right-side navbar button is gone). The initials fallback is a
-    // <span> inside that header.
+    // Avatar lives in the top-bar account menu trigger (#nav-refresh).
+    // The initials fallback is a <span> inside that trigger.
     const avatar = page
-      .locator('[data-testid="sidebar-user-header"] span')
+      .locator('[data-testid="user-menu-trigger"] span')
       .first();
     await expect(avatar).toBeVisible();
     await expect(avatar).toHaveText("PQ");
@@ -40,7 +39,7 @@ test.describe("Avatar", () => {
     await page.goto(`${BASE_URL}/settings/profile`);
     await page.locator('input[type="file"]').setInputFiles(AVATAR_FIXTURE);
 
-    const avatarImg = page.locator('[data-testid="sidebar-user-header"] img');
+    const avatarImg = page.locator('[data-testid="user-menu-trigger"] img');
     await expect(avatarImg).toBeVisible({ timeout: 10000 });
     await expect(avatarImg).toHaveAttribute("src", /\/media\/avatars\/.+\.webp/);
   });

--- a/e2e/tests/groups.spec.js
+++ b/e2e/tests/groups.spec.js
@@ -166,11 +166,14 @@ test.describe("Groups", () => {
     ).toBeVisible();
   });
 
-  test("sidebar shows Groups link when authenticated", async ({ page }) => {
+  test("account menu shows Manage Groups link when authenticated", async ({
+    page,
+  }) => {
     await registerAndSignIn(page, uniqueEmail());
     await openAccountMenu(page);
-    await expect(page.locator("nav >> text=Groups")).toBeVisible();
-    await page.locator("nav >> text=Groups").click();
+    const groupsItem = page.getByRole("menuitem", { name: "Manage Groups" });
+    await expect(groupsItem).toBeVisible();
+    await groupsItem.click();
     await expect(page).toHaveURL(/\/groups/);
   });
 });

--- a/e2e/tests/helpers.js
+++ b/e2e/tests/helpers.js
@@ -80,12 +80,11 @@ async function createTaskInline(page, title, options = {}) {
 }
 
 /**
- * No-op since the authenticated navigation moved from a triggered
- * right-side Sheet to a persistent left sidebar (`<aside>` mounted
- * by Layout). On the desktop viewport Playwright uses, every link
- * the old "account menu" exposed is already visible without a
- * click, so callers don't need to open anything. Kept as a function
- * so the call sites don't have to know about the layout change.
+ * Open the user account menu in the sidebar header (#nav-refresh).
+ * The personal links (My Tasks, Manage Groups, Settings) and Sign Out
+ * now live in a dropdown opened by the avatar/chevron trigger rather
+ * than as always-visible sidebar links. Callers can read menu items
+ * (role="menuitem") once this resolves.
  *
  * @param {import('@playwright/test').Page} page
  */
@@ -97,6 +96,7 @@ async function openAccountMenu(page) {
     state: "attached",
     timeout: 5000,
   });
+  await page.locator('[data-testid="user-menu-trigger"]').first().click();
 }
 
 /**

--- a/e2e/tests/notifications.spec.js
+++ b/e2e/tests/notifications.spec.js
@@ -12,7 +12,8 @@ test.describe("Notifications", () => {
   test("authenticated users see the notification bell with a zero state", async ({ page }) => {
     await registerAndSignIn(page, uniqueEmail());
     // Land on the workspace home (registerAndSignIn redirects there) — the
-    // bell is part of the navbar and is visible on every authenticated route.
+    // bell lives in the sidebar header and is visible on every authenticated
+    // route (#nav-refresh).
     const bell = page.locator('[data-testid="notification-bell"]');
     await expect(bell).toBeVisible();
     // No notifications yet → no count badge rendered.

--- a/e2e/tests/password.spec.js
+++ b/e2e/tests/password.spec.js
@@ -79,10 +79,10 @@ test.describe("Change password (authenticated)", () => {
       page.locator('[data-testid="change-password-success"]')
     ).toBeVisible();
 
-    // Sign out and sign back in with the new password. The Sign Out button
-    // lives inside the right-side "My Account" sheet.
+    // Sign out and sign back in with the new password. Sign Out now
+    // lives in the sidebar header's account dropdown (#nav-refresh).
     await openAccountMenu(page);
-    await page.click('button:has-text("Sign Out")');
+    await page.locator('[data-testid="user-menu-signout"]').click();
     await page.goto(`${BASE_URL}/signin`);
     await page.fill("#email", email);
     await page.fill("#password", "BrandNewPass1!");

--- a/e2e/tests/settings.spec.js
+++ b/e2e/tests/settings.spec.js
@@ -4,6 +4,7 @@ const {
   BASE_URL,
   uniqueEmail: shared,
   registerAndSignIn,
+  openAccountMenu,
 } = require("./helpers");
 
 const uniqueEmail = () => shared("settings");
@@ -136,11 +137,11 @@ test.describe("Settings", () => {
     );
   });
 
-  test("settings link in the sidebar opens the shell", async ({ page }) => {
+  test("settings link in the account menu opens the shell", async ({ page }) => {
     await registerAndSignIn(page, uniqueEmail());
-    const settingsLink = page
-      .locator('[data-testid="app-sidebar"]')
-      .getByRole("link", { name: "Settings" });
+    // Personal links live in the top-bar account menu now (#nav-refresh).
+    await openAccountMenu(page);
+    const settingsLink = page.getByRole("menuitem", { name: "Settings" });
     await expect(settingsLink).toBeVisible();
     await settingsLink.click();
     await expect(page).toHaveURL(/\/settings\/profile/);

--- a/pwa/components/account/AvatarSection.tsx
+++ b/pwa/components/account/AvatarSection.tsx
@@ -78,7 +78,7 @@ const AvatarSection = () => {
   return (
     <div className="space-y-6">
       <div className="flex items-center gap-4">
-        <UserAvatar user={user} size="lg" />
+        <UserAvatar user={user} size="lg" shape="square" />
         <div>
           <Button type="button" onClick={onPick} disabled={isUploading} size="sm">
             {isUploading ? "Uploading..." : "Change avatar"}

--- a/pwa/components/common/ImpersonationBanner.tsx
+++ b/pwa/components/common/ImpersonationBanner.tsx
@@ -26,7 +26,7 @@ const ImpersonationBanner = () => {
 
   return (
     <div
-      className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 border-b border-amber-300 bg-amber-100 px-4 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100"
+      className="flex min-h-11 flex-wrap items-center justify-center gap-x-3 gap-y-1 border-b border-amber-300 bg-amber-100 px-4 py-2 text-sm text-amber-900 md:h-11 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100"
       role="status"
       data-testid="impersonation-banner"
     >

--- a/pwa/components/common/ImpersonationBanner.tsx
+++ b/pwa/components/common/ImpersonationBanner.tsx
@@ -5,10 +5,11 @@ import { displayName } from "@/lib/userDisplay";
 import { Button } from "@/components/ui/button";
 
 /**
- * Sticky bar shown across the top whenever an admin is impersonating another
- * user (the firewall's switch_user). Keeps the operator aware they're acting
- * as someone else and offers a one-click way back to their own session. The
- * side menu carries the same "Stop impersonation" control.
+ * Full-width bar shown above the sticky top bar whenever an admin is
+ * impersonating another user (the firewall's switch_user). Keeps the operator
+ * aware they're acting as someone else and offers a one-click way back to their
+ * own session. The top-bar account menu carries the same "Stop impersonation"
+ * control, so the exit stays reachable once this bar scrolls out of view.
  *
  * Renders nothing in the normal case, so it costs no layout when absent.
  */
@@ -25,7 +26,7 @@ const ImpersonationBanner = () => {
 
   return (
     <div
-      className="sticky top-0 z-50 flex flex-wrap items-center justify-center gap-x-3 gap-y-1 border-b border-amber-300 bg-amber-100 px-4 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100"
+      className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 border-b border-amber-300 bg-amber-100 px-4 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100"
       role="status"
       data-testid="impersonation-banner"
     >

--- a/pwa/components/common/Layout.tsx
+++ b/pwa/components/common/Layout.tsx
@@ -27,15 +27,17 @@ const AppShell = ({ children }: { children: ReactNode }) => {
   }
 
   return (
-    // Full-width sticky top bar spanning the whole viewport; below it a
-    // row of persistent left sidebar (`md:` and up) + content. The
-    // navbar's mobile Sheet handles the small-screen sidebar case. The
-    // Sidebar renders nothing for unauthenticated visitors so the
-    // marketing/auth screens keep their original full-width layout. The
-    // ImpersonationBanner (when active) sits above the sticky top bar.
+    // Full-width sticky header (ImpersonationBanner above the top bar,
+    // pinned together) spanning the whole viewport; below it a row of
+    // persistent left sidebar (`md:` and up) + content. The navbar's
+    // mobile Sheet handles the small-screen sidebar case. The Sidebar
+    // renders nothing for unauthenticated visitors so the marketing/auth
+    // screens keep their original full-width layout.
     <div className="flex min-h-screen flex-col">
-      <ImpersonationBanner />
-      <Navbar />
+      <div className="sticky top-0 z-30">
+        <ImpersonationBanner />
+        <Navbar />
+      </div>
       <div className="flex flex-1 min-h-0">
         <Sidebar />
         <div className="flex-1 min-w-0 flex flex-col">

--- a/pwa/components/common/Layout.tsx
+++ b/pwa/components/common/Layout.tsx
@@ -27,18 +27,21 @@ const AppShell = ({ children }: { children: ReactNode }) => {
   }
 
   return (
-    // Persistent left sidebar (`md:` and up) when signed in; the navbar's
-    // mobile Sheet handles the small-screen case. Sidebar renders nothing
-    // for unauthenticated visitors so the marketing/auth screens keep their
-    // original full-width layout. Sidebar sits outside the navbar+content
-    // column so it spans the full viewport height.
-    <div className="flex min-h-screen">
-      <Sidebar />
-      <div className="flex-1 min-w-0 flex flex-col">
-        <ImpersonationBanner />
-        <Navbar />
-        <div className="flex-1">{children}</div>
-        <Footer />
+    // Full-width sticky top bar spanning the whole viewport; below it a
+    // row of persistent left sidebar (`md:` and up) + content. The
+    // navbar's mobile Sheet handles the small-screen sidebar case. The
+    // Sidebar renders nothing for unauthenticated visitors so the
+    // marketing/auth screens keep their original full-width layout. The
+    // ImpersonationBanner (when active) sits above the sticky top bar.
+    <div className="flex min-h-screen flex-col">
+      <ImpersonationBanner />
+      <Navbar />
+      <div className="flex flex-1 min-h-0">
+        <Sidebar />
+        <div className="flex-1 min-w-0 flex flex-col">
+          <div className="flex-1">{children}</div>
+          <Footer />
+        </div>
       </div>
     </div>
   );

--- a/pwa/components/common/Navbar.tsx
+++ b/pwa/components/common/Navbar.tsx
@@ -11,20 +11,21 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@/components/ui/sheet";
-import NotificationBell from "@/components/notifications/NotificationBell";
 import OverdueBadge from "@/components/tasks/OverdueBadge";
+import NotificationBell from "@/components/notifications/NotificationBell";
 import SearchOverlay from "@/components/search/SearchOverlay";
 import Breadcrumbs from "./Breadcrumbs";
 import SearchBar from "./SearchBar";
 import SidebarNav from "./SidebarNav";
+import UserMenu from "./UserMenu";
 
 const Navbar = () => {
   const { isAuthenticated } = useAuth();
   const { waitlistEnabled } = useSignupStatus();
 
   return (
-    <nav className="border-b bg-background">
-      <div className="px-4 py-3 flex items-center gap-3">
+    <nav className="sticky top-0 z-30 h-14 w-full border-b bg-background">
+      <div className="flex h-full items-center gap-3 px-4">
         <div className="flex items-center gap-1 shrink-0">
           {/* Signed-out viewers get the Madori wordmark as the home
               anchor; signed-in viewers get the Breadcrumbs trail
@@ -60,7 +61,8 @@ const Navbar = () => {
             <>
               <OverdueBadge enabled={isAuthenticated} />
               <NotificationBell enabled={isAuthenticated} />
-              {/* Mobile-only entry to the same nav surface — the
+              <UserMenu />
+              {/* Mobile-only entry to the space/admin nav — the
                   persistent Sidebar takes over on `md` and up. */}
               <Sheet>
                 <SheetTrigger asChild>

--- a/pwa/components/common/Navbar.tsx
+++ b/pwa/components/common/Navbar.tsx
@@ -45,13 +45,12 @@ const Navbar = () => {
 
         {/* When signed in, the breadcrumb trail sits left of the
             search bar and replaces the wordmark as the home anchor.
-            Both trail and search share the flexible middle column —
-            the breadcrumb shrinks first so the search bar keeps a
-            usable footprint on narrow viewports. */}
+            The breadcrumb is content-sized (and shrinks first) so the
+            search bar takes the full remaining width of the middle. */}
         {isAuthenticated && (
           <>
-            <Breadcrumbs className="hidden md:flex flex-1 min-w-0" />
-            <SearchBar className="flex-1 min-w-0 max-w-3xl" />
+            <Breadcrumbs className="hidden md:flex min-w-0 shrink" />
+            <SearchBar className="flex-1 min-w-0 mx-8 lg:mx-16" />
             <SearchOverlay />
           </>
         )}

--- a/pwa/components/common/Navbar.tsx
+++ b/pwa/components/common/Navbar.tsx
@@ -24,7 +24,7 @@ const Navbar = () => {
   const { waitlistEnabled } = useSignupStatus();
 
   return (
-    <nav className="sticky top-0 z-30 h-14 w-full border-b bg-background">
+    <nav className="h-14 w-full border-b bg-background">
       <div className="flex h-full items-center gap-3 px-4">
         <div className="flex items-center gap-1 shrink-0">
           {/* Signed-out viewers get the Madori wordmark as the home

--- a/pwa/components/common/Sidebar.tsx
+++ b/pwa/components/common/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { useAuth } from "@/contexts/AuthContext";
+import { cn } from "@/lib/utils";
 import SidebarNav from "./SidebarNav";
 
 /**
@@ -8,13 +9,24 @@ import SidebarNav from "./SidebarNav";
  *
  * Renders nothing when the user isn't signed in — the public-facing
  * marketing/auth screens keep the original full-width chrome.
+ *
+ * Sticks below the sticky header. The header is the 3.5rem top bar,
+ * plus the 2.75rem ImpersonationBanner when an admin is impersonating
+ * (md+ banner height is fixed so this offset stays flush) — hence the
+ * 6.25rem combined offset in that case.
  */
 const Sidebar = () => {
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, user } = useAuth();
   if (!isAuthenticated) return null;
+  const impersonating = Boolean(user?.impersonator);
   return (
     <aside
-      className="hidden md:flex sticky top-14 h-[calc(100vh-3.5rem)] w-60 shrink-0 border-r bg-background flex-col"
+      className={cn(
+        "hidden md:flex w-60 shrink-0 border-r bg-background flex-col sticky",
+        impersonating
+          ? "top-[6.25rem] h-[calc(100vh-6.25rem)]"
+          : "top-14 h-[calc(100vh-3.5rem)]",
+      )}
       data-testid="app-sidebar"
     >
       <SidebarNav />

--- a/pwa/components/common/Sidebar.tsx
+++ b/pwa/components/common/Sidebar.tsx
@@ -14,7 +14,7 @@ const Sidebar = () => {
   if (!isAuthenticated) return null;
   return (
     <aside
-      className="hidden md:flex sticky top-0 h-screen w-60 shrink-0 border-r bg-background flex-col"
+      className="hidden md:flex sticky top-14 h-[calc(100vh-3.5rem)] w-60 shrink-0 border-r bg-background flex-col"
       data-testid="app-sidebar"
     >
       <SidebarNav />

--- a/pwa/components/common/SidebarNav.tsx
+++ b/pwa/components/common/SidebarNav.tsx
@@ -1,26 +1,15 @@
 import Link from "next/link";
 import { useRouter } from "next/router";
 import type { ReactNode } from "react";
-import { LogOut, VenetianMask } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
-import { displayName } from "@/lib/userDisplay";
-import UserAvatar from "@/components/user/UserAvatar";
 import { Button } from "@/components/ui/button";
-import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
 import SpaceSwitcher from "./SpaceSwitcher";
 
-// Personal section — things scoped to the signed-in user themselves.
-// Lives in its own block at the top of the sidebar with a divider
-// from the shared/space-scoped nav below. Sign Out lives outside this
-// list — it's an action (handler) rather than a destination, so it
-// stays as a button at the bottom of the sidebar.
-const PERSONAL_NAV_LINKS = [
-  { href: "/my-tasks", label: "My Tasks" },
-  { href: "/notifications", label: "Notifications" },
-  { href: "/groups", label: "Groups" },
-  { href: "/settings/profile", label: "Settings" },
-];
+// The account menu (avatar + personal links + sign out + stop
+// impersonation) and the notification bell live in the top bar now —
+// see UserMenu / Navbar. The sidebar carries the space switcher and the
+// admin section.
 
 // The shared section is now a list of accessible spaces (rendered
 // from ActiveSpaceContext at render time, since it's per-user state).
@@ -54,76 +43,26 @@ interface SidebarNavProps {
 /**
  * Shared navigation contents used by both the persistent left-side
  * `<Sidebar>` (`md:` and up) and the mobile-only Sheet variant in the
- * navbar. Single source of truth so the link list, admin section, and
- * account quick-actions stay in sync across both surfaces.
+ * navbar. Single source of truth so the space switcher and admin
+ * section stay in sync across both surfaces.
  */
 const SidebarNav = ({ itemWrapper }: SidebarNavProps) => {
-  const { user, isAuthenticated, logout, stopImpersonation } = useAuth();
+  const { user, isAuthenticated } = useAuth();
   const router = useRouter();
   const isAdmin = user?.roles?.includes("ROLE_ADMIN");
-  const impersonator = user?.impersonator ?? null;
   const wrap = itemWrapper ?? ((c) => c);
-
-  const handleStopImpersonation = () => {
-    void stopImpersonation().then(() => router.push("/"));
-  };
 
   if (!isAuthenticated || !user) return null;
 
   return (
     <div className="flex h-full flex-col">
-      <div
-        className="flex items-start gap-3 px-4 pt-4 pb-3"
-        data-testid="sidebar-user-header"
-      >
-        <UserAvatar user={user} size="sm" />
-        <div className="min-w-0 flex-1">
-          <p className="text-sm font-semibold truncate">{displayName(user)}</p>
-          <p className="text-xs text-muted-foreground truncate">{user.email}</p>
-        </div>
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={logout}
-          aria-label="Sign out"
-          title="Sign out"
-          className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive"
-        >
-          <LogOut className="h-4 w-4" />
-        </Button>
-      </div>
-
-      <Separator className="my-2" />
-
-      <div className="px-2 pb-2">
+      <div className="px-2 pt-4 pb-2">
         <SpaceSwitcher />
       </div>
 
       <nav className="flex flex-col gap-0.5 px-2 pb-4 flex-1 overflow-y-auto">
-        {PERSONAL_NAV_LINKS.map((link) => {
-          const active = router.pathname.startsWith(link.href);
-          return (
-            <span key={link.href}>
-              {wrap(
-                <Button
-                  asChild
-                  variant="ghost"
-                  size="sm"
-                  className={cn(
-                    "justify-start w-full",
-                    active && "bg-accent text-accent-foreground",
-                  )}
-                >
-                  <Link href={link.href}>{link.label}</Link>
-                </Button>,
-              )}
-            </span>
-          );
-        })}
-
         {isAdmin && (
           <>
-            <Separator className="my-2" />
             <p className="px-3 pb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
               Admin
             </p>
@@ -207,44 +146,6 @@ const SidebarNav = ({ itemWrapper }: SidebarNavProps) => {
           </>
         )}
       </nav>
-
-      {/* While impersonating, a prominent way out lives at the bottom of
-          the side menu (mirrors the global top banner). Only the firewall's
-          switch_user exit restores the admin's own session. */}
-      {impersonator && (
-        <div className="border-t border-amber-300 bg-amber-50 px-3 py-2 dark:border-amber-900 dark:bg-amber-950/40">
-          <p className="px-1 pb-2 text-xs text-amber-800 dark:text-amber-200">
-            Impersonating{" "}
-            <span className="font-semibold">{displayName(user)}</span>
-          </p>
-          {wrap(
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleStopImpersonation}
-              className="w-full border-amber-400 text-amber-900 hover:bg-amber-100 dark:border-amber-700 dark:text-amber-100 dark:hover:bg-amber-900/40"
-              data-testid="stop-impersonation"
-            >
-              <VenetianMask className="mr-1.5 h-4 w-4" />
-              Stop impersonation
-            </Button>,
-          )}
-        </div>
-      )}
-
-      {/* Sign Out is an action (handler), not a destination — keep it
-          as a button anchored to the bottom of the sidebar so it
-          doesn't blend into the navigation links above. */}
-      <div className="border-t px-3 py-2">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={logout}
-          className="w-full"
-        >
-          Sign Out
-        </Button>
-      </div>
     </div>
   );
 };

--- a/pwa/components/common/UserMenu.tsx
+++ b/pwa/components/common/UserMenu.tsx
@@ -1,0 +1,113 @@
+import Link from "next/link";
+import { useRouter } from "next/router";
+import {
+  ChevronDown,
+  ListChecks,
+  LogOut,
+  Settings,
+  Users,
+  VenetianMask,
+} from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { displayName } from "@/lib/userDisplay";
+import UserAvatar from "@/components/user/UserAvatar";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+
+// Personal destinations surfaced through the account menu. Notifications
+// live in the bell next to this trigger; Sign Out is appended as an
+// action below the divider.
+const USER_MENU_LINKS = [
+  { href: "/my-tasks", label: "My Tasks", icon: ListChecks },
+  { href: "/groups", label: "Manage Groups", icon: Users },
+  { href: "/settings/profile", label: "Settings", icon: Settings },
+];
+
+/**
+ * Account menu rendered in the top bar — a square avatar + chevron
+ * trigger that opens a dropdown headed by the signed-in user's name and
+ * email, followed by the personal links and Sign Out.
+ */
+const UserMenu = () => {
+  const { user, logout, stopImpersonation } = useAuth();
+  const router = useRouter();
+
+  if (!user) return null;
+
+  const impersonator = user.impersonator;
+  const handleStopImpersonation = () => {
+    void stopImpersonation().then(() => router.push("/"));
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          data-testid="user-menu-trigger"
+          aria-label={`Account menu for ${displayName(user)}`}
+          className={cn(
+            "flex items-center gap-1.5 rounded-md p-1",
+            "hover:bg-accent focus:outline-none focus:ring-2 focus:ring-ring",
+          )}
+        >
+          <UserAvatar user={user} size="sm" shape="square" />
+          <ChevronDown
+            className="h-3.5 w-3.5 shrink-0 text-muted-foreground"
+            aria-hidden
+          />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-[220px]">
+        <div className="flex items-center gap-2 px-2 py-1.5">
+          <UserAvatar user={user} size="sm" shape="square" />
+          <div className="min-w-0">
+            <p className="truncate text-sm font-semibold">{displayName(user)}</p>
+            <p className="truncate text-xs text-muted-foreground">
+              {user.email}
+            </p>
+          </div>
+        </div>
+        <DropdownMenuSeparator />
+        {USER_MENU_LINKS.map(({ href, label, icon: Icon }) => (
+          <DropdownMenuItem key={href} asChild className="cursor-pointer">
+            <Link href={href} className="gap-2">
+              <Icon className="h-4 w-4" aria-hidden />
+              {label}
+            </Link>
+          </DropdownMenuItem>
+        ))}
+        {impersonator && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onSelect={handleStopImpersonation}
+              className="cursor-pointer gap-2 text-amber-700 focus:text-amber-700 dark:text-amber-400 dark:focus:text-amber-400"
+              data-testid="stop-impersonation"
+            >
+              <VenetianMask className="h-4 w-4" aria-hidden />
+              Stop impersonation
+            </DropdownMenuItem>
+          </>
+        )}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          onSelect={logout}
+          className="cursor-pointer gap-2 text-destructive focus:text-destructive"
+          data-testid="user-menu-signout"
+        >
+          <LogOut className="h-4 w-4" aria-hidden />
+          Sign Out
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+export default UserMenu;

--- a/pwa/components/dev/registry.ts
+++ b/pwa/components/dev/registry.ts
@@ -57,6 +57,7 @@ export const componentRegistry: RegistryEntry[] = [
   { slug: "footer", name: "Footer", category: "Layout", description: "Static site footer with product, developer, and project link columns." },
   { slug: "sidebar", name: "Sidebar", category: "Layout", description: "Persistent left navigation column (md and up, authenticated only)." },
   { slug: "sidebar-nav", name: "SidebarNav", category: "Layout", description: "Shared nav contents used by the persistent sidebar and the mobile sheet." },
+  { slug: "user-menu", name: "UserMenu", category: "Layout", description: "Top-bar account menu: square avatar + chevron trigger over a dropdown with name/email, personal links, and sign out." },
   { slug: "search-bar", name: "SearchBar", category: "Layout", description: "Navbar task search with debounced autocomplete; ⌘K opens the SearchOverlay palette." },
   { slug: "search-overlay", name: "SearchOverlay", category: "Layout", description: "⌘K command palette: suggestion chips, recent searches, keyboard nav." },
   { slug: "space-switcher", name: "SpaceSwitcher", category: "Layout", description: "Active-space dropdown that persists the choice via ActiveSpaceContext." },

--- a/pwa/components/user/UserAvatar.tsx
+++ b/pwa/components/user/UserAvatar.tsx
@@ -6,6 +6,7 @@ export interface AvatarUser extends NamedUser {
 }
 
 type Size = "sm" | "md" | "lg";
+type Shape = "circle" | "square";
 
 const SIZE_PX: Record<Size, number> = { sm: 32, md: 40, lg: 96 };
 const SIZE_TEXT: Record<Size, string> = {
@@ -13,20 +14,33 @@ const SIZE_TEXT: Record<Size, string> = {
   md: "text-sm",
   lg: "text-2xl",
 };
+// Square avatars get softly rounded corners that scale with the avatar
+// so the radius stays proportional at every size.
+const SHAPE_RADIUS: Record<Shape, Record<Size, string>> = {
+  circle: { sm: "rounded-full", md: "rounded-full", lg: "rounded-full" },
+  square: { sm: "rounded-md", md: "rounded-lg", lg: "rounded-2xl" },
+};
 
 interface Props {
   user: AvatarUser;
   size?: Size;
+  /** Circle (default) or a square with rounded edges. */
+  shape?: Shape;
   className?: string;
 }
 
-const UserAvatar = ({ user, size = "md", className = "" }: Props) => {
+const UserAvatar = ({
+  user,
+  size = "md",
+  shape = "circle",
+  className = "",
+}: Props) => {
   const px = SIZE_PX[size];
   const useThumb = size !== "lg";
   const src = useThumb ? user.avatarUrls?.thumb : user.avatarUrls?.profile;
 
   const sharedClass =
-    `rounded-full overflow-hidden select-none shrink-0 ${className}`.trim();
+    `${SHAPE_RADIUS[shape][size]} overflow-hidden select-none shrink-0 ${className}`.trim();
 
   if (src) {
     return (

--- a/pwa/pages/admin/users.tsx
+++ b/pwa/pages/admin/users.tsx
@@ -177,7 +177,7 @@ const AdminUsers: NextPage = () => {
                       className="flex items-center gap-3 rounded-md border p-3"
                       data-testid="users-row"
                     >
-                      <UserAvatar user={u} size="sm" />
+                      <UserAvatar user={u} size="sm" shape="square" />
                       <div className="min-w-0 flex-1">
                         <p className="text-sm font-medium truncate">
                           {displayName(u)}
@@ -226,8 +226,8 @@ const AdminUsers: NextPage = () => {
                 {target ? displayName(target) : ""}
               </span>{" "}
               ({target?.email}). A banner stays on screen and a “Stop
-              impersonation” link sits at the bottom of the side menu until you
-              switch back.
+              impersonation” option sits in the account menu until you switch
+              back.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/pwa/pages/dev/components/navbar.tsx
+++ b/pwa/pages/dev/components/navbar.tsx
@@ -4,7 +4,7 @@ import ComponentDoc from "@/components/dev/ComponentDoc";
 const NavbarPage = () => (
   <ComponentDoc
     name="Navbar"
-    description="Top app bar. Signed-out visitors get the Madori wordmark as the home anchor plus Sign In / Sign Up buttons. Signed-in viewers get the Breadcrumbs trail (replacing the wordmark) + SearchBar in the flexible middle, OverdueBadge + NotificationBell on the right, and a mobile-only Sheet trigger that mounts SidebarNav inside a slide-over. Developer doc links live in the Footer, not the navbar."
+    description="Full-width sticky top bar. Signed-out visitors get the Madori wordmark as the home anchor plus Sign In / Sign Up buttons. Signed-in viewers get the Breadcrumbs trail (replacing the wordmark) + SearchBar in the flexible middle, and on the right the OverdueBadge, NotificationBell, UserMenu (account dropdown), and a mobile-only Sheet trigger that mounts SidebarNav inside a slide-over. Developer doc links live in the Footer, not the navbar."
     importPath={`import Navbar from "@/components/common/Navbar";`}
     examples={[
       {

--- a/pwa/pages/dev/components/sidebar-nav.tsx
+++ b/pwa/pages/dev/components/sidebar-nav.tsx
@@ -4,7 +4,7 @@ import ComponentDoc from "@/components/dev/ComponentDoc";
 const SidebarNavPage = () => (
   <ComponentDoc
     name="SidebarNav"
-    description="Shared navigation surface used by both the persistent Sidebar (md and up) and the mobile Sheet variant in the Navbar. Renders the signed-in user header, the SpaceSwitcher, personal links (My Tasks, Notifications, Groups, Settings), an Admin section for ROLE_ADMIN users (Admin, Waitlist, Segments, and the external Mercure debugger), and a Sign Out button anchored to the bottom."
+    description="Shared navigation surface used by both the persistent Sidebar (md and up) and the mobile Sheet variant in the Navbar. Renders the SpaceSwitcher and an Admin section for ROLE_ADMIN users (Admin, Waitlist, Segments, and the external Mercure debugger). The account menu (avatar, personal links, sign out) and notification bell live in the top bar — see UserMenu / Navbar."
     importPath={`import SidebarNav from "@/components/common/SidebarNav";`}
     examples={[
       {

--- a/pwa/pages/dev/components/user-avatar.tsx
+++ b/pwa/pages/dev/components/user-avatar.tsx
@@ -16,7 +16,7 @@ const lin = {
 const UserAvatarPage = () => (
   <ComponentDoc
     name="UserAvatar"
-    description="Renders the uploaded image when present, otherwise white initials on the user's `personalizedColor` (a contrast-safe palette picked at signup). Sizes: sm (32px), md (40px), lg (96px)."
+    description="Renders the uploaded image when present, otherwise white initials on the user's `personalizedColor` (a contrast-safe palette picked at signup). Sizes: sm (32px), md (40px), lg (96px). Shape: circle (default) or square (rounded edges, used in the sidebar header)."
     importPath={`import UserAvatar from "@/components/user/UserAvatar";`}
     examples={[
       {
@@ -33,6 +33,17 @@ const UserAvatarPage = () => (
             <UserAvatar user={ada} size="sm" />
             <UserAvatar user={ada} size="md" />
             <UserAvatar user={lin} size="lg" />
+          </div>
+        ),
+      },
+      {
+        title: "Square shape (rounded edges)",
+        code: `<UserAvatar user={ada} shape="square" />`,
+        preview: (
+          <div className="flex items-center gap-4">
+            <UserAvatar user={ada} size="sm" shape="square" />
+            <UserAvatar user={ada} size="md" shape="square" />
+            <UserAvatar user={lin} size="lg" shape="square" />
           </div>
         ),
       },

--- a/pwa/pages/dev/components/user-menu.tsx
+++ b/pwa/pages/dev/components/user-menu.tsx
@@ -1,0 +1,27 @@
+import UserMenu from "@/components/common/UserMenu";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+const UserMenuPage = () => (
+  <ComponentDoc
+    name="UserMenu"
+    description="Top-bar account menu. A square avatar + chevron button opens a dropdown headed by the signed-in user's name and email, followed by the personal links (My Tasks, Manage Groups, Settings) and Sign Out. Reads from AuthContext and renders nothing until a user is signed in."
+    importPath={`import UserMenu from "@/components/common/UserMenu";`}
+    examples={[
+      {
+        title: "Rendered in the Navbar",
+        code: `<UserMenu />`,
+        preview: (
+          <p className="text-sm text-muted-foreground">
+            Mounted on the right of the <code className="mx-1">Navbar</code> for
+            authenticated sessions, next to the NotificationBell. The live
+            instance is in this page&apos;s top bar.
+          </p>
+        ),
+      },
+    ]}
+  />
+);
+
+void UserMenu;
+
+export default UserMenuPage;


### PR DESCRIPTION
## Description

Reworks the authenticated app chrome so account actions live in the top bar and the avatar adopts a rounded-square style.

- **`UserAvatar` shape prop** — new `shape` prop (`"circle"` default, `"square"` with size-scaled rounded corners). Used for the top-bar/account avatars and the larger settings-page avatar.
- **Account menu in the top bar** — extracted into a new `UserMenu` component and moved out of the sidebar. The trigger is just the square avatar + chevron; **name and email moved into the dropdown header**, followed by My Tasks / Manage Groups / Settings / Sign Out. The **NotificationBell** sits next to it.
- **Full-width sticky top bar** — the `Navbar` is now `sticky top-0 z-30 h-14 w-full`; the `AppShell` places it above the sidebar+content row. The `Sidebar` sticks below it (`top-14`, `calc(100vh - 3.5rem)`) and now carries only the SpaceSwitcher and the admin section.

## Type of Change

- [x] New feature
- [x] Documentation

## Component

- [x] PWA (Next.js)
- [x] E2E Tests
- [x] Documentation

## How Has This Been Tested?

- `tsc --noEmit` passes in the running pwa container.
- Manually verified at `https://localhost` against fixtures (admin@madori.test): square avatar + chevron in the top bar, dropdown shows name/email + links + sign out, bell relocated, sidebar starts at the SpaceSwitcher, top bar spans full width and stays pinned on scroll.
- Updated `avatar.spec.js` (avatar now under `user-menu-trigger`), `groups.spec.js` / `password.spec.js` / `helpers.js` (`openAccountMenu` opens the dropdown), and `notifications.spec.js` comment.

## Reviewer notes

- Because the top bar is now sticky with `z-30`, any in-page element using `sticky top-0` would tuck under it; none spotted, but worth a glance.
- New reusable component `UserMenu` has a dev doc page + registry entry per the components convention.

## Checklist

- [x] My code follows the project's conventions
- [x] I have added tests that prove my fix or feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed