### PR TITLE
feat: sidebar content nav, space switcher in navbar, projects UX

### DIFF
--- a/e2e/tests/comment-mentions.spec.js
+++ b/e2e/tests/comment-mentions.spec.js
@@ -36,17 +36,14 @@ test.describe("Comment @-mentions", () => {
     // space (#185).
     await alicePage.goto(`${BASE_URL}/projects`);
     const projectTitle = `Mentions-${Date.now()}`;
+    // The create form lives behind the "New project" toggle; creating
+    // navigates straight to the new project's detail page.
+    await alicePage.getByTestId("new-project-button").click();
     await alicePage.fill("#title", projectTitle);
     await alicePage.click('button[type="submit"]');
-    const projectItem = alicePage.locator('[data-testid="project-item"]', {
-      hasText: projectTitle,
-    });
-    await expect(projectItem).toBeVisible();
-
-    // Open the project detail page and add Bob to the space via the
-    // shared "Manage members in space" link.
-    await projectItem.locator(`a[href^="/projects/"]`).first().click();
     await expect(alicePage).toHaveURL(/\/projects\/[a-f0-9-]+/);
+
+    // Add Bob to the space via the POST /projects/{id}/members shim.
     const projectIdMatch = alicePage.url().match(/\/projects\/([a-f0-9-]+)/);
     if (!projectIdMatch) throw new Error("Couldn't extract project ID from URL.");
     const projectId = projectIdMatch[1];

--- a/e2e/tests/custom-fields.spec.js
+++ b/e2e/tests/custom-fields.spec.js
@@ -10,13 +10,11 @@ const uniqueEmail = () => shared("custom-fields");
 
 const openCustomFields = async (page, projectTitle) => {
   await page.goto(`${BASE_URL}/projects`);
+  // The create form lives behind the "New project" toggle.
+  await page.getByTestId("new-project-button").click();
   await page.fill("#title", projectTitle);
   await page.click('button[type="submit"]');
-  const projectItem = page.locator('[data-testid="project-item"]', {
-    hasText: projectTitle,
-  });
-  await expect(projectItem).toBeVisible();
-  await projectItem.locator(`a[href^="/projects/"]`).first().click();
+  // Creating navigates straight to the new project's detail page.
   await expect(page).toHaveURL(/\/projects\/[a-f0-9-]+/);
   await page.click('[data-testid="project-custom-fields-link"]');
   await expect(page).toHaveURL(/\/projects\/[a-f0-9-]+\/custom-fields$/);

--- a/e2e/tests/projects.spec.js
+++ b/e2e/tests/projects.spec.js
@@ -23,11 +23,17 @@ test.describe("Projects", () => {
     await expect(page).toHaveTitle("Projects - Madori");
     await expect(page.locator("text=No projects yet")).toBeVisible();
 
-    // Create
+    // Create — the form lives behind the "New project" toggle now.
     const title = `Launch plan ${Date.now()}`;
+    await page.getByTestId("new-project-button").click();
     await page.fill("#title", title);
     await fillDescription(page, undefined, "Q3 marketing push");
     await page.click('button[type="submit"]');
+
+    // Creating navigates to the new project's detail page; head back to
+    // the list to verify it renders there.
+    await expect(page).toHaveURL(/\/projects\/[a-f0-9-]+/);
+    await page.goto(`${BASE_URL}/projects`);
 
     const item = page.locator('[data-testid="project-item"]', { hasText: title });
     await expect(item).toBeVisible();
@@ -35,9 +41,6 @@ test.describe("Projects", () => {
 
     // Creator is auto-added as a member via ProjectOwnerProcessor.
     await expect(item.locator('[data-testid="project-member"]')).toContainText(email);
-
-    // Form clears after submit
-    await expect(page.locator("#title")).toHaveValue("");
 
     // Edit — update title and description
     await item.getByRole("button", { name: /^Edit$/ }).click();
@@ -61,6 +64,7 @@ test.describe("Projects", () => {
   test("description supports markdown formatting", async ({ page }) => {
     await registerAndSignIn(page, uniqueEmail());
     await page.goto(`${BASE_URL}/projects`);
+    await page.getByTestId("new-project-button").click();
 
     const title = `Markdown project ${Date.now()}`;
     await page.fill("#title", title);
@@ -77,6 +81,11 @@ test.describe("Projects", () => {
     await page.keyboard.type("second item");
 
     await page.click('button[type="submit"]');
+
+    // Creating navigates to the new project's detail page; head back to
+    // the list to verify the rendered markdown there.
+    await expect(page).toHaveURL(/\/projects\/[a-f0-9-]+/);
+    await page.goto(`${BASE_URL}/projects`);
 
     const item = page.locator('[data-testid="project-item"]', { hasText: title });
     // MarkdownView renders headings as real <h1> elements and list items as <li>.
@@ -95,8 +104,13 @@ test.describe("Projects", () => {
     const alicePage = await aliceContext.newPage();
     await registerAndSignIn(alicePage, aliceEmail);
     await alicePage.goto(`${BASE_URL}/projects`);
+    await alicePage.getByTestId("new-project-button").click();
     await alicePage.fill("#title", aliceProject);
     await alicePage.click('button[type="submit"]');
+    // Creating navigates to the new project's detail page; head back to
+    // the list to verify it renders there.
+    await expect(alicePage).toHaveURL(/\/projects\/[a-f0-9-]+/);
+    await alicePage.goto(`${BASE_URL}/projects`);
     await expect(
       alicePage.locator('[data-testid="project-item"]', { hasText: aliceProject }),
     ).toBeVisible();

--- a/pwa/components/common/Navbar.tsx
+++ b/pwa/components/common/Navbar.tsx
@@ -17,6 +17,7 @@ import SearchOverlay from "@/components/search/SearchOverlay";
 import Breadcrumbs from "./Breadcrumbs";
 import SearchBar from "./SearchBar";
 import SidebarNav from "./SidebarNav";
+import SpaceSwitcher from "./SpaceSwitcher";
 import UserMenu from "./UserMenu";
 
 const Navbar = () => {
@@ -26,11 +27,12 @@ const Navbar = () => {
   return (
     <nav className="h-14 w-full border-b bg-background">
       <div className="flex h-full items-center gap-3 px-4">
-        <div className="flex items-center gap-1 shrink-0">
+        <div className="flex items-center gap-2 shrink-0">
           {/* Signed-out viewers get the Madori wordmark as the home
-              anchor; signed-in viewers get the Breadcrumbs trail
-              below (with its own Home icon), so the wordmark would
-              be redundant. Developer-facing doc links (API reference,
+              anchor; signed-in viewers get the active-space switcher
+              here on the left (md+) plus the Breadcrumbs trail below
+              (with its own Home icon), so the wordmark would be
+              redundant. Developer-facing doc links (API reference,
               component library, guides) live in the page Footer to
               keep the navbar focused on the active session. */}
           {!isAuthenticated && (
@@ -40,6 +42,11 @@ const Navbar = () => {
             >
               Madori
             </Link>
+          )}
+          {isAuthenticated && (
+            <div className="hidden md:block w-44 lg:w-52">
+              <SpaceSwitcher />
+            </div>
           )}
         </div>
 
@@ -79,6 +86,7 @@ const Navbar = () => {
                     <SheetTitle>Main navigation</SheetTitle>
                   </SheetHeader>
                   <SidebarNav
+                    includeSpaceSwitcher
                     itemWrapper={(child) => (
                       <SheetClose asChild>{child}</SheetClose>
                     )}

--- a/pwa/components/common/SidebarNav.tsx
+++ b/pwa/components/common/SidebarNav.tsx
@@ -1,15 +1,21 @@
 import Link from "next/link";
 import { useRouter } from "next/router";
-import type { ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { ChevronDown, Plus } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
+import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
+import { apiGetCollection } from "@/lib/apiClient";
+import { CONTENT_SECTIONS } from "@/lib/contentSections";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import SpaceSwitcher from "./SpaceSwitcher";
 
 // The account menu (avatar + personal links + sign out + stop
 // impersonation) and the notification bell live in the top bar now —
-// see UserMenu / Navbar. The sidebar carries the space switcher and the
-// admin section.
+// see UserMenu / Navbar. The sidebar carries the space switcher, the
+// active space's content sections (projects / pages / discussions),
+// and the admin section.
 
 // The shared section is now a list of accessible spaces (rendered
 // from ActiveSpaceContext at render time, since it's per-user state).
@@ -32,22 +38,201 @@ const ADMIN_EXTERNAL_LINKS =
     ? []
     : [{ href: "/.well-known/mercure/ui/", label: "Mercure" }];
 
+// The active space's content surfaces (Projects / Pages / Discussions)
+// are rendered as their own sidebar sections from the shared
+// CONTENT_SECTIONS map (icon + color shared with the aggregator page
+// headers). Each heading links to its top-level aggregator (scoped to
+// the active space, with the inline create composer); the items below
+// are the active space's rows; an "add" link sits at the foot of each
+// section. Headings + add link show even when the space has none, so
+// the structure is always discoverable.
+
+// Cap how many rows a section lists so a large space can't push the
+// admin section (and the section below it) far off-screen. The heading
+// links to the full aggregator for the rest.
+const MAX_SECTION_ITEMS = 8;
+
+interface ResourceRow {
+  "@id": string;
+  id: string;
+  title: string;
+}
+
+/**
+ * Fetch the active space's rows for one resource (`projects` / `pages`
+ * / `discussions`), scoped by `?space=<iri>` — the same filter the
+ * aggregators and SpaceContentTabs use.
+ *
+ * Keyed under the resource's react-query prefix (e.g. `["projects", …]`)
+ * so the aggregators' `invalidateQueries({ queryKey: ["projects"] })`
+ * on create/edit/delete refreshes this list too — a project added on
+ * `/projects` shows up here without a manual reload.
+ */
+function useSpaceResources(
+  spaceIri: string | null,
+  resource: (typeof CONTENT_SECTIONS)[number]["resource"],
+): ResourceRow[] {
+  const query = useQuery({
+    queryKey: [resource, spaceIri, "nav"],
+    enabled: !!spaceIri,
+    queryFn: () => {
+      if (!spaceIri) return Promise.resolve<ResourceRow[]>([]);
+      return apiGetCollection<ResourceRow>(
+        `/${resource}?space=${encodeURIComponent(spaceIri)}&itemsPerPage=50`,
+        { errorMessage: `Failed to load ${resource}.` },
+      );
+    },
+  });
+
+  // A failed fetch leaves the section as just its heading + add link
+  // rather than breaking the nav.
+  return query.data ?? [];
+}
+
 interface SidebarNavProps {
   /**
    * Wrap each interactive item — used by the mobile Sheet variant to
    * auto-close on selection. The persistent sidebar passes through.
    */
   itemWrapper?: (children: ReactNode) => ReactNode;
+  /**
+   * Render the active-space switcher at the top. The navbar shows the
+   * switcher on its left at `md` and up, so only the mobile Sheet
+   * variant (where there's no room for it in the top bar) sets this.
+   */
+  includeSpaceSwitcher?: boolean;
 }
+
+interface ContentSectionProps {
+  section: (typeof CONTENT_SECTIONS)[number];
+  spaceIri: string;
+  wrap: (children: ReactNode) => ReactNode;
+}
+
+/**
+ * One sidebar section: a heading (links to the aggregator) with a
+ * collapse toggle, the active space's rows, and an "add" link. The
+ * heading + toggle always render; the rows and "add" link collapse
+ * behind the chevron, with the open/closed choice persisted per
+ * resource in localStorage.
+ */
+const ContentSection = ({ section, spaceIri, wrap }: ContentSectionProps) => {
+  const router = useRouter();
+  const items = useSpaceResources(spaceIri, section.resource);
+  const aggregatorHref = `/${section.resource}`;
+  const shown = items.slice(0, MAX_SECTION_ITEMS);
+  const currentPath = router.asPath.split("?")[0];
+  const Icon = section.icon;
+
+  // Persist the collapsed state per resource. Start expanded on the
+  // server / first paint, then hydrate the stored choice after mount so
+  // there's no SSR mismatch.
+  const storageKey = `madori.navCollapsed.${section.resource}`;
+  const [collapsed, setCollapsed] = useState(false);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    setCollapsed(window.localStorage.getItem(storageKey) === "1");
+  }, [storageKey]);
+
+  const toggle = () =>
+    setCollapsed((c) => {
+      const next = !c;
+      try {
+        window.localStorage.setItem(storageKey, next ? "1" : "0");
+      } catch {
+        // Storage-disabled browsers: state still toggles for the session.
+      }
+      return next;
+    });
+
+  return (
+    <div className="mt-3 first:mt-0">
+      <div className="flex items-center px-3 pb-1">
+        {wrap(
+          <Link
+            href={aggregatorHref}
+            className="flex min-w-0 items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground hover:text-foreground"
+          >
+            <Icon className={cn("size-3.5 shrink-0", section.iconClass)} />
+            <span className="truncate">{section.label}</span>
+          </Link>,
+        )}
+        <button
+          type="button"
+          onClick={toggle}
+          aria-expanded={!collapsed}
+          aria-label={`${collapsed ? "Expand" : "Collapse"} ${section.label}`}
+          className="ml-auto rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+        >
+          <ChevronDown
+            className={cn(
+              "size-3.5 transition-transform",
+              collapsed && "-rotate-90",
+            )}
+          />
+        </button>
+      </div>
+
+      {!collapsed && (
+        <>
+          {shown.map((item) => {
+            const href = `/${section.resource}/${item.id}`;
+            return (
+              <span key={item["@id"]}>
+                {wrap(
+                  <Button
+                    asChild
+                    variant="ghost"
+                    size="sm"
+                    className={cn(
+                      "w-full min-w-0 justify-start font-normal",
+                      currentPath === href && "bg-accent text-accent-foreground",
+                    )}
+                  >
+                    <Link href={href}>
+                      {/* pl-5 ≈ heading icon (size-3.5) + gap-1.5, so the row
+                          text lines up under the heading label. */}
+                      <span className="truncate pl-5">{item.title}</span>
+                    </Link>
+                  </Button>,
+                )}
+              </span>
+            );
+          })}
+
+          <span>
+            {wrap(
+              <Button
+                asChild
+                variant="ghost"
+                size="sm"
+                className="w-full justify-start font-normal text-muted-foreground"
+              >
+                <Link href={aggregatorHref}>
+                  <Plus className="size-4" />
+                  New {section.singular}
+                </Link>
+              </Button>,
+            )}
+          </span>
+        </>
+      )}
+    </div>
+  );
+};
 
 /**
  * Shared navigation contents used by both the persistent left-side
  * `<Sidebar>` (`md:` and up) and the mobile-only Sheet variant in the
- * navbar. Single source of truth so the space switcher and admin
- * section stay in sync across both surfaces.
+ * navbar. Single source of truth so the space switcher, content
+ * sections, and admin section stay in sync across both surfaces.
  */
-const SidebarNav = ({ itemWrapper }: SidebarNavProps) => {
+const SidebarNav = ({
+  itemWrapper,
+  includeSpaceSwitcher = false,
+}: SidebarNavProps) => {
   const { user, isAuthenticated } = useAuth();
+  const { activeSpace } = useActiveSpace();
   const router = useRouter();
   const isAdmin = user?.roles?.includes("ROLE_ADMIN");
   const wrap = itemWrapper ?? ((c) => c);
@@ -56,16 +241,31 @@ const SidebarNav = ({ itemWrapper }: SidebarNavProps) => {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="px-2 pt-4 pb-2">
-        <SpaceSwitcher />
-      </div>
+      {includeSpaceSwitcher && (
+        <div className="px-2 pt-4 pb-2">
+          <SpaceSwitcher />
+        </div>
+      )}
 
-      <nav className="flex flex-col gap-0.5 px-2 pb-4 flex-1 overflow-y-auto">
-        {isAdmin && (
-          <>
-            <p className="px-3 pb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              Admin
-            </p>
+      <nav className="flex flex-col gap-0.5 px-2 pt-2 pb-4 flex-1 overflow-y-auto">
+        {activeSpace &&
+          CONTENT_SECTIONS.map((section) => (
+            <ContentSection
+              key={section.resource}
+              section={section}
+              spaceIri={activeSpace["@id"]}
+              wrap={wrap}
+            />
+          ))}
+      </nav>
+
+      {/* Admin tooling is pinned to the foot of the sidebar, below the
+          (scrollable) space content, separated by a divider. */}
+      {isAdmin && (
+        <div className="flex flex-col gap-0.5 border-t px-2 py-3">
+          <p className="px-3 pb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Admin
+          </p>
             <span>
               {wrap(
                 <Button
@@ -127,9 +327,8 @@ const SidebarNav = ({ itemWrapper }: SidebarNavProps) => {
                 </a>
               </Button>
             ))}
-          </>
-        )}
-      </nav>
+        </div>
+      )}
     </div>
   );
 };

--- a/pwa/components/discussions/DiscussionsPanel.tsx
+++ b/pwa/components/discussions/DiscussionsPanel.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
+import { useQueryClient } from "@tanstack/react-query";
 import {
   Lock,
   MessageSquare,
@@ -112,6 +113,7 @@ const DiscussionsPanel = ({
   isSpaceAdmin,
   onCountChange,
 }: Props) => {
+  const queryClient = useQueryClient();
   const [discussions, setDiscussions] = useState<Discussion[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -212,6 +214,8 @@ const DiscussionsPanel = ({
       const created: Discussion = await res.json();
       trackEvent("discussion-create", { category: newCategory });
       setDiscussions((prev) => sortDiscussions([created, ...prev]));
+      // Refresh the sidebar nav list (shares the ["discussions"] key prefix).
+      void queryClient.invalidateQueries({ queryKey: ["discussions"] });
       setNewTitle("");
       setNewBody("");
       setNewCategory("general");

--- a/pwa/lib/contentSections.ts
+++ b/pwa/lib/contentSections.ts
@@ -1,0 +1,54 @@
+import {
+  FileText,
+  FolderKanban,
+  MessagesSquare,
+  type LucideIcon,
+} from "lucide-react";
+
+/**
+ * Shared identity for the three space-content surfaces (Projects /
+ * Pages / Discussions): the lucide icon and its color. Single source of
+ * truth so the aggregator page headers and the sidebar nav sections
+ * always render the same icon + hue per resource.
+ */
+export type ContentResource = "projects" | "pages" | "discussions";
+
+export interface ContentSectionMeta {
+  resource: ContentResource;
+  /** Plural label / aggregator title. */
+  label: string;
+  /** Singular noun for the "New <singular>" affordance. */
+  singular: string;
+  icon: LucideIcon;
+  /** Tailwind text-color classes for the icon (light + dark). */
+  iconClass: string;
+}
+
+export const CONTENT_SECTIONS: ContentSectionMeta[] = [
+  {
+    resource: "projects",
+    label: "Projects",
+    singular: "project",
+    icon: FolderKanban,
+    iconClass: "text-violet-600 dark:text-violet-400",
+  },
+  {
+    resource: "pages",
+    label: "Pages",
+    singular: "page",
+    icon: FileText,
+    iconClass: "text-emerald-600 dark:text-emerald-400",
+  },
+  {
+    resource: "discussions",
+    label: "Discussions",
+    singular: "discussion",
+    icon: MessagesSquare,
+    iconClass: "text-cyan-600 dark:text-cyan-400",
+  },
+];
+
+export const contentSectionFor = (
+  resource: ContentResource,
+): ContentSectionMeta =>
+  CONTENT_SECTIONS.find((s) => s.resource === resource) as ContentSectionMeta;

--- a/pwa/next.config.js
+++ b/pwa/next.config.js
@@ -2,6 +2,10 @@
 const nextConfig = {
   reactStrictMode: true,
   output: 'standalone',
+  // Next.js dev tools indicator (dev-only) pinned to the bottom-right corner.
+  devIndicators: {
+    position: 'bottom-right',
+  },
   async redirects() {
     // Account management consolidated into the Settings shell. Server-side
     // redirects so old links/bookmarks (and the post-login fallback) resolve

--- a/pwa/pages/dev/components/sidebar-nav.tsx
+++ b/pwa/pages/dev/components/sidebar-nav.tsx
@@ -4,7 +4,7 @@ import ComponentDoc from "@/components/dev/ComponentDoc";
 const SidebarNavPage = () => (
   <ComponentDoc
     name="SidebarNav"
-    description="Shared navigation surface used by both the persistent Sidebar (md and up) and the mobile Sheet variant in the Navbar. Renders the SpaceSwitcher and an Admin section for ROLE_ADMIN users (Admin, Waitlist, Segments, and the external Mercure debugger). The account menu (avatar, personal links, sign out) and notification bell live in the top bar — see UserMenu / Navbar."
+    description="Shared navigation surface used by both the persistent Sidebar (md and up) and the mobile Sheet variant in the Navbar. Renders the SpaceSwitcher; a content section per surface (Projects / Pages / Discussions) listing the active space's rows, each with a heading that links to its aggregator and an add link at the foot — both shown even when the space is empty; and an Admin section for ROLE_ADMIN users (Admin, Waitlist, Segments, and the external Mercure debugger). The account menu (avatar, personal links, sign out) and notification bell live in the top bar — see UserMenu / Navbar."
     importPath={`import SidebarNav from "@/components/common/SidebarNav";`}
     examples={[
       {

--- a/pwa/pages/pages/index.tsx
+++ b/pwa/pages/pages/index.tsx
@@ -2,12 +2,14 @@ import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { FormEvent, useEffect, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@/contexts/AuthContext";
 import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
 import { trackEvent } from "@/lib/analytics";
 import { apiGetCollection, apiSend } from "@/lib/apiClient";
 import { signinHrefForCurrent } from "@/lib/authRedirect";
+import { contentSectionFor } from "@/lib/contentSections";
+import { cn } from "@/lib/utils";
 import { displayName } from "@/lib/userDisplay";
 import UserAvatar, { type AvatarUser } from "@/components/user/UserAvatar";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -55,6 +57,7 @@ const PagesIndex = () => {
   const { user, isAuthenticated, isLoading: authLoading } = useAuth();
   const { activeSpace } = useActiveSpace();
   const router = useRouter();
+  const queryClient = useQueryClient();
 
   const [search, setSearch] = useState("");
 
@@ -86,6 +89,8 @@ const PagesIndex = () => {
   });
   const pages = pagesQuery.data ?? [];
   const isLoading = pagesQuery.isLoading;
+  const pagesMeta = contentSectionFor("pages");
+  const PagesIcon = pagesMeta.icon;
   const error = pagesQuery.isError
     ? pagesQuery.error instanceof Error
       ? pagesQuery.error.message
@@ -105,6 +110,8 @@ const PagesIndex = () => {
       trackEvent("page-create");
       setNewTitle("");
       setShowComposer(false);
+      // Refresh the sidebar nav list (shares the ["pages"] key prefix).
+      void queryClient.invalidateQueries({ queryKey: ["pages"] });
       if (created) await router.push(`/pages/${created.id}`);
     } catch (err) {
       setCreateError(err instanceof Error ? err.message : "Failed to create.");
@@ -130,7 +137,18 @@ const PagesIndex = () => {
         <div className="max-w-4xl mx-auto px-4 py-8 space-y-6">
           <header className="flex items-start justify-between gap-3">
             <div>
-              <h1 className="text-2xl font-bold">Pages</h1>
+              <div className="flex items-center gap-2">
+                <PagesIcon className={cn("h-6 w-6 shrink-0", pagesMeta.iconClass)} />
+                <h1 className="text-2xl font-bold">Pages</h1>
+                {!isLoading && (
+                  <span
+                    className="rounded-full bg-muted-foreground/15 px-2 py-0.5 text-xs font-medium text-muted-foreground"
+                    data-testid="pages-count"
+                  >
+                    {pages.length}
+                  </span>
+                )}
+              </div>
               <p className="text-sm text-muted-foreground mt-1">
                 {activeSpace
                   ? `Long-form documents in ${activeSpace.name}.`

--- a/pwa/pages/projects/index.tsx
+++ b/pwa/pages/projects/index.tsx
@@ -8,6 +8,8 @@ import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
 import { trackEvent } from "@/lib/analytics";
 import { apiGetCollection, apiSend } from "@/lib/apiClient";
 import { signinHrefForCurrent } from "@/lib/authRedirect";
+import { contentSectionFor } from "@/lib/contentSections";
+import { cn } from "@/lib/utils";
 import MarkdownEditor from "@/components/editor/MarkdownEditor";
 import MarkdownView from "@/components/editor/MarkdownView";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -42,6 +44,9 @@ const Projects = () => {
   const router = useRouter();
   const queryClient = useQueryClient();
 
+  // The create form is hidden behind a "New project" toggle (mirrors the
+  // Pages page) rather than sitting open by default.
+  const [showComposer, setShowComposer] = useState(false);
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   // Bumped after a successful create so the MarkdownEditor remounts empty.
@@ -79,9 +84,12 @@ const Projects = () => {
   const projects = projectsQuery.data ?? [];
   const refreshProjects = () => queryClient.invalidateQueries({ queryKey: ["projects"] });
 
+  const projectsMeta = contentSectionFor("projects");
+  const ProjectsIcon = projectsMeta.icon;
+
   const createMutation = useMutation({
     mutationFn: () =>
-      apiSend("POST", "/projects", {
+      apiSend<Project>("POST", "/projects", {
         errorMessage: "Failed to create project.",
         body: {
           title: title.trim(),
@@ -91,13 +99,17 @@ const Projects = () => {
           ...(spaceIri ? { space: spaceIri } : {}),
         },
       }),
-    onSuccess: () => {
+    onSuccess: (created) => {
       setTitle("");
       setDescription("");
       setEditorResetKey((k) => k + 1);
+      setShowComposer(false);
       setActionError(null);
       trackEvent("project-create");
+      // Refresh the list (and the sidebar, which shares the ["projects"]
+      // key prefix), then jump straight into the new project.
       void refreshProjects();
+      if (created) void router.push(`/projects/${created.id}`);
     },
     onError: (err) => setActionError(errorMessage(err, "Failed to create project.")),
   });
@@ -184,41 +196,64 @@ const Projects = () => {
       </Head>
       <div className="min-h-screen bg-muted px-4 py-12">
         <div className="max-w-2xl mx-auto">
-          <h1 className="text-2xl font-bold mb-6">Projects</h1>
+          <header className="flex items-start justify-between gap-3 mb-6">
+            <div className="flex items-center gap-2">
+              <ProjectsIcon className={cn("h-6 w-6 shrink-0", projectsMeta.iconClass)} />
+              <h1 className="text-2xl font-bold">Projects</h1>
+              {!projectsQuery.isLoading && (
+                <span
+                  className="rounded-full bg-muted-foreground/15 px-2 py-0.5 text-xs font-medium text-muted-foreground"
+                  data-testid="projects-count"
+                >
+                  {projects.length}
+                </span>
+              )}
+            </div>
+            <Button
+              size="sm"
+              onClick={() => setShowComposer((v) => !v)}
+              data-testid="new-project-button"
+            >
+              {showComposer ? "Cancel" : "New project"}
+            </Button>
+          </header>
 
-          <Card className="mb-6">
-            <CardContent className="pt-6">
-              <form onSubmit={handleCreate} className="space-y-4">
-                <div className="space-y-1.5">
-                  <Label htmlFor="title">Title</Label>
-                  <Input
-                    id="title"
-                    type="text"
-                    value={title}
-                    onChange={(e) => setTitle(e.target.value)}
-                    required
-                    maxLength={255}
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="description">
-                    Description{" "}
-                    <span className="text-muted-foreground font-normal">(optional)</span>
-                  </Label>
-                  <MarkdownEditor
-                    key={editorResetKey}
-                    id="description"
-                    ariaLabel="Description"
-                    value={description}
-                    onChange={setDescription}
-                  />
-                </div>
-                <Button type="submit" disabled={createMutation.isPending || !title.trim()}>
-                  {createMutation.isPending ? "Adding..." : "Add Project"}
-                </Button>
-              </form>
-            </CardContent>
-          </Card>
+          {showComposer && (
+            <Card className="mb-6">
+              <CardContent className="pt-6">
+                <form onSubmit={handleCreate} className="space-y-4">
+                  <div className="space-y-1.5">
+                    <Label htmlFor="title">Title</Label>
+                    <Input
+                      id="title"
+                      type="text"
+                      value={title}
+                      onChange={(e) => setTitle(e.target.value)}
+                      required
+                      maxLength={255}
+                      autoFocus
+                    />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="description">
+                      Description{" "}
+                      <span className="text-muted-foreground font-normal">(optional)</span>
+                    </Label>
+                    <MarkdownEditor
+                      key={editorResetKey}
+                      id="description"
+                      ariaLabel="Description"
+                      value={description}
+                      onChange={setDescription}
+                    />
+                  </div>
+                  <Button type="submit" disabled={createMutation.isPending || !title.trim()}>
+                    {createMutation.isPending ? "Adding..." : "Add Project"}
+                  </Button>
+                </form>
+              </CardContent>
+            </Card>
+          )}
 
           {error && (
             <Alert variant="destructive" className="mb-4">
@@ -232,7 +267,7 @@ const Projects = () => {
             <Card>
               <CardContent className="pt-6">
                 <p className="text-muted-foreground">
-                  No projects yet. Create one above to start collaborating.
+                  No projects yet. Click &ldquo;New project&rdquo; to start collaborating.
                 </p>
               </CardContent>
             </Card>


### PR DESCRIPTION
## Description

Reworks the left-hand navigation and the projects/pages aggregator headers.

**Sidebar (`SidebarNav`)**
- New per-resource sections — **Projects / Pages / Discussions** — listing the active space's rows, each with a colored icon, a heading that links to its aggregator, and a **"New &lt;singular&gt;"** add link at the foot. Heading + add link render even when the space is empty so the structure is always discoverable.
- Section lists now fetch via **react-query keyed under each resource prefix** (`["projects", …]`, etc.), so the aggregators' `invalidateQueries` refresh the sidebar when something is created.
- **Collapsible sections** via a chevron toggle on each heading, persisted per resource in `localStorage`.
- **Admin section pinned to the bottom** of the sidebar.
- The **active-space switcher moved to the top bar** (navbar left, `md+`). It's now opt-in on `SidebarNav` via `includeSpaceSwitcher`; the mobile hamburger Sheet keeps it since the top bar hides it on small screens.

**Shared metadata** — new `pwa/lib/contentSections.ts` is the single source of truth for each resource's icon + color, consumed by both the sidebar and the page headers so they can't drift.

**Projects page**
- Create form is now **hidden behind a "New project" toggle** (mirrors the Pages page) instead of sitting open by default.
- Creating a project now **navigates to the new project** and invalidates the list.
- Header gained a **colored icon + item count badge** (like the Discussions page).

**Pages page** — header gained the colored icon + count badge; create now invalidates the `["pages"]` query so the sidebar refreshes.

**Discussions panel** — create invalidates the `["discussions"]` query so the sidebar refreshes.

**Misc** — `next.config.js` pins the Next.js dev-tools indicator to `bottom-right` (dev-only).

## Type of Change

- [x] New feature

## Component

- [x] PWA (Next.js)

## How Has This Been Tested?

Not run locally — the Node toolchain isn't reachable from this environment, so I'm relying on CI (PWA Typecheck / E2E). Changes are prop additions, conditional renders, and react-query wiring that mirror existing verified patterns. Manual review of types done (`apiSend<Project>` guarded for null, `apiGetCollection<ResourceRow>`, shared `LucideIcon` metadata).

## Checklist

- [x] My code follows the project's conventions
- [ ] I have added tests that prove my fix or feature works
- [ ] New and existing tests pass locally
- [x] I have updated documentation if needed (SidebarNav dev-docs description)

## Reviewer notes

- The desktop sidebar and mobile Sheet are separate `SidebarNav` instances, so collapse state and the space switcher sync on mount, not live across both at once.
- Page/discussion **deletes** don't yet invalidate the sidebar (creates do); the sidebar catches up on the next navigation/space switch. Happy to wire deletes up too.
- The Discussions page still hardcodes its own icon; the shared map mirrors it exactly. Can refactor that page onto the shared meta if preferred.