### PR TITLE
feat(pwa): redesign custom fields page

### DIFF
--- a/pwa/components/custom-fields/CustomFieldSheet.tsx
+++ b/pwa/components/custom-fields/CustomFieldSheet.tsx
@@ -5,10 +5,16 @@ import {
   useMemo,
   useState,
 } from "react";
-import { Trash2 } from "lucide-react";
+import { Copy, MoreHorizontal, Trash2 } from "lucide-react";
 import { ENTRYPOINT } from "@/config/entrypoint";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -22,10 +28,14 @@ import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
 import {
   CustomFieldConfigEditor,
+  KIND_BADGE,
   KIND_DESCRIPTORS,
   KIND_ORDER,
+  configSectionLabel,
   defaultConfigFor,
   fallbackSubtypeFor,
+  kindLabelFor,
+  subtypeLabelFor,
 } from "./kind-editors";
 import { fieldHandle } from "./handle";
 import type {
@@ -57,6 +67,8 @@ interface Props {
   valueCount?: number;
   onSaved: (def: CustomFieldDefinition) => void;
   onDeleted?: (def: CustomFieldDefinition) => void;
+  /** Duplicate the field being edited (header overflow menu). */
+  onDuplicate?: (def: CustomFieldDefinition) => void;
 }
 
 const FOOTER_LABELS: Record<FooterKind, string> = {
@@ -87,6 +99,7 @@ const CustomFieldSheet = ({
   valueCount,
   onSaved,
   onDeleted,
+  onDuplicate,
 }: Props) => {
   const isEdit = Boolean(initial);
 
@@ -289,15 +302,45 @@ const CustomFieldSheet = ({
         }}
       >
         <SheetHeader className="border-b px-5 py-4">
-          <SheetTitle className="text-sm font-semibold uppercase tracking-wide">
-            {isEdit ? "Edit field" : "New field"}
-          </SheetTitle>
-          <p className="text-xs text-muted-foreground">
-            <span className="font-mono">{handle}</span>
-            {isEdit && typeof valueCount === "number" && (
-              <> · {valueCount} {valueCount === 1 ? "value" : "values"}</>
+          <div className="flex items-center gap-2 pr-9">
+            <span className={cn("h-2 w-2 shrink-0 rounded-full", KIND_BADGE[kind].dot)} />
+            <SheetTitle className="text-sm font-semibold uppercase tracking-wide">
+              {isEdit ? "Edit field" : "New field"}
+            </SheetTitle>
+            <span className="truncate font-mono text-xs text-muted-foreground">
+              {handle}
+            </span>
+            {isEdit && initial && onDuplicate && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="ghost"
+                    className="ml-auto mr-6 h-7 w-7"
+                    aria-label="Field actions"
+                  >
+                    <MoreHorizontal className="h-4 w-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem
+                    onSelect={() => {
+                      onDuplicate(initial);
+                      onOpenChange(false);
+                    }}
+                  >
+                    <Copy className="mr-2 h-3.5 w-3.5" /> Duplicate field
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
             )}
-          </p>
+          </div>
+          {isEdit && typeof valueCount === "number" && (
+            <p className="text-xs text-muted-foreground">
+              {valueCount} {valueCount === 1 ? "value" : "values"} on tasks
+            </p>
+          )}
         </SheetHeader>
 
         <form
@@ -356,15 +399,48 @@ const CustomFieldSheet = ({
               </div>
             </div>
 
-            <CustomFieldConfigEditor
-              kind={kind}
-              subtype={subtype}
-              config={config}
-              onChange={setConfig}
-              onSubtypeChange={handleSubtypeChange}
-              spaceName={spaceName}
-              optionStats={optionStats}
-            />
+            <div className="flex flex-wrap items-center gap-2 text-xs">
+              <span
+                className={cn("h-1.5 w-1.5 rounded-full", KIND_BADGE[kind].dot)}
+              />
+              <span className="text-muted-foreground">
+                {kindLabelFor(kind).toLowerCase()} ·{" "}
+                {subtypeLabelFor(kind, subtype).toLowerCase()}
+              </span>
+              <span className="rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground">
+                nullable = {String(nullable)}
+              </span>
+            </div>
+
+            {kind !== "boolean" && (
+              <div className="space-y-2">
+                <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                  {configSectionLabel(kind, subtype)}
+                </p>
+                <CustomFieldConfigEditor
+                  kind={kind}
+                  subtype={subtype}
+                  config={config}
+                  onChange={setConfig}
+                  onSubtypeChange={handleSubtypeChange}
+                  spaceName={spaceName}
+                  optionStats={optionStats}
+                />
+              </div>
+            )}
+
+            {kind === "select" && (
+              <ToggleRow
+                id="cf-select-multi"
+                label="Allow multi-select"
+                description="Tasks can hold multiple values · subtype = select.multi"
+                checked={subtype === "multi"}
+                onCheckedChange={(checked) =>
+                  handleSubtypeChange(checked ? "multi" : "single")
+                }
+                testId="custom-field-select-multi-input"
+              />
+            )}
 
             {multiSupported && (
               <ToggleRow
@@ -396,9 +472,62 @@ const CustomFieldSheet = ({
               <Label>
                 Footer aggregation{" "}
                 <span className="text-muted-foreground text-xs">
-                  (shown at the bottom of the task list)
+                  (roll-up shown at the bottom of the task list)
                 </span>
               </Label>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1.5">
+                  <Label
+                    htmlFor="cf-footer-fn"
+                    className="text-xs text-muted-foreground"
+                  >
+                    Function
+                  </Label>
+                  <select
+                    id="cf-footer-fn"
+                    value={footer?.kind ?? "none"}
+                    onChange={(e) =>
+                      toggleFooter(
+                        e.target.value === "none"
+                          ? null
+                          : (e.target.value as FooterKind),
+                      )
+                    }
+                    className="block w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                    data-testid="custom-field-footer-function"
+                  >
+                    <option value="none">None</option>
+                    {descriptor.footerKinds.map((fk) => (
+                      <option key={fk} value={fk}>
+                        {FOOTER_LABELS[fk]}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="space-y-1.5">
+                  <Label
+                    htmlFor="cf-footer-label"
+                    className="text-xs text-muted-foreground"
+                  >
+                    Label override
+                  </Label>
+                  <Input
+                    id="cf-footer-label"
+                    value={footer?.label ?? ""}
+                    onChange={(e) =>
+                      footer &&
+                      setFooter({
+                        kind: footer.kind,
+                        label:
+                          e.target.value === "" ? undefined : e.target.value,
+                      })
+                    }
+                    placeholder="Use field name"
+                    disabled={!footer}
+                    data-testid="custom-field-footer-label"
+                  />
+                </div>
+              </div>
               <div
                 className="flex flex-wrap gap-1.5"
                 data-testid="custom-field-footer-pills"
@@ -417,19 +546,6 @@ const CustomFieldSheet = ({
                   />
                 ))}
               </div>
-              {footer && (
-                <Input
-                  value={footer.label ?? ""}
-                  onChange={(e) =>
-                    setFooter({
-                      kind: footer.kind,
-                      label: e.target.value === "" ? undefined : e.target.value,
-                    })
-                  }
-                  placeholder="Label override (defaults to field name)"
-                  data-testid="custom-field-footer-label"
-                />
-              )}
             </div>
 
             {error && (
@@ -526,9 +642,9 @@ const FooterPill = ({
     onClick={onClick}
     aria-pressed={active}
     className={cn(
-      "rounded-full border px-3 py-1 text-xs font-medium transition",
+      "rounded-full border px-3 py-1 text-xs font-medium uppercase tracking-wide transition",
       active
-        ? "border-primary bg-primary text-primary-foreground"
+        ? "border-emerald-500/40 bg-emerald-500/15 text-emerald-300"
         : "border-input text-muted-foreground hover:text-foreground",
     )}
   >

--- a/pwa/components/custom-fields/CustomFieldsManager.tsx
+++ b/pwa/components/custom-fields/CustomFieldsManager.tsx
@@ -13,7 +13,7 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { GripVertical, History, Pencil, Plus } from "lucide-react";
+import { CircleCheck, Copy, GripVertical, History, Plus, Settings } from "lucide-react";
 import { ENTRYPOINT } from "@/config/entrypoint";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -30,7 +30,7 @@ import { cn } from "@/lib/utils";
 import CustomFieldSheet from "./CustomFieldSheet";
 import CustomFieldChangeLog from "./CustomFieldChangeLog";
 import { fieldHandle } from "./handle";
-import { kindLabelFor, subtypeLabelFor } from "./kind-editors";
+import { KIND_BADGE, kindLabelFor, subtypeLabelFor } from "./kind-editors";
 import type {
   CustomFieldDefinition,
   FieldStatsResponse,
@@ -51,12 +51,22 @@ interface Collection<T> {
 
 interface Props {
   projectIri: string;
-  /** Active space name, surfaced in the reference editor scope note. */
+  /** Project title — slugified for the header `slug · N fields` badge. */
+  projectTitle: string;
+  /** Active space name, surfaced in the admin notice + reference scope note. */
   spaceName?: string;
   isSpaceAdmin: boolean;
 }
 
 const projectIdFromIri = (iri: string): string => iri.split("/").pop() ?? "";
+
+/** `Spring Collection Launch` → `spring-collection-launch` (header badge). */
+const slugify = (value: string): string =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
 
 const errorMessage = async (res: Response): Promise<string> => {
   const data = await res.json().catch(() => ({}));
@@ -76,7 +86,12 @@ const sortByPosition = (
     (a, b) => a.position - b.position || a.name.localeCompare(b.name),
   );
 
-const CustomFieldsManager = ({ projectIri, spaceName, isSpaceAdmin }: Props) => {
+const CustomFieldsManager = ({
+  projectIri,
+  projectTitle,
+  spaceName,
+  isSpaceAdmin,
+}: Props) => {
   const projectId = projectIdFromIri(projectIri);
   const [defs, setDefs] = useState<CustomFieldDefinition[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -86,6 +101,7 @@ const CustomFieldsManager = ({ projectIri, spaceName, isSpaceAdmin }: Props) => 
   const [sheetOpen, setSheetOpen] = useState(false);
   const [editing, setEditing] = useState<CustomFieldDefinition | null>(null);
   const [changeLogOpen, setChangeLogOpen] = useState(false);
+  const [noticeDismissed, setNoticeDismissed] = useState(false);
 
   const sensors = useSensors(useSensor(PointerSensor));
 
@@ -135,6 +151,8 @@ const CustomFieldsManager = ({ projectIri, spaceName, isSpaceAdmin }: Props) => 
   const nextPosition =
     defs.length > 0 ? Math.max(...defs.map((d) => d.position)) + 1 : 0;
 
+  const slug = slugify(projectTitle) || "project";
+
   const openCreate = () => {
     setEditing(null);
     setSheetOpen(true);
@@ -158,6 +176,40 @@ const CustomFieldsManager = ({ projectIri, spaceName, isSpaceAdmin }: Props) => 
   const handleDeleted = (def: CustomFieldDefinition) => {
     setDefs((prev) => prev.filter((d) => d["@id"] !== def["@id"]));
   };
+
+  // Client-side duplicate — there's no copy endpoint, so we POST a fresh
+  // definition mirroring the source's kind/subtype/config/footer/nullable
+  // with a " copy" name suffix at the end of the column order.
+  const handleDuplicate = useCallback(
+    async (def: CustomFieldDefinition) => {
+      setLoadError(null);
+      try {
+        const res = await fetch(`${ENTRYPOINT}/custom_field_definitions`, {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/ld+json" },
+          body: JSON.stringify({
+            name: `${def.name} copy`,
+            kind: def.kind,
+            subtype: def.subtype,
+            config: def.config,
+            nullable: def.nullable,
+            footer: def.footer,
+            project: projectIri,
+            position: nextPosition,
+          }),
+        });
+        if (!res.ok) throw new Error(await errorMessage(res));
+        const saved: CustomFieldDefinition = await res.json();
+        handleSaved(saved);
+      } catch (err) {
+        setLoadError(
+          err instanceof Error ? err.message : "Failed to duplicate field.",
+        );
+      }
+    },
+    [projectIri, nextPosition],
+  );
 
   const persistOrder = useCallback(
     async (ordered: CustomFieldDefinition[]) => {
@@ -202,28 +254,75 @@ const CustomFieldsManager = ({ projectIri, spaceName, isSpaceAdmin }: Props) => 
   );
 
   return (
-    <div className="space-y-4" data-testid="custom-fields-manager">
-      <div className="flex items-center justify-end gap-2">
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={() => setChangeLogOpen(true)}
-          data-testid="custom-fields-changelog"
-        >
-          <History className="mr-1 h-3.5 w-3.5" /> Change log
-        </Button>
-        {isSpaceAdmin && (
+    <div className="space-y-6" data-testid="custom-fields-manager">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-1.5">
+          <div className="flex items-center gap-2.5">
+            <h1 className="text-2xl font-bold">Custom fields</h1>
+            <Badge
+              variant="outline"
+              className="font-mono text-xs font-normal text-muted-foreground"
+            >
+              {slug} · {defs.length} {defs.length === 1 ? "field" : "fields"}
+            </Badge>
+          </div>
+          <p className="max-w-2xl text-sm text-muted-foreground">
+            Schema for every task in this project. Each field has a kind,
+            subtype, footer aggregation, and a required flag.
+            <br />
+            Only space admins can edit definitions.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
           <Button
             type="button"
+            variant="outline"
             size="sm"
-            onClick={openCreate}
-            data-testid="custom-field-add"
+            onClick={() => setChangeLogOpen(true)}
+            data-testid="custom-fields-changelog"
           >
-            <Plus className="mr-1 h-3.5 w-3.5" /> Add field
+            <History className="mr-1 h-3.5 w-3.5" /> Change log
           </Button>
-        )}
+          {isSpaceAdmin && (
+            <Button
+              type="button"
+              size="sm"
+              onClick={openCreate}
+              data-testid="custom-field-add"
+            >
+              <Plus className="mr-1 h-3.5 w-3.5" /> Add field
+            </Button>
+          )}
+        </div>
       </div>
+
+      {!noticeDismissed && (
+        <div className="flex items-center gap-3 rounded-lg border border-emerald-500/20 bg-emerald-500/5 px-4 py-3 text-sm">
+          <CircleCheck className="h-4 w-4 shrink-0 text-emerald-400" />
+          <p className="flex-1 text-muted-foreground">
+            {isSpaceAdmin ? (
+              <>
+                You&apos;re editing as a{" "}
+                <span className="font-medium text-foreground">space admin</span>.
+                Members in {spaceName ?? "this space"} can use these fields on
+                tasks but can&apos;t change definitions.
+              </>
+            ) : (
+              <>
+                Only space admins can edit definitions. You can use these fields
+                on tasks in {spaceName ?? "this space"}.
+              </>
+            )}
+          </p>
+          <button
+            type="button"
+            onClick={() => setNoticeDismissed(true)}
+            className="shrink-0 text-xs font-medium uppercase tracking-wide text-muted-foreground transition hover:text-foreground"
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
 
       {loadError && (
         <Alert variant="destructive">
@@ -263,7 +362,9 @@ const CustomFieldsManager = ({ projectIri, spaceName, isSpaceAdmin }: Props) => 
                 <TableHead>Required</TableHead>
                 <TableHead>Footer</TableHead>
                 <TableHead className="text-right">Filled</TableHead>
-                {isSpaceAdmin && <TableHead className="w-16 text-right">Actions</TableHead>}
+                {isSpaceAdmin && (
+                  <TableHead className="w-20 text-right">Actions</TableHead>
+                )}
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -285,6 +386,7 @@ const CustomFieldsManager = ({ projectIri, spaceName, isSpaceAdmin }: Props) => 
                       isSpaceAdmin={isSpaceAdmin}
                       draggable={isSpaceAdmin && defs.length > 1}
                       onEdit={() => openEdit(def)}
+                      onDuplicate={() => void handleDuplicate(def)}
                     />
                   ))}
                 </SortableContext>
@@ -320,6 +422,7 @@ const CustomFieldsManager = ({ projectIri, spaceName, isSpaceAdmin }: Props) => 
         valueCount={editingValueCount}
         onSaved={handleSaved}
         onDeleted={isSpaceAdmin ? handleDeleted : undefined}
+        onDuplicate={isSpaceAdmin ? handleDuplicate : undefined}
       />
 
       <CustomFieldChangeLog
@@ -338,6 +441,7 @@ const FieldRow = ({
   isSpaceAdmin,
   draggable,
   onEdit,
+  onDuplicate,
 }: {
   def: CustomFieldDefinition;
   total: number;
@@ -345,9 +449,11 @@ const FieldRow = ({
   isSpaceAdmin: boolean;
   draggable: boolean;
   onEdit: () => void;
+  onDuplicate: () => void;
 }) => {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({ id: def["@id"], disabled: !draggable });
+  const badge = KIND_BADGE[def.kind];
 
   return (
     <TableRow
@@ -370,29 +476,44 @@ const FieldRow = ({
         )}
       </TableCell>
       <TableCell>
-        <div className="font-medium" data-testid="custom-field-name">
-          {def.name}
-        </div>
-        <div className="font-mono text-xs text-muted-foreground">
-          {fieldHandle(def.name)}
+        <div className="flex items-baseline gap-2">
+          <span className="font-medium" data-testid="custom-field-name">
+            {def.name}
+          </span>
+          <span className="font-mono text-xs text-muted-foreground">
+            {fieldHandle(def.name)}
+          </span>
         </div>
       </TableCell>
       <TableCell>
-        <Badge variant="outline" className="font-normal">
+        <span
+          className={cn(
+            "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-medium",
+            badge.wrap,
+          )}
+        >
+          <span className={cn("h-1.5 w-1.5 rounded-full", badge.dot)} />
           {kindLabelFor(def.kind).toLowerCase()} ·{" "}
           {subtypeLabelFor(def.kind, def.subtype).toLowerCase()}
-        </Badge>
+        </span>
       </TableCell>
       <TableCell>
         {def.nullable ? (
-          <span className="text-sm text-muted-foreground">Optional</span>
+          <span className="inline-flex items-center gap-1.5 rounded-full border border-input bg-muted/40 px-2.5 py-0.5 text-xs text-muted-foreground">
+            <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/50" />
+            Optional
+          </span>
         ) : (
-          <Badge variant="secondary">Required</Badge>
+          <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-0.5 text-xs font-medium text-emerald-300">
+            <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
+            Required
+          </span>
         )}
       </TableCell>
       <TableCell>
         {def.footer ? (
-          <span className="text-sm font-medium uppercase">
+          <span className="inline-flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            <span className="h-3.5 w-3.5 rounded-[3px] border border-muted-foreground/40" />
             {def.footer.kind}
           </span>
         ) : (
@@ -400,20 +521,34 @@ const FieldRow = ({
         )}
       </TableCell>
       <TableCell className="text-right tabular-nums text-sm text-muted-foreground">
-        {filled}/{total}
+        {filled} / {total}
       </TableCell>
       {isSpaceAdmin && (
         <TableCell className="text-right">
-          <Button
-            type="button"
-            size="sm"
-            variant="ghost"
-            onClick={onEdit}
-            aria-label={`Edit ${def.name}`}
-            data-testid="custom-field-edit"
-          >
-            <Pencil className="h-3.5 w-3.5" />
-          </Button>
+          <div className="flex items-center justify-end gap-0.5">
+            <Button
+              type="button"
+              size="icon"
+              variant="ghost"
+              className="h-8 w-8"
+              onClick={onEdit}
+              aria-label={`Edit ${def.name}`}
+              data-testid="custom-field-edit"
+            >
+              <Settings className="h-3.5 w-3.5" />
+            </Button>
+            <Button
+              type="button"
+              size="icon"
+              variant="ghost"
+              className="h-8 w-8"
+              onClick={onDuplicate}
+              aria-label={`Duplicate ${def.name}`}
+              data-testid="custom-field-duplicate"
+            >
+              <Copy className="h-3.5 w-3.5" />
+            </Button>
+          </div>
         </TableCell>
       )}
     </TableRow>

--- a/pwa/components/custom-fields/handle.ts
+++ b/pwa/components/custom-fields/handle.ts
@@ -1,6 +1,6 @@
 /**
  * Cosmetic display handle for a custom field, derived from its name
- * (`Brief URL` → `cf-brief-url`). Purely a UI affordance — the API keys
+ * (`Brief URL` → `cfd-brief-url`). Purely a UI affordance — the API keys
  * fields by UUID, not by handle — so it's safe that two same-named fields
  * would collide. Used in the field table and the editor sheet header.
  */
@@ -10,5 +10,5 @@ export const fieldHandle = (name: string): string => {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
-  return slug ? `cf-${slug}` : "cf-…";
+  return slug ? `cfd-${slug}` : "cfd-…";
 };

--- a/pwa/components/custom-fields/kind-editors.tsx
+++ b/pwa/components/custom-fields/kind-editors.tsx
@@ -13,7 +13,7 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { Check, GripVertical, Plus, X } from "lucide-react";
+import { Check, GripVertical, Info, Plus, X } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
@@ -150,6 +150,67 @@ export const subtypeLabelFor = (
 ): string =>
   KIND_DESCRIPTORS[kind]?.subtypes.find((s) => s.value === subtype)?.label ??
   subtype;
+
+/**
+ * Per-kind accent palette for the KIND pill (field table) and the
+ * descriptor dot (sheet). Tailwind needs static class strings, so each
+ * kind enumerates its full set rather than interpolating a color name.
+ */
+export const KIND_BADGE: Record<
+  CustomFieldKind,
+  { wrap: string; dot: string }
+> = {
+  text: { wrap: "border-amber-500/30 bg-amber-500/10 text-amber-300", dot: "bg-amber-400" },
+  numeric: { wrap: "border-rose-500/30 bg-rose-500/10 text-rose-300", dot: "bg-rose-400" },
+  date: { wrap: "border-sky-500/30 bg-sky-500/10 text-sky-300", dot: "bg-sky-400" },
+  boolean: { wrap: "border-violet-500/30 bg-violet-500/10 text-violet-300", dot: "bg-violet-400" },
+  select: { wrap: "border-emerald-500/30 bg-emerald-500/10 text-emerald-300", dot: "bg-emerald-400" },
+  reference: { wrap: "border-teal-500/30 bg-teal-500/10 text-teal-300", dot: "bg-teal-400" },
+};
+
+/**
+ * `CONFIG · KIND · SUBTYPE` section label shown above the per-kind editor.
+ * The subtype segment is dropped when it duplicates the kind (e.g. a
+ * `date.date` field reads `CONFIG · DATE`, not `CONFIG · DATE · DATE`).
+ */
+export const configSectionLabel = (
+  kind: CustomFieldKind,
+  subtype: CustomFieldSubtype,
+): string => {
+  const parts = [kind.toUpperCase()];
+  if (subtype.toLowerCase() !== kind.toLowerCase()) {
+    parts.push(subtype.toUpperCase());
+  }
+  return `CONFIG · ${parts.join(" · ")}`;
+};
+
+/**
+ * Hue angle (0–360°) of an sRGB hex color in the OKLCH space, rounded to
+ * a whole degree — surfaced as `oklch · {hue}°` next to each select
+ * option swatch so admins can tell two similar swatches apart. Returns
+ * null for an unparseable hex.
+ */
+export const hexToOklchHue = (hex: string): number | null => {
+  const match = /^#?([0-9a-f]{6})$/i.exec(hex.trim());
+  if (!match) return null;
+  const int = parseInt(match[1], 16);
+  const toLinear = (c: number) =>
+    c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  const r = toLinear(((int >> 16) & 255) / 255);
+  const g = toLinear(((int >> 8) & 255) / 255);
+  const b = toLinear((int & 255) / 255);
+  const l = 0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b;
+  const m = 0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b;
+  const s = 0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b;
+  const lc = Math.cbrt(l);
+  const mc = Math.cbrt(m);
+  const sc = Math.cbrt(s);
+  const oa = 1.9779984951 * lc - 2.428592205 * mc + 0.4505937099 * sc;
+  const ob = 0.0259040371 * lc + 0.7827717662 * mc - 0.808675766 * sc;
+  let hue = (Math.atan2(ob, oa) * 180) / Math.PI;
+  if (hue < 0) hue += 360;
+  return Math.round(hue);
+};
 
 /**
  * Target-type cards for the reference editor. Selecting a card changes
@@ -295,34 +356,52 @@ const TextEditor = ({
   update,
 }: SubEditorProps & { subtype: CustomFieldSubtype }) => (
   <div className="space-y-3">
-    <div className="grid grid-cols-2 gap-3">
-      <NumberField
-        id="cf-text-min"
-        label="Min length"
-        value={config.minLength}
-        onChange={(v) => update({ minLength: v })}
-      />
-      <NumberField
-        id="cf-text-max"
-        label="Max length"
-        value={config.maxLength}
-        onChange={(v) => update({ maxLength: v })}
-      />
+    <div className="space-y-1.5">
+      <Label htmlFor="cf-text-max">Max length</Label>
+      <div className="relative">
+        <Input
+          id="cf-text-max"
+          type="number"
+          value={config.maxLength !== undefined ? String(config.maxLength) : ""}
+          onChange={(e) => {
+            const v = e.target.value;
+            if (v === "") {
+              update({ maxLength: undefined });
+              return;
+            }
+            const parsed = Number(v);
+            if (Number.isFinite(parsed)) update({ maxLength: parsed });
+          }}
+          className="pr-14"
+        />
+        <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-xs text-muted-foreground">
+          chars
+        </span>
+      </div>
     </div>
     <div className="space-y-1.5">
-      <Label htmlFor="cf-text-pattern">
-        Pattern{" "}
-        <span className="text-muted-foreground text-xs">(regex, optional)</span>
+      <Label htmlFor="cf-text-pattern" className="flex items-baseline gap-2">
+        Pattern
+        <span className="text-xs font-normal text-muted-foreground">
+          JS-style RegExp · optional
+        </span>
       </Label>
-      <Input
-        id="cf-text-pattern"
-        value={config.pattern ?? ""}
-        onChange={(e) =>
-          update({ pattern: e.target.value === "" ? undefined : e.target.value })
-        }
-        placeholder={subtype === "url" ? "^https?://" : "^[A-Z]{2,}$"}
-        data-testid="custom-field-pattern-input"
-      />
+      <div className="flex items-center gap-1.5 rounded-md border border-input bg-background px-2 focus-within:ring-2 focus-within:ring-ring">
+        <span className="font-mono text-sm text-muted-foreground">/</span>
+        <input
+          id="cf-text-pattern"
+          value={config.pattern ?? ""}
+          onChange={(e) =>
+            update({
+              pattern: e.target.value === "" ? undefined : e.target.value,
+            })
+          }
+          placeholder={subtype === "url" ? "^https?://" : "^[A-Z]{2,}$"}
+          className="flex-1 bg-transparent py-2 font-mono text-sm outline-none placeholder:text-muted-foreground/60"
+          data-testid="custom-field-pattern-input"
+        />
+        <span className="font-mono text-sm text-muted-foreground">/</span>
+      </div>
     </div>
     {config.pattern && (
       <PatternCheck pattern={config.pattern} isUrl={subtype === "url"} />
@@ -507,10 +586,13 @@ const DateEditor = ({
         onChange={(v) => update({ max: v === "" ? undefined : v })}
       />
     </div>
-    <p className="text-xs text-muted-foreground">
-      Values outside this range are rejected at save time. Leave a bound
-      empty to disable the check on that side.
-    </p>
+    <div className="flex gap-2 rounded-md border border-input bg-muted/30 p-3 text-xs text-muted-foreground">
+      <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+      <p>
+        Values outside this range are rejected with a row-level error. Empty
+        bounds disable the check on that side.
+      </p>
+    </div>
   </div>
 );
 
@@ -654,7 +736,12 @@ const SelectEditor = ({
 
   return (
     <div className="space-y-2" data-testid="custom-field-options">
-      <Label>Options</Label>
+      <Label className="flex items-baseline gap-2">
+        Options
+        <span className="text-xs font-normal text-muted-foreground">
+          Drag to reorder
+        </span>
+      </Label>
       <DndContext
         sensors={sensors}
         collisionDetection={closestCenter}
@@ -726,6 +813,7 @@ const SortableOptionRow = ({
     useSortable({ id: String(index) });
   const [colorOpen, setColorOpen] = useState(false);
   const color = option.color ?? AVATAR_PALETTE[0];
+  const hue = hexToOklchHue(color);
 
   return (
     <div
@@ -772,6 +860,11 @@ const SortableOptionRow = ({
         aria-label={`Option ${index + 1}`}
         data-testid="custom-field-option-input"
       />
+      {hue !== null && (
+        <span className="shrink-0 font-mono text-xs text-muted-foreground tabular-nums">
+          oklch · {hue}°
+        </span>
+      )}
       {typeof usage === "number" && (
         <Badge variant="secondary" className="shrink-0 tabular-nums">
           {usage}

--- a/pwa/pages/dev/components/custom-fields-manager.tsx
+++ b/pwa/pages/dev/components/custom-fields-manager.tsx
@@ -11,6 +11,8 @@ const CustomFieldsManagerPage = () => (
         title: "Live manager (read-only demo)",
         code: `<CustomFieldsManager
   projectIri="/projects/<uuid>"
+  projectTitle="Spring Collection Launch"
+  spaceName="Acme Marketing"
   isSpaceAdmin={true}
 />`,
         // Rendering the live manager here would issue a network call

--- a/pwa/pages/projects/[id]/custom-fields.tsx
+++ b/pwa/pages/projects/[id]/custom-fields.tsx
@@ -151,23 +151,6 @@ const CustomFieldsPage = () => {
                     <span className="text-foreground">Custom fields</span>
                   </nav>
 
-                  <div className="space-y-1">
-                    <h1 className="text-2xl font-bold">Custom fields</h1>
-                    <p className="text-sm text-muted-foreground">
-                      Schema for every task in this project. Each field has a
-                      kind, subtype, footer aggregation, and a required flag.
-                      Only space admins can edit definitions.
-                    </p>
-                  </div>
-
-                  <Alert>
-                    <AlertDescription>
-                      {isSpaceAdmin
-                        ? `You're editing as a space admin. Members in ${space?.name ?? "this space"} can use these fields on tasks but can't change definitions.`
-                        : `Only space admins can edit definitions. You can use these fields on tasks in ${space?.name ?? "this space"}.`}
-                    </AlertDescription>
-                  </Alert>
-
                   {error && (
                     <Alert variant="destructive">
                       <AlertDescription>{error}</AlertDescription>
@@ -176,6 +159,7 @@ const CustomFieldsPage = () => {
 
                   <CustomFieldsManager
                     projectIri={project["@id"]}
+                    projectTitle={project.title}
                     spaceName={space?.name}
                     isSpaceAdmin={isSpaceAdmin}
                   />


### PR DESCRIPTION
Reworks the per-project **Custom fields** management surface to match the new design mocks. First slice of a broader custom-fields + tasks redesign — the Tasks page lands in a follow-up on this branch.

## Custom fields page
- **Manager header**: title + `<slug> · N fields` badge, dismissible space-admin notice, `Change log` / `Add field` actions
- **Table**: color-coded KIND pills (per-kind dot), green `Required` / muted `Optional` pills, footer-function glyph + uppercase label, `N / M` filled, gear (edit) **+ duplicate** row actions, inline `cfd-` handle
- **Sheet**: `EDIT FIELD cfd-…` / `NEW FIELD` header with kind dot + duplicate overflow menu; kind/subtype descriptor line (`nullable = …`); `CONFIG · KIND · SUBTYPE` section header; footer `Function` dropdown + `Label override` + available-function pills; select `Allow multi-select` toggle
- **Editors**: date row-range helper box, text/url single max-length (`chars`) + `/regex/`-delimited pattern field, per-option `oklch · {hue}°` readout

## Notes
- Field duplication is **client-side** (copy POST) — there's no copy endpoint
- Handle prefix changed `cf-` → `cfd-` to match the mocks
- Kept option **usage counts** alongside the new oklch readout; dropped text **min-length** from the editor (URL mock shows max-length only — existing values are preserved, not cleared)
- KIND colors derived from the mock hues
- All e2e `data-testid`s and the `selectOption`-driven native `<select>`s are preserved