### PR TITLE
feat: tasks-page redesign — rich recurrence/reminders, drawer + list

### DIFF
--- a/api/migrations/Version20260613130000.php
+++ b/api/migrations/Version20260613130000.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Convert the legacy `task.reminders` allow-list of offset strings
+ * (`"15m"`, `"1h"`, `"1d"`) into the expanded reminder-object model
+ * (#227 tasks redesign):
+ *
+ *   "15m" → {type:"relative", value:15, unit:"minutes", repeat:false}
+ *   "1h"  → {type:"relative", value:1,  unit:"hours",   repeat:false}
+ *   "1d"  → {type:"relative", value:1,  unit:"days",    repeat:false}
+ *
+ * The column is already `json`, so there's no schema change — this is a
+ * pure data conversion (no-op when no rows have reminders). Unknown legacy
+ * strings are dropped; a row that ends up with no reminders is set to NULL.
+ */
+final class Version20260613130000 extends AbstractMigration
+{
+    private const MAP = [
+        '15m' => ['type' => 'relative', 'value' => 15, 'unit' => 'minutes', 'repeat' => false],
+        '1h' => ['type' => 'relative', 'value' => 1, 'unit' => 'hours', 'repeat' => false],
+        '1d' => ['type' => 'relative', 'value' => 1, 'unit' => 'days', 'repeat' => false],
+    ];
+
+    public function getDescription(): string
+    {
+        return 'Convert task.reminders offset strings to expanded reminder objects.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT id, reminders FROM task WHERE reminders IS NOT NULL',
+        );
+        foreach ($rows as $row) {
+            $raw = $row['reminders'];
+            $decoded = is_string($raw) ? json_decode($raw, true) : $raw;
+            if (!is_array($decoded)) {
+                continue;
+            }
+
+            $converted = [];
+            foreach ($decoded as $entry) {
+                if (is_array($entry)) {
+                    // Already an object (re-run / mixed data) — keep as-is.
+                    $converted[] = $entry;
+                } elseif (is_string($entry) && isset(self::MAP[$entry])) {
+                    $converted[] = self::MAP[$entry];
+                }
+            }
+
+            $this->connection->executeStatement(
+                'UPDATE task SET reminders = :reminders WHERE id = :id',
+                [
+                    'reminders' => [] === $converted ? null : json_encode($converted, JSON_THROW_ON_ERROR),
+                    'id' => $row['id'],
+                ],
+            );
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Best-effort reverse: relative reminders that map back to a legacy
+        // offset become their string; everything else is dropped.
+        $reverse = [
+            'relative:15:minutes' => '15m',
+            'relative:1:hours' => '1h',
+            'relative:1:days' => '1d',
+        ];
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT id, reminders FROM task WHERE reminders IS NOT NULL',
+        );
+        foreach ($rows as $row) {
+            $raw = $row['reminders'];
+            $decoded = is_string($raw) ? json_decode($raw, true) : $raw;
+            if (!is_array($decoded)) {
+                continue;
+            }
+            $offsets = [];
+            foreach ($decoded as $entry) {
+                if (!is_array($entry) || ($entry['type'] ?? null) !== 'relative') {
+                    continue;
+                }
+                $key = sprintf('relative:%s:%s', $entry['value'] ?? '', $entry['unit'] ?? '');
+                if (isset($reverse[$key])) {
+                    $offsets[] = $reverse[$key];
+                }
+            }
+            $this->connection->executeStatement(
+                'UPDATE task SET reminders = :reminders WHERE id = :id',
+                [
+                    'reminders' => [] === $offsets ? null : json_encode($offsets, JSON_THROW_ON_ERROR),
+                    'id' => $row['id'],
+                ],
+            );
+        }
+    }
+}

--- a/api/migrations/Version20260613140000.php
+++ b/api/migrations/Version20260613140000.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Widen notification.reminder_offset from 16 to 80 chars. The expanded
+ * reminder model (#227) stores a per-fire key here — absolute reminders
+ * encode an ISO-8601 timestamp and "repeat daily" reminders append the fire
+ * date, both of which overflow the old 16-char column.
+ */
+final class Version20260613140000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Widen notification.reminder_offset to 80 chars for the expanded reminder keys.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE notification ALTER COLUMN reminder_offset TYPE VARCHAR(80)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE notification ALTER COLUMN reminder_offset TYPE VARCHAR(16)');
+    }
+}

--- a/api/src/Controller/RecurrencePreviewController.php
+++ b/api/src/Controller/RecurrencePreviewController.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Entity\User;
+use App\Service\RecurrenceCalculator;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+
+/**
+ * `POST /recurrence-preview` — computes the next occurrence dates for a
+ * candidate recurrence rule so the editor can render its "next N
+ * occurrences" preview without persisting anything. Delegates to the same
+ * {@see RecurrenceCalculator} the spawn logic uses, so the preview can
+ * never disagree with what completing the task would actually create.
+ *
+ * Body: `{ "dueDate": ISO-8601, "rule": {…}, "count": int? }`.
+ * Response: `{ "occurrences": [ISO-8601, …] }`.
+ *
+ * A malformed rule or missing due date yields an empty list rather than an
+ * error — the preview is advisory, and the real validation happens on save.
+ */
+final class RecurrencePreviewController extends AbstractController
+{
+    private const MAX_PREVIEW = 10;
+
+    public function __construct(
+        private readonly RecurrenceCalculator $recurrence,
+    ) {
+    }
+
+    #[Route('/recurrence-preview', name: 'recurrence_preview', methods: ['POST'])]
+    public function __invoke(Request $request, #[CurrentUser] ?User $user): Response
+    {
+        if (null === $user) {
+            return new JsonResponse(['error' => 'Not authenticated.'], 401);
+        }
+
+        $payload = $request->toArray();
+        $rule = $payload['rule'] ?? null;
+        $dueRaw = $payload['dueDate'] ?? null;
+        $count = $payload['count'] ?? 3;
+
+        $limit = is_int($count) ? max(1, min(self::MAX_PREVIEW, $count)) : 3;
+
+        if (!is_array($rule) || !is_string($dueRaw) || '' === $dueRaw) {
+            return new JsonResponse(['occurrences' => []]);
+        }
+
+        try {
+            $due = new \DateTimeImmutable($dueRaw);
+        } catch (\Exception) {
+            return new JsonResponse(['occurrences' => []]);
+        }
+
+        // Cap the preview at the remaining future occurrences for a
+        // count-based end (count counts the anchor itself).
+        $ends = $rule['ends'] ?? null;
+        if (is_array($ends) && ($ends['type'] ?? null) === 'count') {
+            $total = is_int($ends['count'] ?? null) ? $ends['count'] : 1;
+            $limit = max(0, min($limit, $total - 1));
+        }
+
+        $occurrences = $this->recurrence->nextOccurrences($due, $rule, $limit);
+
+        return new JsonResponse([
+            'occurrences' => array_map(
+                static fn (\DateTimeImmutable $d): string => $d->format(\DateTimeInterface::ATOM),
+                $occurrences,
+            ),
+        ]);
+    }
+}

--- a/api/src/Entity/Notification.php
+++ b/api/src/Entity/Notification.php
@@ -133,11 +133,14 @@ class Notification
     private ?Task $task = null;
 
     /**
-     * Reminder offset string (e.g. "15m", "1h", "1d") this row was created
-     * for. Used together with (recipient, task) as a uniqueness key so the
-     * dispatcher can be re-run safely without producing duplicate rows.
+     * Per-fire reminder key this row was created for — produced by
+     * {@see \App\Service\ReminderScheduler::dueFires()} (e.g.
+     * "rel:15:minutes", "abs:2026-06-01T09:00:00+00:00", or a "repeat daily"
+     * variant suffixed with the fire date). Used together with
+     * (recipient, task) as a uniqueness key so the dispatcher can be re-run
+     * safely without producing duplicate rows.
      */
-    #[ORM\Column(length: 16, nullable: true)]
+    #[ORM\Column(length: 80, nullable: true)]
     private ?string $reminderOffset = null;
 
     /**

--- a/api/src/Entity/Task.php
+++ b/api/src/Entity/Task.php
@@ -174,8 +174,10 @@ class Task
      * (`{type:"absolute", at:ISO-8601, repeat:bool}`, fired at a fixed time).
      * `repeat` means "repeat daily until done". Empty array and null are
      * equivalent — both mean "no reminders". Validated by {@see ValidReminders}.
+     * Typed loosely (`list<mixed>`) because the JSON payload isn't shape-checked
+     * until the validator runs — entries are guarded with `is_array()` there.
      *
-     * @var list<array<string, mixed>>|null
+     * @var list<mixed>|null
      */
     #[ORM\Column(type: 'json', nullable: true)]
     #[Groups(['task:read', 'task:write'])]
@@ -380,7 +382,7 @@ class Task
     }
 
     /**
-     * @return list<array<string, mixed>>|null
+     * @return list<mixed>|null
      */
     public function getReminders(): ?array
     {
@@ -388,7 +390,7 @@ class Task
     }
 
     /**
-     * @param list<array<string, mixed>>|null $reminders
+     * @param list<mixed>|null $reminders
      */
     public function setReminders(?array $reminders): static
     {

--- a/api/src/Entity/Task.php
+++ b/api/src/Entity/Task.php
@@ -395,8 +395,9 @@ class Task
     public function setReminders(?array $reminders): static
     {
         // Normalise empty array to null so we have one canonical "no
-        // reminders" representation for downstream queries.
-        $this->reminders = (null === $reminders || [] === $reminders) ? null : array_values($reminders);
+        // reminders" representation for downstream queries. Input is already
+        // a list, so no array_values reindex is needed.
+        $this->reminders = (null === $reminders || [] === $reminders) ? null : $reminders;
         return $this;
     }
 

--- a/api/src/Entity/Task.php
+++ b/api/src/Entity/Task.php
@@ -152,27 +152,30 @@ class Task
     private ?\DateTimeImmutable $dueDate = null;
 
     /**
-     * Optional recurrence rule. Persisted as a JSON object with shape
-     * `{"frequency": "daily"|"weekly"|"monthly"|"yearly", "interval": int}`.
-     * Validated in detail by {@see ValidRecurrence}; the cross-field rule
-     * (recurrence requires a due date) lives there too. When set, completing
-     * the task triggers {@see TaskUpdateProcessor} to clone the next
-     * occurrence with `dueDate` advanced by the rule.
+     * Optional recurrence rule. Persisted as a JSON object. The base shape is
+     * `{"frequency": "daily"|"weekly"|"monthly"|"yearly", "interval": int}`,
+     * optionally extended with `byDay` (weekday tokens), `monthlyMode`,
+     * `bySetPos`, and an `ends` end-condition — see
+     * {@see \App\Service\RecurrenceCalculator} for the full shape. Validated
+     * by {@see ValidRecurrence} (and the cross-field rule that recurrence
+     * requires a due date). When set, completing the task triggers
+     * {@see TaskUpdateProcessor} to clone the next occurrence.
      *
-     * @var array{frequency: string, interval: int}|null
+     * @var array<string, mixed>|null
      */
     #[ORM\Column(type: 'json', nullable: true)]
     #[Groups(['task:read', 'task:write'])]
     private ?array $recurrenceRule = null;
 
     /**
-     * Reminder offsets to fire ahead of the due date. Each item is one of
-     * the strings in {@see ValidReminders::ALLOWED_OFFSETS} (e.g. "15m",
-     * "1h", "1d"). Empty array and null are equivalent — both mean "no
-     * reminders". Validated by {@see ValidReminders}, which also enforces
-     * the cross-field rule that reminders need a due date.
+     * Reminders to fire around the due date. Each entry is an object — either
+     * relative (`{type:"relative", value:int, unit:"minutes"|"hours"|"days",
+     * repeat:bool}`, fired `value` units before the due date) or absolute
+     * (`{type:"absolute", at:ISO-8601, repeat:bool}`, fired at a fixed time).
+     * `repeat` means "repeat daily until done". Empty array and null are
+     * equivalent — both mean "no reminders". Validated by {@see ValidReminders}.
      *
-     * @var string[]|null
+     * @var list<array<string, mixed>>|null
      */
     #[ORM\Column(type: 'json', nullable: true)]
     #[Groups(['task:read', 'task:write'])]
@@ -360,7 +363,7 @@ class Task
     }
 
     /**
-     * @return array{frequency: string, interval: int}|null
+     * @return array<string, mixed>|null
      */
     public function getRecurrenceRule(): ?array
     {
@@ -368,7 +371,7 @@ class Task
     }
 
     /**
-     * @param array{frequency: string, interval: int}|null $recurrenceRule
+     * @param array<string, mixed>|null $recurrenceRule
      */
     public function setRecurrenceRule(?array $recurrenceRule): static
     {
@@ -377,7 +380,7 @@ class Task
     }
 
     /**
-     * @return string[]|null
+     * @return list<array<string, mixed>>|null
      */
     public function getReminders(): ?array
     {
@@ -385,7 +388,7 @@ class Task
     }
 
     /**
-     * @param string[]|null $reminders
+     * @param list<array<string, mixed>>|null $reminders
      */
     public function setReminders(?array $reminders): static
     {

--- a/api/src/Service/RecurrenceCalculator.php
+++ b/api/src/Service/RecurrenceCalculator.php
@@ -43,7 +43,7 @@ final class RecurrenceCalculator
      *
      * @param array<array-key, mixed> $rule
      *
-     * @return \DateTimeImmutable[]
+     * @return list<\DateTimeImmutable>
      */
     public function nextOccurrences(\DateTimeImmutable $after, array $rule, int $limit): array
     {

--- a/api/src/Service/RecurrenceCalculator.php
+++ b/api/src/Service/RecurrenceCalculator.php
@@ -1,0 +1,277 @@
+<?php
+
+namespace App\Service;
+
+/**
+ * Computes the next due dates for a task recurrence rule (#227 tasks
+ * redesign). Shared by {@see \App\State\TaskUpdateProcessor} (spawns the
+ * single next occurrence when a recurring task is completed) and
+ * {@see \App\Controller\RecurrencePreviewController} (renders the "next N
+ * occurrences" preview in the editor) so the preview can never disagree
+ * with what actually gets created.
+ *
+ * Rule shape (all keys but frequency/interval are optional, so legacy
+ * `{frequency, interval}` rows keep working):
+ *
+ *   {
+ *     "frequency": "daily"|"weekly"|"monthly"|"yearly",
+ *     "interval":  int >= 1,
+ *     "byDay":     ["MO","WE","FR"],     // weekly: which weekdays fire;
+ *                                        // monthly+weekday: the single weekday
+ *     "monthlyMode": "day"|"weekday",    // monthly only; default "day"
+ *     "bySetPos":  int (1..5 | -1),      // monthly+weekday: which week
+ *     "ends": {                          // absent/null => never ends
+ *       "type": "until"|"count",
+ *       "until": "YYYY-MM-DD",           // type=until
+ *       "count": int >= 1                // type=count: total occurrences
+ *     }
+ *   }
+ */
+final class RecurrenceCalculator
+{
+    /** ISO-8601 weekday number (1=Mon … 7=Sun) keyed by RRULE day token. */
+    private const WEEKDAY_NUMBERS = [
+        'MO' => 1, 'TU' => 2, 'WE' => 3, 'TH' => 4, 'FR' => 5, 'SA' => 6, 'SU' => 7,
+    ];
+
+    /**
+     * Returns the occurrence dates strictly after `$after`, in ascending
+     * order, capped at `$limit`. Honours an `until` end bound (inclusive).
+     * `count`-based ends are NOT applied here — the caller tracks remaining
+     * occurrences via the rule's `ends.count` and stops spawning itself, so
+     * the preview can pass the remaining count as `$limit`.
+     *
+     * @param array<string, mixed> $rule
+     *
+     * @return \DateTimeImmutable[]
+     */
+    public function nextOccurrences(\DateTimeImmutable $after, array $rule, int $limit): array
+    {
+        if ($limit < 1) {
+            return [];
+        }
+        $frequency = is_string($rule['frequency'] ?? null) ? $rule['frequency'] : '';
+        $interval = max(1, is_int($rule['interval'] ?? null) ? $rule['interval'] : 1);
+        $until = $this->parseUntil($rule);
+
+        $out = [];
+        $generator = match ($frequency) {
+            'daily' => $this->dailyDates($after, $interval),
+            'weekly' => $this->weeklyDates($after, $interval, $this->byDayNumbers($rule)),
+            'monthly' => $this->monthlyDates($after, $interval, $rule),
+            'yearly' => $this->yearlyDates($after, $interval),
+            default => [],
+        };
+
+        foreach ($generator as $date) {
+            if (null !== $until && $date > $until) {
+                break;
+            }
+            $out[] = $date;
+            if (count($out) >= $limit) {
+                break;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * The single next due date after `$current`, or null when the series has
+     * ended (past `until`, or generation produced nothing). Count-based
+     * limits are the caller's concern.
+     *
+     * @param array<string, mixed> $rule
+     */
+    public function nextDueDate(\DateTimeImmutable $current, array $rule): ?\DateTimeImmutable
+    {
+        return $this->nextOccurrences($current, $rule, 1)[0] ?? null;
+    }
+
+    /**
+     * @param array<string, mixed> $rule
+     *
+     * @return \Generator<int, \DateTimeImmutable>
+     */
+    private function dailyDates(\DateTimeImmutable $after, int $interval): \Generator
+    {
+        $cursor = $after;
+        // A generous upper bound stops a pathological rule from looping
+        // forever; callers always cap with $limit well below this.
+        for ($i = 0; $i < 3660; ++$i) {
+            $cursor = $cursor->modify(sprintf('+%d days', $interval));
+            yield $cursor;
+        }
+    }
+
+    private function yearlyDates(\DateTimeImmutable $after, int $interval): \Generator
+    {
+        $cursor = $after;
+        for ($i = 0; $i < 200; ++$i) {
+            $cursor = $cursor->modify(sprintf('+%d years', $interval));
+            yield $cursor;
+        }
+    }
+
+    /**
+     * Weekly recurrence with an optional weekday set. With no `byDay` the
+     * rule simply advances whole weeks off the anchor. With a `byDay`, every
+     * selected weekday fires within each active week, and (interval-1) weeks
+     * are skipped between active weeks (WKST = Monday).
+     *
+     * @param int[] $byDay ISO weekday numbers (1..7)
+     *
+     * @return \Generator<int, \DateTimeImmutable>
+     */
+    private function weeklyDates(\DateTimeImmutable $after, int $interval, array $byDay): \Generator
+    {
+        if ([] === $byDay) {
+            $cursor = $after;
+            for ($i = 0; $i < 520; ++$i) {
+                $cursor = $cursor->modify(sprintf('+%d weeks', $interval));
+                yield $cursor;
+            }
+            return;
+        }
+
+        sort($byDay);
+        // Monday of the anchor's week.
+        $anchorDow = (int) $after->format('N');
+        $weekStart = $after->modify(sprintf('-%d days', $anchorDow - 1))->setTime(
+            (int) $after->format('H'),
+            (int) $after->format('i'),
+            (int) $after->format('s'),
+        );
+
+        for ($w = 0; $w < 520; ++$w) {
+            $base = $weekStart->modify(sprintf('+%d weeks', $w * $interval));
+            foreach ($byDay as $dow) {
+                $date = $base->modify(sprintf('+%d days', $dow - 1));
+                if ($date > $after) {
+                    yield $date;
+                }
+            }
+        }
+    }
+
+    /**
+     * Monthly recurrence in one of two modes:
+     *  - "day": same day-of-month as the anchor, stepping `interval` months
+     *    (PHP's calendar-aware modify handles short months).
+     *  - "weekday": the Nth weekday of the month (bySetPos + byDay[0]), e.g.
+     *    "2nd Thursday"; -1 means the last such weekday.
+     *
+     * @param array<string, mixed> $rule
+     *
+     * @return \Generator<int, \DateTimeImmutable>
+     */
+    private function monthlyDates(\DateTimeImmutable $after, int $interval, array $rule): \Generator
+    {
+        $mode = ($rule['monthlyMode'] ?? 'day') === 'weekday' ? 'weekday' : 'day';
+
+        if ('day' === $mode) {
+            $cursor = $after;
+            for ($i = 0; $i < 600; ++$i) {
+                $cursor = $cursor->modify(sprintf('+%d months', $interval));
+                yield $cursor;
+            }
+            return;
+        }
+
+        $byDay = $this->byDayNumbers($rule);
+        $weekday = $byDay[0] ?? (int) $after->format('N');
+        $setPos = is_int($rule['bySetPos'] ?? null) ? $rule['bySetPos'] : 1;
+        $hour = (int) $after->format('H');
+        $minute = (int) $after->format('i');
+        $second = (int) $after->format('s');
+
+        // Walk month-by-month from the anchor's month; only emit when the
+        // computed date is strictly after the anchor.
+        $monthCursor = $after->modify('first day of this month')->setTime(0, 0);
+        for ($i = 0; $i < 600; ++$i) {
+            $date = $this->nthWeekdayOfMonth($monthCursor, $weekday, $setPos);
+            if (null !== $date) {
+                $date = $date->setTime($hour, $minute, $second);
+                if ($date > $after) {
+                    yield $date;
+                }
+            }
+            $monthCursor = $monthCursor->modify(sprintf('+%d months', $interval));
+        }
+    }
+
+    /**
+     * The Nth (`$pos`: 1..5, or -1 for last) `$weekday` (ISO 1..7) within the
+     * month of `$monthFirstDay`. Returns null when the month has no such
+     * occurrence (e.g. a 5th Friday that doesn't exist).
+     */
+    private function nthWeekdayOfMonth(
+        \DateTimeImmutable $monthFirstDay,
+        int $weekday,
+        int $pos,
+    ): ?\DateTimeImmutable {
+        $first = $monthFirstDay->modify('first day of this month');
+        $daysInMonth = (int) $first->format('t');
+
+        $matches = [];
+        for ($day = 1; $day <= $daysInMonth; ++$day) {
+            $date = $first->setDate(
+                (int) $first->format('Y'),
+                (int) $first->format('n'),
+                $day,
+            );
+            if ((int) $date->format('N') === $weekday) {
+                $matches[] = $date;
+            }
+        }
+        if ([] === $matches) {
+            return null;
+        }
+        if (-1 === $pos) {
+            return $matches[count($matches) - 1];
+        }
+        $index = $pos - 1;
+        return $matches[$index] ?? null;
+    }
+
+    /**
+     * @param array<string, mixed> $rule
+     *
+     * @return int[]
+     */
+    private function byDayNumbers(array $rule): array
+    {
+        $byDay = $rule['byDay'] ?? null;
+        if (!is_array($byDay)) {
+            return [];
+        }
+        $out = [];
+        foreach ($byDay as $token) {
+            if (is_string($token) && isset(self::WEEKDAY_NUMBERS[$token])) {
+                $out[] = self::WEEKDAY_NUMBERS[$token];
+            }
+        }
+        return array_values(array_unique($out));
+    }
+
+    /**
+     * @param array<string, mixed> $rule
+     */
+    private function parseUntil(array $rule): ?\DateTimeImmutable
+    {
+        $ends = $rule['ends'] ?? null;
+        if (!is_array($ends) || ($ends['type'] ?? null) !== 'until') {
+            return null;
+        }
+        $until = $ends['until'] ?? null;
+        if (!is_string($until) || '' === $until) {
+            return null;
+        }
+        try {
+            // End-of-day so an occurrence falling on the until date counts.
+            return new \DateTimeImmutable($until . ' 23:59:59');
+        } catch (\Exception) {
+            return null;
+        }
+    }
+}

--- a/api/src/Service/RecurrenceCalculator.php
+++ b/api/src/Service/RecurrenceCalculator.php
@@ -60,8 +60,11 @@ final class RecurrenceCalculator
             'weekly' => $this->weeklyDates($after, $interval, $this->byDayNumbers($rule)),
             'monthly' => $this->monthlyDates($after, $interval, $rule),
             'yearly' => $this->yearlyDates($after, $interval),
-            default => [],
+            default => null,
         };
+        if (null === $generator) {
+            return [];
+        }
 
         foreach ($generator as $date) {
             if (null !== $until && $date > $until) {
@@ -102,6 +105,9 @@ final class RecurrenceCalculator
         }
     }
 
+    /**
+     * @return \Generator<int, \DateTimeImmutable>
+     */
     private function yearlyDates(\DateTimeImmutable $after, int $interval): \Generator
     {
         $cursor = $after;

--- a/api/src/Service/RecurrenceCalculator.php
+++ b/api/src/Service/RecurrenceCalculator.php
@@ -41,7 +41,7 @@ final class RecurrenceCalculator
      * occurrences via the rule's `ends.count` and stops spawning itself, so
      * the preview can pass the remaining count as `$limit`.
      *
-     * @param array<string, mixed> $rule
+     * @param array<array-key, mixed> $rule
      *
      * @return \DateTimeImmutable[]
      */
@@ -81,7 +81,7 @@ final class RecurrenceCalculator
      * ended (past `until`, or generation produced nothing). Count-based
      * limits are the caller's concern.
      *
-     * @param array<string, mixed> $rule
+     * @param array<array-key, mixed> $rule
      */
     public function nextDueDate(\DateTimeImmutable $current, array $rule): ?\DateTimeImmutable
     {
@@ -89,8 +89,6 @@ final class RecurrenceCalculator
     }
 
     /**
-     * @param array<string, mixed> $rule
-     *
      * @return \Generator<int, \DateTimeImmutable>
      */
     private function dailyDates(\DateTimeImmutable $after, int $interval): \Generator
@@ -161,7 +159,7 @@ final class RecurrenceCalculator
      *  - "weekday": the Nth weekday of the month (bySetPos + byDay[0]), e.g.
      *    "2nd Thursday"; -1 means the last such weekday.
      *
-     * @param array<string, mixed> $rule
+     * @param array<array-key, mixed> $rule
      *
      * @return \Generator<int, \DateTimeImmutable>
      */
@@ -235,7 +233,7 @@ final class RecurrenceCalculator
     }
 
     /**
-     * @param array<string, mixed> $rule
+     * @param array<array-key, mixed> $rule
      *
      * @return int[]
      */
@@ -255,7 +253,7 @@ final class RecurrenceCalculator
     }
 
     /**
-     * @param array<string, mixed> $rule
+     * @param array<array-key, mixed> $rule
      */
     private function parseUntil(array $rule): ?\DateTimeImmutable
     {

--- a/api/src/Service/ReminderScheduler.php
+++ b/api/src/Service/ReminderScheduler.php
@@ -20,7 +20,7 @@ final class ReminderScheduler
     /**
      * True when the entry is a well-formed relative or absolute reminder.
      *
-     * @param array<string, mixed> $reminder
+     * @param array<array-key, mixed> $reminder
      */
     public function isValidShape(array $reminder): bool
     {
@@ -50,7 +50,7 @@ final class ReminderScheduler
     /**
      * True when the reminder needs a due date to anchor to (relative only).
      *
-     * @param array<string, mixed> $reminder
+     * @param array<array-key, mixed> $reminder
      */
     public function requiresDueDate(array $reminder): bool
     {
@@ -61,7 +61,7 @@ final class ReminderScheduler
      * A stable identifier for the reminder, independent of any single fire.
      * Used to dedup the list and as the base of the per-fire notification key.
      *
-     * @param array<string, mixed> $reminder
+     * @param array<array-key, mixed> $reminder
      */
     public function canonicalKey(array $reminder): string
     {
@@ -87,7 +87,7 @@ final class ReminderScheduler
      * <= now (we don't backfill missed days — one catch-up is enough), keyed
      * with the fire date so each day is a distinct notification.
      *
-     * @param array<string, mixed> $reminder
+     * @param array<array-key, mixed> $reminder
      *
      * @return list<array{key: string, at: \DateTimeImmutable}>
      */
@@ -121,7 +121,7 @@ final class ReminderScheduler
     /**
      * Human-readable description for emails / notification bodies.
      *
-     * @param array<string, mixed> $reminder
+     * @param array<array-key, mixed> $reminder
      */
     public function describe(array $reminder): string
     {
@@ -147,7 +147,7 @@ final class ReminderScheduler
      * The reminder's base fire time: due − offset for relative, the fixed
      * timestamp for absolute. Null when a relative reminder has no due date.
      *
-     * @param array<string, mixed> $reminder
+     * @param array<array-key, mixed> $reminder
      */
     private function anchorTime(array $reminder, ?\DateTimeImmutable $due): ?\DateTimeImmutable
     {

--- a/api/src/Service/ReminderScheduler.php
+++ b/api/src/Service/ReminderScheduler.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace App\Service;
+
+use App\Validator\ValidReminders;
+
+/**
+ * Shared reminder logic for the expanded reminder model (#227 tasks
+ * redesign). One place computes a reminder's canonical key (dedup +
+ * idempotency) and its fire times, so the validator
+ * ({@see \App\Validator\ValidRemindersValidator}) and the dispatcher
+ * ({@see TaskReminderDispatcher}) can never drift apart.
+ *
+ * Reminder entries are objects:
+ *  - relative: {type:"relative", value:int>=0, unit:"minutes"|"hours"|"days", repeat:bool}
+ *  - absolute: {type:"absolute", at:ISO-8601, repeat:bool}
+ */
+final class ReminderScheduler
+{
+    /**
+     * True when the entry is a well-formed relative or absolute reminder.
+     *
+     * @param array<string, mixed> $reminder
+     */
+    public function isValidShape(array $reminder): bool
+    {
+        $type = $reminder['type'] ?? null;
+        // `repeat` is optional but, when present, must be a bool.
+        if (array_key_exists('repeat', $reminder) && !is_bool($reminder['repeat'])) {
+            return false;
+        }
+
+        if ('relative' === $type) {
+            $value = $reminder['value'] ?? null;
+            $unit = $reminder['unit'] ?? null;
+            return is_int($value)
+                && $value >= 0
+                && is_string($unit)
+                && in_array($unit, ValidReminders::ALLOWED_UNITS, true);
+        }
+
+        if ('absolute' === $type) {
+            $at = $reminder['at'] ?? null;
+            return is_string($at) && null !== $this->parseAt($at);
+        }
+
+        return false;
+    }
+
+    /**
+     * True when the reminder needs a due date to anchor to (relative only).
+     *
+     * @param array<string, mixed> $reminder
+     */
+    public function requiresDueDate(array $reminder): bool
+    {
+        return 'relative' === ($reminder['type'] ?? null);
+    }
+
+    /**
+     * A stable identifier for the reminder, independent of any single fire.
+     * Used to dedup the list and as the base of the per-fire notification key.
+     *
+     * @param array<string, mixed> $reminder
+     */
+    public function canonicalKey(array $reminder): string
+    {
+        $type = $reminder['type'] ?? null;
+        if ('relative' === $type) {
+            $value = is_int($reminder['value'] ?? null) ? $reminder['value'] : 0;
+            $unit = is_string($reminder['unit'] ?? null) ? $reminder['unit'] : 'minutes';
+            return sprintf('rel:%d:%s', $value, $unit);
+        }
+        if ('absolute' === $type) {
+            $at = is_string($reminder['at'] ?? null) ? $reminder['at'] : '';
+            $parsed = $this->parseAt($at);
+            return 'abs:' . ($parsed?->format(\DateTimeInterface::ATOM) ?? $at);
+        }
+        return 'unknown:' . md5(serialize($reminder));
+    }
+
+    /**
+     * The fires for this reminder that are due at or before `$now`.
+     *
+     * For a one-shot reminder that's at most one entry (the anchor time). For
+     * a "repeat daily until done" reminder it's the most recent daily fire
+     * <= now (we don't backfill missed days — one catch-up is enough), keyed
+     * with the fire date so each day is a distinct notification.
+     *
+     * @param array<string, mixed> $reminder
+     *
+     * @return list<array{key: string, at: \DateTimeImmutable}>
+     */
+    public function dueFires(
+        array $reminder,
+        ?\DateTimeImmutable $due,
+        \DateTimeImmutable $now,
+    ): array {
+        $anchor = $this->anchorTime($reminder, $due);
+        if (null === $anchor || $anchor > $now) {
+            return [];
+        }
+
+        $baseKey = $this->canonicalKey($reminder);
+        $repeat = ($reminder['repeat'] ?? false) === true;
+
+        if (!$repeat) {
+            return [['key' => $baseKey, 'at' => $anchor]];
+        }
+
+        // Latest daily occurrence at the anchor's clock time, <= now.
+        $secondsSince = $now->getTimestamp() - $anchor->getTimestamp();
+        $daysSince = intdiv($secondsSince, 86400);
+        $latest = $anchor->modify(sprintf('+%d days', $daysSince));
+        return [[
+            'key' => $baseKey . ':' . $latest->format('Y-m-d'),
+            'at' => $latest,
+        ]];
+    }
+
+    /**
+     * Human-readable description for emails / notification bodies.
+     *
+     * @param array<string, mixed> $reminder
+     */
+    public function describe(array $reminder): string
+    {
+        $type = $reminder['type'] ?? null;
+        if ('relative' === $type) {
+            $value = is_int($reminder['value'] ?? null) ? $reminder['value'] : 0;
+            $unit = is_string($reminder['unit'] ?? null) ? $reminder['unit'] : 'minutes';
+            if (0 === $value) {
+                return 'when due';
+            }
+            $label = rtrim($unit, 's');
+            return sprintf('%d %s%s before due', $value, $label, 1 === $value ? '' : 's');
+        }
+        if ('absolute' === $type) {
+            $at = is_string($reminder['at'] ?? null) ? $reminder['at'] : '';
+            $parsed = $this->parseAt($at);
+            return null !== $parsed ? 'on ' . $parsed->format('M j, Y g:i a') : 'at a set time';
+        }
+        return 'reminder';
+    }
+
+    /**
+     * The reminder's base fire time: due − offset for relative, the fixed
+     * timestamp for absolute. Null when a relative reminder has no due date.
+     *
+     * @param array<string, mixed> $reminder
+     */
+    private function anchorTime(array $reminder, ?\DateTimeImmutable $due): ?\DateTimeImmutable
+    {
+        $type = $reminder['type'] ?? null;
+        if ('relative' === $type) {
+            if (null === $due) {
+                return null;
+            }
+            $value = is_int($reminder['value'] ?? null) ? $reminder['value'] : 0;
+            $unit = is_string($reminder['unit'] ?? null) ? $reminder['unit'] : 'minutes';
+            return $due->modify(sprintf('-%d %s', $value, $unit));
+        }
+        if ('absolute' === $type) {
+            $at = is_string($reminder['at'] ?? null) ? $reminder['at'] : '';
+            return $this->parseAt($at);
+        }
+        return null;
+    }
+
+    private function parseAt(string $at): ?\DateTimeImmutable
+    {
+        if ('' === $at) {
+            return null;
+        }
+        try {
+            return new \DateTimeImmutable($at);
+        } catch (\Exception) {
+            return null;
+        }
+    }
+}

--- a/api/src/Service/TaskReminderDispatcher.php
+++ b/api/src/Service/TaskReminderDispatcher.php
@@ -84,6 +84,9 @@ final class TaskReminderDispatcher
 
             $dueDate = $task->getDueDate();
             foreach ($reminders as $reminder) {
+                if (!is_array($reminder)) {
+                    continue;
+                }
                 foreach ($this->scheduler->dueFires($reminder, $dueDate, $now) as $fire) {
                     $key = $fire['key'];
                     $label = $this->scheduler->describe($reminder);

--- a/api/src/Service/TaskReminderDispatcher.php
+++ b/api/src/Service/TaskReminderDispatcher.php
@@ -10,7 +10,6 @@ use App\Push\PushSenderInterface;
 use App\Repository\NotificationRepository;
 use App\Repository\PushSubscriptionRepository;
 use App\Repository\TaskRepository;
-use App\Validator\ValidReminders;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -20,18 +19,23 @@ use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mailer\MailerInterface;
 
 /**
- * Walks every active recurring or due-soon task and creates Notification
- * rows for any reminder offsets that have come due since the last run.
+ * Walks every active task with reminders and creates Notification rows for
+ * any reminder fires that have come due since the last run.
+ *
+ * Reminders are relative ("15 minutes before due") or absolute ("on Apr 2
+ * 9:00am"), each optionally "repeat daily until done". Fire computation +
+ * the canonical fire key live in {@see ReminderScheduler} so this dispatcher
+ * and the validator agree on what a reminder means.
  *
  * Recipients = task owner + assignees (one notification each). Idempotency
- * is enforced two ways: a SELECT before INSERT to avoid the round-trip,
- * and a unique index on (recipient, task, offset) as a hard backstop so
- * concurrent runs can't double up.
+ * is enforced two ways: a SELECT before INSERT to avoid the round-trip, and
+ * a unique index on (recipient, task, reminder_offset) as a hard backstop —
+ * `reminder_offset` here stores the per-fire key, so a "repeat daily"
+ * reminder produces one distinct row per day.
  *
  * Shared by App\Command\DispatchTaskRemindersCommand (manual / one-off
  * runs) and App\MessageHandler\DispatchTaskRemindersHandler (the
- * scheduler's every-5-minutes pass). Safe to run at any time — no state
- * outside the notification table.
+ * scheduler's every-5-minutes pass). Safe to run at any time.
  */
 final class TaskReminderDispatcher
 {
@@ -43,6 +47,7 @@ final class TaskReminderDispatcher
         private EntityManagerInterface $em,
         private MailerInterface $mailer,
         private LoggerInterface $logger,
+        private ReminderScheduler $scheduler,
         #[Autowire('%env(APP_FRONTEND_URL)%')]
         private string $frontendUrl,
         #[Autowire('%env(default::MAILER_FROM)%')]
@@ -56,12 +61,10 @@ final class TaskReminderDispatcher
         $emailsSent = 0;
         $pushesSent = 0;
 
-        // We could narrow this by `dueDate >= now - 7 days` to bound the
-        // scan, but for an MVP the dataset is small enough that the
-        // simpler full scan keeps the logic readable.
+        // Absolute reminders fire without a due date, so we no longer filter
+        // on dueDate here — only on "incomplete + has reminders".
         $candidates = $this->tasks->createQueryBuilder('t')
             ->where('t.completedOn IS NULL')
-            ->andWhere('t.dueDate IS NOT NULL')
             ->andWhere('t.reminders IS NOT NULL')
             ->getQuery()
             ->getResult();
@@ -70,8 +73,7 @@ final class TaskReminderDispatcher
         /** @var Task $task */
         foreach ($candidates as $task) {
             $reminders = $task->getReminders() ?? [];
-            $dueDate = $task->getDueDate();
-            if (null === $dueDate || [] === $reminders) {
+            if ([] === $reminders) {
                 continue;
             }
 
@@ -80,43 +82,42 @@ final class TaskReminderDispatcher
                 continue;
             }
 
-            foreach ($reminders as $offset) {
-                $fireAt = $this->subtractOffset($dueDate, $offset);
-                if (null === $fireAt || $fireAt > $now) {
-                    continue;
-                }
+            $dueDate = $task->getDueDate();
+            foreach ($reminders as $reminder) {
+                foreach ($this->scheduler->dueFires($reminder, $dueDate, $now) as $fire) {
+                    $key = $fire['key'];
+                    $label = $this->scheduler->describe($reminder);
 
-                foreach ($recipients as $recipient) {
-                    if ($this->notifications->taskReminderExists($recipient, $task, $offset)) {
-                        continue;
+                    foreach ($recipients as $recipient) {
+                        if ($this->notifications->taskReminderExists($recipient, $task, $key)) {
+                            continue;
+                        }
+
+                        $notification = new Notification();
+                        $notification->setRecipient($recipient);
+                        $notification->setTask($task);
+                        $notification->setReminderOffset($key);
+                        $notification->setType(Notification::TYPE_TASK_REMINDER);
+                        $notification->setTitle(sprintf('Reminder: %s', $task->getTitle()));
+                        $notification->setBody($this->buildBody($task, $label));
+                        $this->em->persist($notification);
+
+                        try {
+                            $this->em->flush();
+                            ++$created;
+                        } catch (UniqueConstraintViolationException) {
+                            // Concurrent dispatcher beat us to it. Recover the
+                            // EM, drop our pending entity, and move on.
+                            $this->em->clear();
+                            continue;
+                        }
+
+                        if ($this->sendReminderEmail($recipient, $task, $label)) {
+                            ++$emailsSent;
+                        }
+
+                        $pushesSent += $this->sendReminderPush($recipient, $task, $key, $label);
                     }
-
-                    $notification = new Notification();
-                    $notification->setRecipient($recipient);
-                    $notification->setTask($task);
-                    $notification->setReminderOffset($offset);
-                    $notification->setType(Notification::TYPE_TASK_REMINDER);
-                    $notification->setTitle(sprintf('Reminder: %s', $task->getTitle()));
-                    $notification->setBody($this->buildBody($task, $offset));
-                    $this->em->persist($notification);
-
-                    try {
-                        $this->em->flush();
-                        ++$created;
-                    } catch (UniqueConstraintViolationException) {
-                        // Concurrent dispatcher beat us to it. Recover the
-                        // EM, drop our pending entity, and move on — the
-                        // notification still landed, just from the other
-                        // worker.
-                        $this->em->clear();
-                        continue;
-                    }
-
-                    if ($this->sendReminderEmail($recipient, $task, $offset)) {
-                        ++$emailsSent;
-                    }
-
-                    $pushesSent += $this->sendReminderPush($recipient, $task, $offset);
                 }
             }
         }
@@ -126,15 +127,12 @@ final class TaskReminderDispatcher
 
     /**
      * Sends a Web Push for the reminder to every subscription the recipient
-     * has registered, gated on `pushNotificationsEnabled`. Subscriptions
-     * the browser's push service reports as expired (404/410) are pruned
-     * inline so the next dispatcher pass doesn't re-attempt them.
+     * has registered, gated on `pushNotificationsEnabled`. Subscriptions the
+     * push service reports as expired (404/410) are pruned inline.
      *
-     * Returns the count of pushes the transport accepted (i.e. pushes that
-     * actually left the box) so the caller can keep the success summary
-     * accurate.
+     * Returns the count of pushes the transport accepted.
      */
-    private function sendReminderPush(User $recipient, Task $task, string $offset): int
+    private function sendReminderPush(User $recipient, Task $task, string $key, string $label): int
     {
         $prefs = $recipient->getPreferences();
         if (true !== ($prefs['pushNotificationsEnabled'] ?? false)) {
@@ -148,17 +146,15 @@ final class TaskReminderDispatcher
 
         $payload = new PushPayload(
             title: sprintf('Reminder: %s', $task->getTitle()),
-            body: $this->buildBody($task, $offset),
+            body: $this->buildBody($task, $label),
             url: rtrim($this->frontendUrl, '/') . '/tasks/' . $task->getId(),
-            tag: 'task-reminder-' . $task->getId() . '-' . $offset,
+            tag: 'task-reminder-' . $task->getId() . '-' . $key,
         );
 
         $delivered = 0;
         foreach ($subscriptions as $subscription) {
             $result = $this->pushSender->send($subscription, $payload);
             if ($result->subscriptionExpired) {
-                // Browser revoked or GC'd the registration. Prune the row
-                // so we don't keep retrying a dead endpoint forever.
                 $this->em->remove($subscription);
                 $this->em->flush();
                 continue;
@@ -173,12 +169,10 @@ final class TaskReminderDispatcher
 
     /**
      * Sends the reminder email if the recipient's preferences allow it.
-     * Digest frequencies (hourly/daily) are explicitly skipped — that's
-     * the digest dispatcher's territory. Returns true when an email was
-     * actually handed to the mailer transport so the caller can keep an
-     * accurate count for the success summary.
+     * Digest frequencies are skipped — that's the digest dispatcher's
+     * territory. Returns true when an email was handed to the transport.
      */
-    private function sendReminderEmail(User $recipient, Task $task, string $offset): bool
+    private function sendReminderEmail(User $recipient, Task $task, string $label): bool
     {
         $prefs = $recipient->getPreferences();
         if (false === ($prefs['emailNotificationsEnabled'] ?? true)) {
@@ -197,7 +191,7 @@ final class TaskReminderDispatcher
             ->context([
                 'recipient' => $recipient,
                 'task' => $task,
-                'offsetLabel' => $this->humanOffset($offset),
+                'offsetLabel' => $label,
                 'tasksUrl' => rtrim($this->frontendUrl, '/') . '/tasks',
             ]);
 
@@ -205,10 +199,6 @@ final class TaskReminderDispatcher
             $this->mailer->send($email);
             return true;
         } catch (TransportExceptionInterface $e) {
-            // Don't blow up the whole dispatcher run if the mail server is
-            // momentarily unreachable — the in-app notification already
-            // landed, and the next scheduled pass will retry untouched
-            // users.
             $this->logger->warning(sprintf(
                 'Failed to send reminder email to %s: %s',
                 $recipient->getEmail(),
@@ -236,38 +226,12 @@ final class TaskReminderDispatcher
         return array_values($seen);
     }
 
-    private function subtractOffset(\DateTimeImmutable $dueDate, string $offset): ?\DateTimeImmutable
+    private function buildBody(Task $task, string $label): string
     {
-        if (!in_array($offset, ValidReminders::ALLOWED_OFFSETS, true)) {
-            return null;
+        $due = $task->getDueDate()?->format('M j, Y g:i a');
+        if (null !== $due) {
+            return sprintf('"%s" — reminder %s (due %s).', $task->getTitle(), $label, $due);
         }
-        // $offset is one of ALLOWED_OFFSETS (the in_array guard above),
-        // so the match is exhaustive over the literal values.
-        return match ($offset) {
-            '15m' => $dueDate->modify('-15 minutes'),
-            '1h' => $dueDate->modify('-1 hour'),
-            '1d' => $dueDate->modify('-1 day'),
-        };
-    }
-
-    private function buildBody(Task $task, string $offset): string
-    {
-        $due = $task->getDueDate()?->format('M j, Y g:i a') ?? '';
-        return sprintf(
-            '"%s" is due in %s (%s).',
-            $task->getTitle(),
-            $this->humanOffset($offset),
-            $due,
-        );
-    }
-
-    private function humanOffset(string $offset): string
-    {
-        return match ($offset) {
-            '15m' => '15 minutes',
-            '1h' => '1 hour',
-            '1d' => '1 day',
-            default => $offset,
-        };
+        return sprintf('"%s" — reminder %s.', $task->getTitle(), $label);
     }
 }

--- a/api/src/State/TaskUpdateProcessor.php
+++ b/api/src/State/TaskUpdateProcessor.php
@@ -7,6 +7,7 @@ use ApiPlatform\State\ProcessorInterface;
 use App\Entity\Task;
 use App\Entity\User;
 use App\Repository\TaskRepository;
+use App\Service\RecurrenceCalculator;
 use App\Service\TaskActivityNotifier;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -37,6 +38,7 @@ final class TaskUpdateProcessor implements ProcessorInterface
         private TaskRepository $tasks,
         private Security $security,
         private TaskActivityNotifier $activity,
+        private RecurrenceCalculator $recurrence,
     ) {
     }
 
@@ -95,20 +97,41 @@ final class TaskUpdateProcessor implements ProcessorInterface
     private function createNextOccurrence(Task $completed): void
     {
         // Caller only invokes us after asserting both fields are set —
-        // re-narrow so phpstan can see the non-null shape on the
-        // advanceDueDate call below.
+        // re-narrow so phpstan sees the non-null shape below.
         $dueDate = $completed->getDueDate();
         $rule = $completed->getRecurrenceRule();
         if (null === $dueDate || null === $rule) {
             return;
         }
+
+        // A count-based end treats `ends.count` as the number of occurrences
+        // remaining in the series including the one just completed. When only
+        // one remains, this WAS the last — spawn nothing. Otherwise the clone
+        // carries the count decremented by one.
+        $nextRule = $rule;
+        $ends = $rule['ends'] ?? null;
+        if (is_array($ends) && ($ends['type'] ?? null) === 'count') {
+            $remaining = is_int($ends['count'] ?? null) ? $ends['count'] : 1;
+            if ($remaining <= 1) {
+                return;
+            }
+            $nextRule['ends'] = ['type' => 'count', 'count' => $remaining - 1];
+        }
+
+        $nextDue = $this->recurrence->nextDueDate($dueDate, $rule);
+        if (null === $nextDue) {
+            // Series ended (e.g. past the `until` bound).
+            return;
+        }
+
         $next = new Task();
         $next->setOwner($completed->getOwner());
         $next->setProject($completed->getProject());
         $next->setTitle($completed->getTitle());
         $next->setDescription($completed->getDescription());
-        $next->setRecurrenceRule($rule);
-        $next->setDueDate($this->advanceDueDate($dueDate, $rule));
+        $next->setRecurrenceRule($nextRule);
+        $next->setDueDate($nextDue);
+        $next->setReminders($completed->getReminders());
 
         foreach ($completed->getTags() as $tag) {
             $next->addTag($tag);
@@ -125,27 +148,5 @@ final class TaskUpdateProcessor implements ProcessorInterface
 
         $this->em->persist($next);
         $this->em->flush();
-    }
-
-    /**
-     * Compute the next dueDate from the previous one + recurrence rule.
-     * Advances off the original `dueDate` (not "now") so missing a deadline
-     * doesn't shift the schedule forward.
-     *
-     * @param array{frequency: string, interval: int} $rule
-     */
-    private function advanceDueDate(\DateTimeImmutable $current, array $rule): \DateTimeImmutable
-    {
-        $interval = max(1, $rule['interval']);
-        // \DateTimeImmutable::modify is calendar-aware: "+1 month" off Jan 31
-        // becomes Mar 3 (skipping Feb), which is the standard PHP behaviour
-        // and matches what users intuitively expect for monthly recurrence.
-        return match ($rule['frequency']) {
-            'daily' => $current->modify(sprintf('+%d days', $interval)),
-            'weekly' => $current->modify(sprintf('+%d weeks', $interval)),
-            'monthly' => $current->modify(sprintf('+%d months', $interval)),
-            'yearly' => $current->modify(sprintf('+%d years', $interval)),
-            default => $current,
-        };
     }
 }

--- a/api/src/Validator/ValidRecurrence.php
+++ b/api/src/Validator/ValidRecurrence.php
@@ -5,18 +5,28 @@ namespace App\Validator;
 use Symfony\Component\Validator\Constraint;
 
 /**
- * Class-level constraint on Task. Two rules:
- *  1. `recurrenceRule` must be a `{frequency, interval}` shape, where
- *     frequency is daily/weekly/monthly/yearly and interval is a positive
- *     integer.
- *  2. A recurrence rule may only be set when a `dueDate` is also set —
- *     there's no anchor to advance off otherwise.
+ * Class-level constraint on Task. Validates the (expanded) `recurrenceRule`
+ * shape and the cross-field rule that a recurrence requires a due date.
+ *
+ * Shape (see {@see \App\Service\RecurrenceCalculator}):
+ *  - frequency: daily|weekly|monthly|yearly
+ *  - interval:  positive integer
+ *  - byDay:     optional array of MO..SU tokens (weekly + monthly-weekday)
+ *  - monthlyMode: optional "day"|"weekday" (monthly only)
+ *  - bySetPos:  optional int in 1..5 or -1 (monthly-weekday only)
+ *  - ends:      optional {type: until, until: Y-m-d} | {type: count, count: >=1}
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
 final class ValidRecurrence extends Constraint
 {
+    public const ALLOWED_FREQUENCIES = ['daily', 'weekly', 'monthly', 'yearly'];
+    public const ALLOWED_DAYS = ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU'];
+
     public string $messageRequiresDueDate = 'A recurrence rule requires a due date.';
-    public string $messageInvalidShape = 'Recurrence rule must be {"frequency": daily|weekly|monthly|yearly, "interval": positive integer}.';
+    public string $messageInvalidShape = 'Recurrence rule must have a valid frequency (daily|weekly|monthly|yearly) and a positive interval.';
+    public string $messageInvalidDays = 'Recurrence byDay entries must be MO, TU, WE, TH, FR, SA or SU.';
+    public string $messageInvalidMonthly = 'Monthly "weekday" mode requires a single byDay and a bySetPos of 1–5 or -1.';
+    public string $messageInvalidEnds = 'Recurrence end condition is invalid.';
 
     public function getTargets(): string
     {

--- a/api/src/Validator/ValidRecurrenceValidator.php
+++ b/api/src/Validator/ValidRecurrenceValidator.php
@@ -89,8 +89,9 @@ final class ValidRecurrenceValidator extends ConstraintValidator
      */
     private function validateMonthly(array $rule, ValidRecurrence $constraint): bool
     {
+        // `?? 'day'` already collapses an absent/null mode to "day".
         $mode = $rule['monthlyMode'] ?? 'day';
-        if ('day' === $mode || null === $mode) {
+        if ('day' === $mode) {
             return true;
         }
         if ('weekday' !== $mode) {

--- a/api/src/Validator/ValidRecurrenceValidator.php
+++ b/api/src/Validator/ValidRecurrenceValidator.php
@@ -10,8 +10,6 @@ use Symfony\Component\Validator\Exception\UnexpectedValueException;
 
 final class ValidRecurrenceValidator extends ConstraintValidator
 {
-    private const ALLOWED_FREQUENCIES = ['daily', 'weekly', 'monthly', 'yearly'];
-
     public function validate(mixed $value, Constraint $constraint): void
     {
         if (!$constraint instanceof ValidRecurrence) {
@@ -31,8 +29,12 @@ final class ValidRecurrenceValidator extends ConstraintValidator
             return;
         }
 
-        $hasShape = in_array($rule['frequency'], self::ALLOWED_FREQUENCIES, true)
-            && $rule['interval'] >= 1;
+        $frequency = $rule['frequency'] ?? null;
+        $interval = $rule['interval'] ?? null;
+        $hasShape = is_string($frequency)
+            && in_array($frequency, ValidRecurrence::ALLOWED_FREQUENCIES, true)
+            && is_int($interval)
+            && $interval >= 1;
 
         if (!$hasShape) {
             $this->context->buildViolation($constraint->messageInvalidShape)
@@ -41,10 +43,109 @@ final class ValidRecurrenceValidator extends ConstraintValidator
             return;
         }
 
+        if (!$this->validateByDay($rule, $constraint)) {
+            return;
+        }
+
+        if ('monthly' === $frequency && !$this->validateMonthly($rule, $constraint)) {
+            return;
+        }
+
+        if (!$this->validateEnds($rule, $constraint)) {
+            return;
+        }
+
         if (null === $value->getDueDate()) {
             $this->context->buildViolation($constraint->messageRequiresDueDate)
                 ->atPath('recurrenceRule')
                 ->addViolation();
         }
+    }
+
+    /**
+     * @param array<string, mixed> $rule
+     */
+    private function validateByDay(array $rule, ValidRecurrence $constraint): bool
+    {
+        $byDay = $rule['byDay'] ?? null;
+        if (null === $byDay) {
+            return true;
+        }
+        if (!is_array($byDay)) {
+            $this->addViolation($constraint->messageInvalidDays);
+            return false;
+        }
+        foreach ($byDay as $token) {
+            if (!is_string($token) || !in_array($token, ValidRecurrence::ALLOWED_DAYS, true)) {
+                $this->addViolation($constraint->messageInvalidDays);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * @param array<string, mixed> $rule
+     */
+    private function validateMonthly(array $rule, ValidRecurrence $constraint): bool
+    {
+        $mode = $rule['monthlyMode'] ?? 'day';
+        if ('day' === $mode || null === $mode) {
+            return true;
+        }
+        if ('weekday' !== $mode) {
+            $this->addViolation($constraint->messageInvalidMonthly);
+            return false;
+        }
+        $byDay = $rule['byDay'] ?? null;
+        $bySetPos = $rule['bySetPos'] ?? null;
+        $validDays = is_array($byDay) && 1 === count($byDay);
+        $validPos = is_int($bySetPos) && (-1 === $bySetPos || ($bySetPos >= 1 && $bySetPos <= 5));
+        if (!$validDays || !$validPos) {
+            $this->addViolation($constraint->messageInvalidMonthly);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * @param array<string, mixed> $rule
+     */
+    private function validateEnds(array $rule, ValidRecurrence $constraint): bool
+    {
+        $ends = $rule['ends'] ?? null;
+        if (null === $ends) {
+            return true;
+        }
+        if (!is_array($ends)) {
+            $this->addViolation($constraint->messageInvalidEnds);
+            return false;
+        }
+        $type = $ends['type'] ?? null;
+        if ('count' === $type) {
+            $count = $ends['count'] ?? null;
+            if (!is_int($count) || $count < 1) {
+                $this->addViolation($constraint->messageInvalidEnds);
+                return false;
+            }
+            return true;
+        }
+        if ('until' === $type) {
+            $until = $ends['until'] ?? null;
+            if (!is_string($until) || 1 !== preg_match('/^\d{4}-\d{2}-\d{2}$/', $until)) {
+                $this->addViolation($constraint->messageInvalidEnds);
+                return false;
+            }
+            return true;
+        }
+        $this->addViolation($constraint->messageInvalidEnds);
+        return false;
+    }
+
+    private function addViolation(string $message): void
+    {
+        $this->context->buildViolation($message)
+            ->atPath('recurrenceRule')
+            ->addViolation();
     }
 }

--- a/api/src/Validator/ValidReminders.php
+++ b/api/src/Validator/ValidReminders.php
@@ -5,24 +5,29 @@ namespace App\Validator;
 use Symfony\Component\Validator\Constraint;
 
 /**
- * Class-level constraint on Task. Validates the `reminders` field:
- *  - Each entry must be one of {@see self::ALLOWED_OFFSETS}.
- *  - Duplicates are rejected.
- *  - When non-empty, a `dueDate` must also be set (a reminder offset has
- *    nothing to anchor to without a due date).
+ * Class-level constraint on Task. Validates the (expanded) `reminders`
+ * field — a list of relative/absolute reminder objects:
+ *
+ *  - relative: {type:"relative", value:int>=0, unit:"minutes"|"hours"|"days", repeat:bool}
+ *  - absolute: {type:"absolute", at:ISO-8601, repeat:bool}
+ *
+ * Rules:
+ *  - Each entry must match one of the shapes above.
+ *  - Duplicates (same canonical key) are rejected.
+ *  - At most {@see self::MAX_REMINDERS} entries.
+ *  - A *relative* reminder needs a `dueDate` to anchor to; absolute
+ *    reminders stand on their own clock and don't.
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
 final class ValidReminders extends Constraint
 {
-    /**
-     * Allowlist of reminder offset strings. Kept short and human-readable —
-     * the dispatcher and the PWA both reference this list.
-     */
-    public const ALLOWED_OFFSETS = ['15m', '1h', '1d'];
+    public const ALLOWED_UNITS = ['minutes', 'hours', 'days'];
+    public const MAX_REMINDERS = 10;
 
-    public string $messageRequiresDueDate = 'Reminders require a due date.';
-    public string $messageInvalidOffset = 'Reminder offsets must be one of: 15m, 1h, 1d.';
-    public string $messageDuplicate = 'Reminder offsets must not contain duplicates.';
+    public string $messageRequiresDueDate = 'Relative reminders require a due date.';
+    public string $messageInvalidShape = 'Each reminder must be a relative ({value, unit}) or absolute ({at}) entry.';
+    public string $messageDuplicate = 'Reminders must not contain duplicates.';
+    public string $messageTooMany = 'A task can have at most 10 reminders.';
 
     public function getTargets(): string
     {

--- a/api/src/Validator/ValidRemindersValidator.php
+++ b/api/src/Validator/ValidRemindersValidator.php
@@ -3,6 +3,7 @@
 namespace App\Validator;
 
 use App\Entity\Task;
+use App\Service\ReminderScheduler;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -10,6 +11,11 @@ use Symfony\Component\Validator\Exception\UnexpectedValueException;
 
 final class ValidRemindersValidator extends ConstraintValidator
 {
+    public function __construct(
+        private readonly ReminderScheduler $scheduler,
+    ) {
+    }
+
     public function validate(mixed $value, Constraint $constraint): void
     {
         if (!$constraint instanceof ValidReminders) {
@@ -29,26 +35,38 @@ final class ValidRemindersValidator extends ConstraintValidator
             return;
         }
 
-        if (count($reminders) !== count(array_unique($reminders))) {
-            $this->context->buildViolation($constraint->messageDuplicate)
-                ->atPath('reminders')
-                ->addViolation();
+        if (count($reminders) > ValidReminders::MAX_REMINDERS) {
+            $this->violate($constraint->messageTooMany);
             return;
         }
 
-        foreach ($reminders as $offset) {
-            if (!in_array($offset, ValidReminders::ALLOWED_OFFSETS, true)) {
-                $this->context->buildViolation($constraint->messageInvalidOffset)
-                    ->atPath('reminders')
-                    ->addViolation();
+        $keys = [];
+        $needsDueDate = false;
+        foreach ($reminders as $reminder) {
+            if (!is_array($reminder) || !$this->scheduler->isValidShape($reminder)) {
+                $this->violate($constraint->messageInvalidShape);
                 return;
+            }
+            $key = $this->scheduler->canonicalKey($reminder);
+            if (isset($keys[$key])) {
+                $this->violate($constraint->messageDuplicate);
+                return;
+            }
+            $keys[$key] = true;
+            if ($this->scheduler->requiresDueDate($reminder)) {
+                $needsDueDate = true;
             }
         }
 
-        if (null === $value->getDueDate()) {
-            $this->context->buildViolation($constraint->messageRequiresDueDate)
-                ->atPath('reminders')
-                ->addViolation();
+        if ($needsDueDate && null === $value->getDueDate()) {
+            $this->violate($constraint->messageRequiresDueDate);
         }
+    }
+
+    private function violate(string $message): void
+    {
+        $this->context->buildViolation($message)
+            ->atPath('reminders')
+            ->addViolation();
     }
 }

--- a/api/templates/emails/task_reminder.html.twig
+++ b/api/templates/emails/task_reminder.html.twig
@@ -3,9 +3,9 @@
 <p>Hi {{ recipient.givenName ?: recipient.email }},</p>
 
 <p>
-    This is a reminder that
+    This is a reminder for
     <strong>&ldquo;{{ task.title }}&rdquo;</strong>
-    is due in {{ offsetLabel }}{% if task.dueDate %} (<time datetime="{{ task.dueDate|date('c') }}">{{ task.dueDate|date('M j, Y g:i a') }}</time>){% endif %}.
+    — {{ offsetLabel }}{% if task.dueDate %} (due <time datetime="{{ task.dueDate|date('c') }}">{{ task.dueDate|date('M j, Y g:i a') }}</time>){% endif %}.
 </p>
 
 {% if task.recurrenceRule %}

--- a/api/templates/emails/task_reminder.txt.twig
+++ b/api/templates/emails/task_reminder.txt.twig
@@ -2,7 +2,7 @@
 {# @var recipient \App\Entity\User #}
 Hi {{ recipient.givenName ?: recipient.email }},
 
-This is a reminder that "{{ task.title }}" is due in {{ offsetLabel }}{% if task.dueDate %} ({{ task.dueDate|date('M j, Y g:i a') }}){% endif %}.
+This is a reminder for "{{ task.title }}" — {{ offsetLabel }}{% if task.dueDate %} (due {{ task.dueDate|date('M j, Y g:i a') }}){% endif %}.
 {% if task.recurrenceRule %}
 
 This task recurs on a schedule, so a fresh occurrence will be created once you mark this one complete.

--- a/api/tests/Api/NotificationTest.php
+++ b/api/tests/Api/NotificationTest.php
@@ -155,7 +155,10 @@ class NotificationTest extends ApiTestCase
         $task->setOwner($alice);
         $task->setTitle('Standup');
         $task->setDueDate((new \DateTimeImmutable())->modify('+30 minutes'));
-        $task->setReminders(['1h', '15m']);
+        $task->setReminders([
+            ['type' => 'relative', 'value' => 1, 'unit' => 'hours', 'repeat' => false],
+            ['type' => 'relative', 'value' => 15, 'unit' => 'minutes', 'repeat' => false],
+        ]);
         $this->entityManager->persist($task);
         $this->entityManager->flush();
 
@@ -165,7 +168,7 @@ class NotificationTest extends ApiTestCase
         $this->entityManager->clear();
         $rows = $this->entityManager->getRepository(Notification::class)->findAll();
         $this->assertCount(1, $rows);
-        $this->assertSame('1h', $rows[0]->getReminderOffset());
+        $this->assertSame('rel:1:hours', $rows[0]->getReminderOffset());
         $this->assertSame(Notification::TYPE_TASK_REMINDER, $rows[0]->getType());
     }
 
@@ -176,7 +179,7 @@ class NotificationTest extends ApiTestCase
         $task->setOwner($alice);
         $task->setTitle('Standup');
         $task->setDueDate((new \DateTimeImmutable())->modify('+30 minutes'));
-        $task->setReminders(['1h']);
+        $task->setReminders([['type' => 'relative', 'value' => 1, 'unit' => 'hours', 'repeat' => false]]);
         $this->entityManager->persist($task);
         $this->entityManager->flush();
 
@@ -195,7 +198,7 @@ class NotificationTest extends ApiTestCase
         $task->setOwner($alice);
         $task->setTitle('Already done');
         $task->setDueDate((new \DateTimeImmutable())->modify('+30 minutes'));
-        $task->setReminders(['1h']);
+        $task->setReminders([['type' => 'relative', 'value' => 1, 'unit' => 'hours', 'repeat' => false]]);
         $task->setCompletedOn(new \DateTimeImmutable('-5 minutes'));
         $this->entityManager->persist($task);
         $this->entityManager->flush();
@@ -221,7 +224,7 @@ class NotificationTest extends ApiTestCase
         $task->setProject($project);
         $task->setTitle('Standup');
         $task->setDueDate((new \DateTimeImmutable())->modify('+30 minutes'));
-        $task->setReminders(['1h']);
+        $task->setReminders([['type' => 'relative', 'value' => 1, 'unit' => 'hours', 'repeat' => false]]);
         $task->addAssignee($bob);
         $this->entityManager->persist($task);
         $this->entityManager->flush();
@@ -250,8 +253,8 @@ class NotificationTest extends ApiTestCase
         $this->assertEmailHeaderSame($message, 'To', 'alice@example.com');
         $this->assertEmailHeaderSame($message, 'Subject', 'Reminder: Standup');
         $this->assertEmailHtmlBodyContains($message, 'Standup');
-        $this->assertEmailHtmlBodyContains($message, 'due in 1 hour');
-        $this->assertEmailTextBodyContains($message, 'due in 1 hour');
+        $this->assertEmailHtmlBodyContains($message, '1 hour before due');
+        $this->assertEmailTextBodyContains($message, '1 hour before due');
     }
 
     public function testDispatcherSkipsEmailWhenUserDisabledIt(): void
@@ -312,7 +315,7 @@ class NotificationTest extends ApiTestCase
         $task->setOwner($owner);
         $task->setTitle($title);
         $task->setDueDate((new \DateTimeImmutable())->modify('+30 minutes'));
-        $task->setReminders(['1h']);
+        $task->setReminders([['type' => 'relative', 'value' => 1, 'unit' => 'hours', 'repeat' => false]]);
         $this->entityManager->persist($task);
         $this->entityManager->flush();
         return $task;

--- a/api/tests/Api/TaskTest.php
+++ b/api/tests/Api/TaskTest.php
@@ -593,7 +593,7 @@ class TaskTest extends ApiTestCase
 
         $client = static::createClient();
         $client->loginUser($alice);
-        $client->request('POST', '/recurrence-preview', [
+        $response = $client->request('POST', '/recurrence-preview', [
             'json' => [
                 'dueDate' => '2026-06-01T08:00:00+00:00',
                 'rule' => ['frequency' => 'daily', 'interval' => 2],
@@ -603,15 +603,19 @@ class TaskTest extends ApiTestCase
         ]);
 
         $this->assertResponseIsSuccessful();
-        $body = json_decode((string) $client->getResponse()->getContent(), true);
-        $this->assertIsArray($body);
+        $body = $response->toArray();
         $occurrences = $body['occurrences'] ?? null;
         $this->assertIsArray($occurrences);
         $this->assertCount(3, $occurrences);
-        $this->assertIsString($occurrences[0]);
-        $this->assertStringStartsWith('2026-06-03', $occurrences[0]);
-        $this->assertStringStartsWith('2026-06-05', $occurrences[1]);
-        $this->assertStringStartsWith('2026-06-07', $occurrences[2]);
+        $first = $occurrences[0];
+        $second = $occurrences[1];
+        $third = $occurrences[2];
+        $this->assertIsString($first);
+        $this->assertIsString($second);
+        $this->assertIsString($third);
+        $this->assertStringStartsWith('2026-06-03', $first);
+        $this->assertStringStartsWith('2026-06-05', $second);
+        $this->assertStringStartsWith('2026-06-07', $third);
     }
 
     public function testCreateTaskWithReminders(): void

--- a/api/tests/Api/TaskTest.php
+++ b/api/tests/Api/TaskTest.php
@@ -491,6 +491,129 @@ class TaskTest extends ApiTestCase
         $this->assertSame(1, $count);
     }
 
+    public function testCompletingWeeklyByDayRecurrenceAdvancesToNextSelectedWeekday(): void
+    {
+        // 2026-06-01 is a Monday; with byDay = Mon/Wed/Fri the next
+        // occurrence after a Monday is the Wednesday of the same week.
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->createTask($alice, 'ByDay recurring');
+        $task->setDueDate(new \DateTimeImmutable('2026-06-01T08:00:00+00:00'));
+        $task->setRecurrenceRule([
+            'frequency' => 'weekly',
+            'interval' => 1,
+            'byDay' => ['MO', 'WE', 'FR'],
+        ]);
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/tasks/' . $task->getId(), [
+            'json' => ['completedOn' => '2026-06-01T12:00:00+00:00'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $this->entityManager->clear();
+        $repo = $this->entityManager->getRepository(Task::class);
+        /** @var Task[] $pending */
+        $pending = array_values(array_filter(
+            $repo->findBy(['title' => 'ByDay recurring']),
+            fn (Task $t) => null === $t->getCompletedOn(),
+        ));
+        $this->assertCount(1, $pending);
+        $this->assertNotNull($pending[0]->getDueDate());
+        $this->assertSame('2026-06-03', $pending[0]->getDueDate()->format('Y-m-d'));
+    }
+
+    public function testCountOneRecurrenceDoesNotSpawn(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->createTask($alice, 'Last occurrence');
+        $task->setDueDate(new \DateTimeImmutable('2026-06-01T08:00:00+00:00'));
+        $task->setRecurrenceRule([
+            'frequency' => 'daily',
+            'interval' => 1,
+            'ends' => ['type' => 'count', 'count' => 1],
+        ]);
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/tasks/' . $task->getId(), [
+            'json' => ['completedOn' => '2026-06-01T12:00:00+00:00'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $this->entityManager->clear();
+        $count = (int) $this->entityManager->createQuery(
+            'SELECT COUNT(t) FROM App\Entity\Task t WHERE t.title = :title',
+        )->setParameter('title', 'Last occurrence')->getSingleScalarResult();
+        $this->assertSame(1, $count, 'A count=1 series must not spawn a successor.');
+    }
+
+    public function testCountBasedRecurrenceSpawnsWithDecrementedCount(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->createTask($alice, 'Counted');
+        $task->setDueDate(new \DateTimeImmutable('2026-06-01T08:00:00+00:00'));
+        $task->setRecurrenceRule([
+            'frequency' => 'daily',
+            'interval' => 1,
+            'ends' => ['type' => 'count', 'count' => 2],
+        ]);
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/tasks/' . $task->getId(), [
+            'json' => ['completedOn' => '2026-06-01T12:00:00+00:00'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $this->entityManager->clear();
+        $repo = $this->entityManager->getRepository(Task::class);
+        /** @var Task[] $pending */
+        $pending = array_values(array_filter(
+            $repo->findBy(['title' => 'Counted']),
+            fn (Task $t) => null === $t->getCompletedOn(),
+        ));
+        $this->assertCount(1, $pending, 'A count=2 series spawns exactly one successor.');
+        $rule = $pending[0]->getRecurrenceRule();
+        $this->assertNotNull($rule);
+        $this->assertSame(['type' => 'count', 'count' => 1], $rule['ends'] ?? null);
+    }
+
+    public function testRecurrencePreviewReturnsNextOccurrences(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/recurrence-preview', [
+            'json' => [
+                'dueDate' => '2026-06-01T08:00:00+00:00',
+                'rule' => ['frequency' => 'daily', 'interval' => 2],
+                'count' => 3,
+            ],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $body = json_decode((string) $client->getResponse()->getContent(), true);
+        $this->assertIsArray($body);
+        $occurrences = $body['occurrences'] ?? null;
+        $this->assertIsArray($occurrences);
+        $this->assertCount(3, $occurrences);
+        $this->assertIsString($occurrences[0]);
+        $this->assertStringStartsWith('2026-06-03', $occurrences[0]);
+        $this->assertStringStartsWith('2026-06-05', $occurrences[1]);
+        $this->assertStringStartsWith('2026-06-07', $occurrences[2]);
+    }
+
     public function testCreateTaskWithReminders(): void
     {
         $alice = $this->createUser('alice@example.com');
@@ -501,17 +624,47 @@ class TaskTest extends ApiTestCase
             'json' => [
                 'title' => 'Take medication',
                 'dueDate' => '2026-06-01T08:00:00+00:00',
-                'reminders' => ['1h', '15m'],
+                'reminders' => [
+                    ['type' => 'relative', 'value' => 1, 'unit' => 'hours', 'repeat' => false],
+                    ['type' => 'relative', 'value' => 15, 'unit' => 'minutes', 'repeat' => false],
+                ],
             ],
             'headers' => ['Content-Type' => 'application/ld+json'],
         ]);
 
         $this->assertResponseStatusCodeSame(201);
         $task = $this->reloadTaskByTitle('Take medication');
-        $this->assertSame(['1h', '15m'], $task->getReminders());
+        $this->assertSame(
+            [
+                ['type' => 'relative', 'value' => 1, 'unit' => 'hours', 'repeat' => false],
+                ['type' => 'relative', 'value' => 15, 'unit' => 'minutes', 'repeat' => false],
+            ],
+            $task->getReminders(),
+        );
     }
 
-    public function testRemindersWithoutDueDateAreRejected(): void
+    public function testCreateTaskWithAbsoluteReminderNeedsNoDueDate(): void
+    {
+        // Absolute reminders fire on their own clock, so they don't require
+        // a due date the way relative reminders do.
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks', [
+            'json' => [
+                'title' => 'Standalone absolute',
+                'reminders' => [
+                    ['type' => 'absolute', 'at' => '2026-06-01T09:00:00+00:00', 'repeat' => true],
+                ],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+    }
+
+    public function testRelativeRemindersWithoutDueDateAreRejected(): void
     {
         $alice = $this->createUser('alice@example.com');
 
@@ -520,7 +673,9 @@ class TaskTest extends ApiTestCase
         $client->request('POST', '/tasks', [
             'json' => [
                 'title' => 'Orphan reminder',
-                'reminders' => ['1h'],
+                'reminders' => [
+                    ['type' => 'relative', 'value' => 1, 'unit' => 'hours', 'repeat' => false],
+                ],
             ],
             'headers' => ['Content-Type' => 'application/ld+json'],
         ]);
@@ -528,7 +683,7 @@ class TaskTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(422);
     }
 
-    public function testInvalidReminderOffsetIsRejected(): void
+    public function testInvalidReminderShapeIsRejected(): void
     {
         $alice = $this->createUser('alice@example.com');
 
@@ -536,9 +691,11 @@ class TaskTest extends ApiTestCase
         $client->loginUser($alice);
         $client->request('POST', '/tasks', [
             'json' => [
-                'title' => 'Bad offset',
+                'title' => 'Bad unit',
                 'dueDate' => '2026-06-01T08:00:00+00:00',
-                'reminders' => ['2h'],
+                'reminders' => [
+                    ['type' => 'relative', 'value' => 2, 'unit' => 'fortnights', 'repeat' => false],
+                ],
             ],
             'headers' => ['Content-Type' => 'application/ld+json'],
         ]);
@@ -546,7 +703,7 @@ class TaskTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(422);
     }
 
-    public function testDuplicateReminderOffsetIsRejected(): void
+    public function testDuplicateReminderIsRejected(): void
     {
         $alice = $this->createUser('alice@example.com');
 
@@ -554,9 +711,12 @@ class TaskTest extends ApiTestCase
         $client->loginUser($alice);
         $client->request('POST', '/tasks', [
             'json' => [
-                'title' => 'Dup offset',
+                'title' => 'Dup reminder',
                 'dueDate' => '2026-06-01T08:00:00+00:00',
-                'reminders' => ['1h', '1h'],
+                'reminders' => [
+                    ['type' => 'relative', 'value' => 1, 'unit' => 'hours', 'repeat' => false],
+                    ['type' => 'relative', 'value' => 1, 'unit' => 'hours', 'repeat' => true],
+                ],
             ],
             'headers' => ['Content-Type' => 'application/ld+json'],
         ]);

--- a/api/tests/Service/RecurrenceCalculatorTest.php
+++ b/api/tests/Service/RecurrenceCalculatorTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service;
+
+use App\Service\RecurrenceCalculator;
+use PHPUnit\Framework\TestCase;
+
+class RecurrenceCalculatorTest extends TestCase
+{
+    private RecurrenceCalculator $calc;
+
+    protected function setUp(): void
+    {
+        $this->calc = new RecurrenceCalculator();
+    }
+
+    public function testDailyInterval(): void
+    {
+        $dates = $this->calc->nextOccurrences(
+            new \DateTimeImmutable('2026-06-01T08:00:00+00:00'),
+            ['frequency' => 'daily', 'interval' => 2],
+            3,
+        );
+        $this->assertSame(
+            ['2026-06-03', '2026-06-05', '2026-06-07'],
+            array_map(fn (\DateTimeImmutable $d) => $d->format('Y-m-d'), $dates),
+        );
+    }
+
+    public function testWeeklyWithoutByDayAdvancesWholeWeeks(): void
+    {
+        $dates = $this->calc->nextOccurrences(
+            new \DateTimeImmutable('2026-06-01T08:00:00+00:00'),
+            ['frequency' => 'weekly', 'interval' => 2],
+            2,
+        );
+        $this->assertSame(
+            ['2026-06-15', '2026-06-29'],
+            array_map(fn (\DateTimeImmutable $d) => $d->format('Y-m-d'), $dates),
+        );
+    }
+
+    public function testWeeklyByDayCyclesSelectedWeekdays(): void
+    {
+        // 2026-06-01 is a Monday. Mon/Wed/Fri → next three are Wed, Fri, Mon.
+        $dates = $this->calc->nextOccurrences(
+            new \DateTimeImmutable('2026-06-01T08:00:00+00:00'),
+            ['frequency' => 'weekly', 'interval' => 1, 'byDay' => ['MO', 'WE', 'FR']],
+            3,
+        );
+        $this->assertSame(
+            ['2026-06-03', '2026-06-05', '2026-06-08'],
+            array_map(fn (\DateTimeImmutable $d) => $d->format('Y-m-d'), $dates),
+        );
+    }
+
+    public function testMonthlyByDayOfMonth(): void
+    {
+        $dates = $this->calc->nextOccurrences(
+            new \DateTimeImmutable('2026-01-10T08:00:00+00:00'),
+            ['frequency' => 'monthly', 'interval' => 1, 'monthlyMode' => 'day'],
+            2,
+        );
+        $this->assertSame(
+            ['2026-02-10', '2026-03-10'],
+            array_map(fn (\DateTimeImmutable $d) => $d->format('Y-m-d'), $dates),
+        );
+    }
+
+    public function testMonthlyNthWeekday(): void
+    {
+        // Second Thursday of each month starting after 2026-04-09 (itself the
+        // 2nd Thursday of April 2026).
+        $dates = $this->calc->nextOccurrences(
+            new \DateTimeImmutable('2026-04-09T09:00:00+00:00'),
+            [
+                'frequency' => 'monthly',
+                'interval' => 1,
+                'monthlyMode' => 'weekday',
+                'byDay' => ['TH'],
+                'bySetPos' => 2,
+            ],
+            3,
+        );
+        $formatted = array_map(fn (\DateTimeImmutable $d) => $d->format('Y-m-d'), $dates);
+        $this->assertSame(['2026-05-14', '2026-06-11', '2026-07-09'], $formatted);
+        foreach ($dates as $d) {
+            $this->assertSame('Thursday', $d->format('l'));
+        }
+    }
+
+    public function testUntilBoundStopsGeneration(): void
+    {
+        $dates = $this->calc->nextOccurrences(
+            new \DateTimeImmutable('2026-06-01T08:00:00+00:00'),
+            [
+                'frequency' => 'daily',
+                'interval' => 1,
+                'ends' => ['type' => 'until', 'until' => '2026-06-03'],
+            ],
+            5,
+        );
+        $this->assertSame(
+            ['2026-06-02', '2026-06-03'],
+            array_map(fn (\DateTimeImmutable $d) => $d->format('Y-m-d'), $dates),
+        );
+    }
+
+    public function testYearly(): void
+    {
+        $this->assertSame(
+            '2027-05-10',
+            $this->calc->nextDueDate(
+                new \DateTimeImmutable('2026-05-10T00:00:00+00:00'),
+                ['frequency' => 'yearly', 'interval' => 1],
+            )?->format('Y-m-d'),
+        );
+    }
+}

--- a/api/tests/Service/ReminderSchedulerTest.php
+++ b/api/tests/Service/ReminderSchedulerTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service;
+
+use App\Service\ReminderScheduler;
+use PHPUnit\Framework\TestCase;
+
+class ReminderSchedulerTest extends TestCase
+{
+    private ReminderScheduler $scheduler;
+
+    protected function setUp(): void
+    {
+        $this->scheduler = new ReminderScheduler();
+    }
+
+    public function testRelativeCanonicalKeyAndShape(): void
+    {
+        $reminder = ['type' => 'relative', 'value' => 15, 'unit' => 'minutes', 'repeat' => false];
+        $this->assertTrue($this->scheduler->isValidShape($reminder));
+        $this->assertSame('rel:15:minutes', $this->scheduler->canonicalKey($reminder));
+        $this->assertTrue($this->scheduler->requiresDueDate($reminder));
+    }
+
+    public function testAbsoluteDoesNotRequireDueDate(): void
+    {
+        $reminder = ['type' => 'absolute', 'at' => '2026-06-01T09:00:00+00:00', 'repeat' => false];
+        $this->assertTrue($this->scheduler->isValidShape($reminder));
+        $this->assertFalse($this->scheduler->requiresDueDate($reminder));
+    }
+
+    public function testInvalidUnitRejected(): void
+    {
+        $this->assertFalse($this->scheduler->isValidShape(
+            ['type' => 'relative', 'value' => 1, 'unit' => 'fortnights'],
+        ));
+    }
+
+    public function testRelativeFiresOnceWhenWindowOpen(): void
+    {
+        $due = new \DateTimeImmutable('2026-06-01T09:00:00+00:00');
+        $now = new \DateTimeImmutable('2026-06-01T08:45:00+00:00'); // 15m before due
+        $reminder = ['type' => 'relative', 'value' => 30, 'unit' => 'minutes', 'repeat' => false];
+        // 30m-before window opened at 08:30, now is 08:45 → fires once.
+        $fires = $this->scheduler->dueFires($reminder, $due, $now);
+        $this->assertCount(1, $fires);
+        $this->assertSame('rel:30:minutes', $fires[0]['key']);
+    }
+
+    public function testRelativeDoesNotFireBeforeWindow(): void
+    {
+        $due = new \DateTimeImmutable('2026-06-01T09:00:00+00:00');
+        $now = new \DateTimeImmutable('2026-06-01T08:00:00+00:00');
+        $reminder = ['type' => 'relative', 'value' => 30, 'unit' => 'minutes', 'repeat' => false];
+        // 30m window opens at 08:30; now is 08:00 → no fire yet.
+        $this->assertCount(0, $this->scheduler->dueFires($reminder, $due, $now));
+    }
+
+    public function testRepeatDailyKeysByDay(): void
+    {
+        $due = new \DateTimeImmutable('2026-06-01T09:00:00+00:00');
+        $reminder = ['type' => 'relative', 'value' => 0, 'unit' => 'minutes', 'repeat' => true];
+        // Anchor = due (value 0). Two days later → latest daily fire is the
+        // 2026-06-03 occurrence, keyed with that date.
+        $now = new \DateTimeImmutable('2026-06-03T10:00:00+00:00');
+        $fires = $this->scheduler->dueFires($reminder, $due, $now);
+        $this->assertCount(1, $fires);
+        $this->assertStringEndsWith(':2026-06-03', $fires[0]['key']);
+    }
+}

--- a/e2e/tests/tasks.spec.js
+++ b/e2e/tests/tasks.spec.js
@@ -274,7 +274,9 @@ test.describe("Tasks", () => {
     const persisted = (json.member ?? json["hydra:member"] ?? []).find(
       (t) => t.title === title,
     );
-    expect(persisted.reminders).toEqual(["1h"]);
+    expect(persisted.reminders).toEqual([
+      { type: "relative", value: 1, unit: "hours", repeat: false },
+    ]);
   });
 
   test("user can reorder tasks via keyboard drag", async ({ page }) => {

--- a/pwa/components/custom-fields/CustomFieldValueCell.tsx
+++ b/pwa/components/custom-fields/CustomFieldValueCell.tsx
@@ -1,0 +1,132 @@
+import type { ReactNode } from "react";
+import { currencyFractionDigits } from "@/lib/currencies";
+import { cn } from "@/lib/utils";
+import type { CustomFieldDefinition } from "./types";
+
+/**
+ * Compact, read-only renderer for one custom-field value in a task-list
+ * column (#227 tasks redesign). Mirrors the value encodings written by
+ * `value-editors.tsx`:
+ *   boolean -> bool · text/url -> string · numeric -> number
+ *   money   -> {amount:int-minor, currency} · date/time/datetime -> string
+ *   select  -> option key (or key[]) · reference -> IRI (or IRI[])
+ */
+interface Props {
+  definition: CustomFieldDefinition;
+  value: unknown;
+  /** Resolve a reference IRI to a display label (e.g. user name). */
+  resolveRef?: (iri: string) => string | null;
+  className?: string;
+}
+
+const dateFmt = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+});
+
+const isEmpty = (v: unknown): boolean =>
+  v === null ||
+  v === undefined ||
+  v === "" ||
+  (Array.isArray(v) && v.length === 0);
+
+const asStringArray = (v: unknown): string[] =>
+  Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
+
+const CustomFieldValueCell = ({
+  definition,
+  value,
+  resolveRef,
+  className,
+}: Props) => {
+  if (isEmpty(value)) {
+    return <span className={cn("text-muted-foreground/50", className)}>—</span>;
+  }
+
+  const wrap = (node: ReactNode) => (
+    <span className={cn("text-sm", className)}>{node}</span>
+  );
+
+  switch (definition.kind) {
+    case "boolean":
+      return wrap(value === true ? "Yes" : "No");
+
+    case "text":
+      return wrap(<span className="truncate">{String(value)}</span>);
+
+    case "numeric": {
+      if (definition.subtype === "money" && isMoney(value)) {
+        const digits = currencyFractionDigits(value.currency);
+        const major = value.amount / 10 ** digits;
+        return wrap(
+          new Intl.NumberFormat(undefined, {
+            style: "currency",
+            currency: value.currency,
+          }).format(major),
+        );
+      }
+      return wrap(
+        typeof value === "number"
+          ? new Intl.NumberFormat().format(value)
+          : String(value),
+      );
+    }
+
+    case "date": {
+      const str = String(value);
+      if (definition.subtype === "time") return wrap(str.slice(0, 5));
+      const d = new Date(str);
+      return wrap(Number.isNaN(d.getTime()) ? str : dateFmt.format(d));
+    }
+
+    case "select": {
+      const options = definition.config.options ?? [];
+      const keys =
+        definition.subtype === "multi" ? asStringArray(value) : [String(value)];
+      return (
+        <span className={cn("flex flex-wrap items-center gap-1", className)}>
+          {keys.map((key) => {
+            const opt = options.find((o) => o.key === key);
+            return (
+              <span
+                key={key}
+                className="inline-flex items-center gap-1 text-sm"
+              >
+                {opt?.color && (
+                  <span
+                    className="h-2 w-2 shrink-0 rounded-full"
+                    style={{ backgroundColor: opt.color }}
+                  />
+                )}
+                {opt?.label ?? key}
+              </span>
+            );
+          })}
+        </span>
+      );
+    }
+
+    case "reference": {
+      const iris = Array.isArray(value) ? asStringArray(value) : [String(value)];
+      const labels = iris.map(
+        (iri) => resolveRef?.(iri) ?? iri.split("/").pop() ?? iri,
+      );
+      return wrap(labels.join(", "));
+    }
+
+    default:
+      return wrap(String(value));
+  }
+};
+
+interface Money {
+  amount: number;
+  currency: string;
+}
+const isMoney = (v: unknown): v is Money =>
+  typeof v === "object" &&
+  v !== null &&
+  typeof (v as Money).amount === "number" &&
+  typeof (v as Money).currency === "string";
+
+export default CustomFieldValueCell;

--- a/pwa/components/tasks/DueDateCell.tsx
+++ b/pwa/components/tasks/DueDateCell.tsx
@@ -9,18 +9,18 @@ import {
 } from "@/components/ui/popover";
 import RecurrencePicker from "@/components/tasks/RecurrencePicker";
 import {
-  REMINDER_LABELS,
-  REMINDER_OFFSETS,
+  REMINDER_PRESETS,
   addDays,
   addMonths,
   formatDueDate,
   formatRecurrenceSummary,
   isoToLocalDate,
   localDateToIso,
+  reminderKey,
   todayLocalMidnight,
   type DueDateStatus,
   type RecurrenceRule,
-  type ReminderOffset,
+  type Reminder,
 } from "@/components/tasks/taskHelpers";
 import { cn } from "@/lib/utils";
 
@@ -38,8 +38,8 @@ interface DueDateCellProps {
    *  checkboxes for each allowed offset inside the same popover. Clearing
    *  the date also clears reminders (the server-side validator rejects
    *  reminders without an anchor). */
-  remindersValue?: ReminderOffset[] | null;
-  onRemindersChange?: (next: ReminderOffset[] | null) => void | Promise<void>;
+  remindersValue?: Reminder[] | null;
+  onRemindersChange?: (next: Reminder[] | null) => void | Promise<void>;
   /** Toggles overdue/today colouring. Completed tasks pass `"none"` so a missed
    *  deadline doesn't keep glowing red after the work is done. */
   status?: DueDateStatus;
@@ -103,12 +103,13 @@ const DueDateCell = ({
     status === "today" && "text-amber-600 dark:text-amber-400 font-medium",
   );
 
-  const toggleReminder = (offset: ReminderOffset) => {
+  const togglePreset = (preset: (typeof REMINDER_PRESETS)[number]) => {
     if (!onRemindersChange) return;
     const current = remindersValue ?? [];
-    const next = current.includes(offset)
-      ? current.filter((o) => o !== offset)
-      : [...current, offset];
+    const has = current.some((r) => reminderKey(r) === preset.key);
+    const next = has
+      ? current.filter((r) => reminderKey(r) !== preset.key)
+      : [...current, preset.reminder];
     void onRemindersChange(next.length === 0 ? null : next);
   };
 
@@ -211,21 +212,23 @@ const DueDateCell = ({
             <p className="text-xs font-medium text-muted-foreground px-1">
               Remind me
             </p>
-            {REMINDER_OFFSETS.map((offset) => {
-              const checked = (remindersValue ?? []).includes(offset);
+            {REMINDER_PRESETS.map((preset) => {
+              const checked = (remindersValue ?? []).some(
+                (r) => reminderKey(r) === preset.key,
+              );
               return (
                 <label
-                  key={offset}
+                  key={preset.id}
                   className="flex items-center gap-2 px-1 py-1 text-sm cursor-pointer"
                 >
                   <input
                     type="checkbox"
                     checked={checked}
-                    onChange={() => toggleReminder(offset)}
+                    onChange={() => togglePreset(preset)}
                     className="h-3.5 w-3.5"
-                    data-testid={`${testIdPrefix}-reminder-${offset}`}
+                    data-testid={`${testIdPrefix}-reminder-${preset.id}`}
                   />
-                  {REMINDER_LABELS[offset]}
+                  {preset.label}
                 </label>
               );
             })}

--- a/pwa/components/tasks/RecurrenceEditor.tsx
+++ b/pwa/components/tasks/RecurrenceEditor.tsx
@@ -1,0 +1,447 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Trash2 } from "lucide-react";
+import { ENTRYPOINT } from "@/config/entrypoint";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import {
+  WEEKDAYS,
+  WEEKDAY_INITIALS,
+  WEEKDAY_LABELS,
+  type MonthlyMode,
+  type RecurrenceEnds,
+  type RecurrenceFrequency,
+  type RecurrenceRule,
+  type Weekday,
+} from "@/components/tasks/taskHelpers";
+
+/**
+ * The "Repeats" RRULE editor (#227 tasks redesign). A self-contained panel —
+ * the drawer mounts it inside a Popover anchored to the Repeats field. Edits
+ * a local draft and only commits on Apply, so opening + cancelling never
+ * mutates the task. The "Next 3 occurrences" preview is computed server-side
+ * via POST /recurrence-preview so it can't disagree with the spawn logic.
+ */
+interface RecurrenceEditorProps {
+  value: RecurrenceRule | null;
+  /** Anchor for the occurrence preview + derived monthly/weekly defaults. */
+  dueDate: string | null;
+  onApply: (next: RecurrenceRule) => void;
+  onRemove: () => void;
+  onCancel: () => void;
+}
+
+const FREQUENCIES: { value: RecurrenceFrequency; label: string }[] = [
+  { value: "daily", label: "Daily" },
+  { value: "weekly", label: "Weekly" },
+  { value: "monthly", label: "Monthly" },
+  { value: "yearly", label: "Yearly" },
+];
+
+const INTERVAL_NOUN: Record<RecurrenceFrequency, string> = {
+  daily: "days",
+  weekly: "weeks",
+  monthly: "months",
+  yearly: "years",
+};
+
+const SET_POS_OPTIONS: { value: number; label: string }[] = [
+  { value: 1, label: "First" },
+  { value: 2, label: "Second" },
+  { value: 3, label: "Third" },
+  { value: 4, label: "Fourth" },
+  { value: 5, label: "Fifth" },
+  { value: -1, label: "Last" },
+];
+
+const ISO_WEEKDAY: Record<number, Weekday> = {
+  1: "MO",
+  2: "TU",
+  3: "WE",
+  4: "TH",
+  5: "FR",
+  6: "SA",
+  7: "SU",
+};
+
+type EndsType = "never" | "until" | "count";
+
+const previewFormatter = new Intl.DateTimeFormat(undefined, {
+  weekday: "short",
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+});
+
+const weekdayFromIso = (iso: string | null): Weekday => {
+  if (!iso) return "MO";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "MO";
+  const isoDow = d.getDay() === 0 ? 7 : d.getDay();
+  return ISO_WEEKDAY[isoDow] ?? "MO";
+};
+
+const dayOfMonthFromIso = (iso: string | null): number => {
+  if (!iso) return 1;
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? 1 : d.getDate();
+};
+
+const RecurrenceEditor = ({
+  value,
+  dueDate,
+  onApply,
+  onRemove,
+  onCancel,
+}: RecurrenceEditorProps) => {
+  const [frequency, setFrequency] = useState<RecurrenceFrequency>(
+    value?.frequency ?? "weekly",
+  );
+  const [interval, setIntervalValue] = useState<number>(value?.interval ?? 1);
+  const [byDay, setByDay] = useState<Weekday[]>(
+    value?.byDay ?? [weekdayFromIso(dueDate)],
+  );
+  const [monthlyMode, setMonthlyMode] = useState<MonthlyMode>(
+    value?.monthlyMode ?? "day",
+  );
+  const [bySetPos, setBySetPos] = useState<number>(value?.bySetPos ?? 2);
+  const [weekdayForMonthly, setWeekdayForMonthly] = useState<Weekday>(
+    value?.byDay?.[0] ?? weekdayFromIso(dueDate),
+  );
+  const [endsType, setEndsType] = useState<EndsType>(value?.ends?.type ?? "never");
+  const [until, setUntil] = useState<string>(
+    value?.ends?.type === "until" ? value.ends.until : (dueDate?.slice(0, 10) ?? ""),
+  );
+  const [count, setCount] = useState<number>(
+    value?.ends?.type === "count" ? value.ends.count : 6,
+  );
+
+  const draft = useMemo<RecurrenceRule>(() => {
+    const ends: RecurrenceEnds | null =
+      endsType === "until"
+        ? { type: "until", until }
+        : endsType === "count"
+          ? { type: "count", count: Math.max(1, count) }
+          : null;
+    const rule: RecurrenceRule = {
+      frequency,
+      interval: Math.max(1, interval),
+      ends,
+    };
+    if (frequency === "weekly" && byDay.length > 0) {
+      rule.byDay = WEEKDAYS.filter((d) => byDay.includes(d));
+    }
+    if (frequency === "monthly") {
+      rule.monthlyMode = monthlyMode;
+      if (monthlyMode === "weekday") {
+        rule.byDay = [weekdayForMonthly];
+        rule.bySetPos = bySetPos;
+      }
+    }
+    return rule;
+  }, [
+    frequency,
+    interval,
+    byDay,
+    monthlyMode,
+    bySetPos,
+    weekdayForMonthly,
+    endsType,
+    until,
+    count,
+  ]);
+
+  const [preview, setPreview] = useState<string[]>([]);
+
+  // Debounced server preview. Skipped when there's no anchor — relative
+  // occurrences need a due date to count from.
+  useEffect(() => {
+    if (!dueDate) {
+      setPreview([]);
+      return;
+    }
+    let cancelled = false;
+    const handle = setTimeout(() => {
+      void (async () => {
+        try {
+          const res = await fetch(`${ENTRYPOINT}/recurrence-preview`, {
+            method: "POST",
+            credentials: "include",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ dueDate, rule: draft, count: 3 }),
+          });
+          if (!res.ok || cancelled) return;
+          const data: { occurrences?: string[] } = await res.json();
+          if (!cancelled) setPreview(data.occurrences ?? []);
+        } catch {
+          /* preview is advisory — ignore failures */
+        }
+      })();
+    }, 250);
+    return () => {
+      cancelled = true;
+      clearTimeout(handle);
+    };
+  }, [draft, dueDate]);
+
+  const toggleDay = useCallback((day: Weekday) => {
+    setByDay((prev) =>
+      prev.includes(day) ? prev.filter((d) => d !== day) : [...prev, day],
+    );
+  }, []);
+
+  const dayOfMonth = dayOfMonthFromIso(dueDate);
+
+  return (
+    <div className="w-80 text-sm" data-testid="recurrence-editor">
+      <div className="border-b px-3 py-2.5">
+        <span className="font-semibold">Repeats</span>{" "}
+        <span className="text-xs uppercase tracking-wide text-muted-foreground">
+          RRULE editor
+        </span>
+      </div>
+
+      <div className="max-h-[min(460px,60vh)] space-y-4 overflow-y-auto px-3 py-3">
+        {/* Frequency segmented control */}
+        <div className="grid grid-cols-4 gap-1 rounded-md bg-muted/50 p-1">
+          {FREQUENCIES.map((f) => (
+            <button
+              key={f.value}
+              type="button"
+              onClick={() => setFrequency(f.value)}
+              aria-pressed={frequency === f.value}
+              className={cn(
+                "rounded px-2 py-1 text-xs font-medium transition",
+                frequency === f.value
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+              data-testid={`recurrence-freq-${f.value}`}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Interval */}
+        <div className="space-y-1">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Interval
+          </p>
+          <div className="flex items-center gap-2">
+            <span className="text-muted-foreground">Every</span>
+            <Input
+              type="number"
+              min={1}
+              max={99}
+              value={interval}
+              onChange={(e) =>
+                setIntervalValue(Math.max(1, Number.parseInt(e.target.value, 10) || 1))
+              }
+              className="h-8 w-16"
+              data-testid="recurrence-interval"
+            />
+            <span className="text-muted-foreground">{INTERVAL_NOUN[frequency]}</span>
+          </div>
+        </div>
+
+        {/* Weekly: weekday picker */}
+        {frequency === "weekly" && (
+          <div className="space-y-1.5">
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              On <span className="normal-case">· pick one or more days</span>
+            </p>
+            <div className="flex gap-1">
+              {WEEKDAYS.map((day) => (
+                <button
+                  key={day}
+                  type="button"
+                  onClick={() => toggleDay(day)}
+                  aria-pressed={byDay.includes(day)}
+                  aria-label={WEEKDAY_LABELS[day]}
+                  className={cn(
+                    "flex h-8 w-8 items-center justify-center rounded-full text-xs font-medium transition",
+                    byDay.includes(day)
+                      ? "bg-primary text-primary-foreground"
+                      : "border border-input text-muted-foreground hover:text-foreground",
+                  )}
+                  data-testid={`recurrence-day-${day}`}
+                >
+                  {WEEKDAY_INITIALS[day]}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Monthly: day-of-month vs nth-weekday */}
+        {frequency === "monthly" && (
+          <div className="space-y-2">
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              On
+            </p>
+            <label className="flex items-center gap-2">
+              <input
+                type="radio"
+                name="monthly-mode"
+                checked={monthlyMode === "day"}
+                onChange={() => setMonthlyMode("day")}
+                data-testid="recurrence-monthly-day"
+              />
+              <span>Day {dayOfMonth} of the month</span>
+            </label>
+            <label className="flex items-center gap-2">
+              <input
+                type="radio"
+                name="monthly-mode"
+                checked={monthlyMode === "weekday"}
+                onChange={() => setMonthlyMode("weekday")}
+                data-testid="recurrence-monthly-weekday"
+              />
+              <span className="flex items-center gap-1">
+                The
+                <select
+                  value={bySetPos}
+                  onChange={(e) => setBySetPos(Number.parseInt(e.target.value, 10))}
+                  onFocus={() => setMonthlyMode("weekday")}
+                  className="h-7 rounded-md border border-input bg-background px-1 text-sm"
+                  data-testid="recurrence-setpos"
+                >
+                  {SET_POS_OPTIONS.map((o) => (
+                    <option key={o.value} value={o.value}>
+                      {o.label}
+                    </option>
+                  ))}
+                </select>
+                <select
+                  value={weekdayForMonthly}
+                  onChange={(e) => setWeekdayForMonthly(e.target.value as Weekday)}
+                  onFocus={() => setMonthlyMode("weekday")}
+                  className="h-7 rounded-md border border-input bg-background px-1 text-sm"
+                  data-testid="recurrence-weekday"
+                >
+                  {WEEKDAYS.map((d) => (
+                    <option key={d} value={d}>
+                      {WEEKDAY_LABELS[d]}
+                    </option>
+                  ))}
+                </select>
+              </span>
+            </label>
+          </div>
+        )}
+
+        {/* Ends */}
+        <div className="space-y-2">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Ends
+          </p>
+          <label className="flex items-center gap-2">
+            <input
+              type="radio"
+              name="ends"
+              checked={endsType === "never"}
+              onChange={() => setEndsType("never")}
+              data-testid="recurrence-ends-never"
+            />
+            <span>Never</span>
+          </label>
+          <label className="flex items-center gap-2">
+            <input
+              type="radio"
+              name="ends"
+              checked={endsType === "until"}
+              onChange={() => setEndsType("until")}
+              data-testid="recurrence-ends-until"
+            />
+            <span>On date</span>
+            <input
+              type="date"
+              value={until}
+              onChange={(e) => {
+                setUntil(e.target.value);
+                setEndsType("until");
+              }}
+              className="h-7 rounded-md border border-input bg-background px-2 text-sm"
+              data-testid="recurrence-until"
+            />
+          </label>
+          <label className="flex items-center gap-2">
+            <input
+              type="radio"
+              name="ends"
+              checked={endsType === "count"}
+              onChange={() => setEndsType("count")}
+              data-testid="recurrence-ends-count"
+            />
+            <span>After</span>
+            <Input
+              type="number"
+              min={1}
+              max={999}
+              value={count}
+              onChange={(e) => {
+                setCount(Math.max(1, Number.parseInt(e.target.value, 10) || 1));
+                setEndsType("count");
+              }}
+              className="h-7 w-16"
+              data-testid="recurrence-count"
+            />
+            <span className="text-muted-foreground">occurrences</span>
+          </label>
+        </div>
+
+        {/* Preview */}
+        <div className="space-y-1">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Next 3 occurrences
+          </p>
+          {preview.length === 0 ? (
+            <p className="text-xs text-muted-foreground">
+              {dueDate ? "No further occurrences." : "Set a due date to preview."}
+            </p>
+          ) : (
+            <ol className="space-y-0.5" data-testid="recurrence-preview">
+              {preview.map((iso, i) => (
+                <li
+                  key={iso}
+                  className="rounded bg-primary/10 px-2 py-1 text-xs text-foreground"
+                >
+                  {i + 1}. {previewFormatter.format(new Date(iso))}
+                </li>
+              ))}
+            </ol>
+          )}
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between border-t px-3 py-2.5">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="text-destructive hover:text-destructive"
+          onClick={onRemove}
+          data-testid="recurrence-remove"
+        >
+          <Trash2 className="mr-1 h-3.5 w-3.5" /> Remove
+        </Button>
+        <div className="flex gap-2">
+          <Button type="button" variant="outline" size="sm" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => onApply(draft)}
+            data-testid="recurrence-apply"
+          >
+            Apply
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RecurrenceEditor;

--- a/pwa/components/tasks/RemindersEditor.tsx
+++ b/pwa/components/tasks/RemindersEditor.tsx
@@ -1,0 +1,261 @@
+import { useState } from "react";
+import { Bell, Clock, Plus, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { cn } from "@/lib/utils";
+import {
+  describeReminder,
+  reminderKey,
+  type Reminder,
+  type ReminderUnit,
+} from "@/components/tasks/taskHelpers";
+
+/**
+ * Reminders list + add-form for the task drawer (#227 tasks redesign).
+ * Renders each reminder with a RELATIVE / ABSOLUTE badge and a "repeats
+ * daily" sub-line, plus an inline composer for new reminders. Relative
+ * reminders fire a fixed offset before the due date; absolute reminders fire
+ * at a wall-clock time and need no due date. Persists the whole array.
+ */
+interface RemindersEditorProps {
+  value: Reminder[] | null;
+  /** Relative reminders anchor to this; absolute reminders don't need it. */
+  dueDate: string | null;
+  onChange: (next: Reminder[] | null) => void | Promise<void>;
+}
+
+const UNITS: { value: ReminderUnit; label: string }[] = [
+  { value: "minutes", label: "minutes" },
+  { value: "hours", label: "hours" },
+  { value: "days", label: "days" },
+];
+
+// "2026-06-01T09:00" (datetime-local) → ISO with offset, and back.
+const toLocalInput = (iso: string): string => {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+};
+
+const RemindersEditor = ({ value, dueDate, onChange }: RemindersEditorProps) => {
+  const reminders = value ?? [];
+  const [adding, setAdding] = useState(false);
+  const [mode, setMode] = useState<"relative" | "absolute">(
+    dueDate ? "relative" : "absolute",
+  );
+  const [relValue, setRelValue] = useState(15);
+  const [relUnit, setRelUnit] = useState<ReminderUnit>("minutes");
+  const [absAt, setAbsAt] = useState("");
+  const [repeat, setRepeat] = useState(false);
+
+  const resetForm = () => {
+    setAdding(false);
+    setMode(dueDate ? "relative" : "absolute");
+    setRelValue(15);
+    setRelUnit("minutes");
+    setAbsAt("");
+    setRepeat(false);
+  };
+
+  const handleRemove = (target: Reminder) => {
+    const next = reminders.filter((r) => reminderKey(r) !== reminderKey(target));
+    void onChange(next.length === 0 ? null : next);
+  };
+
+  const handleAdd = () => {
+    let reminder: Reminder;
+    if (mode === "relative") {
+      reminder = {
+        type: "relative",
+        value: Math.max(0, relValue),
+        unit: relUnit,
+        repeat,
+      };
+    } else {
+      if (absAt === "") return;
+      reminder = {
+        type: "absolute",
+        at: new Date(absAt).toISOString(),
+        repeat,
+      };
+    }
+    // Skip exact duplicates (same canonical key).
+    if (reminders.some((r) => reminderKey(r) === reminderKey(reminder))) {
+      resetForm();
+      return;
+    }
+    void onChange([...reminders, reminder]);
+    resetForm();
+  };
+
+  return (
+    <div className="space-y-2" data-testid="reminders-editor">
+      <div className="flex items-center justify-between">
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Reminders
+        </p>
+        {reminders.length > 0 && (
+          <span className="text-xs text-muted-foreground">
+            {reminders.length} active
+          </span>
+        )}
+      </div>
+
+      {reminders.length > 0 && (
+        <ul className="space-y-1.5">
+          {reminders.map((r) => (
+            <li
+              key={reminderKey(r)}
+              className="flex items-center gap-2 rounded-md border border-input px-2.5 py-2"
+              data-testid="reminder-item"
+            >
+              {r.type === "relative" ? (
+                <Bell className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              ) : (
+                <Clock className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              )}
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm">{describeReminder(r)}</p>
+                {r.repeat && (
+                  <p className="text-xs text-muted-foreground">
+                    Repeats daily until done
+                  </p>
+                )}
+              </div>
+              <span
+                className={cn(
+                  "rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
+                  r.type === "relative"
+                    ? "bg-primary/15 text-primary"
+                    : "bg-accent text-accent-foreground",
+                )}
+              >
+                {r.type}
+              </span>
+              <button
+                type="button"
+                onClick={() => handleRemove(r)}
+                className="text-muted-foreground hover:text-destructive"
+                aria-label="Remove reminder"
+                data-testid="reminder-remove"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {adding ? (
+        <div className="space-y-3 rounded-md border border-input p-3" data-testid="reminder-form">
+          <div className="grid grid-cols-2 gap-1 rounded-md bg-muted/50 p-1">
+            <button
+              type="button"
+              onClick={() => setMode("relative")}
+              disabled={!dueDate}
+              aria-pressed={mode === "relative"}
+              className={cn(
+                "rounded px-2 py-1 text-xs font-medium transition disabled:opacity-40",
+                mode === "relative"
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+              data-testid="reminder-mode-relative"
+            >
+              Relative
+            </button>
+            <button
+              type="button"
+              onClick={() => setMode("absolute")}
+              aria-pressed={mode === "absolute"}
+              className={cn(
+                "rounded px-2 py-1 text-xs font-medium transition",
+                mode === "absolute"
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+              data-testid="reminder-mode-absolute"
+            >
+              Absolute
+            </button>
+          </div>
+
+          {mode === "relative" ? (
+            <div className="flex items-center gap-2">
+              <Input
+                type="number"
+                min={0}
+                max={999}
+                value={relValue}
+                onChange={(e) =>
+                  setRelValue(Math.max(0, Number.parseInt(e.target.value, 10) || 0))
+                }
+                className="h-8 w-16"
+                data-testid="reminder-rel-value"
+              />
+              <select
+                value={relUnit}
+                onChange={(e) => setRelUnit(e.target.value as ReminderUnit)}
+                className="h-8 rounded-md border border-input bg-background px-2 text-sm"
+                data-testid="reminder-rel-unit"
+              >
+                {UNITS.map((u) => (
+                  <option key={u.value} value={u.value}>
+                    {u.label}
+                  </option>
+                ))}
+              </select>
+              <span className="text-sm text-muted-foreground">before due</span>
+            </div>
+          ) : (
+            <input
+              type="datetime-local"
+              value={absAt === "" ? "" : toLocalInput(absAt)}
+              onChange={(e) =>
+                setAbsAt(e.target.value === "" ? "" : new Date(e.target.value).toISOString())
+              }
+              className="h-8 w-full rounded-md border border-input bg-background px-2 text-sm"
+              data-testid="reminder-abs-at"
+            />
+          )}
+
+          <div className="flex items-center justify-between">
+            <span className="text-sm">Repeat daily until done</span>
+            <Switch
+              checked={repeat}
+              onCheckedChange={setRepeat}
+              data-testid="reminder-repeat"
+            />
+          </div>
+
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="outline" size="sm" onClick={resetForm}>
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              onClick={handleAdd}
+              data-testid="reminder-add-confirm"
+            >
+              Add reminder
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setAdding(true)}
+          className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+          data-testid="reminder-add"
+        >
+          <Plus className="h-3.5 w-3.5" /> Add reminder
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default RemindersEditor;

--- a/pwa/components/tasks/TaskDetailDrawer.tsx
+++ b/pwa/components/tasks/TaskDetailDrawer.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { Calendar as CalendarIcon, Bell, Repeat } from "lucide-react";
+import { Repeat } from "lucide-react";
 import { ENTRYPOINT } from "@/config/entrypoint";
 import { Sheet, SheetContent } from "@/components/ui/sheet";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -7,11 +7,19 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import AssigneesCombobox, {
   type AssigneeOption,
 } from "@/components/tasks/AssigneesCombobox";
 import TagsCombobox, { type TagOption } from "@/components/tasks/TagsCombobox";
 import AttachmentsPanel from "@/components/tasks/AttachmentsPanel";
+import DueDateCell from "@/components/tasks/DueDateCell";
+import RecurrenceEditor from "@/components/tasks/RecurrenceEditor";
+import RemindersEditor from "@/components/tasks/RemindersEditor";
 import CommentsPanel from "@/components/common/CommentsPanel";
 import ActivityPanel from "@/components/activity/ActivityPanel";
 import CustomFieldValueList, {
@@ -19,6 +27,12 @@ import CustomFieldValueList, {
 } from "@/components/tasks/CustomFieldValueList";
 import type { AvatarUser } from "@/components/user/UserAvatar";
 import type { CustomFieldDefinition } from "@/components/custom-fields/types";
+import {
+  dueDateStatus,
+  formatRecurrenceSummary,
+  type RecurrenceRule,
+  type Reminder,
+} from "@/components/tasks/taskHelpers";
 import { parseViolations, type ViolationMap } from "@/lib/violations";
 
 interface DrawerAttachment {
@@ -48,8 +62,8 @@ interface DrawerTask {
   completedOn: string | null;
   dueDate: string | null;
   owner: { "@id": string };
-  recurrenceRule: { frequency: string; interval: number } | null;
-  reminders: string[] | null;
+  recurrenceRule: RecurrenceRule | null;
+  reminders: Reminder[] | null;
   attachments: DrawerAttachment[];
   tags: TagOption[];
   assignees: AssigneeOption[];
@@ -64,33 +78,6 @@ interface Collection<T> {
 
 const membersOf = <T,>(data: Collection<T>): T[] =>
   data.member ?? data["hydra:member"] ?? [];
-
-const REMINDER_LABELS: Record<string, string> = {
-  "15m": "15 minutes before",
-  "1h": "1 hour before",
-  "1d": "1 day before",
-};
-
-const recurrenceSummary = (
-  rule: { frequency: string; interval: number } | null,
-): string | null => {
-  if (!rule) return null;
-  const noun =
-    { daily: "day", weekly: "week", monthly: "month", yearly: "year" }[
-      rule.frequency
-    ] ?? rule.frequency;
-  return rule.interval === 1 ? `Every ${noun}` : `Every ${rule.interval} ${noun}s`;
-};
-
-const formatDue = (iso: string | null): string => {
-  if (!iso) return "No due date";
-  const d = new Date(iso);
-  return d.toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
-};
 
 export interface TaskDetailDrawerProps {
   taskId: string | null;
@@ -127,6 +114,7 @@ const TaskDetailDrawer = ({
   const [loading, setLoading] = useState(false);
   const [notFound, setNotFound] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [recurrenceOpen, setRecurrenceOpen] = useState(false);
 
   // Load the task whenever the drawer opens on a new id.
   useEffect(() => {
@@ -395,7 +383,28 @@ const TaskDetailDrawer = ({
                   className="border-0 px-0 text-lg font-semibold shadow-none focus-visible:ring-0"
                   data-testid="task-detail-title"
                 />
+                {task.completedOn && (
+                  <span className="mt-1.5 shrink-0 rounded-full bg-primary/15 px-2 py-0.5 text-xs font-medium text-primary">
+                    Done
+                  </span>
+                )}
               </div>
+              {task.tags.length > 0 && (
+                <div className="mt-2 flex flex-wrap gap-1.5 pl-6">
+                  {task.tags.map((tag) => (
+                    <span
+                      key={tag["@id"]}
+                      className="rounded px-1.5 py-0.5 text-xs font-medium"
+                      style={{
+                        backgroundColor: `${tag.color}22`,
+                        color: tag.color,
+                      }}
+                    >
+                      {tag.title}
+                    </span>
+                  ))}
+                </div>
+              )}
               <TabsList variant="line" className="mt-3">
                 <TabsTrigger value="details" data-testid="task-tab-details">
                   Details
@@ -443,30 +452,54 @@ const TaskDetailDrawer = ({
                     />
                   </Row>
                   <Row label="Due">
-                    <span className="flex items-center gap-1.5 text-muted-foreground">
-                      <CalendarIcon className="h-3.5 w-3.5" />
-                      {formatDue(task.dueDate)}
-                    </span>
+                    <DueDateCell
+                      value={task.dueDate}
+                      onChange={(next) => void patchTask({ dueDate: next })}
+                      ariaLabel={`Due date for ${task.title}`}
+                      testIdPrefix="task-detail-due"
+                      status={dueDateStatus(task.dueDate, Boolean(task.completedOn))}
+                    />
                   </Row>
-                  {recurrenceSummary(task.recurrenceRule) && (
-                    <Row label="Repeats">
-                      <span className="flex items-center gap-1.5 text-muted-foreground">
-                        <Repeat className="h-3.5 w-3.5" />
-                        {recurrenceSummary(task.recurrenceRule)}
-                      </span>
-                    </Row>
-                  )}
-                  {task.reminders && task.reminders.length > 0 && (
-                    <Row label="Reminders">
-                      <span className="flex items-center gap-1.5 text-muted-foreground">
-                        <Bell className="h-3.5 w-3.5" />
-                        {task.reminders
-                          .map((r) => REMINDER_LABELS[r] ?? r)
-                          .join(", ")}
-                      </span>
-                    </Row>
-                  )}
+                  <Row label="Repeats">
+                    <Popover open={recurrenceOpen} onOpenChange={setRecurrenceOpen}>
+                      <PopoverTrigger asChild>
+                        <button
+                          type="button"
+                          className="flex items-center gap-1.5 text-left hover:text-foreground"
+                          data-testid="task-detail-repeats"
+                        >
+                          <Repeat className="h-3.5 w-3.5 text-muted-foreground" />
+                          {task.recurrenceRule ? (
+                            <span>{formatRecurrenceSummary(task.recurrenceRule)}</span>
+                          ) : (
+                            <span className="text-muted-foreground">Does not repeat</span>
+                          )}
+                        </button>
+                      </PopoverTrigger>
+                      <PopoverContent align="start" className="w-auto p-0">
+                        <RecurrenceEditor
+                          value={task.recurrenceRule}
+                          dueDate={task.dueDate}
+                          onApply={(rule) => {
+                            void patchTask({ recurrenceRule: rule });
+                            setRecurrenceOpen(false);
+                          }}
+                          onRemove={() => {
+                            void patchTask({ recurrenceRule: null });
+                            setRecurrenceOpen(false);
+                          }}
+                          onCancel={() => setRecurrenceOpen(false)}
+                        />
+                      </PopoverContent>
+                    </Popover>
+                  </Row>
                 </dl>
+
+                <RemindersEditor
+                  value={task.reminders}
+                  dueDate={task.dueDate}
+                  onChange={(next) => void patchTask({ reminders: next })}
+                />
 
                 {task.project && definitions.length > 0 && (
                   <CustomFieldValueList

--- a/pwa/components/tasks/TaskRow.tsx
+++ b/pwa/components/tasks/TaskRow.tsx
@@ -30,7 +30,7 @@ import {
   dueDateStatus,
   plainTextDescription,
   type RecurrenceRule,
-  type ReminderOffset,
+  type Reminder,
   type Tag,
   type Task,
 } from "@/components/tasks/taskHelpers";
@@ -54,7 +54,7 @@ interface TaskRowProps {
   onRecurrenceChange: (task: Task, nextRule: RecurrenceRule | null) => Promise<void>;
   onRemindersChange: (
     task: Task,
-    nextReminders: ReminderOffset[] | null,
+    nextReminders: Reminder[] | null,
   ) => Promise<void>;
   onAssigneesChange: (task: Task, nextIris: string[]) => Promise<void>;
   onAssigneeAvatarClick: (assignee: AssigneeOption) => void;

--- a/pwa/components/tasks/taskHelpers.ts
+++ b/pwa/components/tasks/taskHelpers.ts
@@ -16,20 +16,129 @@ export interface Tag {
 
 export type RecurrenceFrequency = "daily" | "weekly" | "monthly" | "yearly";
 
+export type Weekday = "MO" | "TU" | "WE" | "TH" | "FR" | "SA" | "SU";
+
+// Picker order is Sun-first to match the mock's S M T W T F S row.
+export const WEEKDAYS: Weekday[] = ["SU", "MO", "TU", "WE", "TH", "FR", "SA"];
+
+export const WEEKDAY_LABELS: Record<Weekday, string> = {
+  MO: "Mon",
+  TU: "Tue",
+  WE: "Wed",
+  TH: "Thu",
+  FR: "Fri",
+  SA: "Sat",
+  SU: "Sun",
+};
+
+// Single-letter labels for the compact day picker (the duplicate S/T are fine
+// because position disambiguates, exactly like the mock).
+export const WEEKDAY_INITIALS: Record<Weekday, string> = {
+  SU: "S",
+  MO: "M",
+  TU: "T",
+  WE: "W",
+  TH: "T",
+  FR: "F",
+  SA: "S",
+};
+
+export type MonthlyMode = "day" | "weekday";
+
+export type RecurrenceEnds =
+  | { type: "until"; until: string } // YYYY-MM-DD
+  | { type: "count"; count: number };
+
+// The rule mirrors the API's expanded JSON shape. Only frequency + interval
+// are required; the rest specialise weekly (byDay) and monthly (monthlyMode +
+// bySetPos), plus an optional end condition. A bare {frequency, interval} is
+// still valid, so legacy rows and the simple list picker keep working.
 export interface RecurrenceRule {
   frequency: RecurrenceFrequency;
   interval: number;
+  byDay?: Weekday[];
+  monthlyMode?: MonthlyMode;
+  bySetPos?: number; // 1..5 or -1 (last)
+  ends?: RecurrenceEnds | null;
 }
 
-// Allowlist of reminder offsets the API accepts on Task.reminders. Kept in
-// the same order the picker renders so checkbox state ↔ JSON array stay
-// trivially aligned.
-export const REMINDER_OFFSETS = ["15m", "1h", "1d"] as const;
-export type ReminderOffset = (typeof REMINDER_OFFSETS)[number];
-export const REMINDER_LABELS: Record<ReminderOffset, string> = {
-  "15m": "15 minutes before",
-  "1h": "1 hour before",
-  "1d": "1 day before",
+export type ReminderUnit = "minutes" | "hours" | "days";
+
+// A reminder is either relative to the due date or pinned to an absolute
+// timestamp; either may "repeat daily until done". Mirrors the API shape.
+export type Reminder =
+  | { type: "relative"; value: number; unit: ReminderUnit; repeat: boolean }
+  | { type: "absolute"; at: string; repeat: boolean };
+
+// Quick presets surfaced as checkboxes in the simple list due-date popover.
+// The rich per-reminder editor lives in the task drawer.
+export interface ReminderPreset {
+  /** Short, stable id for test selectors / DOM keys. */
+  id: string;
+  key: string;
+  label: string;
+  reminder: Reminder;
+}
+export const REMINDER_PRESETS: ReminderPreset[] = [
+  {
+    id: "15m",
+    key: "rel:15:minutes",
+    label: "15 minutes before",
+    reminder: { type: "relative", value: 15, unit: "minutes", repeat: false },
+  },
+  {
+    id: "1h",
+    key: "rel:1:hours",
+    label: "1 hour before",
+    reminder: { type: "relative", value: 1, unit: "hours", repeat: false },
+  },
+  {
+    id: "1d",
+    key: "rel:1:days",
+    label: "1 day before",
+    reminder: { type: "relative", value: 1, unit: "days", repeat: false },
+  },
+];
+
+// Canonical key for a reminder — mirrors ReminderScheduler::canonicalKey on
+// the API so the UI can dedup / toggle presets consistently. Ignores the
+// `repeat` flag (same as the server) so a preset matches regardless.
+export const reminderKey = (r: Reminder): string =>
+  r.type === "relative"
+    ? `rel:${r.value}:${r.unit}`
+    : `abs:${r.at}`;
+
+const REMINDER_UNIT_SINGULAR: Record<ReminderUnit, string> = {
+  minutes: "minute",
+  hours: "hour",
+  days: "day",
+};
+
+const absoluteReminderFormatter = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+});
+
+// Human label for one reminder, e.g. "30 minutes before due" / "On Apr 2,
+// 9:00 AM". Used in the drawer list + the read-only summaries.
+export const describeReminder = (r: Reminder): string => {
+  if (r.type === "relative") {
+    if (r.value === 0) return "When due";
+    const unit = REMINDER_UNIT_SINGULAR[r.unit];
+    return `${r.value} ${unit}${r.value === 1 ? "" : "s"} before due`;
+  }
+  const at = new Date(r.at);
+  return Number.isNaN(at.getTime())
+    ? "At a set time"
+    : `On ${absoluteReminderFormatter.format(at)}`;
+};
+
+export const summarizeReminders = (reminders: Reminder[] | null): string => {
+  if (!reminders || reminders.length === 0) return "";
+  if (reminders.length === 1) return describeReminder(reminders[0]);
+  return `${reminders.length} reminders`;
 };
 
 export interface Task {
@@ -45,7 +154,7 @@ export interface Task {
   // delete-rights for the task owner without an extra fetch.
   owner: { "@id": string };
   recurrenceRule: RecurrenceRule | null;
-  reminders: ReminderOffset[] | null;
+  reminders: Reminder[] | null;
   // Attachments embed inline under `task:read`. The PWA uploads via
   // `POST /media-objects?kind=attachment`, then PATCHes the IRI here.
   attachments: Attachment[];
@@ -64,10 +173,41 @@ export const FREQUENCY_LABELS: Record<RecurrenceFrequency, string> = {
   yearly: "year",
 };
 
+// 1 → "1st", 2 → "2nd", -1 → "last" (for monthly "2nd Thursday").
+export const ordinalLabel = (n: number): string => {
+  if (n === -1) return "last";
+  const s = ["th", "st", "nd", "rd"];
+  const v = n % 100;
+  return `${n}${s[(v - 20) % 10] ?? s[v] ?? s[0]}`;
+};
+
+// Compact one-line summary matching the mock chips: "Daily · every 2 days",
+// "Weekly · Mon / Wed / Fri", "Monthly · 2nd Thursday".
 export const formatRecurrenceSummary = (rule: RecurrenceRule): string => {
-  const noun = FREQUENCY_LABELS[rule.frequency];
-  if (rule.interval === 1) return `Every ${noun}`;
-  return `Every ${rule.interval} ${noun}s`;
+  switch (rule.frequency) {
+    case "daily":
+      return rule.interval === 1 ? "Daily" : `Daily · every ${rule.interval} days`;
+    case "weekly": {
+      const base = rule.interval === 1 ? "Weekly" : `Weekly · every ${rule.interval} weeks`;
+      if (rule.byDay && rule.byDay.length > 0) {
+        const days = WEEKDAYS.filter((d) => rule.byDay?.includes(d))
+          .map((d) => WEEKDAY_LABELS[d])
+          .join(" / ");
+        return `${base} · ${days}`;
+      }
+      return base;
+    }
+    case "monthly": {
+      if (rule.monthlyMode === "weekday" && rule.byDay && rule.byDay[0] && rule.bySetPos) {
+        return `Monthly · ${ordinalLabel(rule.bySetPos)} ${WEEKDAY_LABELS[rule.byDay[0]]}`;
+      }
+      return rule.interval === 1 ? "Monthly" : `Monthly · every ${rule.interval} months`;
+    }
+    case "yearly":
+      return rule.interval === 1 ? "Yearly" : `Yearly · every ${rule.interval} years`;
+    default:
+      return "Repeats";
+  }
 };
 
 // "manual" maps to the persisted `position` order — drag-to-reorder is only

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -1,22 +1,37 @@
 import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { FormEvent, useCallback, useEffect, useState } from "react";
-import { Lock } from "lucide-react";
+import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+import { Lock, PanelRight, Plus, Settings2 } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
 import { ENTRYPOINT } from "@/config/entrypoint";
 import { signinHrefForCurrent } from "@/lib/authRedirect";
+import { displayName } from "@/lib/userDisplay";
 import MarkdownEditor from "@/components/editor/MarkdownEditor";
-import MarkdownView from "@/components/editor/MarkdownView";
 import ActivityPanel from "@/components/activity/ActivityPanel";
 import CustomFieldFooterRow from "@/components/custom-fields/CustomFieldFooterRow";
+import CustomFieldValueCell from "@/components/custom-fields/CustomFieldValueCell";
+import TaskDetailDrawer from "@/components/tasks/TaskDetailDrawer";
+import UserAvatar from "@/components/user/UserAvatar";
+import type { AssigneeOption } from "@/components/tasks/AssigneesCombobox";
+import type { TagOption } from "@/components/tasks/TagsCombobox";
+import type { CustomFieldDefinition } from "@/components/custom-fields/types";
+import {
+  dueDateStatus,
+  formatDueDate,
+  isoToLocalDate,
+  todayLocalMidnight,
+  type Reminder,
+  type RecurrenceRule,
+} from "@/components/tasks/taskHelpers";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 
 interface Member {
@@ -39,33 +54,29 @@ interface Project {
   description: string | null;
   createdOn: string;
   owner: Member;
-  // Members read-only from the API as a virtual getter; kept here so
-  // the page can render member chips without a follow-up fetch. Mutation
-  // happens via the space (#187) — see the "Manage in space" link
-  // surfaced below.
   members: Member[];
-  // Server returns the parent space embedded under `project:read`;
-  // PWA falls back to looking it up by IRI in the user's space list
-  // for the admin role check.
   space: string | SpaceRef;
 }
 
-interface Tag {
-  "@id": string;
-  id: string;
-  title: string;
-  color: string;
+interface CustomFieldValuePair {
+  definition: string;
+  value: unknown;
 }
 
-interface Task {
+interface ProjectTask {
   "@id": string;
   id: string;
   title: string;
   description: string | null;
   createdOn: string;
   completedOn: string | null;
+  dueDate: string | null;
   position: number;
-  tags: Tag[];
+  tags: TagOption[];
+  assignees: AssigneeOption[];
+  recurrenceRule: RecurrenceRule | null;
+  reminders: Reminder[] | null;
+  customFieldValues: CustomFieldValuePair[];
 }
 
 interface Collection<T> {
@@ -73,43 +84,94 @@ interface Collection<T> {
   "hydra:member"?: T[];
 }
 
+const membersOf = <T,>(c: Collection<T>): T[] =>
+  c.member ?? c["hydra:member"] ?? [];
+
 const projectSpaceIri = (project: Project): string =>
   typeof project.space === "string" ? project.space : project.space["@id"];
 
+// Due-date buckets for the grouped list, in render order.
+type Bucket = "overdue" | "week" | "later" | "none" | "done";
+const BUCKET_LABELS: Record<Bucket, string> = {
+  overdue: "Overdue",
+  week: "This week",
+  later: "Later",
+  none: "No due date",
+  done: "Completed",
+};
+const BUCKET_ORDER: Bucket[] = ["overdue", "week", "later", "none", "done"];
+
+const bucketFor = (task: ProjectTask): Bucket => {
+  if (task.completedOn) return "done";
+  const status = dueDateStatus(task.dueDate, false);
+  if (status === "overdue") return "overdue";
+  if (!task.dueDate) return "none";
+  const due = isoToLocalDate(task.dueDate);
+  if (!due) return "none";
+  const weekEnd = todayLocalMidnight();
+  weekEnd.setDate(weekEnd.getDate() + 7);
+  return due.getTime() <= weekEnd.getTime() ? "week" : "later";
+};
+
 const ProjectDetail = () => {
-  const { isAuthenticated, isLoading: authLoading } = useAuth();
+  const { user, isAuthenticated, isLoading: authLoading } = useAuth();
   const { spaces } = useActiveSpace();
   const router = useRouter();
   const { id } = router.query;
   const projectId = typeof id === "string" ? id : null;
+  const currentUserIri = user ? `/users/${user.id}` : null;
 
   const [project, setProject] = useState<Project | null>(null);
-  const [tasks, setTasks] = useState<Task[]>([]);
+  const [tasks, setTasks] = useState<ProjectTask[]>([]);
+  const [definitions, setDefinitions] = useState<CustomFieldDefinition[]>([]);
+  const [assignableUsers, setAssignableUsers] = useState<AssigneeOption[]>([]);
+  const [allTags, setAllTags] = useState<TagOption[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Task creation
+  // Quick add-task (collapsed behind "+ New task").
+  const [addOpen, setAddOpen] = useState(false);
   const [newTaskTitle, setNewTaskTitle] = useState("");
   const [newTaskDescription, setNewTaskDescription] = useState("");
   const [isCreatingTask, setIsCreatingTask] = useState(false);
   const [taskEditorKey, setTaskEditorKey] = useState(0);
 
-  // Move-to-space (#182)
+  // Move / copy to space (#182).
+  const [settingsOpen, setSettingsOpen] = useState(false);
   const [moveTargetIri, setMoveTargetIri] = useState("");
   const [isMoving, setIsMoving] = useState(false);
+  const [isCopying, setIsCopying] = useState(false);
+  const [copyIncludeTasks, setCopyIncludeTasks] = useState(false);
   const [moveMessage, setMoveMessage] = useState<{
     text: string;
     kind: "success" | "error";
   } | null>(null);
 
-  // Copy-to-space (#182). Reuses the same target picker but POSTs to
-  // /copy instead of /move. On success we navigate to the new
-  // project's detail page so the user lands on the clone.
-  const [isCopying, setIsCopying] = useState(false);
-  // Opt-in deep-copy: when true, the POST body asks the server to
-  // also clone the project's tasks (#182 deep-copy slice).
-  const [copyIncludeTasks, setCopyIncludeTasks] = useState(false);
+  // Deep-linkable task drawer (?task={id}).
+  const activeTaskId =
+    typeof router.query.task === "string" ? router.query.task : null;
+  const openTaskDetail = useCallback(
+    (task: ProjectTask) => {
+      void router.push(
+        { pathname: router.pathname, query: { ...router.query, task: task.id } },
+        undefined,
+        { shallow: true },
+      );
+    },
+    [router],
+  );
+  const closeTaskDetail = useCallback(
+    (open: boolean) => {
+      if (open) return;
+      const query = { ...router.query };
+      delete query.task;
+      void router.push({ pathname: router.pathname, query }, undefined, {
+        shallow: true,
+      });
+    },
+    [router],
+  );
 
   useEffect(() => {
     if (!authLoading && !isAuthenticated) {
@@ -122,10 +184,14 @@ const ProjectDetail = () => {
     setError(null);
     setIsLoading(true);
     try {
-      const projectRes = await fetch(`${ENTRYPOINT}/projects/${encodeURIComponent(projectId)}`, {
-        credentials: "include",
+      const init = {
+        credentials: "include" as const,
         headers: { Accept: "application/ld+json" },
-      });
+      };
+      const projectRes = await fetch(
+        `${ENTRYPOINT}/projects/${encodeURIComponent(projectId)}`,
+        init,
+      );
       if (projectRes.status === 404 || projectRes.status === 403) {
         setNotFound(true);
         return;
@@ -134,16 +200,27 @@ const ProjectDetail = () => {
       const projectData: Project = await projectRes.json();
       setProject(projectData);
 
-      const tasksRes = await fetch(
-        `${ENTRYPOINT}/tasks?project=${encodeURIComponent(projectData["@id"])}`,
-        {
-          credentials: "include",
-          headers: { Accept: "application/ld+json" },
-        },
-      );
+      const projectIri = projectData["@id"];
+      const [tasksRes, defsRes, usersRes, tagsRes] = await Promise.all([
+        fetch(`${ENTRYPOINT}/tasks?project=${encodeURIComponent(projectIri)}`, init),
+        fetch(
+          `${ENTRYPOINT}/custom_field_definitions?project=${encodeURIComponent(projectIri)}`,
+          init,
+        ),
+        fetch(`${ENTRYPOINT}/me/assignable-users`, init),
+        fetch(`${ENTRYPOINT}/tags`, init),
+      ]);
       if (!tasksRes.ok) throw new Error("Failed to load tasks.");
-      const tasksData: Collection<Task> = await tasksRes.json();
-      setTasks(tasksData.member ?? tasksData["hydra:member"] ?? []);
+      setTasks(membersOf<ProjectTask>(await tasksRes.json()));
+      if (defsRes.ok) {
+        setDefinitions(
+          membersOf<CustomFieldDefinition>(await defsRes.json()).sort(
+            (a, b) => a.position - b.position,
+          ),
+        );
+      }
+      if (usersRes.ok) setAssignableUsers(membersOf<AssigneeOption>(await usersRes.json()));
+      if (tagsRes.ok) setAllTags(membersOf<TagOption>(await tagsRes.json()));
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load project.");
     } finally {
@@ -152,12 +229,18 @@ const ProjectDetail = () => {
   }, [projectId]);
 
   useEffect(() => {
-    if (isAuthenticated && projectId) {
-      load();
-    }
+    if (isAuthenticated && projectId) void load();
   }, [isAuthenticated, projectId, load]);
 
-  const toggleComplete = async (task: Task) => {
+  const resolveRef = useCallback(
+    (iri: string): string | null => {
+      const u = assignableUsers.find((a) => a["@id"] === iri);
+      return u ? displayName(u) : null;
+    },
+    [assignableUsers],
+  );
+
+  const toggleComplete = async (task: ProjectTask) => {
     const completedOn = task.completedOn ? null : new Date().toISOString();
     setError(null);
     try {
@@ -168,7 +251,7 @@ const ProjectDetail = () => {
         body: JSON.stringify({ completedOn }),
       });
       if (!res.ok) throw new Error("Failed to update task.");
-      const updated: Task = await res.json();
+      const updated: ProjectTask = await res.json();
       setTasks((prev) => prev.map((t) => (t["@id"] === task["@id"] ? updated : t)));
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to update task.");
@@ -178,7 +261,6 @@ const ProjectDetail = () => {
   const handleCreateTask = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!project || !newTaskTitle.trim()) return;
-
     setIsCreatingTask(true);
     setError(null);
     try {
@@ -198,11 +280,12 @@ const ProjectDetail = () => {
           data.description || data.detail || data["hydra:description"] || "Failed to create task.",
         );
       }
-      const created: Task = await res.json();
+      const created: ProjectTask = await res.json();
       setTasks((prev) => [...prev, created]);
       setNewTaskTitle("");
       setNewTaskDescription("");
       setTaskEditorKey((k) => k + 1);
+      setAddOpen(false);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to create task.");
     } finally {
@@ -254,14 +337,7 @@ const ProjectDetail = () => {
     setIsCopying(true);
     setMoveMessage(null);
     try {
-      // Empty body = clone into the source's own space; specifying a
-      // target uses the picker's current selection. The server accepts
-      // both shapes. `includeTasks` is the only opt-in deep-copy flag —
-      // discussions live at the space level and are never carried.
-      const body: {
-        space?: string;
-        includeTasks?: boolean;
-      } = {};
+      const body: { space?: string; includeTasks?: boolean } = {};
       if (moveTargetIri) body.space = moveTargetIri;
       if (copyIncludeTasks) body.includeTasks = true;
       const res = await fetch(
@@ -279,11 +355,7 @@ const ProjectDetail = () => {
           data.detail || data.error || data["hydra:description"] || "Failed to copy project.",
         );
       }
-      // Land the user on the freshly-cloned project so they can rename
-      // it or start filling it in.
-      if (data.id) {
-        await router.push(`/projects/${data.id}`);
-      }
+      if (data.id) await router.push(`/projects/${data.id}`);
     } catch (err) {
       setMoveMessage({
         text: err instanceof Error ? err.message : "Failed to copy project.",
@@ -293,6 +365,24 @@ const ProjectDetail = () => {
       setIsCopying(false);
     }
   };
+
+  const grouped = useMemo(() => {
+    const ordered = [...tasks].sort((a, b) => a.position - b.position);
+    const map = new Map<Bucket, ProjectTask[]>();
+    for (const task of ordered) {
+      const bucket = bucketFor(task);
+      const list = map.get(bucket) ?? [];
+      list.push(task);
+      map.set(bucket, list);
+    }
+    return BUCKET_ORDER.map((bucket) => ({
+      bucket,
+      tasks: map.get(bucket) ?? [],
+    })).filter((g) => g.tasks.length > 0);
+  }, [tasks]);
+
+  const openCount = tasks.filter((t) => !t.completedOn).length;
+  const totalCols = 6 + definitions.length;
 
   if (authLoading || !isAuthenticated) {
     return (
@@ -320,19 +410,25 @@ const ProjectDetail = () => {
     );
   }
 
-  const openTasks = tasks.filter((t) => !t.completedOn);
-  const completedTasks = tasks.filter((t) => t.completedOn);
+  const space = project
+    ? spaces.find((s) => s["@id"] === projectSpaceIri(project))
+    : undefined;
+  const spaceId = project
+    ? typeof project.space === "string"
+      ? project.space.split("/").pop()
+      : project.space.id
+    : undefined;
 
   return (
     <>
       <Head>
         <title>{project ? `${project.title} - Madori` : "Project - Madori"}</title>
       </Head>
-      <div className="min-h-screen bg-muted px-4 py-12">
-        <div className="max-w-2xl mx-auto">
+      <div className="min-h-screen bg-muted px-4 py-8">
+        <div className="max-w-7xl mx-auto">
           <Link
             href="/projects"
-            className="inline-block text-sm text-primary hover:underline mb-3 no-underline"
+            className="mb-4 inline-block text-sm text-muted-foreground hover:text-foreground"
           >
             ← All projects
           </Link>
@@ -341,138 +437,149 @@ const ProjectDetail = () => {
             <p className="text-muted-foreground">Loading project...</p>
           ) : (
             <>
-              <Card className="mb-6">
-                <CardContent className="pt-6">
-                  <h1 className="text-2xl font-bold mb-2">{project.title}</h1>
-                  {project.description && (
-                    <MarkdownView source={project.description} className="mb-3" />
+              {/* Header */}
+              <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+                <div className="flex items-center gap-3">
+                  <h1 className="text-2xl font-bold">{project.title}</h1>
+                  {definitions.length > 0 && (
+                    <Badge variant="secondary" className="font-normal">
+                      {definitions.length} custom field
+                      {definitions.length === 1 ? "" : "s"}
+                    </Badge>
                   )}
+                  {space?.isPersonal && (
+                    <Lock className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
+                  )}
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setSettingsOpen((v) => !v)}
+                    aria-pressed={settingsOpen}
+                    data-testid="project-settings-toggle"
+                  >
+                    <Settings2 className="mr-1 h-3.5 w-3.5" /> Settings
+                  </Button>
+                  <Button
+                    asChild
+                    variant="outline"
+                    size="sm"
+                    data-testid="project-custom-fields-link"
+                  >
+                    <Link href={`/projects/${project.id}/custom-fields`}>
+                      Custom fields
+                    </Link>
+                  </Button>
+                  <Button
+                    size="sm"
+                    onClick={() => setAddOpen((v) => !v)}
+                    data-testid="project-new-task"
+                  >
+                    <Plus className="mr-1 h-3.5 w-3.5" /> New task
+                  </Button>
+                </div>
+              </div>
 
-                  <div className="mt-3 space-y-2" data-testid="project-space-info">
-                    {(() => {
-                      const space = spaces.find(
-                        (s) => s["@id"] === projectSpaceIri(project),
-                      );
-                      const spaceLabel =
-                        typeof project.space === "string"
-                          ? null
-                          : project.space.name;
-                      const spaceId =
-                        typeof project.space === "string"
-                          ? project.space.split("/").pop()
-                          : project.space.id;
-                      const isPersonal = space?.isPersonal ?? false;
-                      return (
-                        <div className="flex flex-wrap items-center gap-2">
-                          <span className="text-xs text-muted-foreground">
-                            Space
-                          </span>
-                          <Badge variant="secondary" className="gap-1">
-                            {isPersonal && (
-                              <Lock className="h-3 w-3" aria-hidden />
-                            )}
-                            {space?.name ?? spaceLabel ?? "Unknown space"}
-                          </Badge>
-                          {spaceId && (
-                            <Button asChild variant="link" size="sm" className="h-auto p-0">
-                              <Link href={`/spaces/${spaceId}`}>
-                                Manage members in space
-                              </Link>
-                            </Button>
-                          )}
-                        </div>
-                      );
-                    })()}
+              {error && (
+                <Alert variant="destructive" className="mb-4">
+                  <AlertDescription>{error}</AlertDescription>
+                </Alert>
+              )}
 
-                    {/* Move / Copy (#182). Showing every space the
-                        caller belongs to — server enforces the source
-                        + target membership rule. Move is disabled
-                        when there's nowhere else to go; Copy works
-                        with no target (clones into the current
-                        space). */}
+              {/* Collapsible project settings (space badge + move/copy + members) */}
+              {settingsOpen && (
+                <Card className="mb-4">
+                  <CardContent className="space-y-3 pt-6" data-testid="project-space-info">
+                    {project.description && (
+                      <p className="text-sm text-muted-foreground">{project.description}</p>
+                    )}
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-xs text-muted-foreground">Space</span>
+                      <Badge variant="secondary" className="gap-1">
+                        {space?.isPersonal && <Lock className="h-3 w-3" aria-hidden />}
+                        {space?.name ??
+                          (typeof project.space === "string" ? "Unknown space" : project.space.name)}
+                      </Badge>
+                      {spaceId && (
+                        <Button asChild variant="link" size="sm" className="h-auto p-0">
+                          <Link href={`/spaces/${spaceId}`}>Manage members in space</Link>
+                        </Button>
+                      )}
+                    </div>
+
                     <div
                       className="flex flex-wrap items-center gap-2"
                       data-testid="project-move-form"
                     >
-                        <Label
-                          htmlFor="project-move-target"
-                          className="text-xs text-muted-foreground"
+                      <Label
+                        htmlFor="project-move-target"
+                        className="text-xs text-muted-foreground"
+                      >
+                        Move to
+                      </Label>
+                      <select
+                        id="project-move-target"
+                        value={moveTargetIri}
+                        onChange={(e) => setMoveTargetIri(e.target.value)}
+                        className="h-8 rounded-md border border-input bg-background px-2 text-sm"
+                        data-testid="project-move-select"
+                      >
+                        <option value="">Pick a space…</option>
+                        {spaces
+                          .filter((s) => s["@id"] !== projectSpaceIri(project))
+                          .map((s) => (
+                            <option key={s["@id"]} value={s["@id"]}>
+                              {s.name}
+                              {s.isPersonal ? " (Private)" : ""}
+                            </option>
+                          ))}
+                      </select>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        onClick={handleMove}
+                        disabled={!moveTargetIri || isMoving || isCopying}
+                        data-testid="project-move-submit"
+                      >
+                        {isMoving ? "Moving…" : "Move"}
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        onClick={handleCopy}
+                        disabled={isMoving || isCopying}
+                        data-testid="project-copy-submit"
+                      >
+                        {isCopying ? "Copying…" : "Copy"}
+                      </Button>
+                      <label className="flex items-center gap-1.5 text-xs text-muted-foreground select-none">
+                        <input
+                          type="checkbox"
+                          checked={copyIncludeTasks}
+                          onChange={(e) => setCopyIncludeTasks(e.target.checked)}
+                          className="h-3.5 w-3.5"
+                          data-testid="project-copy-include-tasks"
+                        />
+                        include tasks
+                      </label>
+                      {moveMessage && (
+                        <span
+                          role="alert"
+                          className={cn(
+                            "text-xs",
+                            moveMessage.kind === "success"
+                              ? "text-muted-foreground"
+                              : "text-destructive",
+                          )}
                         >
-                          Move to
-                        </Label>
-                        <select
-                          id="project-move-target"
-                          value={moveTargetIri}
-                          onChange={(e) => setMoveTargetIri(e.target.value)}
-                          className="h-8 rounded-md border border-input bg-background px-2 text-sm"
-                          data-testid="project-move-select"
-                        >
-                          <option value="">Pick a space…</option>
-                          {spaces
-                            .filter((s) => s["@id"] !== projectSpaceIri(project))
-                            .map((s) => (
-                              <option key={s["@id"]} value={s["@id"]}>
-                                {s.name}
-                                {s.isPersonal ? " (Private)" : ""}
-                              </option>
-                            ))}
-                        </select>
-                        <Button
-                          type="button"
-                          size="sm"
-                          variant="outline"
-                          onClick={handleMove}
-                          disabled={!moveTargetIri || isMoving || isCopying}
-                          data-testid="project-move-submit"
-                        >
-                          {isMoving ? "Moving…" : "Move"}
-                        </Button>
-                        <Button
-                          type="button"
-                          size="sm"
-                          variant="outline"
-                          onClick={handleCopy}
-                          disabled={isMoving || isCopying}
-                          data-testid="project-copy-submit"
-                          title={
-                            moveTargetIri
-                              ? "Copy this project into the selected space"
-                              : "Copy this project into its current space"
-                          }
-                        >
-                          {isCopying ? "Copying…" : "Copy"}
-                        </Button>
-                        {/* Deep-copy opt-in. Hidden until the user
-                            actually intends to copy — Move ignores it. */}
-                        <label
-                          className="flex items-center gap-1.5 text-xs text-muted-foreground select-none"
-                          data-testid="project-copy-include-tasks-label"
-                        >
-                          <input
-                            type="checkbox"
-                            checked={copyIncludeTasks}
-                            onChange={(e) =>
-                              setCopyIncludeTasks(e.target.checked)
-                            }
-                            className="h-3.5 w-3.5"
-                            data-testid="project-copy-include-tasks"
-                          />
-                          include tasks
-                        </label>
-                        {moveMessage && (
-                          <span
-                            role="alert"
-                            className={cn(
-                              "text-xs",
-                              moveMessage.kind === "success"
-                                ? "text-muted-foreground"
-                                : "text-destructive",
-                            )}
-                          >
-                            {moveMessage.text}
-                          </span>
-                        )}
-                      </div>
+                          {moveMessage.text}
+                        </span>
+                      )}
+                    </div>
+
                     {project.members.length > 0 && (
                       <ul
                         className="flex flex-wrap items-center gap-1"
@@ -485,140 +592,288 @@ const ProjectDetail = () => {
                         ))}
                       </ul>
                     )}
-                  </div>
-                </CardContent>
-              </Card>
-
-              {error && (
-                <Alert variant="destructive" className="mb-4">
-                  <AlertDescription>{error}</AlertDescription>
-                </Alert>
-              )}
-
-              <div className="mb-6 flex flex-wrap justify-end gap-2">
-                <Button
-                  asChild
-                  variant="outline"
-                  size="sm"
-                  data-testid="project-custom-fields-link"
-                >
-                  <Link href={`/projects/${project.id}/custom-fields`}>
-                    Custom fields
-                  </Link>
-                </Button>
-              </div>
-
-              <div className="space-y-6">
-              <Card>
-                <CardContent className="pt-6">
-                  <form
-                    onSubmit={handleCreateTask}
-                    className="space-y-4"
-                    data-testid="create-task-form"
-                  >
-                    <h2 className="text-lg font-semibold">Add a task</h2>
-                    <div className="space-y-1.5">
-                      <Label htmlFor="task-title">Title</Label>
-                      <Input
-                        id="task-title"
-                        type="text"
-                        value={newTaskTitle}
-                        onChange={(e) => setNewTaskTitle(e.target.value)}
-                        required
-                        maxLength={255}
-                      />
-                    </div>
-                    <div className="space-y-1.5">
-                      <Label htmlFor="task-description">
-                        Description{" "}
-                        <span className="text-muted-foreground font-normal">(optional)</span>
-                      </Label>
-                      <MarkdownEditor
-                        key={taskEditorKey}
-                        id="task-description"
-                        ariaLabel="Task description"
-                        value={newTaskDescription}
-                        onChange={setNewTaskDescription}
-                      />
-                    </div>
-                    <Button type="submit" disabled={isCreatingTask || !newTaskTitle.trim()}>
-                      {isCreatingTask ? "Adding..." : "Add Task"}
-                    </Button>
-                  </form>
-                </CardContent>
-              </Card>
-
-              <h2 className="text-lg font-semibold mb-2">
-                Tasks{" "}
-                <span className="text-sm font-normal text-muted-foreground">
-                  ({openTasks.length} open
-                  {completedTasks.length > 0 ? `, ${completedTasks.length} done` : ""})
-                </span>
-              </h2>
-
-              {tasks.length === 0 ? (
-                <Card>
-                  <CardContent className="pt-6">
-                    <p className="text-muted-foreground">No tasks in this project yet.</p>
                   </CardContent>
                 </Card>
-              ) : (
-                <ul className="space-y-2" data-testid="project-task-list">
-                  {[...openTasks, ...completedTasks].map((task) => (
-                    <li key={task["@id"]} data-testid="project-task-item">
-                      <Card>
-                        <CardContent className="pt-4 pb-4 flex gap-3">
-                          <input
-                            type="checkbox"
-                            checked={!!task.completedOn}
-                            onChange={() => toggleComplete(task)}
-                            aria-label={`Mark "${task.title}" as ${task.completedOn ? "open" : "done"}`}
-                            className="mt-1 h-4 w-4 shrink-0 cursor-pointer"
-                          />
-                          <div className="min-w-0 flex-1">
-                            <div
-                              className={cn(
-                                "font-medium",
-                                task.completedOn && "text-muted-foreground line-through",
-                              )}
-                            >
-                              {task.title}
-                            </div>
-                            {task.description && (
-                              <MarkdownView source={task.description} className="mt-1 text-sm" />
-                            )}
-                            {task.tags.length > 0 && (
-                              <div className="mt-2 flex flex-wrap gap-1">
-                                {task.tags.map((tag) => (
-                                  <span
-                                    key={tag["@id"]}
-                                    className="inline-block px-2 py-0.5 rounded text-xs text-white"
-                                    style={{ backgroundColor: tag.color }}
-                                  >
-                                    {tag.title}
-                                  </span>
-                                ))}
-                              </div>
-                            )}
-                          </div>
-                        </CardContent>
-                      </Card>
-                    </li>
-                  ))}
-                </ul>
               )}
-              <CustomFieldFooterRow projectId={project.id} />
-              </div>
 
-              <div className="mt-6">
-                <ActivityPanel endpoint={`/projects/${project.id}/activity`} />
-              </div>
+              {/* Quick add-task */}
+              {addOpen && (
+                <Card className="mb-4">
+                  <CardContent className="pt-6">
+                    <form
+                      onSubmit={handleCreateTask}
+                      className="space-y-4"
+                      data-testid="create-task-form"
+                    >
+                      <div className="space-y-1.5">
+                        <Label htmlFor="task-title">Title</Label>
+                        <Input
+                          id="task-title"
+                          type="text"
+                          value={newTaskTitle}
+                          onChange={(e) => setNewTaskTitle(e.target.value)}
+                          required
+                          maxLength={255}
+                          autoFocus
+                        />
+                      </div>
+                      <div className="space-y-1.5">
+                        <Label htmlFor="task-description">
+                          Description{" "}
+                          <span className="text-muted-foreground font-normal">(optional)</span>
+                        </Label>
+                        <MarkdownEditor
+                          key={taskEditorKey}
+                          id="task-description"
+                          ariaLabel="Task description"
+                          value={newTaskDescription}
+                          onChange={setNewTaskDescription}
+                        />
+                      </div>
+                      <div className="flex gap-2">
+                        <Button type="submit" disabled={isCreatingTask || !newTaskTitle.trim()}>
+                          {isCreatingTask ? "Adding..." : "Add task"}
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          onClick={() => setAddOpen(false)}
+                        >
+                          Cancel
+                        </Button>
+                      </div>
+                    </form>
+                  </CardContent>
+                </Card>
+              )}
+
+              <Tabs defaultValue="tasks">
+                <TabsList variant="line">
+                  <TabsTrigger value="tasks">
+                    Tasks{" "}
+                    <span className="ml-1 text-xs text-muted-foreground">{openCount}</span>
+                  </TabsTrigger>
+                  <TabsTrigger value="activity">Activity</TabsTrigger>
+                </TabsList>
+
+                <TabsContent value="tasks" className="mt-4">
+                  {tasks.length === 0 ? (
+                    <Card>
+                      <CardContent className="pt-6">
+                        <p className="text-muted-foreground">
+                          No tasks in this project yet.
+                        </p>
+                      </CardContent>
+                    </Card>
+                  ) : (
+                    <div className="overflow-x-auto rounded-lg border">
+                      <table className="w-full text-sm" data-testid="project-task-list">
+                        <thead>
+                          <tr className="border-b text-xs uppercase tracking-wide text-muted-foreground">
+                            <th className="w-8 px-3 py-2" />
+                            <th className="w-10 px-1 py-2 text-left font-medium">#</th>
+                            <th className="px-2 py-2 text-left font-medium">Task</th>
+                            {definitions.map((def) => (
+                              <th
+                                key={def["@id"]}
+                                className="px-2 py-2 text-left font-medium whitespace-nowrap"
+                              >
+                                {def.name}
+                              </th>
+                            ))}
+                            <th className="px-2 py-2 text-left font-medium">Due</th>
+                            <th className="px-2 py-2 text-left font-medium">Assignees</th>
+                            <th className="w-10 px-2 py-2" />
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {grouped.map((group) => (
+                            <GroupRows
+                              key={group.bucket}
+                              label={BUCKET_LABELS[group.bucket]}
+                              count={group.tasks.length}
+                              colSpan={totalCols}
+                              tasks={group.tasks}
+                              definitions={definitions}
+                              resolveRef={resolveRef}
+                              onToggle={toggleComplete}
+                              onOpen={openTaskDetail}
+                            />
+                          ))}
+                        </tbody>
+                      </table>
+                      <CustomFieldFooterRow projectId={project.id} />
+                    </div>
+                  )}
+                </TabsContent>
+
+                <TabsContent value="activity" className="mt-4">
+                  <ActivityPanel endpoint={`/projects/${project.id}/activity`} />
+                </TabsContent>
+              </Tabs>
             </>
           )}
         </div>
       </div>
+
+      <TaskDetailDrawer
+        taskId={activeTaskId}
+        open={Boolean(activeTaskId)}
+        onOpenChange={closeTaskDetail}
+        currentUserIri={currentUserIri}
+        assignableUsers={assignableUsers}
+        allTags={allTags}
+        onTaskChanged={(updated) =>
+          setTasks((prev) =>
+            prev.map((t) =>
+              t["@id"] === updated["@id"]
+                ? {
+                    ...t,
+                    title: updated.title,
+                    completedOn: updated.completedOn,
+                    dueDate: updated.dueDate,
+                    tags: updated.tags,
+                    assignees: updated.assignees,
+                    recurrenceRule: updated.recurrenceRule,
+                    reminders: updated.reminders,
+                    customFieldValues: updated.customFieldValues,
+                  }
+                : t,
+            ),
+          )
+        }
+      />
     </>
   );
 };
+
+const GroupRows = ({
+  label,
+  count,
+  colSpan,
+  tasks,
+  definitions,
+  resolveRef,
+  onToggle,
+  onOpen,
+}: {
+  label: string;
+  count: number;
+  colSpan: number;
+  tasks: ProjectTask[];
+  definitions: CustomFieldDefinition[];
+  resolveRef: (iri: string) => string | null;
+  onToggle: (task: ProjectTask) => void;
+  onOpen: (task: ProjectTask) => void;
+}) => (
+  <>
+    <tr className="border-b bg-muted/40">
+      <td colSpan={colSpan} className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {label} <span className="text-muted-foreground/60">{count}</span>
+      </td>
+    </tr>
+    {tasks.map((task, i) => {
+      const valueByDef = new Map(
+        task.customFieldValues.map((v) => [v.definition, v.value]),
+      );
+      return (
+        <tr
+          key={task["@id"]}
+          className="border-b last:border-0 hover:bg-accent/40"
+          data-testid="project-task-item"
+        >
+          <td className="px-3 py-2 align-top">
+            <input
+              type="checkbox"
+              checked={!!task.completedOn}
+              onChange={() => onToggle(task)}
+              aria-label={`Mark "${task.title}" as ${task.completedOn ? "open" : "done"}`}
+              className="mt-0.5 h-4 w-4 cursor-pointer"
+            />
+          </td>
+          <td className="px-1 py-2 align-top text-xs text-muted-foreground">
+            T{i + 1}
+          </td>
+          <td className="px-2 py-2 align-top">
+            <button
+              type="button"
+              onClick={() => onOpen(task)}
+              className={cn(
+                "text-left font-medium hover:text-primary",
+                task.completedOn && "text-muted-foreground line-through",
+              )}
+            >
+              {task.title}
+            </button>
+            {task.tags.length > 0 && (
+              <div className="mt-1 flex flex-wrap gap-1">
+                {task.tags.map((tag) => (
+                  <span
+                    key={tag["@id"]}
+                    className="rounded px-1.5 py-0.5 text-xs font-medium"
+                    style={{ backgroundColor: `${tag.color}22`, color: tag.color }}
+                  >
+                    {tag.title}
+                  </span>
+                ))}
+              </div>
+            )}
+          </td>
+          {definitions.map((def) => (
+            <td key={def["@id"]} className="px-2 py-2 align-top">
+              <CustomFieldValueCell
+                definition={def}
+                value={valueByDef.get(def["@id"])}
+                resolveRef={resolveRef}
+              />
+            </td>
+          ))}
+          <td className="px-2 py-2 align-top whitespace-nowrap">
+            {task.dueDate ? (
+              <span
+                className={cn(
+                  "text-sm",
+                  dueDateStatus(task.dueDate, !!task.completedOn) === "overdue" &&
+                    "text-destructive",
+                )}
+              >
+                {formatDueDate(task.dueDate)}
+              </span>
+            ) : (
+              <span className="text-muted-foreground/50">—</span>
+            )}
+          </td>
+          <td className="px-2 py-2 align-top">
+            {task.assignees.length > 0 ? (
+              <div className="flex -space-x-1.5">
+                {task.assignees.slice(0, 4).map((a) => (
+                  <UserAvatar
+                    key={a["@id"]}
+                    user={a}
+                    size="sm"
+                    className="h-6 w-6 ring-2 ring-background"
+                  />
+                ))}
+              </div>
+            ) : (
+              <span className="text-muted-foreground/50">—</span>
+            )}
+          </td>
+          <td className="px-2 py-2 align-top">
+            <button
+              type="button"
+              onClick={() => onOpen(task)}
+              aria-label={`Open details for "${task.title}"`}
+              className="text-muted-foreground hover:text-foreground"
+              data-testid="project-task-open-detail"
+            >
+              <PanelRight className="h-4 w-4" />
+            </button>
+          </td>
+        </tr>
+      );
+    })}
+  </>
+);
 
 export default ProjectDetail;

--- a/pwa/pages/tasks.tsx
+++ b/pwa/pages/tasks.tsx
@@ -39,7 +39,7 @@ import {
   plainTextDescription,
   removeComment,
   type RecurrenceRule,
-  type ReminderOffset,
+  type Reminder,
   type SortKey,
   type SortState,
   type Tag,
@@ -578,7 +578,7 @@ const Tasks = () => {
 
   const handleRemindersChange = async (
     task: Task,
-    nextReminders: ReminderOffset[] | null,
+    nextReminders: Reminder[] | null,
   ) => {
     const previous = tasks;
     setTasks(


### PR DESCRIPTION
## Tasks-page redesign (recurrence + reminders, drawer, list)

Implements the Tasks-page design set. Backend models expanded first; the UI builds on them.

### Backend — richer recurrence + reminders
- **Recurrence** (`Task.recurrenceRule`): adds by-weekday (weekly), monthly *nth-weekday* vs *day-of-month*, and an **ends** condition (never / until-date / after-N-count). New `RecurrenceCalculator` powers both the completion-spawn (`TaskUpdateProcessor`) and a new `POST /recurrence-preview` endpoint, so the editor's "next 3 occurrences" can't disagree with what actually gets created. `ValidRecurrence` validates the expanded shape.
- **Reminders** (`Task.reminders`): moved from the fixed `15m/1h/1d` allowlist to **relative** (value+unit before due) and **absolute** (fixed datetime) objects, each with optional **repeat daily until done**. New `ReminderScheduler` computes canonical keys + fire times for both the validator and `TaskReminderDispatcher`. `notification.reminder_offset` widened to 80 chars; data migration converts legacy offset strings.

### Frontend
- **Task drawer**: editable due date, a **Repeats** popover (full RRULE editor with live preview), an inline **reminders editor**, tag chips + done badge.
- **Project detail**: full-width **Tasks / Activity** tabs with a dense table — custom-field value columns in definition order, due-date grouping, assignee avatars, the aggregation footer, and row-click into the deep-linked drawer. Move/copy/add-task fold into a settings panel.
- New reusable bits: `RecurrenceEditor`, `RemindersEditor`, `CustomFieldValueCell`; expanded `taskHelpers` types/helpers.

### Tests
- PHPUnit: `RecurrenceCalculatorTest`, `ReminderSchedulerTest`, plus expanded `TaskTest` (by-weekday spawn, count-based ends, preview endpoint, absolute/relative reminder validation) and updated `NotificationTest` dispatcher cases.
- E2E: updated the reminder assertion to the new object shape.
