### PR TITLE
test: fill unit-test gaps + enforce minimum coverage floors (PWA & API)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -42,7 +42,18 @@ Use lowercase `kebab-case` for branch names.
 Every PR must keep CI green, which includes the test suites:
 
 - **API** — PHPUnit (`bin/phpunit`). New endpoints, services, and behaviour
-  changes need tests under `api/tests/`.
+  changes need tests under `api/tests/`. A **minimum line-coverage floor** is
+  enforced on PRs: the *Tests* CI job runs the suite with coverage
+  (`XDEBUG_MODE=coverage … --coverage-clover`) and then
+  [`api/bin/coverage-check.php`](../api/bin/coverage-check.php) fails the build
+  if `api/src` line coverage drops below the floor (currently 70%; measured
+  ~75.5%). To check locally:
+
+  ```bash
+  docker compose exec -e XDEBUG_MODE=coverage php php -d memory_limit=-1 \
+    bin/phpunit --coverage-clover var/coverage.xml
+  docker compose exec php php bin/coverage-check.php var/coverage.xml 70
+  ```
 - **PWA** — Vitest over the framework-free logic in `pwa/lib`
   (`pnpm test`). A **minimum-coverage floor** is enforced on PRs via
   `pnpm test:coverage`: the modules listed in `coverage.include` in

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -46,13 +46,14 @@ Every PR must keep CI green, which includes the test suites:
   enforced on PRs: the *Tests* CI job runs the suite with coverage
   (`XDEBUG_MODE=coverage … --coverage-clover`) and then
   [`api/bin/coverage-check.php`](../api/bin/coverage-check.php) fails the build
-  if `api/src` line coverage drops below the floor (currently 70%; measured
-  ~75.5%). To check locally:
+  if `api/src` line coverage drops below the floor (currently 84%; measured
+  ~85%). Dev/test seeders under `src/DataFixtures` are excluded from coverage
+  (see `api/phpunit.xml.dist`). To check locally:
 
   ```bash
   docker compose exec -e XDEBUG_MODE=coverage php php -d memory_limit=-1 \
     bin/phpunit --coverage-clover var/coverage.xml
-  docker compose exec php php bin/coverage-check.php var/coverage.xml 70
+  docker compose exec php php bin/coverage-check.php var/coverage.xml 84
   ```
 - **PWA** — Vitest over the framework-free logic in `pwa/lib`
   (`pnpm test`). A **minimum-coverage floor** is enforced on PRs via

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -37,6 +37,25 @@ Use lowercase `kebab-case` for branch names.
 - **PHP**: Follow [Symfony coding standards](https://symfony.com/doc/current/contributing/code/standards.html)
 - **TypeScript/React**: Follow the existing patterns in the codebase
 
+### Testing
+
+Every PR must keep CI green, which includes the test suites:
+
+- **API** — PHPUnit (`bin/phpunit`). New endpoints, services, and behaviour
+  changes need tests under `api/tests/`.
+- **PWA** — Vitest over the framework-free logic in `pwa/lib`
+  (`pnpm test`). A **minimum-coverage floor** is enforced on PRs via
+  `pnpm test:coverage`: the modules listed in `coverage.include` in
+  [`pwa/vitest.config.ts`](../pwa/vitest.config.ts) must stay above the
+  configured thresholds (lines/statements ≥ 85%, functions ≥ 90%,
+  branches ≥ 75%). When you add a new pure-logic helper under `pwa/lib`,
+  add it (and its `*.test.ts`) to that allowlist so the gate keeps it
+  covered. Component/integration coverage lives in the Playwright **e2e**
+  suite rather than the unit layer.
+
+If your change is genuinely untestable in these layers (pure infra/config),
+say so in the PR description.
+
 See `docs/developer/branching-and-releases.md` for the full branching and release strategy.
 
 ## License

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,5 +25,6 @@
 
 - [ ] My code follows the project's conventions
 - [ ] I have added tests that prove my fix or feature works
-- [ ] New and existing tests pass locally
+- [ ] New and existing tests pass locally (PHPUnit / `pnpm test:coverage`)
+- [ ] New pure-logic helpers under `pwa/lib` are added to the coverage allowlist in `pwa/vitest.config.ts`
 - [ ] I have updated documentation if needed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,8 +264,12 @@ jobs:
       -
         name: PWA unit tests
         # Vitest over the pure logic in pwa/lib (query parsing, validation
-        # mapping, password strength). Component coverage stays in e2e.
-        run: docker compose exec -T pwa pnpm test
+        # mapping, password strength, auth-redirect sanitisation, …).
+        # `test:coverage` enforces the minimum-coverage floor declared in
+        # pwa/vitest.config.ts over the tested-module allowlist, so a PR
+        # that drops a covered branch fails here. Component coverage stays
+        # in the e2e suite.
+        run: docker compose exec -T pwa pnpm test:coverage
 
   e2e:
     name: E2E

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,13 +113,24 @@ jobs:
         name: Run migrations
         run: docker compose exec -T php bin/console -e test doctrine:migrations:migrate --no-interaction
       -
-        name: Run PHPUnit
+        name: Run PHPUnit (with coverage)
         # PHPUnit's deprecation tracker accumulates context across the whole
         # suite, so peak memory grows with test count. The default 128M was
         # tight even before; 512M then started tipping over as the suite
         # grew, so we run unbounded here — GitHub runners have GBs free and
         # the limit was only ever an accidental ceiling, not a real budget.
-        run: docker compose exec -T php php -d memory_limit=-1 bin/phpunit
+        #
+        # Coverage rides along on this single run: XDEBUG_MODE=coverage flips
+        # the (installed-but-off) Xdebug driver on for this process only, and
+        # --coverage-clover writes the report the floor gate reads next. One
+        # suite execution covers both the pass/fail signal and the floor.
+        run: docker compose exec -T -e XDEBUG_MODE=coverage php php -d memory_limit=-1 bin/phpunit --coverage-clover var/coverage.xml
+      -
+        name: Enforce coverage floor
+        # Fails the build when line coverage of api/src drops below the floor.
+        # The floor is a *minimum* regression guard (measured ~75.5%), not a
+        # target — ratchet the trailing floor argument up as coverage climbs.
+        run: docker compose exec -T php php bin/coverage-check.php var/coverage.xml 70
 
   phpstan:
     name: PHPStan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,10 +127,11 @@ jobs:
         run: docker compose exec -T -e XDEBUG_MODE=coverage php php -d memory_limit=-1 bin/phpunit --coverage-clover var/coverage.xml
       -
         name: Enforce coverage floor
-        # Fails the build when line coverage of api/src drops below the floor.
-        # The floor is a *minimum* regression guard (measured ~75.5%), not a
+        # Fails the build when line coverage of api/src drops below the floor
+        # (DataFixtures are excluded from coverage — see phpunit.xml.dist).
+        # The floor is a *minimum* regression guard (measured ~85%), not a
         # target — ratchet the trailing floor argument up as coverage climbs.
-        run: docker compose exec -T php php bin/coverage-check.php var/coverage.xml 70
+        run: docker compose exec -T php php bin/coverage-check.php var/coverage.xml 84
 
   phpstan:
     name: PHPStan

--- a/api/bin/coverage-check.php
+++ b/api/bin/coverage-check.php
@@ -1,0 +1,65 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Minimal PHP coverage-floor gate (no Composer dependency).
+ *
+ * Parses a Clover XML report and fails (exit 1) when line coverage falls
+ * below a floor. Wired into CI after PHPUnit runs with `--coverage-clover`.
+ * The floor is intentionally a *minimum* — a regression guard, not a target.
+ *
+ * Usage:
+ *   php bin/coverage-check.php <clover.xml> [minPercent]
+ *
+ * `minPercent` defaults to the COVERAGE_MIN env var, then to 70.
+ *
+ * "Line coverage" here is Clover's `coveredstatements / statements`, which
+ * matches the "Lines" figure PHPUnit's own `--coverage-text` summary prints.
+ */
+
+$cloverPath = $argv[1] ?? '';
+if ($cloverPath === '' || !is_file($cloverPath)) {
+    fwrite(STDERR, "coverage-check: clover report not found at '{$cloverPath}'\n");
+    fwrite(STDERR, "usage: php bin/coverage-check.php <clover.xml> [minPercent]\n");
+    exit(2);
+}
+
+$minRaw = $argv[2] ?? getenv('COVERAGE_MIN');
+$min = is_numeric($minRaw) ? (float) $minRaw : 70.0;
+
+$xml = @simplexml_load_file($cloverPath);
+if ($xml === false) {
+    fwrite(STDERR, "coverage-check: could not parse clover XML at '{$cloverPath}'\n");
+    exit(2);
+}
+
+// Project-level summary metrics (one node: /coverage/project/metrics).
+$metrics = $xml->xpath('/coverage/project/metrics');
+if ($metrics === false || $metrics === null || count($metrics) === 0) {
+    fwrite(STDERR, "coverage-check: no <project><metrics> node in clover report\n");
+    exit(2);
+}
+
+$summary = $metrics[0];
+$statements = (int) ($summary['statements'] ?? 0);
+$covered = (int) ($summary['coveredstatements'] ?? 0);
+
+if ($statements === 0) {
+    fwrite(STDERR, "coverage-check: zero statements reported — refusing to pass a hollow run\n");
+    exit(2);
+}
+
+$percent = $covered / $statements * 100;
+$rounded = round($percent, 2);
+
+printf("Line coverage: %.2f%% (%d/%d statements) — floor %.2f%%\n", $rounded, $covered, $statements, $min);
+
+if ($percent + 1e-9 < $min) {
+    fwrite(STDERR, sprintf("coverage-check: FAIL — %.2f%% is below the %.2f%% floor\n", $rounded, $min));
+    exit(1);
+}
+
+echo "coverage-check: OK\n";
+exit(0);

--- a/api/phpunit.xml.dist
+++ b/api/phpunit.xml.dist
@@ -27,6 +27,12 @@
         <include>
             <directory suffix=".php">src</directory>
         </include>
+        <exclude>
+            <!-- Dev/test data seeders, not production logic — they run during
+                 E2E fixture loading, not PHPUnit, so they only ever skew the
+                 coverage denominator. -->
+            <directory suffix=".php">src/DataFixtures</directory>
+        </exclude>
     </coverage>
 
     <listeners>

--- a/api/tests/Api/CustomFieldDefinitionReorderEdgeTest.php
+++ b/api/tests/Api/CustomFieldDefinitionReorderEdgeTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\CustomField\CustomFieldKind;
+use App\Entity\CustomFieldDefinition;
+use App\Entity\Project;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Edge-branch coverage for App\Controller\CustomFieldDefinitionReorderController.
+ * The base CustomFieldDefinitionReorderTest covers admin happy-path,
+ * non-admin 404, incomplete + duplicate payloads. This adds: unknown /
+ * malformed project id, missing `order` key, malformed IRI, and an IRI
+ * that belongs to another project.
+ */
+class CustomFieldDefinitionReorderEdgeTest extends ApiTestCase
+{
+    use SpaceMembershipFixture;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\CustomFieldDefinition')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testUnknownProjectIs404(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/projects/00000000-0000-0000-0000-000000000000/custom_field_definitions/reorder', [
+            'json' => ['order' => []],
+        ]);
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testInvalidProjectIdIs404(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/projects/not-a-uuid/custom_field_definitions/reorder', [
+            'json' => ['order' => []],
+        ]);
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testMissingOrderKeyIs400(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/projects/' . $project->getId() . '/custom_field_definitions/reorder', [
+            'json' => ['nope' => []],
+        ]);
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    public function testMalformedIriIs400(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $this->seedField($project, 'Alpha', 0);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/projects/' . $project->getId() . '/custom_field_definitions/reorder', [
+            'json' => ['order' => ['/custom_field_definitions/not-a-uuid']],
+        ]);
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    public function testIriFromAnotherProjectIs400(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $projectA = $this->createProject($alice, 'Alpha project');
+        $projectB = $this->createProject($alice, 'Beta project');
+        // One field on each project.
+        $this->seedField($projectA, 'Local', 0);
+        $foreign = $this->seedField($projectB, 'Foreign', 0);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        // Reorder project A but list project B's field — rejected (not part
+        // of this project / contiguity guard).
+        $client->request('POST', '/projects/' . $projectA->getId() . '/custom_field_definitions/reorder', [
+            'json' => ['order' => ['/custom_field_definitions/' . $foreign->getId()]],
+        ]);
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    private function createProject(User $owner, string $title): Project
+    {
+        $project = new Project();
+        $project->setOwner($owner);
+        $project->setTitle($title);
+        $this->addProjectMember($project, $owner);
+        $this->entityManager->persist($project);
+        $this->entityManager->flush();
+        return $project;
+    }
+
+    private function createUser(string $email): User
+    {
+        $container = static::getContainer();
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+        return $user;
+    }
+
+    private function seedField(Project $project, string $name, int $position): CustomFieldDefinition
+    {
+        $field = new CustomFieldDefinition();
+        $field->setProject($project)
+            ->setName($name)
+            ->setKind(CustomFieldKind::TEXT->value)
+            ->setSubtype('text')
+            ->setConfig(['multi' => false])
+            ->setPosition($position);
+        $this->entityManager->persist($field);
+        $this->entityManager->flush();
+        return $field;
+    }
+}

--- a/api/tests/Api/CustomFieldFooterEdgeTest.php
+++ b/api/tests/Api/CustomFieldFooterEdgeTest.php
@@ -1,0 +1,233 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\CustomField\CustomFieldKind;
+use App\Entity\CustomFieldDefinition;
+use App\Entity\CustomFieldValue;
+use App\Entity\Project;
+use App\Entity\Task;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Extra branch coverage for {@see \App\Controller\CustomFieldFooterController}
+ * that CustomFieldFooterTest doesn't reach: the `?overdue=`, `?dueDate[...]`
+ * and `?search=` task-filter arms, plus min/max numeric aggregation.
+ */
+class CustomFieldFooterEdgeTest extends ApiTestCase
+{
+    use SpaceMembershipFixture;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\CustomFieldValue')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\CustomFieldDefinition')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testOutsiderGets404(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $this->seedNumericField($project, 'Estimate', footerKind: 'sum');
+
+        $client = static::createClient();
+        $client->loginUser($bob);
+        $client->request('GET', '/projects/' . $project->getId() . '/custom_field_footers');
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testOverdueFilterRestrictsAggregation(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $field = $this->seedNumericField($project, 'Estimate', footerKind: 'sum');
+
+        // Overdue task (past due, not completed) counts; future task doesn't.
+        $overdue = $this->seedTaskWithValue($alice, $project, $field, 3);
+        $overdue->setDueDate(new \DateTimeImmutable('-2 days'));
+        $future = $this->seedTaskWithValue($alice, $project, $field, 5);
+        $future->setDueDate(new \DateTimeImmutable('+5 days'));
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/projects/' . $project->getId() . '/custom_field_footers?overdue=true');
+        $this->assertResponseIsSuccessful();
+        $first = $this->firstFooter($client);
+        $this->assertEqualsCanonicalizing(3, $first['value']);
+    }
+
+    public function testDueDateBoundFilter(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $field = $this->seedNumericField($project, 'Estimate', footerKind: 'sum');
+
+        $early = $this->seedTaskWithValue($alice, $project, $field, 3);
+        $early->setDueDate(new \DateTimeImmutable('2026-01-01'));
+        $late = $this->seedTaskWithValue($alice, $project, $field, 5);
+        $late->setDueDate(new \DateTimeImmutable('2026-12-31'));
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        // Only the early task is due on/before mid-year → sum is 3.
+        $client->request(
+            'GET',
+            '/projects/' . $project->getId() . '/custom_field_footers?dueDate[before]=2026-06-01',
+        );
+        $this->assertResponseIsSuccessful();
+        $first = $this->firstFooter($client);
+        $this->assertEqualsCanonicalizing(3, $first['value']);
+    }
+
+    public function testSearchFilterRestrictsAggregation(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $field = $this->seedNumericField($project, 'Estimate', footerKind: 'sum');
+
+        $matching = $this->seedTaskWithValue($alice, $project, $field, 3);
+        $matching->setTitle('Pineapple harvest');
+        $other = $this->seedTaskWithValue($alice, $project, $field, 5);
+        $other->setTitle('Mango delivery');
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request(
+            'GET',
+            '/projects/' . $project->getId() . '/custom_field_footers?search=pineapple',
+        );
+        $this->assertResponseIsSuccessful();
+        $first = $this->firstFooter($client);
+        $this->assertEqualsCanonicalizing(3, $first['value']);
+    }
+
+    public function testMinAndMaxAggregation(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $minField = $this->seedNumericField($project, 'Low', footerKind: 'min');
+        $maxField = $this->seedNumericField($project, 'High', footerKind: 'max');
+
+        $this->seedTaskWithValues($alice, $project, [[$minField, 4], [$maxField, 4]]);
+        $this->seedTaskWithValues($alice, $project, [[$minField, 9], [$maxField, 9]]);
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/projects/' . $project->getId() . '/custom_field_footers');
+        $this->assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+        $footers = $body['footers'] ?? null;
+        $this->assertIsArray($footers);
+        $byName = array_column($footers, null, 'name');
+        $low = $byName['Low'] ?? null;
+        $this->assertIsArray($low);
+        $this->assertEqualsCanonicalizing(4, $low['value']);
+        $high = $byName['High'] ?? null;
+        $this->assertIsArray($high);
+        $this->assertEqualsCanonicalizing(9, $high['value']);
+    }
+
+    /**
+     * @return array<int|string, mixed>
+     */
+    private function firstFooter(Client $client): array
+    {
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+        $footers = $body['footers'] ?? null;
+        $this->assertIsArray($footers);
+        $first = $footers[0] ?? null;
+        $this->assertIsArray($first);
+        return $first;
+    }
+
+    private function createProject(User $owner, string $title): Project
+    {
+        $project = new Project();
+        $project->setOwner($owner);
+        $project->setTitle($title);
+        $this->addProjectMember($project, $owner);
+        $this->entityManager->persist($project);
+        $this->entityManager->flush();
+        return $project;
+    }
+
+    private function createUser(string $email): User
+    {
+        $container = static::getContainer();
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+        return $user;
+    }
+
+    private function seedNumericField(Project $project, string $name, ?string $footerKind): CustomFieldDefinition
+    {
+        $field = new CustomFieldDefinition();
+        $field->setProject($project)
+            ->setName($name)
+            ->setKind(CustomFieldKind::NUMERIC->value)
+            ->setSubtype('float')
+            ->setConfig(['multi' => false]);
+        if (null !== $footerKind) {
+            $field->setFooter(['kind' => $footerKind]);
+        }
+        $this->entityManager->persist($field);
+        $this->entityManager->flush();
+        return $field;
+    }
+
+    private function seedTaskWithValue(User $owner, Project $project, CustomFieldDefinition $field, mixed $value): Task
+    {
+        return $this->seedTaskWithValues($owner, $project, [[$field, $value]]);
+    }
+
+    /**
+     * @param list<array{0: CustomFieldDefinition, 1: mixed}> $pairs
+     */
+    private function seedTaskWithValues(User $owner, Project $project, array $pairs): Task
+    {
+        $task = new Task();
+        $task->setOwner($owner);
+        $task->setProject($project);
+        $task->setTitle('Task');
+        $this->entityManager->persist($task);
+        foreach ($pairs as [$field, $value]) {
+            $cfv = new CustomFieldValue();
+            $cfv->setTask($task);
+            $cfv->setDefinition($field);
+            $cfv->setValue($value);
+            $this->entityManager->persist($cfv);
+        }
+        return $task;
+    }
+}

--- a/api/tests/Api/McpExtraToolsTest.php
+++ b/api/tests/Api/McpExtraToolsTest.php
@@ -1,0 +1,447 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Entity\ApiToken;
+use App\Entity\Comment;
+use App\Entity\MediaObject;
+use App\Entity\Project;
+use App\Entity\Space;
+use App\Entity\Task;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Coverage for the file-oriented MCP tools (upload_file, list_files,
+ * download_file) plus additional update_task / get_my_tasks /
+ * list_task_comments branches and validation-error paths. These exercise
+ * {@see \App\Mcp\McpInputHelper} and {@see \App\Mcp\McpEntitySerializer}
+ * surfaces the other MCP tests don't reach.
+ *
+ * upload_file round-trips real bytes through ImageUploadService into the
+ * `media.storage` filesystem, so download_file can read them straight
+ * back — no manual storage wiring needed. list_files is additionally
+ * exercised against a Space by attaching a seeded MediaObject via the EM.
+ *
+ * Test fixtures must be persisted *before* the first call to
+ * {@see static::createClient()} — that boots the test kernel and any
+ * entities staged through `$this->entityManager` afterwards arrive
+ * detached, producing "A new entity was found" cascades.
+ */
+class McpExtraToolsTest extends ApiTestCase
+{
+    use SpaceMembershipFixture;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\ApiToken')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Comment')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testUploadFileToTaskReturnsMediaObject(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->makeTask($alice, 'Has an attachment');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'upload_file',
+            'arguments' => [
+                'entityType' => 'task',
+                'entityId' => (string) $task->getId(),
+                'fileName' => 'notes.txt',
+                'content' => base64_encode("Hello from MCP.\n"),
+            ],
+        ]);
+
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $this->assertSame('notes.txt', $structured['name']);
+        $this->assertSame('attachment', $structured['kind']);
+        $this->assertIsString($structured['id']);
+        $this->assertNotSame('', $structured['id']);
+    }
+
+    public function testUploadFileMissingRequiredArgIsError(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->makeTask($alice, 'Target');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        // Omit the required `content` field to trip McpInputHelper::requireString.
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'upload_file',
+            'arguments' => [
+                'entityType' => 'task',
+                'entityId' => (string) $task->getId(),
+                'fileName' => 'notes.txt',
+            ],
+        ]);
+
+        $this->assertTrue($body['result']['isError'] ?? null);
+        $content = $body['result']['content'] ?? null;
+        $this->assertIsArray($content);
+        $this->assertIsArray($content[0]);
+        $this->assertIsString($content[0]['text']);
+        $this->assertStringContainsString('content', $content[0]['text']);
+    }
+
+    public function testListFilesOnTaskReturnsUploadedFile(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->makeTask($alice, 'Files here');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $upload = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'upload_file',
+            'arguments' => [
+                'entityType' => 'task',
+                'entityId' => (string) $task->getId(),
+                'fileName' => 'report.txt',
+                'content' => base64_encode("body\n"),
+            ],
+        ]);
+        $this->assertFalse($upload['result']['isError'] ?? null);
+
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_files',
+            'arguments' => [
+                'entityType' => 'task',
+                'entityId' => (string) $task->getId(),
+            ],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $names = array_column($items, 'name');
+        $this->assertContains('report.txt', $names);
+    }
+
+    public function testListFilesOnSpaceReturnsSeededAttachment(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        // A project pins its creator's personal space via the listener.
+        $project = $this->makeProject($alice, [$alice], 'Space holder');
+        $space = $project->getSpace();
+        $this->assertNotNull($space);
+        $media = $this->seedAttachment($alice, 'shared.pdf');
+        $space->addAttachment($media);
+        $this->entityManager->flush();
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_files',
+            'arguments' => [
+                'entityType' => 'space',
+                'entityId' => (string) $space->getId(),
+            ],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $names = array_column($items, 'name');
+        $this->assertContains('shared.pdf', $names);
+    }
+
+    public function testDownloadFileReturnsBase64Content(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->makeTask($alice, 'Downloadable');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $payload = "Round-trip me.\n";
+        $upload = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'upload_file',
+            'arguments' => [
+                'entityType' => 'task',
+                'entityId' => (string) $task->getId(),
+                'fileName' => 'rt.txt',
+                'content' => base64_encode($payload),
+            ],
+        ]);
+        $this->assertFalse($upload['result']['isError'] ?? null);
+        $uploaded = $upload['result']['structuredContent'] ?? null;
+        $this->assertIsArray($uploaded);
+        $fileId = $uploaded['id'] ?? null;
+        $this->assertIsString($fileId);
+
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'download_file',
+            'arguments' => ['fileId' => $fileId],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $this->assertSame('rt.txt', $structured['name']);
+        $returned = $structured['content'] ?? null;
+        $this->assertIsString($returned);
+        $this->assertSame($payload, base64_decode($returned, true));
+    }
+
+    public function testDownloadFileUnknownIdIsError(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        // A well-formed but non-existent UUID — exercises the not-found branch.
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'download_file',
+            'arguments' => ['fileId' => '00000000-0000-7000-8000-000000000000'],
+        ]);
+        $this->assertTrue($body['result']['isError'] ?? null);
+        $content = $body['result']['content'] ?? null;
+        $this->assertIsArray($content);
+        $this->assertIsArray($content[0]);
+        $this->assertIsString($content[0]['text']);
+        $this->assertStringContainsString('not found', $content[0]['text']);
+    }
+
+    public function testUpdateTaskSetsAndClearsDueDate(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->makeTask($alice, 'Schedule me');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'update_task',
+            'arguments' => [
+                'taskId' => (string) $task->getId(),
+                'dueDate' => '2026-12-31T09:00:00+00:00',
+            ],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $dueDate = $structured['dueDate'] ?? null;
+        $this->assertIsString($dueDate);
+        $this->assertStringContainsString('2026-12-31', $dueDate);
+
+        // Passing null clears it again.
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'update_task',
+            'arguments' => [
+                'taskId' => (string) $task->getId(),
+                'dueDate' => null,
+            ],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $this->assertNull($structured['dueDate']);
+    }
+
+    public function testGetMyTasksReturnsMultipleAssignedTasks(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $first = $this->makeTask($alice, 'First mine');
+        $first->addAssignee($alice);
+        $second = $this->makeTask($alice, 'Second mine');
+        $second->addAssignee($alice);
+        $this->makeTask($alice, 'Not assigned');
+        $this->entityManager->flush();
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'get_my_tasks',
+            'arguments' => [],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $titles = array_column($items, 'title');
+        $this->assertContains('First mine', $titles);
+        $this->assertContains('Second mine', $titles);
+        $this->assertNotContains('Not assigned', $titles);
+    }
+
+    public function testListTaskCommentsReturnsAllComments(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->makeTask($alice, 'Threaded');
+        $this->makeComment($task, $alice, 'Earliest note');
+        $this->makeComment($task, $alice, 'Middle note');
+        $this->makeComment($task, $alice, 'Latest note');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_task_comments',
+            'arguments' => ['taskId' => (string) $task->getId()],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $bodies = array_column($items, 'body');
+        $this->assertContains('Earliest note', $bodies);
+        $this->assertContains('Middle note', $bodies);
+        $this->assertContains('Latest note', $bodies);
+
+        // Each comment carries an author summary from McpEntitySerializer.
+        $first = $items[0] ?? null;
+        $this->assertIsArray($first);
+        $author = $first['author'] ?? null;
+        $this->assertIsArray($author);
+        $this->assertSame('alice@example.com', $author['email']);
+    }
+
+    /**
+     * Returns the JSON-RPC response body. Every site that uses this
+     * helper goes through {@see assertResponseIsSuccessful()} and
+     * checks a `result`, so the shape is widened to `array<string, mixed>`
+     * on result (deep nesting is narrowed per-callsite with explicit
+     * `assertIsArray()` / `assertArrayHasKey()` calls).
+     *
+     * @param array<string, mixed> $params
+     * @return array{
+     *   jsonrpc: string,
+     *   id?: int|string,
+     *   result: array<string, mixed>,
+     *   error?: array{code: int, message: string, data?: mixed}
+     * }
+     */
+    private function callMcp(Client $client, string $bearer, string $method, array $params = []): array
+    {
+        $client->request('POST', '/mcp', [
+            'json' => [
+                'jsonrpc' => '2.0',
+                'id' => mt_rand(1, 99999),
+                'method' => $method,
+                'params' => $params,
+            ],
+            'headers' => ['Authorization' => 'Bearer ' . $bearer],
+        ]);
+        $this->assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        /**
+         * @var array{
+         *   jsonrpc: string,
+         *   id?: int|string,
+         *   result: array<string, mixed>,
+         *   error?: array{code: int, message: string, data?: mixed}
+         * } $body
+         */
+        $body = $response->toArray();
+        return $body;
+    }
+
+    /**
+     * @param array<string, mixed>|null $accessPolicy
+     */
+    private function mintToken(
+        User $user,
+        string $name,
+        ?\DateTimeImmutable $expiresAt = null,
+        ?array $accessPolicy = null,
+    ): string {
+        $plain = ApiToken::PLAINTEXT_PREFIX . bin2hex(random_bytes(16));
+        $token = new ApiToken();
+        $token->setUser($user);
+        $token->setName($name);
+        $token->setTokenHash(hash('sha256', $plain));
+        $token->setExpiresAt($expiresAt);
+        $token->setAccessPolicy($accessPolicy);
+        $this->entityManager->persist($token);
+        $this->entityManager->flush();
+        return $plain;
+    }
+
+    private function makeTask(User $owner, string $title): Task
+    {
+        $task = new Task();
+        $task->setOwner($owner);
+        $task->setTitle($title);
+        $this->entityManager->persist($task);
+        $this->entityManager->flush();
+        return $task;
+    }
+
+    private function makeComment(Task $task, User $author, string $body): Comment
+    {
+        $comment = new Comment();
+        $comment->setTask($task);
+        $comment->setAuthor($author);
+        $comment->setBody($body);
+        $this->entityManager->persist($comment);
+        $this->entityManager->flush();
+        return $comment;
+    }
+
+    /**
+     * @param User[] $members
+     */
+    private function makeProject(User $owner, array $members, string $title): Project
+    {
+        $project = new Project();
+        $project->setOwner($owner);
+        $project->setTitle($title);
+        foreach ($members as $member) {
+            $this->addProjectMember($project, $member);
+        }
+        $this->entityManager->persist($project);
+        $this->entityManager->flush();
+        return $project;
+    }
+
+    private function seedAttachment(User $owner, string $name): MediaObject
+    {
+        $media = new MediaObject();
+        $media->setOwner($owner);
+        $media->setKind(MediaObject::KIND_ATTACHMENT);
+        $media->setVariants(['original' => 'attachments/seeded-' . $name]);
+        $media->setOriginalName($name);
+        $media->setMimeType('application/pdf');
+        $media->setByteSize(1024);
+        $this->entityManager->persist($media);
+        $this->entityManager->flush();
+        return $media;
+    }
+
+    private function createUser(string $email): User
+    {
+        $container = static::getContainer();
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+        return $user;
+    }
+}

--- a/api/tests/Api/McpReadToolsTest.php
+++ b/api/tests/Api/McpReadToolsTest.php
@@ -1,0 +1,323 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Entity\ApiToken;
+use App\Entity\Comment;
+use App\Entity\Project;
+use App\Entity\Task;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Additional coverage for the under-tested read-oriented MCP tools
+ * (list_tasks, get_my_tasks, search_tasks, list_task_comments,
+ * get_project, get_custom_fields) plus extra update_task branches.
+ * Drives each via the JSON-RPC `tools/call` endpoint and asserts the
+ * structured response shape.
+ *
+ * Test fixtures must be persisted *before* the first call to
+ * {@see static::createClient()} — that boots the test kernel and any
+ * entities you've staged through `$this->entityManager` afterwards
+ * arrive detached, producing "A new entity was found" cascades.
+ */
+class McpReadToolsTest extends ApiTestCase
+{
+    use SpaceMembershipFixture;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\ApiToken')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Comment')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testListTasksReturnsItemsAndFilters(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $this->makeTask($alice, 'Open task');
+        $done = $this->makeTask($alice, 'Done task');
+        $done->setCompletedOn(new \DateTimeImmutable());
+        $this->entityManager->flush();
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_tasks',
+            'arguments' => [],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $titles = array_column($items, 'title');
+        $this->assertContains('Open task', $titles);
+        $this->assertContains('Done task', $titles);
+
+        // `status=open` narrows to the unfinished task only.
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_tasks',
+            'arguments' => ['status' => 'open'],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $titles = array_column($items, 'title');
+        $this->assertContains('Open task', $titles);
+        $this->assertNotContains('Done task', $titles);
+    }
+
+    public function testGetMyTasksReturnsAssignedItems(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->makeTask($alice, 'Assigned to me');
+        $task->addAssignee($alice);
+        $this->entityManager->flush();
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'get_my_tasks',
+            'arguments' => [],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $titles = array_column($items, 'title');
+        $this->assertContains('Assigned to me', $titles);
+    }
+
+    public function testSearchTasksFindsByQuery(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $this->makeTask($alice, 'A distinctiveword appears here');
+        $this->makeTask($alice, 'Unrelated chore');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'search_tasks',
+            'arguments' => ['query' => 'distinctiveword'],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $titles = array_column($items, 'title');
+        $this->assertContains('A distinctiveword appears here', $titles);
+        $this->assertNotContains('Unrelated chore', $titles);
+    }
+
+    public function testListTaskCommentsReturnsComment(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->makeTask($alice, 'Has comments');
+        $this->makeComment($task, $alice, 'First comment body');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_task_comments',
+            'arguments' => ['taskId' => (string) $task->getId()],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $bodies = array_column($items, 'body');
+        $this->assertContains('First comment body', $bodies);
+    }
+
+    public function testGetProjectReturnsTitle(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->makeProject($alice, [$alice], 'Roadmap');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'get_project',
+            'arguments' => ['projectId' => (string) $project->getId()],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $this->assertSame('Roadmap', $structured['title']);
+    }
+
+    public function testGetCustomFieldsReturnsShape(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->makeProject($alice, [$alice], 'With fields');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'get_custom_fields',
+            'arguments' => ['projectId' => (string) $project->getId()],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+    }
+
+    public function testUpdateTaskTitleAndDescription(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->makeTask($alice, 'Old title');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'update_task',
+            'arguments' => [
+                'taskId' => (string) $task->getId(),
+                'title' => 'New title',
+                'description' => 'A fresh description',
+            ],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $this->assertSame('New title', $structured['title']);
+        $this->assertSame('A fresh description', $structured['description']);
+    }
+
+    /**
+     * Returns the JSON-RPC response body. Every site that uses this
+     * helper goes through {@see assertResponseIsSuccessful()} and
+     * checks a `result`, so the shape is widened to `array<string, mixed>`
+     * on result (deep nesting is narrowed per-callsite with explicit
+     * `assertIsArray()` / `assertArrayHasKey()` calls).
+     *
+     * @param array<string, mixed> $params
+     * @return array{
+     *   jsonrpc: string,
+     *   id?: int|string,
+     *   result: array<string, mixed>,
+     *   error?: array{code: int, message: string, data?: mixed}
+     * }
+     */
+    private function callMcp(Client $client, string $bearer, string $method, array $params = []): array
+    {
+        $client->request('POST', '/mcp', [
+            'json' => [
+                'jsonrpc' => '2.0',
+                'id' => mt_rand(1, 99999),
+                'method' => $method,
+                'params' => $params,
+            ],
+            'headers' => ['Authorization' => 'Bearer ' . $bearer],
+        ]);
+        $this->assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        /**
+         * @var array{
+         *   jsonrpc: string,
+         *   id?: int|string,
+         *   result: array<string, mixed>,
+         *   error?: array{code: int, message: string, data?: mixed}
+         * } $body
+         */
+        $body = $response->toArray();
+        return $body;
+    }
+
+    /**
+     * @param array<string, mixed>|null $accessPolicy
+     */
+    private function mintToken(
+        User $user,
+        string $name,
+        ?\DateTimeImmutable $expiresAt = null,
+        ?array $accessPolicy = null,
+    ): string {
+        $plain = ApiToken::PLAINTEXT_PREFIX . bin2hex(random_bytes(16));
+        $token = new ApiToken();
+        $token->setUser($user);
+        $token->setName($name);
+        $token->setTokenHash(hash('sha256', $plain));
+        $token->setExpiresAt($expiresAt);
+        $token->setAccessPolicy($accessPolicy);
+        $this->entityManager->persist($token);
+        $this->entityManager->flush();
+        return $plain;
+    }
+
+    private function makeTask(User $owner, string $title): Task
+    {
+        $task = new Task();
+        $task->setOwner($owner);
+        $task->setTitle($title);
+        $this->entityManager->persist($task);
+        $this->entityManager->flush();
+        return $task;
+    }
+
+    private function makeComment(Task $task, User $author, string $body): Comment
+    {
+        $comment = new Comment();
+        $comment->setTask($task);
+        $comment->setAuthor($author);
+        $comment->setBody($body);
+        $this->entityManager->persist($comment);
+        $this->entityManager->flush();
+        return $comment;
+    }
+
+    /**
+     * @param User[] $members
+     */
+    private function makeProject(User $owner, array $members, string $title): Project
+    {
+        $project = new Project();
+        $project->setOwner($owner);
+        $project->setTitle($title);
+        foreach ($members as $member) {
+            $this->addProjectMember($project, $member);
+        }
+        $this->entityManager->persist($project);
+        $this->entityManager->flush();
+        return $project;
+    }
+
+    private function createUser(string $email): User
+    {
+        $container = static::getContainer();
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+        return $user;
+    }
+}

--- a/api/tests/Api/McpToolBranchesTest.php
+++ b/api/tests/Api/McpToolBranchesTest.php
@@ -1,0 +1,589 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Entity\ApiToken;
+use App\Entity\MediaObject;
+use App\Entity\Project;
+use App\Entity\Task;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Branch coverage for the MCP server that the existing suites
+ * ({@see McpTest}, {@see McpReadToolsTest}, {@see McpExtraToolsTest})
+ * don't exercise:
+ *  - {@see \App\Mcp\Tool\ListTasksTool} filter args (projectId, search,
+ *    dueBefore, pagination) + an unreachable projectId.
+ *  - {@see \App\Mcp\Tool\UpdateTaskTool} assigneeIds / projectId / tagIds
+ *    branches and the entity-validation (422) path.
+ *  - {@see \App\Mcp\Tool\DownloadFileTool} forbidden-file + malformed-id
+ *    branches.
+ *  - {@see \App\Mcp\McpInputHelper} type-coercion edge cases (missing
+ *    required arg, wrong JSON type, out-of-range enum).
+ *  - {@see \App\Controller\McpController} malformed JSON-RPC envelopes.
+ *
+ * Test fixtures must be persisted *before* the first call to
+ * {@see static::createClient()} — that boots the test kernel and any
+ * entities staged through `$this->entityManager` afterwards arrive
+ * detached, producing "A new entity was found" cascades.
+ */
+class McpToolBranchesTest extends ApiTestCase
+{
+    use SpaceMembershipFixture;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\ApiToken')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Comment')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    // ---- ListTasksTool filter branches ----------------------------------
+
+    public function testListTasksFiltersByProjectId(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->makeProject($alice, [$alice], 'Scoped');
+        $this->makeTaskInProject($alice, $project, 'In project');
+        $this->makeTask($alice, 'Standalone');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_tasks',
+            'arguments' => ['projectId' => (string) $project->getId()],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $titles = array_column($items, 'title');
+        $this->assertContains('In project', $titles);
+        $this->assertNotContains('Standalone', $titles);
+    }
+
+    public function testListTasksFiltersBySearch(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $this->makeTask($alice, 'Quarterly planning meeting');
+        $this->makeTask($alice, 'Water the plants');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_tasks',
+            'arguments' => ['search' => 'quarterly'],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $titles = array_column($items, 'title');
+        $this->assertContains('Quarterly planning meeting', $titles);
+        $this->assertNotContains('Water the plants', $titles);
+    }
+
+    public function testListTasksFiltersByDueBefore(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $soon = $this->makeTask($alice, 'Due soon');
+        $soon->setDueDate(new \DateTimeImmutable('2026-01-01T00:00:00+00:00'));
+        $later = $this->makeTask($alice, 'Due later');
+        $later->setDueDate(new \DateTimeImmutable('2027-01-01T00:00:00+00:00'));
+        $this->entityManager->flush();
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_tasks',
+            'arguments' => ['dueBefore' => '2026-06-01T00:00:00+00:00'],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $titles = array_column($items, 'title');
+        $this->assertContains('Due soon', $titles);
+        $this->assertNotContains('Due later', $titles);
+    }
+
+    public function testListTasksPaginates(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $this->makeTask($alice, 'First');
+        $this->makeTask($alice, 'Second');
+        $this->makeTask($alice, 'Third');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_tasks',
+            'arguments' => ['page' => 1, 'limit' => 2],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        // The page is clamped to the requested limit even though three exist.
+        $this->assertCount(2, $items);
+        $this->assertSame(3, $structured['total']);
+        $this->assertSame(1, $structured['page']);
+        $this->assertSame(2, $structured['limit']);
+    }
+
+    public function testListTasksUnreachableProjectReturnsEmpty(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        // A project alice can't see — filtering by it yields no rows (no error).
+        $hidden = $this->makeProject($bob, [$bob], 'Hidden');
+        $this->makeTask($alice, 'Visible to alice');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_tasks',
+            'arguments' => ['projectId' => (string) $hidden->getId()],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $this->assertSame([], $items);
+        $this->assertSame(0, $structured['total']);
+    }
+
+    // ---- UpdateTaskTool branches ----------------------------------------
+
+    public function testUpdateTaskReplacesAssignees(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $project = $this->makeProject($alice, [$alice, $bob], 'Team');
+        $task = $this->makeTaskInProject($alice, $project, 'Joint');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'update_task',
+            'arguments' => [
+                'taskId' => (string) $task->getId(),
+                'assigneeIds' => [(string) $bob->getId()],
+            ],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $assignees = $structured['assignees'] ?? null;
+        $this->assertIsArray($assignees);
+        $emails = array_column($assignees, 'email');
+        $this->assertContains('bob@example.com', $emails);
+    }
+
+    public function testUpdateTaskMovesToProject(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->makeProject($alice, [$alice], 'Destination');
+        $task = $this->makeTask($alice, 'Detached');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'update_task',
+            'arguments' => [
+                'taskId' => (string) $task->getId(),
+                'projectId' => (string) $project->getId(),
+            ],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $project = $structured['project'] ?? null;
+        $this->assertIsArray($project);
+        $this->assertSame('Destination', $project['title']);
+    }
+
+    public function testUpdateTaskUnreachableProjectIsError(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $hidden = $this->makeProject($bob, [$bob], 'Hidden');
+        $task = $this->makeTask($alice, 'Mine');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'update_task',
+            'arguments' => [
+                'taskId' => (string) $task->getId(),
+                'projectId' => (string) $hidden->getId(),
+            ],
+        ]);
+        $this->assertTrue($body['result']['isError'] ?? null);
+        $content = $body['result']['content'] ?? null;
+        $this->assertIsArray($content);
+        $this->assertIsArray($content[0]);
+        $this->assertIsString($content[0]['text']);
+        $this->assertStringContainsString('not found', $content[0]['text']);
+    }
+
+    public function testUpdateTaskInvalidAssigneeFailsValidation(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        // bob is neither the owner nor a member of any shared project, so
+        // ValidAssignees rejects him → entity validation (422) branch.
+        $task = $this->makeTask($alice, 'Standalone');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'update_task',
+            'arguments' => [
+                'taskId' => (string) $task->getId(),
+                'assigneeIds' => [(string) $bob->getId()],
+            ],
+        ]);
+        $this->assertTrue($body['result']['isError'] ?? null);
+        $content = $body['result']['content'] ?? null;
+        $this->assertIsArray($content);
+        $this->assertIsArray($content[0]);
+        $this->assertIsString($content[0]['text']);
+        $this->assertStringContainsString('assignees', $content[0]['text']);
+    }
+
+    public function testUpdateTaskUnknownTagIsError(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->makeTask($alice, 'Tag me');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        // A well-formed UUID that doesn't resolve to a tag the caller owns.
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'update_task',
+            'arguments' => [
+                'taskId' => (string) $task->getId(),
+                'tagIds' => ['00000000-0000-7000-8000-000000000000'],
+            ],
+        ]);
+        $this->assertTrue($body['result']['isError'] ?? null);
+        $content = $body['result']['content'] ?? null;
+        $this->assertIsArray($content);
+        $this->assertIsArray($content[0]);
+        $this->assertIsString($content[0]['text']);
+        $this->assertStringContainsString('not found', $content[0]['text']);
+    }
+
+    // ---- DownloadFileTool branches --------------------------------------
+
+    public function testDownloadFileForbiddenAttachmentIsError(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        // bob's private attachment — alice is neither uploader nor a member
+        // of any task/space using it, so canAccess() is false → not found.
+        $media = $this->seedAttachment($bob, 'secret.pdf');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'download_file',
+            'arguments' => ['fileId' => (string) $media->getId()],
+        ]);
+        $this->assertTrue($body['result']['isError'] ?? null);
+        $content = $body['result']['content'] ?? null;
+        $this->assertIsArray($content);
+        $this->assertIsArray($content[0]);
+        $this->assertIsString($content[0]['text']);
+        $this->assertStringContainsString('not found', $content[0]['text']);
+    }
+
+    public function testDownloadFileMalformedIdIsValidationError(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'download_file',
+            'arguments' => ['fileId' => 'not-a-uuid'],
+        ]);
+        $this->assertTrue($body['result']['isError'] ?? null);
+        $content = $body['result']['content'] ?? null;
+        $this->assertIsArray($content);
+        $this->assertIsArray($content[0]);
+        $this->assertIsString($content[0]['text']);
+        $this->assertStringContainsString('UUID', $content[0]['text']);
+    }
+
+    // ---- McpInputHelper edge cases --------------------------------------
+
+    public function testMissingRequiredArgIsError(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        // update_task without taskId → requireUuid sees null → invalid input.
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'update_task',
+            'arguments' => ['title' => 'No id supplied'],
+        ]);
+        $this->assertTrue($body['result']['isError'] ?? null);
+        $content = $body['result']['content'] ?? null;
+        $this->assertIsArray($content);
+        $this->assertIsArray($content[0]);
+        $this->assertIsString($content[0]['text']);
+        $this->assertStringContainsString('taskId', $content[0]['text']);
+    }
+
+    public function testWrongJsonTypeForArrayArgIsError(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        // tagIds is a number, not an array → optionalStringArray rejects it.
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_tasks',
+            'arguments' => ['tagIds' => 42],
+        ]);
+        $this->assertTrue($body['result']['isError'] ?? null);
+        $content = $body['result']['content'] ?? null;
+        $this->assertIsArray($content);
+        $this->assertIsArray($content[0]);
+        $this->assertIsString($content[0]['text']);
+        $this->assertStringContainsString('array', $content[0]['text']);
+    }
+
+    public function testOutOfRangeEnumIsError(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        // status outside {open, completed} → invalid input branch.
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_tasks',
+            'arguments' => ['status' => 'archived'],
+        ]);
+        $this->assertTrue($body['result']['isError'] ?? null);
+        $content = $body['result']['content'] ?? null;
+        $this->assertIsArray($content);
+        $this->assertIsArray($content[0]);
+        $this->assertIsString($content[0]['text']);
+        $this->assertStringContainsString('open', $content[0]['text']);
+    }
+
+    // ---- McpController malformed-envelope branches ----------------------
+
+    public function testMissingMethodReturnsInvalidRequest(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $client->request('POST', '/mcp', [
+            'json' => ['jsonrpc' => '2.0', 'id' => 7],
+            'headers' => ['Authorization' => 'Bearer ' . $plain],
+        ]);
+        $this->assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+        $error = $body['error'] ?? null;
+        $this->assertIsArray($error);
+        $this->assertSame(-32600, $error['code']);
+        $this->assertIsString($error['message']);
+        $this->assertStringContainsString('method', $error['message']);
+    }
+
+    public function testToolsCallWithNonObjectParamsIsError(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        // params is a string, not an object → handleToolsCall raises McpException.
+        $client->request('POST', '/mcp', [
+            'json' => ['jsonrpc' => '2.0', 'id' => 8, 'method' => 'tools/call', 'params' => 'oops'],
+            'headers' => ['Authorization' => 'Bearer ' . $plain],
+        ]);
+        $this->assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+        $result = $body['result'] ?? null;
+        $this->assertIsArray($result);
+        $this->assertTrue($result['isError'] ?? null);
+        $content = $result['content'] ?? null;
+        $this->assertIsArray($content);
+        $this->assertIsArray($content[0]);
+        $this->assertIsString($content[0]['text']);
+        $this->assertStringContainsString('object', $content[0]['text']);
+    }
+
+    public function testParseErrorOnMalformedJson(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        // Raw, un-parseable body → decode() returns null → -32700 parse error.
+        $client->request('POST', '/mcp', [
+            'body' => '{ this is not valid json',
+            'headers' => [
+                'Authorization' => 'Bearer ' . $plain,
+                'Content-Type' => 'application/json',
+            ],
+        ]);
+        $this->assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+        $error = $body['error'] ?? null;
+        $this->assertIsArray($error);
+        $this->assertSame(-32700, $error['code']);
+    }
+
+    /**
+     * Returns the JSON-RPC response body. Every site that uses this
+     * helper goes through {@see assertResponseIsSuccessful()} and
+     * checks a `result`, so the shape is widened to `array<string, mixed>`
+     * on result (deep nesting is narrowed per-callsite with explicit
+     * `assertIsArray()` / `assertArrayHasKey()` calls).
+     *
+     * @param array<string, mixed> $params
+     * @return array{
+     *   jsonrpc: string,
+     *   id?: int|string,
+     *   result: array<string, mixed>,
+     *   error?: array{code: int, message: string, data?: mixed}
+     * }
+     */
+    private function callMcp(Client $client, string $bearer, string $method, array $params = []): array
+    {
+        $client->request('POST', '/mcp', [
+            'json' => [
+                'jsonrpc' => '2.0',
+                'id' => mt_rand(1, 99999),
+                'method' => $method,
+                'params' => $params,
+            ],
+            'headers' => ['Authorization' => 'Bearer ' . $bearer],
+        ]);
+        $this->assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        /**
+         * @var array{
+         *   jsonrpc: string,
+         *   id?: int|string,
+         *   result: array<string, mixed>,
+         *   error?: array{code: int, message: string, data?: mixed}
+         * } $body
+         */
+        $body = $response->toArray();
+        return $body;
+    }
+
+    private function mintToken(User $user, string $name): string
+    {
+        $plain = ApiToken::PLAINTEXT_PREFIX . bin2hex(random_bytes(16));
+        $token = new ApiToken();
+        $token->setUser($user);
+        $token->setName($name);
+        $token->setTokenHash(hash('sha256', $plain));
+        $this->entityManager->persist($token);
+        $this->entityManager->flush();
+        return $plain;
+    }
+
+    private function makeTask(User $owner, string $title): Task
+    {
+        $task = new Task();
+        $task->setOwner($owner);
+        $task->setTitle($title);
+        $this->entityManager->persist($task);
+        $this->entityManager->flush();
+        return $task;
+    }
+
+    private function makeTaskInProject(User $owner, Project $project, string $title): Task
+    {
+        $task = new Task();
+        $task->setOwner($owner);
+        $task->setProject($project);
+        $task->setTitle($title);
+        $this->entityManager->persist($task);
+        $this->entityManager->flush();
+        return $task;
+    }
+
+    /**
+     * @param User[] $members
+     */
+    private function makeProject(User $owner, array $members, string $title): Project
+    {
+        $project = new Project();
+        $project->setOwner($owner);
+        $project->setTitle($title);
+        foreach ($members as $member) {
+            $this->addProjectMember($project, $member);
+        }
+        $this->entityManager->persist($project);
+        $this->entityManager->flush();
+        return $project;
+    }
+
+    private function seedAttachment(User $owner, string $name): MediaObject
+    {
+        $media = new MediaObject();
+        $media->setOwner($owner);
+        $media->setKind(MediaObject::KIND_ATTACHMENT);
+        $media->setVariants(['original' => 'attachments/seeded-' . $name]);
+        $media->setOriginalName($name);
+        $media->setMimeType('application/pdf');
+        $media->setByteSize(1024);
+        $this->entityManager->persist($media);
+        $this->entityManager->flush();
+        return $media;
+    }
+
+    private function createUser(string $email): User
+    {
+        $container = static::getContainer();
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+        return $user;
+    }
+}

--- a/api/tests/Api/MediaObjectDownloadEdgeTest.php
+++ b/api/tests/Api/MediaObjectDownloadEdgeTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\MediaObject;
+use App\Entity\Space;
+use App\Entity\SpaceMembership;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use League\Flysystem\FilesystemOperator;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Extra branch coverage for {@see \App\Controller\MediaObjectDownloadController}
+ * that MediaObjectDownloadTest doesn't reach: the space-attachment
+ * readability arm (member downloads, non-member 404) and the
+ * no-variant-path 404 fallback.
+ */
+class MediaObjectDownloadEdgeTest extends ApiTestCase
+{
+    private EntityManagerInterface $entityManager;
+    private FilesystemOperator $storage;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $container = static::getContainer();
+        $em = $container->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+        $this->storage = $container->get('media.storage');
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\SpaceMembership')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\MediaObject')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Space')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testSpaceMemberCanDownloadSpaceAttachment(): void
+    {
+        $owner = $this->createUser('owner@example.com');
+        $member = $this->createUser('member@example.com');
+        $space = $this->createSpace($owner, [$member]);
+
+        // Uploaded by the owner, attached to the space; a different member
+        // who didn't upload it can still download via space membership.
+        $media = $this->seedAttachment($owner, 'shared.pdf', 'SHAREDBYTES');
+        $space->addAttachment($media);
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($member);
+        $client->request('GET', '/media-objects/' . $media->getId() . '/download');
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testNonSpaceMemberCannotDownloadSpaceAttachment(): void
+    {
+        $owner = $this->createUser('owner@example.com');
+        $stranger = $this->createUser('stranger@example.com');
+        $space = $this->createSpace($owner, []);
+
+        $media = $this->seedAttachment($owner, 'secret.pdf', 'SECRET');
+        $space->addAttachment($media);
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($stranger);
+        $client->request('GET', '/media-objects/' . $media->getId() . '/download');
+        // 404 (not 403) so the endpoint can't enumerate MediaObject ids.
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testMediaWithoutVariantPathReturns404(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        // Owner has access, but the MediaObject has no stored variant, so
+        // the controller can't resolve a path to stream → 404.
+        $media = new MediaObject();
+        $media->setOwner($alice);
+        $media->setKind(MediaObject::KIND_ATTACHMENT);
+        $media->setVariants([]);
+        $media->setOriginalName('empty.pdf');
+        $media->setMimeType('application/pdf');
+        $media->setByteSize(0);
+        $this->entityManager->persist($media);
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/media-objects/' . $media->getId() . '/download');
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    private function seedAttachment(User $owner, string $name, string $bytes): MediaObject
+    {
+        $path = 'attachments/edge-' . bin2hex(random_bytes(4)) . '-' . $name;
+        $this->storage->write($path, $bytes);
+
+        $media = new MediaObject();
+        $media->setOwner($owner);
+        $media->setKind(MediaObject::KIND_ATTACHMENT);
+        $media->setVariants(['original' => $path]);
+        $media->setOriginalName($name);
+        $media->setMimeType('application/pdf');
+        $media->setByteSize(strlen($bytes));
+        $this->entityManager->persist($media);
+        $this->entityManager->flush();
+        return $media;
+    }
+
+    /**
+     * @param User[] $extraMembers
+     */
+    private function createSpace(User $owner, array $extraMembers): Space
+    {
+        $space = new Space();
+        $space->setName('Shared space');
+        $space->setCreatedBy($owner);
+        $this->entityManager->persist($space);
+
+        $admin = (new SpaceMembership())
+            ->setUser($owner)
+            ->setRole(Space::ROLE_ADMIN);
+        $space->addUserMembership($admin);
+        $this->entityManager->persist($admin);
+
+        foreach ($extraMembers as $m) {
+            $membership = (new SpaceMembership())
+                ->setUser($m)
+                ->setRole(Space::ROLE_MEMBER);
+            $space->addUserMembership($membership);
+            $this->entityManager->persist($membership);
+        }
+
+        $this->entityManager->flush();
+        return $space;
+    }
+
+    private function createUser(string $email): User
+    {
+        $container = static::getContainer();
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/api/tests/Api/PageActivityTest.php
+++ b/api/tests/Api/PageActivityTest.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\Page;
+use App\Entity\Space;
+use App\Entity\SpaceMembership;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Coverage for App\Controller\PageActivityController — `GET /pages/{id}/activity`
+ * (#183). Mirrors the Task/Project activity controllers: any space member can
+ * read the audit feed; non-members and unknown ids get 404 (existence-hiding).
+ */
+class PageActivityTest extends ApiTestCase
+{
+    use SpaceMembershipFixture;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Comment')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Page')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Space')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\ActivityLog')->execute();
+    }
+
+    public function testMemberSeesActivityAfterPageEdit(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $space = $this->createSpace($alice);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        // Create + edit the page over the wire so Gedmo's listener fires.
+        $client->request('POST', '/pages', [
+            'json' => [
+                'space' => '/spaces/' . $space->getId(),
+                'title' => 'Runbook',
+                'body' => 'First draft.',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $created = $response->toArray();
+        $pageId = $created['id'];
+        $this->assertIsString($pageId);
+
+        $client->request('PATCH', '/pages/' . $pageId, [
+            'json' => ['title' => 'Runbook v2'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $client->request('GET', '/pages/' . $pageId . '/activity');
+        $this->assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+
+        $this->assertSame(2, $body['totalItems']);
+        $items = $body['items'] ?? null;
+        $this->assertIsArray($items);
+        $this->assertCount(2, $items);
+        $latest = $items[0] ?? null;
+        $this->assertIsArray($latest);
+        $this->assertSame('update', $latest['action']);
+        $actors = $body['actors'] ?? null;
+        $this->assertIsArray($actors);
+        $this->assertArrayHasKey('/users/' . $alice->getId(), $actors);
+    }
+
+    public function testActivityPaginates(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $space = $this->createSpace($alice);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        $client->request('POST', '/pages', [
+            'json' => [
+                'space' => '/spaces/' . $space->getId(),
+                'title' => 'Pageable',
+                'body' => 'Body',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $pageId = $response->toArray()['id'];
+        $this->assertIsString($pageId);
+
+        for ($i = 1; $i <= 4; $i++) {
+            $client->request('PATCH', '/pages/' . $pageId, [
+                'json' => ['title' => 'Pageable v' . $i],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]);
+        }
+
+        $client->request('GET', '/pages/' . $pageId . '/activity?page=1&itemsPerPage=2');
+        $this->assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+        $this->assertSame(5, $body['totalItems']);
+        $items = $body['items'] ?? null;
+        $this->assertIsArray($items);
+        $this->assertCount(2, $items);
+    }
+
+    public function testStrangerCannotReadActivity(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $stranger = $this->createUser('stranger@example.com');
+        $space = $this->createSpace($alice);
+        $page = $this->seedPage($alice, $space, 'Hidden');
+
+        $client = static::createClient();
+        $client->loginUser($stranger);
+        $client->request('GET', '/pages/' . $page->getId() . '/activity');
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testUnknownPageIs404(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $client = static::createClient();
+        $client->loginUser($alice);
+        // Well-formed UUID that doesn't resolve to a page.
+        $client->request('GET', '/pages/00000000-0000-0000-0000-000000000000/activity');
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testInvalidIdIs404(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/pages/not-a-uuid/activity');
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    private function seedPage(User $author, Space $space, string $title, string $body = 'Body'): Page
+    {
+        $page = new Page();
+        $page->setSpace($space);
+        $page->setCreatedBy($author);
+        $page->setTitle($title);
+        $page->setBody($body);
+        $this->entityManager->persist($page);
+        $this->entityManager->flush();
+        return $page;
+    }
+
+    private function createSpace(User $owner, string $name = 'Test space'): Space
+    {
+        $space = new Space();
+        $space->setName($name);
+        $space->setCreatedBy($owner);
+        $this->entityManager->persist($space);
+
+        $admin = (new SpaceMembership())
+            ->setUser($owner)
+            ->setRole(Space::ROLE_ADMIN);
+        $space->addUserMembership($admin);
+        $this->entityManager->persist($admin);
+        $this->entityManager->flush();
+        return $space;
+    }
+
+    private function createUser(string $email): User
+    {
+        $container = static::getContainer();
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/api/tests/Api/RecurrenceValidationTest.php
+++ b/api/tests/Api/RecurrenceValidationTest.php
@@ -1,0 +1,306 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\Task;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Focused coverage of {@see \App\Validator\ValidRecurrenceValidator} branches
+ * — byDay, monthly weekday mode, and the `ends` end-conditions — beyond the
+ * frequency/interval/due-date cases already in {@see TaskTest}.
+ */
+class RecurrenceValidationTest extends ApiTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Notification')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Comment')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testValidWeeklyByDayRecurrenceIsAccepted(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks', [
+            'json' => [
+                'title' => 'Weekly standup',
+                'dueDate' => '2026-06-01T08:00:00+00:00',
+                'recurrenceRule' => [
+                    'frequency' => 'weekly',
+                    'interval' => 1,
+                    'byDay' => ['MO', 'WE', 'FR'],
+                ],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+    }
+
+    public function testValidMonthlyWeekdayRecurrenceIsAccepted(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks', [
+            'json' => [
+                'title' => 'Last Friday of the month',
+                'dueDate' => '2026-06-26T08:00:00+00:00',
+                'recurrenceRule' => [
+                    'frequency' => 'monthly',
+                    'interval' => 1,
+                    'monthlyMode' => 'weekday',
+                    'byDay' => ['FR'],
+                    'bySetPos' => -1,
+                ],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+    }
+
+    public function testValidEndsCountRecurrenceIsAccepted(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks', [
+            'json' => [
+                'title' => 'Three dailies',
+                'dueDate' => '2026-06-01T08:00:00+00:00',
+                'recurrenceRule' => [
+                    'frequency' => 'daily',
+                    'interval' => 1,
+                    'ends' => ['type' => 'count', 'count' => 3],
+                ],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+    }
+
+    public function testValidEndsUntilRecurrenceIsAccepted(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks', [
+            'json' => [
+                'title' => 'Until summer ends',
+                'dueDate' => '2026-06-01T08:00:00+00:00',
+                'recurrenceRule' => [
+                    'frequency' => 'weekly',
+                    'interval' => 2,
+                    'ends' => ['type' => 'until', 'until' => '2026-09-21'],
+                ],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+    }
+
+    public function testPatchToValidRecurrenceIsAccepted(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->createTask($alice, 'Will recur');
+        $task->setDueDate(new \DateTimeImmutable('2026-06-01T08:00:00+00:00'));
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/tasks/' . $task->getId(), [
+            'json' => [
+                'recurrenceRule' => ['frequency' => 'monthly', 'interval' => 1],
+            ],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $reloaded = $this->reloadTaskByTitle('Will recur');
+        $this->assertSame(
+            ['frequency' => 'monthly', 'interval' => 1],
+            $reloaded->getRecurrenceRule(),
+        );
+    }
+
+    public function testMissingFrequencyIsRejected(): void
+    {
+        // No `frequency` key → invalid shape branch.
+        $this->assertRecurrenceRejected(['interval' => 1]);
+    }
+
+    public function testNonIntegerIntervalIsRejected(): void
+    {
+        // `interval` must be an int; a string trips the invalid-shape branch.
+        $this->assertRecurrenceRejected(['frequency' => 'daily', 'interval' => '1']);
+    }
+
+    public function testInvalidByDayTokenIsRejected(): void
+    {
+        $this->assertRecurrenceRejected([
+            'frequency' => 'weekly',
+            'interval' => 1,
+            'byDay' => ['XX'],
+        ]);
+    }
+
+    public function testNonArrayByDayIsRejected(): void
+    {
+        $this->assertRecurrenceRejected([
+            'frequency' => 'weekly',
+            'interval' => 1,
+            'byDay' => 'MO',
+        ]);
+    }
+
+    public function testInvalidMonthlyModeIsRejected(): void
+    {
+        $this->assertRecurrenceRejected([
+            'frequency' => 'monthly',
+            'interval' => 1,
+            'monthlyMode' => 'lunar',
+        ]);
+    }
+
+    public function testMonthlyWeekdayMissingBySetPosIsRejected(): void
+    {
+        // weekday mode requires a single byDay AND a valid bySetPos.
+        $this->assertRecurrenceRejected([
+            'frequency' => 'monthly',
+            'interval' => 1,
+            'monthlyMode' => 'weekday',
+            'byDay' => ['FR'],
+        ]);
+    }
+
+    public function testMonthlyWeekdayOutOfRangeBySetPosIsRejected(): void
+    {
+        $this->assertRecurrenceRejected([
+            'frequency' => 'monthly',
+            'interval' => 1,
+            'monthlyMode' => 'weekday',
+            'byDay' => ['FR'],
+            'bySetPos' => 6,
+        ]);
+    }
+
+    public function testEndsCountZeroIsRejected(): void
+    {
+        $this->assertRecurrenceRejected([
+            'frequency' => 'daily',
+            'interval' => 1,
+            'ends' => ['type' => 'count', 'count' => 0],
+        ]);
+    }
+
+    public function testEndsUntilMalformedDateIsRejected(): void
+    {
+        $this->assertRecurrenceRejected([
+            'frequency' => 'daily',
+            'interval' => 1,
+            'ends' => ['type' => 'until', 'until' => '21-09-2026'],
+        ]);
+    }
+
+    public function testEndsUnknownTypeIsRejected(): void
+    {
+        $this->assertRecurrenceRejected([
+            'frequency' => 'daily',
+            'interval' => 1,
+            'ends' => ['type' => 'forever'],
+        ]);
+    }
+
+    public function testNonArrayEndsIsRejected(): void
+    {
+        $this->assertRecurrenceRejected([
+            'frequency' => 'daily',
+            'interval' => 1,
+            'ends' => 'never',
+        ]);
+    }
+
+    /**
+     * POSTs a task carrying $rule (with a due date so only the rule shape can
+     * trip the validator) and asserts a 422.
+     *
+     * @param array<string, mixed> $rule
+     */
+    private function assertRecurrenceRejected(array $rule): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks', [
+            'json' => [
+                'title' => 'Invalid recurrence',
+                'dueDate' => '2026-06-01T08:00:00+00:00',
+                'recurrenceRule' => $rule,
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    private function createUser(string $email): User
+    {
+        $container = static::getContainer();
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+
+    private function createTask(User $owner, string $title): Task
+    {
+        $task = new Task();
+        $task->setOwner($owner);
+        $task->setTitle($title);
+
+        $this->entityManager->persist($task);
+        $this->entityManager->flush();
+
+        return $task;
+    }
+
+    private function reloadTaskByTitle(string $title): Task
+    {
+        $this->entityManager->clear();
+        $task = $this->entityManager->getRepository(Task::class)->findOneBy(['title' => $title]);
+        assert($task instanceof Task);
+        return $task;
+    }
+}

--- a/api/tests/Api/SearchFilterTest.php
+++ b/api/tests/Api/SearchFilterTest.php
@@ -1,0 +1,306 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\Discussion;
+use App\Entity\Project;
+use App\Entity\Space;
+use App\Entity\SpaceMembership;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Functional coverage for the Postgres full-text-search collection
+ * filters {@see \App\Filter\ProjectSearchFilter} and
+ * {@see \App\Filter\DiscussionSearchFilter}.
+ *
+ * Both filters expose `?search={q}` (their `PARAMETER` constant) on the
+ * Project / Discussion collections, run it through `websearch_to_tsquery`
+ * via the `SEARCH_VECTOR_MATCH` DQL function, and order by `ts_rank`
+ * (`SEARCH_VECTOR_RANK`) unless `?sort=recent` is supplied. Rows are
+ * space-scoped by the access extensions, so the corpus is seeded inside
+ * a space the requesting user belongs to.
+ */
+class SearchFilterTest extends ApiTestCase
+{
+    use SpaceMembershipFixture;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Discussion')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Space')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testProjectSearchMatchesTitleWordOnly(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        // Projects land in the creator's personal space, of which the
+        // creator is the sole admin — so they're visible to Alice.
+        $this->createProject($alice, 'Marketing launch checklist', 'Plan the campaign');
+        $this->createProject($alice, 'Engineering backlog', 'Refactor the parser');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        // `search` is ProjectSearchFilter::PARAMETER.
+        $client->request('GET', '/projects?search=Marketing');
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains(['totalItems' => 1]);
+
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+        $members = $body['member'] ?? null;
+        $this->assertIsArray($members);
+        $this->assertCount(1, $members);
+        $first = $members[0] ?? null;
+        $this->assertIsArray($first);
+        $this->assertSame('Marketing launch checklist', $first['title'] ?? null);
+    }
+
+    public function testProjectSearchMatchesDescriptionWord(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $this->createProject($alice, 'Marketing launch checklist', 'Plan the campaign');
+        $this->createProject($alice, 'Engineering backlog', 'Refactor the parser');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        // "parser" only appears in the second project's description.
+        $client->request('GET', '/projects?search=parser');
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains(['totalItems' => 1]);
+
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+        $members = $body['member'] ?? null;
+        $this->assertIsArray($members);
+        $this->assertCount(1, $members);
+        $first = $members[0] ?? null;
+        $this->assertIsArray($first);
+        $this->assertSame('Engineering backlog', $first['title'] ?? null);
+    }
+
+    public function testProjectSearchNonMatchingTermReturnsNothing(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $this->createProject($alice, 'Marketing launch checklist', 'Plan the campaign');
+        $this->createProject($alice, 'Engineering backlog', 'Refactor the parser');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        $client->request('GET', '/projects?search=zzzznomatch');
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains(['totalItems' => 0]);
+    }
+
+    public function testProjectSearchRelevanceAndRecentSortsBothSucceed(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $this->createProject($alice, 'Marketing launch alpha', 'shared keyword corpus');
+        $this->createProject($alice, 'Marketing launch beta', 'shared keyword corpus');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        // Default ordering is by relevance (ts_rank). Both projects share
+        // the search term, so the matched set is the same in either mode.
+        $client->request('GET', '/projects?search=Marketing&sort=relevance');
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains(['totalItems' => 2]);
+
+        // `sort=recent` swaps the order to createdOn DESC (see
+        // ProjectSearchFilter); the matched set is unchanged.
+        $client->request('GET', '/projects?search=Marketing&sort=recent');
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains(['totalItems' => 2]);
+
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+        $members = $body['member'] ?? null;
+        $this->assertIsArray($members);
+        $this->assertCount(2, $members);
+    }
+
+    public function testDiscussionSearchMatchesTitleWordOnly(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $space = $this->createSpace($alice, 'Backend');
+        $this->seedDiscussion($alice, $space, 'Pricing question for launch', 'How much will it cost');
+        $this->seedDiscussion($alice, $space, 'Idea: switch to pnpm', 'Quick win on installs');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        // `search` is DiscussionSearchFilter::PARAMETER.
+        $client->request('GET', '/discussions?search=Pricing');
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains(['totalItems' => 1]);
+
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+        $members = $body['member'] ?? null;
+        $this->assertIsArray($members);
+        $this->assertCount(1, $members);
+        $first = $members[0] ?? null;
+        $this->assertIsArray($first);
+        $this->assertSame('Pricing question for launch', $first['title'] ?? null);
+    }
+
+    public function testDiscussionSearchMatchesBodyWord(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $space = $this->createSpace($alice, 'Backend');
+        $this->seedDiscussion($alice, $space, 'Pricing question for launch', 'How much will it cost');
+        $this->seedDiscussion($alice, $space, 'Idea: switch to pnpm', 'Quick win on installs');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        // "installs" only appears in the second discussion's body.
+        $client->request('GET', '/discussions?search=installs');
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains(['totalItems' => 1]);
+
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+        $members = $body['member'] ?? null;
+        $this->assertIsArray($members);
+        $this->assertCount(1, $members);
+        $first = $members[0] ?? null;
+        $this->assertIsArray($first);
+        $this->assertSame('Idea: switch to pnpm', $first['title'] ?? null);
+    }
+
+    public function testDiscussionSearchNonMatchingTermReturnsNothing(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $space = $this->createSpace($alice, 'Backend');
+        $this->seedDiscussion($alice, $space, 'Pricing question for launch', 'How much will it cost');
+        $this->seedDiscussion($alice, $space, 'Idea: switch to pnpm', 'Quick win on installs');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        $client->request('GET', '/discussions?search=zzzznomatch');
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains(['totalItems' => 0]);
+    }
+
+    public function testDiscussionSearchKeepsPinnedThreadFirst(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $space = $this->createSpace($alice, 'Backend');
+        // Two threads share the "launch" term; the pinned one must lead
+        // regardless of relevance ranking (see DiscussionSearchFilter,
+        // which orders isPinned DESC before the rank tiebreaker).
+        $this->seedDiscussion($alice, $space, 'Unpinned launch note', 'launch launch launch detail');
+        $this->seedDiscussion($alice, $space, 'Pinned launch note', 'launch summary', true);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        $client->request('GET', '/discussions?search=launch');
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains(['totalItems' => 2]);
+
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+        $members = $body['member'] ?? null;
+        $this->assertIsArray($members);
+        $this->assertCount(2, $members);
+        $first = $members[0] ?? null;
+        $this->assertIsArray($first);
+        $this->assertSame('Pinned launch note', $first['title'] ?? null);
+    }
+
+    private function createProject(User $owner, string $title, string $description): Project
+    {
+        $project = new Project();
+        $project->setOwner($owner);
+        $project->setTitle($title);
+        $project->setDescription($description);
+
+        // ProjectSpaceDefaultListener fills Project.space with the
+        // owner's personal space at PrePersist, so the owner can see it.
+        $this->entityManager->persist($project);
+        $this->entityManager->flush();
+
+        return $project;
+    }
+
+    private function createSpace(User $admin, string $name): Space
+    {
+        $space = new Space();
+        $space->setName($name);
+        $space->setCreatedBy($admin);
+        $this->entityManager->persist($space);
+        $membership = (new SpaceMembership())
+            ->setUser($admin)
+            ->setRole(Space::ROLE_ADMIN);
+        $space->addUserMembership($membership);
+        $this->entityManager->persist($membership);
+        $this->entityManager->flush();
+        return $space;
+    }
+
+    private function seedDiscussion(
+        User $author,
+        Space $space,
+        string $title,
+        string $body,
+        bool $pinned = false,
+    ): Discussion {
+        $disc = new Discussion();
+        $disc->setSpace($space);
+        $disc->setAuthor($author);
+        $disc->setTitle($title);
+        $disc->setBody($body);
+        $disc->setCategory('general');
+        $disc->setIsPinned($pinned);
+        $this->entityManager->persist($disc);
+        $this->entityManager->flush();
+        return $disc;
+    }
+
+    /**
+     * @param string[] $roles
+     */
+    private function createUser(string $email, array $roles = ['ROLE_USER']): User
+    {
+        $container = static::getContainer();
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles($roles);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/api/tests/Api/SegmentMemberControllerTest.php
+++ b/api/tests/Api/SegmentMemberControllerTest.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Entity\Segment;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Edge/error branches of {@see \App\Controller\SegmentMemberController}
+ * that SegmentTest doesn't reach: non-admin forbidden, unknown segment,
+ * unknown email, the re-POST mode flip, DELETE of an unknown member, and
+ * the preview breakdown shape.
+ */
+class SegmentMemberControllerTest extends ApiTestCase
+{
+    use JsonBodyAssertions;
+
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->em = $em;
+        $this->em->createQuery('DELETE FROM App\Entity\SegmentMembership')->execute();
+        $this->em->createQuery('DELETE FROM App\Entity\Segment')->execute();
+        $this->em->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testNonAdminForbidden(): void
+    {
+        $plain = $this->makeUser('plain@example.com');
+        $segment = $this->makeSegment('beta');
+
+        $client = static::createClient();
+        $client->loginUser($plain);
+
+        $client->request('POST', '/segments/' . $segment->getId() . '/members', [
+            'json' => ['email' => 'plain@example.com', 'mode' => 'include'],
+        ]);
+        $this->assertResponseStatusCodeSame(403);
+
+        $client->request('GET', '/segments/' . $segment->getId() . '/preview');
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testUnknownSegmentReturns404(): void
+    {
+        $admin = $this->makeUser('admin@example.com', ['ROLE_ADMIN']);
+        $client = static::createClient();
+        $client->loginUser($admin);
+
+        $client->request('POST', '/segments/01919999-9999-7999-9999-999999999999/members', [
+            'json' => ['email' => 'admin@example.com', 'mode' => 'include'],
+        ]);
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testUnknownEmailReturns404(): void
+    {
+        $admin = $this->makeUser('admin@example.com', ['ROLE_ADMIN']);
+        $segment = $this->makeSegment('beta');
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+
+        $client->request('POST', '/segments/' . $segment->getId() . '/members', [
+            'json' => ['email' => 'nobody@example.com', 'mode' => 'include'],
+        ]);
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testInvalidModeReturns422(): void
+    {
+        $admin = $this->makeUser('admin@example.com', ['ROLE_ADMIN']);
+        $segment = $this->makeSegment('beta');
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+
+        $client->request('POST', '/segments/' . $segment->getId() . '/members', [
+            'json' => ['email' => 'admin@example.com', 'mode' => 'maybe'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testRePostFlipsMode(): void
+    {
+        $admin = $this->makeUser('admin@example.com', ['ROLE_ADMIN']);
+        $target = $this->makeUser('target@example.com');
+        $segment = $this->makeSegment('beta');
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+
+        // First POST creates the override → 201 "added".
+        $client->request('POST', '/segments/' . $segment->getId() . '/members', [
+            'json' => ['email' => 'target@example.com', 'mode' => 'include'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+        $body = $this->body($client);
+        $this->assertSame('added', $this->stringField($body, 'status'));
+        $this->assertSame('include', $this->stringField($body, 'mode'));
+
+        // Re-POST with a new mode updates in place → 200 "updated".
+        $client->request('POST', '/segments/' . $segment->getId() . '/members', [
+            'json' => ['email' => 'target@example.com', 'mode' => 'exclude'],
+        ]);
+        $this->assertResponseStatusCodeSame(200);
+        $body = $this->body($client);
+        $this->assertSame('updated', $this->stringField($body, 'status'));
+        $this->assertSame('exclude', $this->stringField($body, 'mode'));
+    }
+
+    public function testRemoveUnknownMemberReturns404(): void
+    {
+        $admin = $this->makeUser('admin@example.com', ['ROLE_ADMIN']);
+        $other = $this->makeUser('other@example.com');
+        $segment = $this->makeSegment('beta');
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+
+        // A real user that has no override on this segment.
+        $client->request('DELETE', '/segments/' . $segment->getId() . '/members/' . $other->getId());
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testPreviewBreakdownShape(): void
+    {
+        $admin = $this->makeUser('admin@example.com', ['ROLE_ADMIN']);
+        $segment = $this->makeSegment('beta', rollout: 100);
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+
+        $client->request('GET', '/segments/' . $segment->getId() . '/preview');
+        $this->assertResponseIsSuccessful();
+
+        $body = $this->body($client);
+        $this->assertTrue($this->boolField($body, 'enabled'));
+        $this->assertSame(100, $this->intField($body, 'rolloutPercentage'));
+
+        $reach = $this->arrayField($body, 'reach');
+        $this->assertArrayHasKey('total', $reach);
+        $this->assertArrayHasKey('manualIncludes', $reach);
+        $this->assertArrayHasKey('byRole', $reach);
+        $this->assertArrayHasKey('byRollout', $reach);
+        $this->assertArrayHasKey('manualExcludes', $reach);
+    }
+
+    /**
+     * @return array<int|string, mixed>
+     */
+    private function body(Client $client): array
+    {
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        return $response->toArray(false);
+    }
+
+    private function makeSegment(string $key, int $rollout = 0): Segment
+    {
+        $segment = new Segment();
+        $segment->setKey($key);
+        $segment->setName(ucfirst($key));
+        $segment->setRolloutPercentage($rollout);
+        $this->em->persist($segment);
+        $this->em->flush();
+        return $segment;
+    }
+
+    /**
+     * @param list<string> $roles
+     */
+    private function makeUser(string $email, array $roles = []): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles($roles);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $this->em->persist($user);
+        $this->em->flush();
+        return $user;
+    }
+}

--- a/api/tests/Api/UserGroupMemberEdgeTest.php
+++ b/api/tests/Api/UserGroupMemberEdgeTest.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Entity\User;
+use App\Entity\UserGroup;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Edge/error branches of {@see \App\Controller\UserGroupMemberController}
+ * not covered by UserGroupTest: the add-by-email invite branch for an
+ * unknown address, add-already-member 409, the missing-email 400,
+ * removing a user who isn't a member (404), and the non-member-leave
+ * existence-hiding 404.
+ */
+class UserGroupMemberEdgeTest extends ApiTestCase
+{
+    use JsonBodyAssertions;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\GroupInvite')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\UserInvite')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\UserGroup')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testAddUnknownEmailCreatesInvite(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $group = $this->createGroup($alice, 'Solo', [$alice]);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/groups/' . $group->getId() . '/members', [
+            'json' => ['email' => 'newcomer@example.com'],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(200);
+        $body = $this->body($client);
+        $this->assertSame('invited', $this->stringField($body, 'status'));
+        $this->assertSame('newcomer@example.com', $this->stringField($body, 'email'));
+        $this->assertArrayHasKey('inviteId', $body);
+        $this->assertArrayHasKey('expiresAt', $body);
+    }
+
+    public function testAddAlreadyMemberReturns409(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $group = $this->createGroup($alice, 'Shared', [$alice, $bob]);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/groups/' . $group->getId() . '/members', [
+            'json' => ['email' => 'bob@example.com'],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(409);
+    }
+
+    public function testAddMemberWithMissingEmailReturns400(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $group = $this->createGroup($alice, 'Solo', [$alice]);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/groups/' . $group->getId() . '/members', [
+            'json' => ['email' => '  '],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    public function testAddMemberWithInvalidEmailReturns422(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $group = $this->createGroup($alice, 'Solo', [$alice]);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/groups/' . $group->getId() . '/members', [
+            'json' => ['email' => 'not-an-email'],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testRemoveUserWhoIsNotAMemberReturns404(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $outsider = $this->createUser('outsider@example.com');
+        $group = $this->createGroup($alice, 'Solo', [$alice]);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        // A real user that isn't part of the group.
+        $client->request('DELETE', '/groups/' . $group->getId() . '/members/' . $outsider->getId());
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testNonMemberLeaveReturns404(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $outsider = $this->createUser('outsider@example.com');
+        $group = $this->createGroup($alice, 'Solo', [$alice]);
+
+        $client = static::createClient();
+        $client->loginUser($outsider);
+        // Existence-hiding: a non-member probing /leave gets a 404.
+        $client->request('POST', '/groups/' . $group->getId() . '/leave');
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    /**
+     * @return array<int|string, mixed>
+     */
+    private function body(Client $client): array
+    {
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        return $response->toArray(false);
+    }
+
+    private function createUser(string $email): User
+    {
+        $container = static::getContainer();
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+
+    /**
+     * @param User[] $members
+     */
+    private function createGroup(User $owner, string $title, array $members): UserGroup
+    {
+        $group = new UserGroup();
+        $group->setOwner($owner);
+        $group->setTitle($title);
+        $slug = trim((string) preg_replace('/[^a-z0-9]+/', '-', strtolower($title)), '-');
+        $group->setSlug('' === $slug ? 'group' : $slug);
+        foreach ($members as $member) {
+            $group->addMember($member);
+        }
+
+        $this->entityManager->persist($group);
+        $this->entityManager->flush();
+
+        return $group;
+    }
+}

--- a/api/tests/Api/UserInviteControllerEdgeTest.php
+++ b/api/tests/Api/UserInviteControllerEdgeTest.php
@@ -1,0 +1,244 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\GroupInvite;
+use App\Entity\User;
+use App\Entity\UserGroup;
+use App\Entity\UserInvite;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Edge-branch coverage for App\Controller\UserInviteController — the
+ * resend endpoint (token rotation), unknown-invite / cross-group 404s,
+ * and the non-owner / stranger authorization branches that the base
+ * UserInviteTest doesn't exercise.
+ */
+class UserInviteControllerEdgeTest extends ApiTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\GroupInvite')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\UserInvite')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\UserGroup')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->entityManager->close();
+        self::ensureKernelShutdown();
+        parent::tearDown();
+    }
+
+    public function testOwnerCanResendAndTokenRotates(): void
+    {
+        $owner = $this->createUser('alice@example.com');
+        $group = $this->createGroup($owner, 'Backend', [$owner]);
+        $this->inviteEmail($owner, $group, 'newcomer@example.com');
+
+        $invite = $this->entityManager->getRepository(GroupInvite::class)->findAll()[0];
+        $oldHash = $invite->getUserInvite()->getTokenHash();
+
+        $client = static::createClient();
+        $client->loginUser($owner);
+        $client->request('POST', sprintf(
+            '/groups/%s/invites/%s/resend',
+            $group->getId(),
+            $invite->getId(),
+        ), ['headers' => ['Content-Type' => 'application/json']]);
+
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains(['status' => 'resent', 'email' => 'newcomer@example.com']);
+
+        $this->entityManager->clear();
+        $reloaded = $this->entityManager->getRepository(UserInvite::class)
+            ->findOneBy(['email' => 'newcomer@example.com']);
+        $this->assertNotNull($reloaded);
+        // Token rotated → new authoritative link.
+        $this->assertNotSame($oldHash, $reloaded->getTokenHash());
+    }
+
+    public function testResendUnknownInviteIs404(): void
+    {
+        $owner = $this->createUser('alice@example.com');
+        $group = $this->createGroup($owner, 'Backend', [$owner]);
+
+        $client = static::createClient();
+        $client->loginUser($owner);
+        $client->request('POST', sprintf(
+            '/groups/%s/invites/%s/resend',
+            $group->getId(),
+            '00000000-0000-0000-0000-000000000000',
+        ), ['headers' => ['Content-Type' => 'application/json']]);
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testResendInviteFromAnotherGroupIs404(): void
+    {
+        $owner = $this->createUser('alice@example.com');
+        $groupA = $this->createGroup($owner, 'Alpha', [$owner]);
+        $groupB = $this->createGroup($owner, 'Beta', [$owner]);
+        // Invite attached to group A only.
+        $this->inviteEmail($owner, $groupA, 'newcomer@example.com');
+        $invite = $this->entityManager->getRepository(GroupInvite::class)->findAll()[0];
+
+        $client = static::createClient();
+        $client->loginUser($owner);
+        // Address the group-A invite under group B's path → mismatch 404.
+        $client->request('POST', sprintf(
+            '/groups/%s/invites/%s/resend',
+            $groupB->getId(),
+            $invite->getId(),
+        ), ['headers' => ['Content-Type' => 'application/json']]);
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testNonOwnerMemberCannotResend(): void
+    {
+        $owner = $this->createUser('alice@example.com');
+        $member = $this->createUser('bob@example.com');
+        $group = $this->createGroup($owner, 'Shared', [$owner, $member]);
+        $this->inviteEmail($owner, $group, 'newcomer@example.com');
+        $invite = $this->entityManager->getRepository(GroupInvite::class)->findAll()[0];
+
+        $client = static::createClient();
+        $client->loginUser($member);
+        $client->request('POST', sprintf(
+            '/groups/%s/invites/%s/resend',
+            $group->getId(),
+            $invite->getId(),
+        ), ['headers' => ['Content-Type' => 'application/json']]);
+
+        // Non-owner member of the group → 403 (existence not hidden).
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testStrangerListingInvitesIs404(): void
+    {
+        $owner = $this->createUser('alice@example.com');
+        $stranger = $this->createUser('stranger@example.com');
+        $group = $this->createGroup($owner, 'Backend', [$owner]);
+
+        $client = static::createClient();
+        $client->loginUser($stranger);
+        $client->request('GET', '/groups/' . $group->getId() . '/invites');
+        // Non-member → existence hidden as 404.
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testRevokeUnknownInviteIs404(): void
+    {
+        $owner = $this->createUser('alice@example.com');
+        $group = $this->createGroup($owner, 'Backend', [$owner]);
+
+        $client = static::createClient();
+        $client->loginUser($owner);
+        $client->request('DELETE', sprintf(
+            '/groups/%s/invites/%s',
+            $group->getId(),
+            '00000000-0000-0000-0000-000000000000',
+        ));
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testRevokeOnUnknownGroupIs404(): void
+    {
+        $owner = $this->createUser('alice@example.com');
+        $this->createGroup($owner, 'Backend', [$owner]);
+
+        $client = static::createClient();
+        $client->loginUser($owner);
+        $client->request('DELETE', sprintf(
+            '/groups/%s/invites/%s',
+            '00000000-0000-0000-0000-000000000000',
+            '00000000-0000-0000-0000-000000000001',
+        ));
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    /**
+     * Build a UserInvite + GroupInvite directly (mirrors UserInviteTest).
+     */
+    private function inviteEmail(User $owner, UserGroup $group, string $email): string
+    {
+        $plainToken = bin2hex(random_bytes(32));
+        $tokenHash = hash('sha256', $plainToken);
+        $expiresAt = new \DateTimeImmutable('+14 days');
+
+        $invite = $this->entityManager->getRepository(UserInvite::class)
+            ->findOneBy(['email' => $email]);
+        if (null === $invite) {
+            $invite = new UserInvite($email, $tokenHash, $expiresAt);
+            $this->entityManager->persist($invite);
+        } else {
+            $invite->setTokenHash($tokenHash);
+            $invite->setExpiresAt($expiresAt);
+        }
+
+        $existing = $this->entityManager->getRepository(GroupInvite::class)
+            ->findOneBy(['userInvite' => $invite, 'group' => $group]);
+        if (null === $existing) {
+            new GroupInvite($invite, $group, $owner);
+        }
+
+        $this->entityManager->flush();
+
+        return $plainToken;
+    }
+
+    /**
+     * @param string[] $roles
+     */
+    private function createUser(string $email, array $roles = ['ROLE_USER']): User
+    {
+        $container = static::getContainer();
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles($roles);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+
+    /**
+     * @param User[] $members
+     */
+    private function createGroup(User $owner, string $title, array $members): UserGroup
+    {
+        $group = new UserGroup();
+        $group->setOwner($owner);
+        $group->setTitle($title);
+        $base = trim((string) preg_replace('/[^a-z0-9]+/', '-', strtolower($title)), '-');
+        $group->setSlug(('' === $base ? 'group' : $base) . '-' . (++self::$slugCounter));
+        foreach ($members as $member) {
+            $group->addMember($member);
+        }
+
+        $this->entityManager->persist($group);
+        $this->entityManager->flush();
+
+        return $group;
+    }
+
+    private static int $slugCounter = 0;
+}

--- a/api/tests/Command/AccountExportPruneCommandTest.php
+++ b/api/tests/Command/AccountExportPruneCommandTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Tests\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class AccountExportPruneCommandTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = self::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->em = $em;
+        $this->em->createQuery('DELETE FROM App\Entity\AccountExport')->execute();
+    }
+
+    public function testRunsOnEmptyDatabase(): void
+    {
+        $kernel = self::$kernel;
+        assert(null !== $kernel);
+        $application = new Application($kernel);
+        $tester = new CommandTester($application->find('app:account-exports:prune'));
+        $tester->execute([]);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('Deleted 0', $tester->getDisplay());
+    }
+}

--- a/api/tests/Command/DispatchNotificationDigestCommandTest.php
+++ b/api/tests/Command/DispatchNotificationDigestCommandTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Tests\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class DispatchNotificationDigestCommandTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = self::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->em = $em;
+        $this->em->createQuery('DELETE FROM App\Entity\Notification')->execute();
+    }
+
+    public function testRunsOnEmptyDatabase(): void
+    {
+        $kernel = self::$kernel;
+        assert(null !== $kernel);
+        $application = new Application($kernel);
+        $tester = new CommandTester($application->find('app:notifications:dispatch-digest'));
+        $tester->execute(['--period' => 'hourly']);
+
+        $tester->assertCommandIsSuccessful();
+    }
+}

--- a/api/tests/Command/DispatchTaskRemindersCommandTest.php
+++ b/api/tests/Command/DispatchTaskRemindersCommandTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Tests\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class DispatchTaskRemindersCommandTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = self::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->em = $em;
+        $this->em->createQuery('DELETE FROM App\Entity\Task')->execute();
+    }
+
+    public function testRunsOnEmptyDatabase(): void
+    {
+        $kernel = self::$kernel;
+        assert(null !== $kernel);
+        $application = new Application($kernel);
+        $tester = new CommandTester($application->find('app:tasks:reminders:dispatch'));
+        $tester->execute([]);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('notification', $tester->getDisplay());
+    }
+}

--- a/api/tests/Command/SegmentCommandCoverageTest.php
+++ b/api/tests/Command/SegmentCommandCoverageTest.php
@@ -1,0 +1,272 @@
+<?php
+
+namespace App\Tests\Command;
+
+use App\Entity\Segment;
+use App\Entity\SegmentMembership;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Coverage for the `app:segment` action branches not exercised by
+ * {@see SegmentCommandTest}: list, show, enable, disable, roles (valid),
+ * exclude, remove, delete, plus the obvious error paths (unknown action,
+ * unknown key, missing key, missing args, duplicate-create).
+ */
+class SegmentCommandCoverageTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = self::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->em = $em;
+        $this->em->createQuery('DELETE FROM App\Entity\SegmentMembership')->execute();
+        $this->em->createQuery('DELETE FROM App\Entity\Segment')->execute();
+        $this->em->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testCreateViaCommandThenShow(): void
+    {
+        // "create" with name + purpose + roles options on a fresh key.
+        $tester = $this->invoke([
+            'action' => 'create',
+            'args' => ['rollout-cohort'],
+            '--name' => 'Rollout cohort',
+            '--purpose' => Segment::PURPOSE_ROLLOUT,
+            '--roles' => 'ROLE_ADMIN,ROLE_USER',
+        ]);
+        $tester->assertCommandIsSuccessful();
+        $display = $tester->getDisplay();
+        // create() ends by calling show(), so the definition list renders.
+        $this->assertStringContainsString('ROLE_SEGMENT_ROLLOUT_COHORT', $display);
+
+        $segment = $this->reload('rollout-cohort');
+        $this->assertSame('Rollout cohort', $segment->getName());
+        $this->assertSame(Segment::PURPOSE_ROLLOUT, $segment->getPurpose());
+        $this->assertSame(['ROLE_ADMIN', 'ROLE_USER'], $segment->getIncludedRoles());
+    }
+
+    public function testShowAction(): void
+    {
+        $this->seedSegment('beta');
+        $tester = $this->invoke(['action' => 'show', 'args' => ['beta']]);
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('ROLE_SEGMENT_BETA', $tester->getDisplay());
+    }
+
+    public function testListAction(): void
+    {
+        $this->seedSegment('alpha');
+        $this->seedSegment('beta');
+
+        $tester = $this->invoke(['action' => 'list', 'args' => []]);
+        $tester->assertCommandIsSuccessful();
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('alpha', $display);
+        $this->assertStringContainsString('beta', $display);
+    }
+
+    public function testListActionWithNoSegments(): void
+    {
+        $tester = $this->invoke(['action' => 'list', 'args' => []]);
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('No segments yet', $tester->getDisplay());
+    }
+
+    public function testEnableAndDisableActions(): void
+    {
+        $this->seedSegment('toggle');
+
+        $this->invoke(['action' => 'disable', 'args' => ['toggle']])->assertCommandIsSuccessful();
+        $this->assertFalse($this->reload('toggle')->isEnabled());
+
+        $this->invoke(['action' => 'enable', 'args' => ['toggle']])->assertCommandIsSuccessful();
+        $this->assertTrue($this->reload('toggle')->isEnabled());
+    }
+
+    public function testRolloutZeroClearsPercentage(): void
+    {
+        $segment = $this->seedSegment('grad');
+        $segment->setRolloutPercentage(40);
+        $this->em->flush();
+
+        $this->invoke(['action' => 'rollout', 'args' => ['grad', '0']])->assertCommandIsSuccessful();
+        // 0% is stored as null per setRollout().
+        $this->assertNull($this->reload('grad')->getRolloutPercentage());
+    }
+
+    public function testRolesActionSetsValidRoles(): void
+    {
+        $this->seedSegment('beta');
+        $this->invoke(['action' => 'roles', 'args' => ['beta', 'ROLE_ADMIN,role_user']])
+            ->assertCommandIsSuccessful();
+        // parseRoles upper-cases + dedupes.
+        $this->assertSame(['ROLE_ADMIN', 'ROLE_USER'], $this->reload('beta')->getIncludedRoles());
+    }
+
+    public function testExcludeCreatesManualExcludeOverride(): void
+    {
+        $segment = $this->seedSegment('beta');
+        $this->makeUser('excluded@example.com');
+
+        $this->invoke(['action' => 'exclude', 'args' => ['beta', 'excluded@example.com']])
+            ->assertCommandIsSuccessful();
+
+        $membership = $this->em->getRepository(SegmentMembership::class)
+            ->findOneBy(['segment' => $segment]);
+        assert($membership instanceof SegmentMembership);
+        $this->assertSame(SegmentMembership::MODE_EXCLUDE, $membership->getMode());
+    }
+
+    public function testRemoveDropsOverride(): void
+    {
+        $segment = $this->seedSegment('beta');
+        $this->makeUser('member@example.com');
+
+        $this->invoke(['action' => 'add', 'args' => ['beta', 'member@example.com']])
+            ->assertCommandIsSuccessful();
+        $this->assertNotNull(
+            $this->em->getRepository(SegmentMembership::class)->findOneBy(['segment' => $segment]),
+        );
+
+        $this->invoke(['action' => 'remove', 'args' => ['beta', 'member@example.com']])
+            ->assertCommandIsSuccessful();
+        $this->em->clear();
+        $reloaded = $this->em->getRepository(Segment::class)->findOneByKey('beta');
+        assert($reloaded instanceof Segment);
+        $this->assertNull(
+            $this->em->getRepository(SegmentMembership::class)->findOneBy(['segment' => $reloaded]),
+        );
+    }
+
+    public function testAddWithUnknownEmailFails(): void
+    {
+        $this->seedSegment('beta');
+        // No matching user → nothing changed → FAILURE.
+        $tester = $this->invoke(['action' => 'add', 'args' => ['beta', 'ghost@example.com']]);
+        $this->assertNotSame(0, $tester->getStatusCode());
+    }
+
+    public function testAddWithoutEmailsIsInvalid(): void
+    {
+        $this->seedSegment('beta');
+        $tester = $this->invoke(['action' => 'add', 'args' => ['beta']]);
+        $this->assertNotSame(0, $tester->getStatusCode());
+    }
+
+    public function testRemoveWithoutOverrideFails(): void
+    {
+        $this->seedSegment('beta');
+        $this->makeUser('member@example.com');
+        // User exists but has no override → nothing removed → FAILURE.
+        $tester = $this->invoke(['action' => 'remove', 'args' => ['beta', 'member@example.com']]);
+        $this->assertNotSame(0, $tester->getStatusCode());
+    }
+
+    public function testDeleteAction(): void
+    {
+        $this->seedSegment('gone');
+        $this->invoke(['action' => 'delete', 'args' => ['gone']])->assertCommandIsSuccessful();
+
+        $this->em->clear();
+        $this->assertNull($this->em->getRepository(Segment::class)->findOneByKey('gone'));
+    }
+
+    public function testUnknownActionIsRejected(): void
+    {
+        $tester = $this->invoke(['action' => 'frobnicate', 'args' => []]);
+        $this->assertNotSame(0, $tester->getStatusCode());
+    }
+
+    public function testUnknownKeyFails(): void
+    {
+        $tester = $this->invoke(['action' => 'show', 'args' => ['no-such-key']]);
+        $this->assertNotSame(0, $tester->getStatusCode());
+        $this->assertStringContainsString('No segment with key', $tester->getDisplay());
+    }
+
+    public function testMissingKeyIsInvalid(): void
+    {
+        $tester = $this->invoke(['action' => 'show', 'args' => []]);
+        $this->assertNotSame(0, $tester->getStatusCode());
+    }
+
+    public function testRolloutMissingValueIsInvalid(): void
+    {
+        $this->seedSegment('grad');
+        $tester = $this->invoke(['action' => 'rollout', 'args' => ['grad']]);
+        $this->assertNotSame(0, $tester->getStatusCode());
+    }
+
+    public function testRolloutOutOfRangeIsInvalid(): void
+    {
+        $this->seedSegment('grad');
+        $tester = $this->invoke(['action' => 'rollout', 'args' => ['grad', '150']]);
+        $this->assertNotSame(0, $tester->getStatusCode());
+    }
+
+    public function testCreateDuplicateKeyFails(): void
+    {
+        $this->seedSegment('beta');
+        $tester = $this->invoke(['action' => 'create', 'args' => ['beta']]);
+        $this->assertNotSame(0, $tester->getStatusCode());
+    }
+
+    public function testCreateWithoutKeyIsInvalid(): void
+    {
+        $tester = $this->invoke(['action' => 'create', 'args' => []]);
+        $this->assertNotSame(0, $tester->getStatusCode());
+    }
+
+    /**
+     * @param array<string, string|list<string>> $input
+     */
+    private function invoke(array $input): CommandTester
+    {
+        $kernel = self::$kernel;
+        assert(null !== $kernel);
+        $application = new Application($kernel);
+        $tester = new CommandTester($application->find('app:segment'));
+        $tester->execute($input);
+        return $tester;
+    }
+
+    private function seedSegment(string $key): Segment
+    {
+        $segment = new Segment();
+        $segment->setKey($key);
+        $segment->setName($key);
+        $this->em->persist($segment);
+        $this->em->flush();
+        return $segment;
+    }
+
+    private function makeUser(string $email): User
+    {
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $this->em->persist($user);
+        $this->em->flush();
+        return $user;
+    }
+
+    private function reload(string $key): Segment
+    {
+        $this->em->clear();
+        $segment = $this->em->getRepository(Segment::class)->findOneByKey($key);
+        assert($segment instanceof Segment);
+        return $segment;
+    }
+}

--- a/api/tests/Command/SpaceExportPruneCommandTest.php
+++ b/api/tests/Command/SpaceExportPruneCommandTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Tests\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class SpaceExportPruneCommandTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = self::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->em = $em;
+        $this->em->createQuery('DELETE FROM App\Entity\SpaceExport')->execute();
+    }
+
+    public function testRunsOnEmptyDatabase(): void
+    {
+        $kernel = self::$kernel;
+        assert(null !== $kernel);
+        $application = new Application($kernel);
+        $tester = new CommandTester($application->find('app:space-exports:prune'));
+        $tester->execute([]);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('Deleted 0', $tester->getDisplay());
+    }
+}

--- a/api/tests/Command/UsageReportCommandTest.php
+++ b/api/tests/Command/UsageReportCommandTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Tests\Command;
+
+use App\Entity\User;
+use App\Entity\UserUsageSnapshot;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+class UsageReportCommandTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = self::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->em = $em;
+        $this->em->createQuery('DELETE FROM App\Entity\UserUsageSnapshot')->execute();
+        $this->em->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testEmptyDatabaseWarnsNoSnapshots(): void
+    {
+        $tester = $this->invoke();
+        $tester->assertCommandIsSuccessful();
+
+        $this->assertStringContainsString('No usage snapshots', $tester->getDisplay());
+    }
+
+    public function testListsUserWithSnapshot(): void
+    {
+        $user = $this->makeUser('usage@example.com');
+
+        $snapshot = new UserUsageSnapshot();
+        $snapshot->setUser($user);
+        $snapshot->setCapturedOn(new \DateTimeImmutable('today', new \DateTimeZone('UTC')));
+        $snapshot->setDiskBytes(2048);
+        $snapshot->setDbBytesEst(1024);
+        $snapshot->setApiCalls(10);
+        $snapshot->setMcpCalls(5);
+        $this->em->persist($snapshot);
+        $this->em->flush();
+
+        $tester = $this->invoke();
+        $tester->assertCommandIsSuccessful();
+
+        $this->assertStringContainsString('usage@example.com', $tester->getDisplay());
+    }
+
+    private function invoke(): CommandTester
+    {
+        $kernel = self::$kernel;
+        assert(null !== $kernel);
+        $application = new Application($kernel);
+        $tester = new CommandTester($application->find('app:usage:report'));
+        $tester->execute([]);
+        return $tester;
+    }
+
+    private function makeUser(string $email): User
+    {
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $this->em->persist($user);
+        $this->em->flush();
+        return $user;
+    }
+}

--- a/api/tests/Command/UsageSnapshotCommandTest.php
+++ b/api/tests/Command/UsageSnapshotCommandTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Tests\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class UsageSnapshotCommandTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = self::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->em = $em;
+        $this->em->createQuery('DELETE FROM App\Entity\UserUsageSnapshot')->execute();
+        $this->em->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testRunsWithNoOptions(): void
+    {
+        $this->invoke([])->assertCommandIsSuccessful();
+    }
+
+    public function testRunsWithDateOption(): void
+    {
+        $this->invoke(['--date' => '2026-06-10'])->assertCommandIsSuccessful();
+    }
+
+    public function testInvalidDateFails(): void
+    {
+        $tester = $this->invoke(['--date' => 'not-a-date']);
+
+        $this->assertNotSame(0, $tester->getStatusCode());
+        $this->assertStringContainsString('Invalid', $tester->getDisplay());
+    }
+
+    /**
+     * @param array<string, string> $input
+     */
+    private function invoke(array $input): CommandTester
+    {
+        $kernel = self::$kernel;
+        assert(null !== $kernel);
+        $application = new Application($kernel);
+        $tester = new CommandTester($application->find('app:usage:snapshot'));
+        $tester->execute($input);
+        return $tester;
+    }
+}

--- a/api/tests/CustomField/DateStrategyTest.php
+++ b/api/tests/CustomField/DateStrategyTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace App\Tests\CustomField;
+
+use App\CustomField\Footer\FooterKind;
+use App\CustomField\Type\Date\DateStrategy;
+use App\CustomField\Type\Date\DateTimeStrategy;
+use App\CustomField\Type\Date\TimeStrategy;
+use App\Entity\CustomFieldDefinition;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Coverage for the date-flavoured strategies and their shared abstract
+ * base (#227). Direct construction — no kernel, no DB. Complements
+ * TypeStrategiesTest by exercising the multi walk, config bounds, the
+ * search-text projection, and the per-subtype scalar overrides.
+ */
+final class DateStrategyTest extends TestCase
+{
+    public function testKeysAndCapabilities(): void
+    {
+        $date = new DateStrategy();
+        $time = new TimeStrategy();
+        $datetime = new DateTimeStrategy();
+
+        $this->assertSame('date.date', $date->key());
+        $this->assertSame('date.time', $time->key());
+        $this->assertSame('date.datetime', $datetime->key());
+
+        foreach ([$date, $time, $datetime] as $s) {
+            $this->assertTrue($s->supportsMulti());
+            $this->assertSame(
+                [FooterKind::MIN->value, FooterKind::MAX->value, FooterKind::COUNT->value],
+                $s->supportedAggregations(),
+            );
+        }
+    }
+
+    public function testDateRangeBounds(): void
+    {
+        $date = new DateStrategy();
+        $def = new CustomFieldDefinition();
+
+        $config = ['min' => '2026-01-01', 'max' => '2026-12-31'];
+        $this->assertCount(0, $date->validateValue('2026-06-15', $config, $def));
+        $this->assertCount(1, $date->validateValue('2025-12-31', $config, $def)); // before min
+        $this->assertCount(1, $date->validateValue('2027-01-01', $config, $def)); // after max
+        // Calendar overflow is rejected by the round-trip parse guard.
+        $this->assertCount(1, $date->validateValue('2026-02-30', [], $def));
+        // Non-string scalar.
+        $this->assertCount(1, $date->validateValue(20260615, [], $def));
+    }
+
+    public function testDateConfigValidation(): void
+    {
+        $date = new DateStrategy();
+
+        $this->assertEmpty($date->validateConfig([]));
+        $this->assertEmpty($date->validateConfig(['min' => '2026-01-01', 'max' => '2026-12-31']));
+        // Unparseable bound.
+        $this->assertNotEmpty($date->validateConfig(['min' => 'not-a-date']));
+        // Non-string bound.
+        $this->assertNotEmpty($date->validateConfig(['max' => 123]));
+        // min after max.
+        $this->assertNotEmpty($date->validateConfig(['min' => '2026-12-31', 'max' => '2026-01-01']));
+        // multi flag is honoured by the shared multi-config check.
+        $this->assertEmpty($date->validateConfig(['multi' => true]));
+        $this->assertNotEmpty($date->validateConfig(['multi' => 'yes']));
+    }
+
+    public function testDateMultiWalk(): void
+    {
+        $date = new DateStrategy();
+        $def = new CustomFieldDefinition();
+        $multi = ['multi' => true];
+
+        $this->assertCount(0, $date->validateValue(['2026-01-01', '2026-02-02'], $multi, $def));
+        // One bad element -> one violation.
+        $this->assertCount(1, $date->validateValue(['2026-01-01', 'nope'], $multi, $def));
+        // Non-list under multi -> single top-level violation.
+        $this->assertCount(1, $date->validateValue('2026-01-01', $multi, $def));
+        // Associative map under multi -> shape violation.
+        $this->assertCount(1, $date->validateValue(['a' => '2026-01-01'], $multi, $def));
+    }
+
+    public function testDateSearchText(): void
+    {
+        $date = new DateStrategy();
+
+        $this->assertNull($date->searchText(null, []));
+        $this->assertSame('2026-06-15', $date->searchText('2026-06-15', []));
+        // Invalid string projects nothing.
+        $this->assertNull($date->searchText('garbage', []));
+        // Multi: only the parseable elements survive.
+        $this->assertSame(
+            '2026-01-01 2026-02-02',
+            $date->searchText(['2026-01-01', 'bad', '2026-02-02'], ['multi' => true]),
+        );
+        $this->assertNull($date->searchText(['bad'], ['multi' => true]));
+    }
+
+    public function testTimeStrictFormatMessage(): void
+    {
+        $time = new TimeStrategy();
+        $def = new CustomFieldDefinition();
+
+        $this->assertCount(0, $time->validateValue('09:30', [], $def));
+        // Missing leading zero gets the subtype-specific message branch.
+        $this->assertCount(1, $time->validateValue('9:30', [], $def));
+        // Out-of-range hour rejected by the round-trip parse.
+        $this->assertCount(1, $time->validateValue('25:00', [], $def));
+        // Non-string falls through to the abstract base path.
+        $this->assertCount(1, $time->validateValue(930, [], $def));
+
+        // In-range bound honoured.
+        $config = ['min' => '08:00', 'max' => '17:00'];
+        $this->assertCount(0, $time->validateValue('12:00', $config, $def));
+        $this->assertCount(1, $time->validateValue('07:59', $config, $def));
+    }
+
+    public function testDateTimeIsoTolerance(): void
+    {
+        $datetime = new DateTimeStrategy();
+        $def = new CustomFieldDefinition();
+
+        $this->assertCount(0, $datetime->validateValue('2026-05-12T14:30:00+02:00', [], $def));
+        // JS toISOString shape (Z + fractional seconds) tolerated.
+        $this->assertCount(0, $datetime->validateValue('2026-05-12T14:30:00.000Z', [], $def));
+        // Space separator (no offset) rejected.
+        $this->assertCount(1, $datetime->validateValue('2026-05-12 14:30:00', [], $def));
+        // Non-string falls through to the abstract base path.
+        $this->assertCount(1, $datetime->validateValue(42, [], $def));
+    }
+
+    public function testDateTimeNormalize(): void
+    {
+        $datetime = new DateTimeStrategy();
+
+        $this->assertNull($datetime->normalize(null, []));
+        // Z + fractional seconds normalized to an explicit offset.
+        $this->assertSame(
+            '2026-05-12T14:30:00+00:00',
+            $datetime->normalize('2026-05-12T14:30:00.000Z', []),
+        );
+        // Multi normalizes each element; non-strings pass through.
+        $this->assertSame(
+            ['2026-05-12T14:30:00+00:00', 5],
+            $datetime->normalize(['2026-05-12T14:30:00.000Z', 5], ['multi' => true]),
+        );
+        // Multi with non-array input is returned unchanged.
+        $this->assertSame('x', $datetime->normalize('x', ['multi' => true]));
+    }
+}

--- a/api/tests/CustomField/FooterAggregatorTest.php
+++ b/api/tests/CustomField/FooterAggregatorTest.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace App\Tests\CustomField;
+
+use App\CustomField\CustomFieldTypeRegistry;
+use App\CustomField\Footer\FooterAggregator;
+use App\CustomField\Footer\FooterKind;
+use App\CustomField\Type\Boolean\BooleanStrategy;
+use App\CustomField\Type\Date\DateStrategy;
+use App\CustomField\Type\Numeric\FloatStrategy;
+use App\CustomField\Type\Numeric\IntStrategy;
+use App\CustomField\Type\Numeric\MoneyStrategy;
+use App\Entity\CustomFieldDefinition;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Coverage for FooterAggregator's row-assembly + dispatch logic (#227).
+ *
+ * The SQL aggregation paths (sum/avg/min/max over custom_field_value)
+ * are integration-tested against a live Postgres in the API suite. Here
+ * we cover the parts that run without ever issuing a query:
+ *   - skip rows with no footer / an invalid footer.kind / an aggregation
+ *     the strategy doesn't support;
+ *   - the empty-task-set short-circuit in compute() (count -> 0,
+ *     everything else -> null).
+ *
+ * The {@see Connection} is mocked and must never be touched — passing an
+ * empty task-id list keeps every path off the database.
+ */
+final class FooterAggregatorTest extends TestCase
+{
+    private function registry(): CustomFieldTypeRegistry
+    {
+        return new CustomFieldTypeRegistry([
+            new BooleanStrategy(),
+            new IntStrategy(),
+            new FloatStrategy(),
+            new MoneyStrategy(),
+            new DateStrategy(),
+        ]);
+    }
+
+    private function aggregator(Connection $connection): FooterAggregator
+    {
+        return new FooterAggregator($connection, $this->registry());
+    }
+
+    /**
+     * @param array{kind: string, label?: string}|null $footer
+     */
+    private function definition(string $kind, string $subtype, ?array $footer): CustomFieldDefinition
+    {
+        $def = new CustomFieldDefinition();
+        $def->setKind($kind);
+        $def->setSubtype($subtype);
+        if (null !== $footer) {
+            $def->setFooter($footer);
+        }
+        return $def;
+    }
+
+    public function testSkipsDefinitionsWithoutAFooter(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->never())->method('executeQuery');
+
+        $rows = $this->aggregator($connection)->aggregate(
+            [$this->definition('numeric', 'int', null)],
+            [],
+        );
+
+        $this->assertSame([], $rows);
+    }
+
+    public function testSkipsInvalidFooterKind(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->never())->method('executeQuery');
+
+        $rows = $this->aggregator($connection)->aggregate(
+            [$this->definition('numeric', 'int', ['kind' => 'bogus'])],
+            [],
+        );
+
+        $this->assertSame([], $rows);
+    }
+
+    public function testSkipsAggregationNotSupportedByStrategy(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->never())->method('executeQuery');
+
+        // Booleans only support COUNT — asking for SUM is dropped.
+        $rows = $this->aggregator($connection)->aggregate(
+            [$this->definition('boolean', 'boolean', ['kind' => FooterKind::SUM->value])],
+            [],
+        );
+
+        $this->assertSame([], $rows);
+    }
+
+    public function testSkipsUnknownTypeKey(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->never())->method('executeQuery');
+
+        // 'numeric.decimal' isn't a registered strategy -> dropped.
+        $rows = $this->aggregator($connection)->aggregate(
+            [$this->definition('numeric', 'decimal', ['kind' => FooterKind::SUM->value])],
+            [],
+        );
+
+        $this->assertSame([], $rows);
+    }
+
+    public function testEmptyTaskSetCountIsZero(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->never())->method('executeQuery');
+
+        $rows = $this->aggregator($connection)->aggregate(
+            [$this->definition('numeric', 'int', ['kind' => FooterKind::COUNT->value, 'label' => 'Filled'])],
+            [],
+        );
+
+        $this->assertCount(1, $rows);
+        $this->assertSame(FooterKind::COUNT->value, $rows[0]['kind']);
+        $this->assertSame('Filled', $rows[0]['label']);
+        $this->assertSame(0, $rows[0]['value']);
+    }
+
+    public function testEmptyTaskSetNonCountIsNull(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->never())->method('executeQuery');
+
+        $rows = $this->aggregator($connection)->aggregate(
+            [
+                $this->definition('numeric', 'int', ['kind' => FooterKind::SUM->value]),
+                $this->definition('numeric', 'float', ['kind' => FooterKind::AVG->value]),
+                $this->definition('numeric', 'money', ['kind' => FooterKind::MAX->value]),
+                $this->definition('date', 'date', ['kind' => FooterKind::MIN->value]),
+            ],
+            [],
+        );
+
+        $this->assertCount(4, $rows);
+        foreach ($rows as $row) {
+            $this->assertNull($row['value']);
+        }
+    }
+
+    public function testMissingLabelIsNull(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->never())->method('executeQuery');
+
+        $rows = $this->aggregator($connection)->aggregate(
+            [$this->definition('numeric', 'int', ['kind' => FooterKind::COUNT->value])],
+            [],
+        );
+
+        $this->assertCount(1, $rows);
+        $this->assertNull($rows[0]['label']);
+    }
+}

--- a/api/tests/CustomField/MoneyStrategyTest.php
+++ b/api/tests/CustomField/MoneyStrategyTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Tests\CustomField;
+
+use App\CustomField\Footer\FooterKind;
+use App\CustomField\Type\Numeric\MoneyStrategy;
+use App\Entity\CustomFieldDefinition;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Coverage for numeric.money (#227). Direct construction — no kernel,
+ * no DB. Complements TypeStrategiesTest's happy-path checks with the
+ * config branches, the min/max amount bounds, and the search/normalize
+ * edge cases.
+ */
+final class MoneyStrategyTest extends TestCase
+{
+    public function testKeyAndCapabilities(): void
+    {
+        $s = new MoneyStrategy();
+
+        $this->assertSame('numeric.money', $s->key());
+        $this->assertFalse($s->supportsMulti());
+        $this->assertSame(
+            [
+                FooterKind::SUM->value,
+                FooterKind::AVG->value,
+                FooterKind::MIN->value,
+                FooterKind::MAX->value,
+                FooterKind::COUNT->value,
+            ],
+            $s->supportedAggregations(),
+        );
+    }
+
+    public function testConfigValidation(): void
+    {
+        $s = new MoneyStrategy();
+
+        // Currency required + must be known.
+        $this->assertNotEmpty($s->validateConfig([]));
+        $this->assertNotEmpty($s->validateConfig(['currency' => '']));
+        $this->assertNotEmpty($s->validateConfig(['currency' => 123]));
+        $this->assertNotEmpty($s->validateConfig(['currency' => 'XXX']));
+        $this->assertEmpty($s->validateConfig(['currency' => 'USD']));
+        // Lower-case is accepted (uppercased before the existence check).
+        $this->assertEmpty($s->validateConfig(['currency' => 'usd']));
+
+        // min/max must be integers (minor units).
+        $this->assertNotEmpty($s->validateConfig(['currency' => 'USD', 'min' => 1.5]));
+        $this->assertNotEmpty($s->validateConfig(['currency' => 'USD', 'max' => 'x']));
+        // min > max.
+        $this->assertNotEmpty($s->validateConfig(['currency' => 'USD', 'min' => 100, 'max' => 10]));
+        $this->assertEmpty($s->validateConfig(['currency' => 'USD', 'min' => 10, 'max' => 100]));
+    }
+
+    public function testValueShapeAndCurrencyPin(): void
+    {
+        $s = new MoneyStrategy();
+        $def = new CustomFieldDefinition();
+        $config = ['currency' => 'USD'];
+
+        $this->assertCount(0, $s->validateValue(['amount' => 100, 'currency' => 'USD'], $config, $def));
+        // Non-array value.
+        $this->assertCount(1, $s->validateValue('100', $config, $def));
+        // Non-integer amount.
+        $this->assertNotEmpty($s->validateValue(['amount' => 1.5, 'currency' => 'USD'], $config, $def));
+        // Missing currency.
+        $this->assertNotEmpty($s->validateValue(['amount' => 100], $config, $def));
+        // Unknown currency code.
+        $this->assertNotEmpty($s->validateValue(['amount' => 100, 'currency' => 'XXX'], $config, $def));
+        // Mismatch against the pinned field currency.
+        $this->assertNotEmpty($s->validateValue(['amount' => 100, 'currency' => 'EUR'], $config, $def));
+    }
+
+    public function testAmountBounds(): void
+    {
+        $s = new MoneyStrategy();
+        $def = new CustomFieldDefinition();
+        $config = ['currency' => 'USD', 'min' => 0, 'max' => 1000];
+
+        $this->assertCount(0, $s->validateValue(['amount' => 500, 'currency' => 'USD'], $config, $def));
+        $this->assertNotEmpty($s->validateValue(['amount' => -1, 'currency' => 'USD'], $config, $def));
+        $this->assertNotEmpty($s->validateValue(['amount' => 1001, 'currency' => 'USD'], $config, $def));
+    }
+
+    public function testNormalize(): void
+    {
+        $s = new MoneyStrategy();
+        $config = ['currency' => 'USD'];
+
+        $this->assertSame(
+            ['amount' => 1000, 'currency' => 'USD'],
+            $s->normalize(['amount' => '1000', 'currency' => 'usd'], $config),
+        );
+        // Non-array passes through unchanged.
+        $this->assertSame('x', $s->normalize('x', $config));
+        // Non-numeric amount + non-string currency are left as-is.
+        $this->assertSame(
+            ['amount' => null, 'currency' => 5],
+            $s->normalize(['amount' => null, 'currency' => 5], $config),
+        );
+    }
+
+    public function testSearchText(): void
+    {
+        $s = new MoneyStrategy();
+        $config = ['currency' => 'USD'];
+
+        $this->assertSame('1000 USD', $s->searchText(['amount' => 1000, 'currency' => 'USD'], $config));
+        // Non-array -> null.
+        $this->assertNull($s->searchText('1000', $config));
+        // Malformed shape -> null.
+        $this->assertNull($s->searchText(['amount' => 'x', 'currency' => 'USD'], $config));
+        $this->assertNull($s->searchText(['amount' => 1000, 'currency' => 5], $config));
+    }
+}

--- a/api/tests/CustomField/ReferenceStrategyTest.php
+++ b/api/tests/CustomField/ReferenceStrategyTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Tests\CustomField;
+
+use App\CustomField\Footer\FooterKind;
+use App\CustomField\Type\Reference\ProjectReferenceStrategy;
+use App\CustomField\Type\Reference\TaskReferenceStrategy;
+use App\CustomField\Type\Reference\UserReferenceStrategy;
+use App\Entity\CustomFieldDefinition;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Coverage for the reference strategies' non-DB branches (#227).
+ *
+ * The DB-resolution path (IRI -> repository lookup -> space-scope check)
+ * is exercised end-to-end by TaskCustomFieldValueTest's integration
+ * suite, which needs a real EntityManager + fixtures. Here we cover
+ * everything that runs *before* the repository is touched — key/kind,
+ * capabilities, multi-shape rejection, non-string and bad-IRI scalars,
+ * and the search-text null branches — with a mocked EntityManager that
+ * is never invoked.
+ */
+final class ReferenceStrategyTest extends TestCase
+{
+    private function em(): EntityManagerInterface
+    {
+        return $this->createMock(EntityManagerInterface::class);
+    }
+
+    public function testKeysAndCapabilities(): void
+    {
+        $user = new UserReferenceStrategy($this->em());
+        $task = new TaskReferenceStrategy($this->em());
+        $project = new ProjectReferenceStrategy($this->em());
+
+        $this->assertSame('reference.user', $user->key());
+        $this->assertSame('reference.task', $task->key());
+        $this->assertSame('reference.project', $project->key());
+
+        foreach ([$user, $task, $project] as $s) {
+            $this->assertTrue($s->supportsMulti());
+            // References don't aggregate beyond count.
+            $this->assertSame([FooterKind::COUNT->value], $s->supportedAggregations());
+        }
+    }
+
+    public function testRejectsNonStringScalar(): void
+    {
+        $user = new UserReferenceStrategy($this->em());
+        $def = new CustomFieldDefinition(); // no space -> scope check skipped
+
+        // Non-string value never reaches the repository.
+        $this->assertCount(1, $user->validateValue(42, [], $def));
+    }
+
+    public function testRejectsMalformedIri(): void
+    {
+        $user = new UserReferenceStrategy($this->em());
+        $def = new CustomFieldDefinition();
+
+        // Wrong prefix -> extractUuid bails before any lookup.
+        $this->assertCount(1, $user->validateValue('/tasks/00000000-0000-0000-0000-000000000000', [], $def));
+        // Right prefix, non-UUID tail.
+        $this->assertCount(1, $user->validateValue('/users/not-a-uuid', [], $def));
+    }
+
+    public function testMultiShapeRejection(): void
+    {
+        $user = new UserReferenceStrategy($this->em());
+        $def = new CustomFieldDefinition();
+        $multi = ['multi' => true];
+
+        // Non-list under multi -> single shape violation, no lookup.
+        $this->assertCount(1, $user->validateValue('/users/00000000-0000-0000-0000-000000000000', $multi, $def));
+        // Associative map under multi -> shape violation.
+        $this->assertCount(1, $user->validateValue(['k' => '/users/x'], $multi, $def));
+    }
+
+    public function testSearchTextNullBranches(): void
+    {
+        $user = new UserReferenceStrategy($this->em());
+
+        $this->assertNull($user->searchText(null, []));
+        // Non-string single value resolves to null without a lookup.
+        $this->assertNull($user->searchText(42, []));
+        // Malformed IRI -> labelFor returns null without a lookup.
+        $this->assertNull($user->searchText('/tasks/abc', []));
+        // Multi with no resolvable elements -> null.
+        $this->assertNull($user->searchText([42, '/bad/iri'], ['multi' => true]));
+    }
+}

--- a/api/tests/CustomField/TextStrategyTest.php
+++ b/api/tests/CustomField/TextStrategyTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Tests\CustomField;
+
+use App\CustomField\Footer\FooterKind;
+use App\CustomField\Type\Text\RichTextStrategy;
+use App\CustomField\Type\Text\TextStrategy;
+use App\CustomField\Type\Text\UrlStrategy;
+use App\Entity\CustomFieldDefinition;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Coverage for the text-flavoured strategies and their shared abstract
+ * base (#227). Direct construction — no kernel, no DB. Complements
+ * TypeStrategiesTest by exercising config bounds, normalization, the
+ * search projection, and the URL scheme override.
+ */
+final class TextStrategyTest extends TestCase
+{
+    public function testKeysAndCapabilities(): void
+    {
+        $text = new TextStrategy();
+        $url = new UrlStrategy();
+        $rich = new RichTextStrategy();
+
+        $this->assertSame('text.text', $text->key());
+        $this->assertSame('text.url', $url->key());
+        $this->assertSame('text.rich_text', $rich->key());
+
+        foreach ([$text, $url, $rich] as $s) {
+            $this->assertTrue($s->supportsMulti());
+            $this->assertSame([FooterKind::COUNT->value], $s->supportedAggregations());
+        }
+    }
+
+    public function testConfigBounds(): void
+    {
+        $text = new TextStrategy();
+
+        $this->assertEmpty($text->validateConfig([]));
+        $this->assertEmpty($text->validateConfig(['minLength' => 1, 'maxLength' => 5, 'pattern' => '^[a-z]+$']));
+
+        // minLength must be a non-negative integer.
+        $this->assertNotEmpty($text->validateConfig(['minLength' => -1]));
+        $this->assertNotEmpty($text->validateConfig(['minLength' => 'x']));
+        // maxLength must be a positive integer.
+        $this->assertNotEmpty($text->validateConfig(['maxLength' => 0]));
+        $this->assertNotEmpty($text->validateConfig(['maxLength' => 'x']));
+        // min > max.
+        $this->assertNotEmpty($text->validateConfig(['minLength' => 5, 'maxLength' => 2]));
+        // pattern must be a string and a valid regex.
+        $this->assertNotEmpty($text->validateConfig(['pattern' => 123]));
+        $this->assertNotEmpty($text->validateConfig(['pattern' => '[']));
+    }
+
+    public function testValueLengthAndPattern(): void
+    {
+        $text = new TextStrategy();
+        $def = new CustomFieldDefinition();
+
+        $config = ['minLength' => 3, 'maxLength' => 5, 'pattern' => '^[a-z]+$'];
+        $this->assertCount(0, $text->validateValue('abc', $config, $def));
+        $this->assertCount(1, $text->validateValue('ab', $config, $def));      // too short
+        $this->assertCount(1, $text->validateValue('abcdef', $config, $def));  // too long
+        $this->assertCount(1, $text->validateValue('ABC', $config, $def));     // pattern miss
+        // Non-string scalar.
+        $this->assertCount(1, $text->validateValue(42, [], $def));
+    }
+
+    public function testNormalizeTrims(): void
+    {
+        $text = new TextStrategy();
+
+        $this->assertNull($text->normalize(null, []));
+        $this->assertSame('hello', $text->normalize('  hello  ', []));
+        // Non-string single passes through.
+        $this->assertSame(7, $text->normalize(7, []));
+        // Multi trims each element; non-array passes through.
+        $this->assertSame(['a', 'b'], $text->normalize([' a ', ' b '], ['multi' => true]));
+        $this->assertSame('x', $text->normalize('x', ['multi' => true]));
+    }
+
+    public function testSearchText(): void
+    {
+        $text = new TextStrategy();
+
+        $this->assertNull($text->searchText(null, []));
+        $this->assertSame('hi', $text->searchText('  hi  ', []));
+        // Whitespace-only -> nothing searchable.
+        $this->assertNull($text->searchText('   ', []));
+        // Non-string -> null.
+        $this->assertNull($text->searchText(5, []));
+        // Multi: empties dropped, rest joined.
+        $this->assertSame('a b', $text->searchText([' a ', '', ' b '], ['multi' => true]));
+        $this->assertNull($text->searchText(['', '  '], ['multi' => true]));
+    }
+
+    public function testUrlSchemeValidation(): void
+    {
+        $url = new UrlStrategy();
+        $def = new CustomFieldDefinition();
+
+        $this->assertCount(0, $url->validateValue('https://example.com', [], $def));
+        $this->assertCount(0, $url->validateValue('http://example.com', [], $def));
+        $this->assertCount(0, $url->validateValue('mailto:alice@example.com', [], $def));
+        // Disallowed scheme.
+        $this->assertCount(1, $url->validateValue('ftp://example.com', [], $def));
+        // Not a URL at all.
+        $this->assertCount(1, $url->validateValue('not a url', [], $def));
+        // Empty/whitespace short-circuits the URL check (only base rules apply,
+        // which are satisfied here -> no violation).
+        $this->assertCount(0, $url->validateValue('   ', [], $def));
+    }
+
+    public function testRichTextBehavesLikeText(): void
+    {
+        $rich = new RichTextStrategy();
+        $def = new CustomFieldDefinition();
+
+        $this->assertCount(0, $rich->validateValue('**bold**', [], $def));
+        $this->assertSame('hello', $rich->searchText(' hello ', ['multi' => false]));
+    }
+}

--- a/api/tests/Entity/UserUsageCounterTest.php
+++ b/api/tests/Entity/UserUsageCounterTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Tests\Entity;
+
+use App\Entity\User;
+use App\Entity\UserUsageCounter;
+use PHPUnit\Framework\TestCase;
+
+class UserUsageCounterTest extends TestCase
+{
+    public function testDefaultsToTodayUtcWithZeroCount(): void
+    {
+        $counter = new UserUsageCounter();
+
+        $this->assertNull($counter->getId());
+        $this->assertSame(0, $counter->getCount());
+        $this->assertSame('', $counter->getMetric());
+        // Constructor pins the bucket to "today" in UTC.
+        $this->assertSame(
+            (new \DateTimeImmutable('today', new \DateTimeZone('UTC')))->format('Y-m-d'),
+            $counter->getDay()->format('Y-m-d'),
+        );
+    }
+
+    public function testAccessorsRoundTrip(): void
+    {
+        $user = new User();
+        $user->setEmail('counter@example.com');
+
+        $day = new \DateTimeImmutable('2026-06-10', new \DateTimeZone('UTC'));
+        $counter = new UserUsageCounter();
+        $counter->setUser($user);
+        $counter->setDay($day);
+        $counter->setMetric('api_call');
+        $counter->setCount(42);
+
+        $this->assertSame($user, $counter->getUser());
+        $this->assertSame($day, $counter->getDay());
+        $this->assertSame('api_call', $counter->getMetric());
+        $this->assertSame(42, $counter->getCount());
+    }
+
+    public function testSettersAreFluent(): void
+    {
+        $counter = new UserUsageCounter();
+
+        $this->assertSame($counter, $counter->setMetric('mcp_call'));
+        $this->assertSame($counter, $counter->setCount(1));
+        $this->assertSame($counter, $counter->setDay(new \DateTimeImmutable('2026-01-01')));
+    }
+}

--- a/pwa/.gitignore
+++ b/pwa/.gitignore
@@ -4,6 +4,7 @@
 /node_modules
 /.pnp
 .pnp.js
+/.pnpm-store
 
 # testing
 /coverage

--- a/pwa/lib/authRedirect.test.ts
+++ b/pwa/lib/authRedirect.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { isSafeNextPath, safeNextPath, signinHrefForCurrent } from "./authRedirect";
+
+describe("isSafeNextPath", () => {
+  it("accepts a plain root-relative path", () => {
+    expect(isSafeNextPath("/projects")).toBe(true);
+    expect(isSafeNextPath("/tasks?status=open#top")).toBe(true);
+  });
+
+  it("rejects non-strings and empty strings", () => {
+    expect(isSafeNextPath(undefined)).toBe(false);
+    expect(isSafeNextPath(null)).toBe(false);
+    expect(isSafeNextPath(42)).toBe(false);
+    expect(isSafeNextPath("")).toBe(false);
+  });
+
+  it("rejects values that don't start with a single slash", () => {
+    expect(isSafeNextPath("projects")).toBe(false);
+    expect(isSafeNextPath("https://evil.com")).toBe(false);
+    expect(isSafeNextPath("javascript:alert(1)")).toBe(false);
+    expect(isSafeNextPath("data:text/html,x")).toBe(false);
+  });
+
+  it("rejects protocol-relative and backslash-smuggled hosts", () => {
+    expect(isSafeNextPath("//evil.com/x")).toBe(false);
+    expect(isSafeNextPath("/\\evil.com/x")).toBe(false);
+  });
+});
+
+describe("safeNextPath", () => {
+  it("returns the normalised path for a safe candidate", () => {
+    expect(safeNextPath("/tasks?status=open")).toBe("/tasks?status=open");
+    expect(safeNextPath("/a/b#frag")).toBe("/a/b#frag");
+  });
+
+  it("falls back to /projects for hostile or invalid input", () => {
+    expect(safeNextPath("//evil.com")).toBe("/projects");
+    expect(safeNextPath("https://evil.com/x")).toBe("/projects");
+    expect(safeNextPath(undefined)).toBe("/projects");
+    expect(safeNextPath("")).toBe("/projects");
+  });
+
+  it("honours a custom fallback", () => {
+    expect(safeNextPath(undefined, "/settings/profile")).toBe("/settings/profile");
+    expect(safeNextPath("//evil.com", "/home")).toBe("/home");
+  });
+});
+
+describe("signinHrefForCurrent", () => {
+  it("preserves a safe current path as ?next=", () => {
+    expect(signinHrefForCurrent("/projects/123")).toBe(
+      "/signin?next=%2Fprojects%2F123",
+    );
+  });
+
+  it("encodes query strings in the preserved path", () => {
+    expect(signinHrefForCurrent("/tasks?status=open")).toBe(
+      `/signin?next=${encodeURIComponent("/tasks?status=open")}`,
+    );
+  });
+
+  it("returns plain /signin for unsafe paths", () => {
+    expect(signinHrefForCurrent(undefined)).toBe("/signin");
+    expect(signinHrefForCurrent("//evil.com")).toBe("/signin");
+  });
+
+  it("does not loop back onto the auth pages themselves", () => {
+    expect(signinHrefForCurrent("/signin")).toBe("/signin");
+    expect(signinHrefForCurrent("/signin?next=/x")).toBe("/signin");
+    expect(signinHrefForCurrent("/signup")).toBe("/signin");
+  });
+});

--- a/pwa/lib/avatarPalette.test.ts
+++ b/pwa/lib/avatarPalette.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  AVATAR_PALETTE,
+  deterministicPaletteColor,
+  resolveGroupColor,
+  resolveSpaceColor,
+} from "./avatarPalette";
+
+describe("deterministicPaletteColor", () => {
+  it("returns the first palette entry for an empty seed", () => {
+    expect(deterministicPaletteColor("")).toBe(AVATAR_PALETTE[0]);
+  });
+
+  it("is stable for the same seed", () => {
+    expect(deterministicPaletteColor("team-alpha")).toBe(
+      deterministicPaletteColor("team-alpha"),
+    );
+  });
+
+  it("always returns a value from the palette", () => {
+    for (const seed of ["a", "longer-seed", "🙂", "Group 42"]) {
+      expect(AVATAR_PALETTE).toContain(deterministicPaletteColor(seed));
+    }
+  });
+});
+
+describe("resolveSpaceColor", () => {
+  it("prefers an explicit color", () => {
+    expect(
+      resolveSpaceColor({ color: "#123456", createdBy: { personalizedColor: "#abcdef" } }),
+    ).toBe("#123456");
+  });
+
+  it("inherits the creator's personalized color", () => {
+    expect(
+      resolveSpaceColor({ color: null, createdBy: { personalizedColor: "#abcdef" } }),
+    ).toBe("#abcdef");
+  });
+
+  it("falls back to the first palette entry", () => {
+    expect(resolveSpaceColor({ color: null, createdBy: null })).toBe(AVATAR_PALETTE[0]);
+    expect(resolveSpaceColor({ color: null, createdBy: {} })).toBe(AVATAR_PALETTE[0]);
+  });
+});
+
+describe("resolveGroupColor", () => {
+  it("prefers an explicit color, then owner color, then fallback", () => {
+    expect(resolveGroupColor({ color: "#111111" })).toBe("#111111");
+    expect(resolveGroupColor({ owner: { personalizedColor: "#222222" } })).toBe("#222222");
+    expect(resolveGroupColor({})).toBe(AVATAR_PALETTE[0]);
+    expect(resolveGroupColor({ color: null, owner: { personalizedColor: null } })).toBe(
+      AVATAR_PALETTE[0],
+    );
+  });
+});

--- a/pwa/lib/currencies.test.ts
+++ b/pwa/lib/currencies.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { CURRENCIES, currencyFractionDigits, findCurrency } from "./currencies";
+
+describe("findCurrency", () => {
+  it("looks up a known code case-insensitively", () => {
+    expect(findCurrency("USD")?.name).toBe("US Dollar");
+    expect(findCurrency("usd")?.code).toBe("USD");
+  });
+
+  it("returns undefined for an unknown code", () => {
+    expect(findCurrency("ZZZ")).toBeUndefined();
+  });
+});
+
+describe("currencyFractionDigits", () => {
+  it("returns the curated digits for known codes", () => {
+    expect(currencyFractionDigits("USD")).toBe(2);
+    expect(currencyFractionDigits("JPY")).toBe(0);
+    expect(currencyFractionDigits("KWD")).toBe(3);
+    expect(currencyFractionDigits("jpy")).toBe(0); // case-insensitive
+  });
+
+  it("falls back to Intl for a valid code outside the curated list", () => {
+    // TND (Tunisian Dinar) is a real 3-digit currency we don't curate.
+    expect(currencyFractionDigits("TND")).toBe(3);
+  });
+
+  it("falls back to 2 for an ill-formed code that Intl rejects", () => {
+    // A 2-letter code is not a well-formed ISO-4217 currency → Intl throws.
+    expect(currencyFractionDigits("US")).toBe(2);
+  });
+});
+
+describe("CURRENCIES list integrity", () => {
+  it("has unique, upper-case 3-letter codes", () => {
+    const codes = CURRENCIES.map((c) => c.code);
+    expect(new Set(codes).size).toBe(codes.length);
+    for (const code of codes) {
+      expect(code).toMatch(/^[A-Z]{3}$/);
+    }
+  });
+
+  it("only carries non-negative fraction digits", () => {
+    for (const c of CURRENCIES) {
+      expect(c.fractionDigits).toBeGreaterThanOrEqual(0);
+    }
+  });
+});

--- a/pwa/lib/landingDestination.test.ts
+++ b/pwa/lib/landingDestination.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_LANDING,
+  landingPathFor,
+  readLanding,
+} from "./landingDestination";
+
+describe("readLanding", () => {
+  it("returns the default when preferences are missing or malformed", () => {
+    expect(readLanding(undefined)).toEqual(DEFAULT_LANDING);
+    expect(readLanding(null)).toEqual(DEFAULT_LANDING);
+    // @ts-expect-error — exercising the runtime guard against a bad shape.
+    expect(readLanding({ landing: "nope" })).toEqual(DEFAULT_LANDING);
+  });
+
+  it("passes through a recognised page", () => {
+    expect(readLanding({ landing: { page: "tasks", spaceId: null } })).toEqual({
+      page: "tasks",
+      spaceId: null,
+    });
+  });
+
+  it("falls back to the default page for an unknown page value", () => {
+    expect(
+      // @ts-expect-error — stale/unknown page from an older client.
+      readLanding({ landing: { page: "bogus", spaceId: null } }),
+    ).toEqual(DEFAULT_LANDING);
+  });
+
+  it("keeps spaceId only for the 'space' page", () => {
+    expect(readLanding({ landing: { page: "space", spaceId: "abc" } })).toEqual({
+      page: "space",
+      spaceId: "abc",
+    });
+    // A spaceId riding on a non-space page is normalised away.
+    expect(
+      readLanding({ landing: { page: "tasks", spaceId: "abc" } }),
+    ).toEqual({ page: "tasks", spaceId: null });
+  });
+
+  it("defaults a missing spaceId on the space page to null", () => {
+    expect(
+      // @ts-expect-error — spaceId omitted entirely.
+      readLanding({ landing: { page: "space" } }),
+    ).toEqual({ page: "space", spaceId: null });
+  });
+});
+
+describe("landingPathFor", () => {
+  it("maps each page to its route", () => {
+    expect(landingPathFor({ page: "tasks", spaceId: null })).toBe("/tasks");
+    expect(landingPathFor({ page: "notifications", spaceId: null })).toBe(
+      "/notifications",
+    );
+    expect(landingPathFor({ page: "spaces", spaceId: null })).toBe("/spaces");
+    expect(landingPathFor({ page: "space", spaceId: "x" })).toBe("/projects");
+  });
+
+  it("falls back to the default route for an unrecognised page", () => {
+    // @ts-expect-error — defends against a value outside the union.
+    expect(landingPathFor({ page: "bogus", spaceId: null })).toBe("/projects");
+  });
+});

--- a/pwa/lib/notificationPrefs.test.ts
+++ b/pwa/lib/notificationPrefs.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  allOnMatrix,
+  DEFAULT_NOTIFICATION_MATRIX,
+  NOTIFICATION_ROWS,
+} from "./notificationPrefs";
+
+describe("notification preference defaults", () => {
+  it("has a default-matrix entry for every row", () => {
+    for (const row of NOTIFICATION_ROWS) {
+      expect(DEFAULT_NOTIFICATION_MATRIX[row.key]).toBeDefined();
+    }
+    expect(Object.keys(DEFAULT_NOTIFICATION_MATRIX).sort()).toEqual(
+      NOTIFICATION_ROWS.map((r) => r.key).sort(),
+    );
+  });
+
+  it("uses unique row keys", () => {
+    const keys = NOTIFICATION_ROWS.map((r) => r.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});
+
+describe("allOnMatrix", () => {
+  it("turns every row on for both channels", () => {
+    const matrix = allOnMatrix();
+    expect(Object.keys(matrix).sort()).toEqual(
+      NOTIFICATION_ROWS.map((r) => r.key).sort(),
+    );
+    for (const channel of Object.values(matrix)) {
+      expect(channel).toEqual({ inApp: true, email: true });
+    }
+  });
+});

--- a/pwa/lib/notificationTypes.test.ts
+++ b/pwa/lib/notificationTypes.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  collectionMembers,
+  collectionTotal,
+  metaFor,
+  NOTIFICATION_META,
+} from "./notificationTypes";
+
+describe("collectionMembers", () => {
+  it("reads the plain `member` key", () => {
+    expect(collectionMembers({ member: [{ id: "1" } as never] })).toHaveLength(1);
+  });
+
+  it("falls back to the JSON-LD `hydra:member` key, then []", () => {
+    expect(collectionMembers({ "hydra:member": [{ id: "1" } as never] })).toHaveLength(1);
+    expect(collectionMembers({})).toEqual([]);
+  });
+});
+
+describe("collectionTotal", () => {
+  it("reads totalItems, then hydra:totalItems, then 0", () => {
+    expect(collectionTotal({ totalItems: 5 })).toBe(5);
+    expect(collectionTotal({ "hydra:totalItems": 7 })).toBe(7);
+    expect(collectionTotal({})).toBe(0);
+  });
+});
+
+describe("metaFor", () => {
+  it("returns the matching meta for a known type", () => {
+    expect(metaFor("mention")).toBe(NOTIFICATION_META.mention);
+    expect(metaFor("status").label).toBe("STATUS");
+  });
+
+  it("returns the UPDATE fallback for an unknown type", () => {
+    expect(metaFor("totally-unknown").label).toBe("UPDATE");
+  });
+});

--- a/pwa/lib/passwordStrength.test.ts
+++ b/pwa/lib/passwordStrength.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   estimatePasswordStrength,
+  STRENGTH_MEDIUM,
+  STRENGTH_STRONG,
   STRENGTH_VERY_STRONG,
   STRENGTH_VERY_WEAK,
+  STRENGTH_WEAK,
 } from "./passwordStrength";
 
 describe("estimatePasswordStrength", () => {
@@ -25,5 +28,25 @@ describe("estimatePasswordStrength", () => {
     const weak = estimatePasswordStrength("password");
     const stronger = estimatePasswordStrength("P@ssw0rd!2024xyz");
     expect(stronger).toBeGreaterThan(weak);
+  });
+
+  it("walks every intermediate bucket as entropy climbs", () => {
+    // All-distinct lowercase keeps pool fixed at 26, so entropy is exactly
+    // length * log2(26) ≈ length * 4.7004 — no ICU/locale dependence. The
+    // chosen lengths land squarely inside each band's return branch.
+    expect(estimatePasswordStrength("abcdefghijklmn")).toBe(STRENGTH_WEAK); // 14 → ≈65.8 (60–80)
+    expect(estimatePasswordStrength("abcdefghijklmnopqr")).toBe(STRENGTH_MEDIUM); // 18 → ≈84.6 (80–100)
+    expect(estimatePasswordStrength("abcdefghijklmnopqrstuv")).toBe(STRENGTH_STRONG); // 22 → ≈103.4 (100–120)
+  });
+
+  it("accounts for symbol, control, and high-bit character classes", () => {
+    // These inputs route through the `symbol`, `control`, and `other`
+    // (high-bit) arms of the class-detection loop. We only assert the
+    // result is a valid 0–4 score — enough to exercise each branch without
+    // pinning a boundary-sensitive bucket.
+    for (const pw of ["!@#$%^&*()_+", "\x01\x02abcdEFG1", "éàüœ®©abc12"]) {
+      const score = estimatePasswordStrength(pw);
+      expect([0, 1, 2, 3, 4]).toContain(score);
+    }
   });
 });

--- a/pwa/lib/relativeTime.test.ts
+++ b/pwa/lib/relativeTime.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { formatRelative, isRecent, timeGroup } from "./relativeTime";
+
+// Pin "now" so Date.now()-relative output is deterministic.
+const NOW = new Date("2026-06-14T12:00:00.000Z");
+const minutes = (n: number) => n * 60_000;
+const hours = (n: number) => n * 3_600_000;
+const days = (n: number) => n * 86_400_000;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("isRecent", () => {
+  it("is true within the window and false outside it", () => {
+    expect(isRecent(new Date(NOW.getTime() - minutes(1)), minutes(5))).toBe(true);
+    expect(isRecent(new Date(NOW.getTime() - minutes(10)), minutes(5))).toBe(false);
+  });
+
+  it("accepts an ISO string as well as a Date", () => {
+    expect(isRecent(new Date(NOW.getTime() - minutes(1)).toISOString(), minutes(5))).toBe(true);
+  });
+
+  it("is false for an unparseable timestamp", () => {
+    expect(isRecent("not-a-date", minutes(5))).toBe(false);
+  });
+});
+
+describe("formatRelative", () => {
+  it("returns empty string for an invalid date", () => {
+    expect(formatRelative("not-a-date")).toBe("");
+  });
+
+  it("buckets past timestamps into the right unit", () => {
+    expect(formatRelative(new Date(NOW.getTime() - 30_000))).toMatch(/second|now/i);
+    expect(formatRelative(new Date(NOW.getTime() - minutes(5)))).toMatch(/minute/);
+    expect(formatRelative(new Date(NOW.getTime() - hours(3)))).toMatch(/hour/);
+    expect(formatRelative(new Date(NOW.getTime() - days(2)))).toMatch(/day/);
+    expect(formatRelative(new Date(NOW.getTime() - days(45)))).toMatch(/month/);
+    expect(formatRelative(new Date(NOW.getTime() - days(400)))).toMatch(/year/);
+  });
+
+  it("handles future timestamps too", () => {
+    expect(formatRelative(new Date(NOW.getTime() + minutes(5)))).toMatch(/minute/);
+  });
+});
+
+describe("timeGroup", () => {
+  it("buckets into Today / This week / Earlier", () => {
+    expect(timeGroup(new Date(NOW.getTime() - hours(2)))).toBe("Today");
+    expect(timeGroup(new Date(NOW.getTime() - days(3)))).toBe("This week");
+    expect(timeGroup(new Date(NOW.getTime() - days(30)))).toBe("Earlier");
+  });
+
+  it("treats an invalid timestamp as Earlier", () => {
+    expect(timeGroup("not-a-date")).toBe("Earlier");
+  });
+});

--- a/pwa/lib/userDisplay.test.ts
+++ b/pwa/lib/userDisplay.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { displayName, initialsFor } from "./userDisplay";
+
+describe("displayName", () => {
+  it("prefers a trimmed nickname", () => {
+    expect(displayName({ nickname: "  Bob  ", givenName: "Robert", email: "r@x.io" })).toBe("Bob");
+  });
+
+  it("falls back to given + family name", () => {
+    expect(displayName({ givenName: "Robo", familyName: "Parker" })).toBe("Robo Parker");
+    expect(displayName({ givenName: "Robo" })).toBe("Robo");
+    expect(displayName({ familyName: "Parker" })).toBe("Parker");
+  });
+
+  it("falls back to email, then Unknown", () => {
+    expect(displayName({ email: "r@x.io" })).toBe("r@x.io");
+    expect(displayName({})).toBe("Unknown");
+    expect(displayName({ nickname: "   ", givenName: " ", email: "  " })).toBe("Unknown");
+  });
+});
+
+describe("initialsFor", () => {
+  it("uses the first nickname character, upper-cased", () => {
+    expect(initialsFor({ nickname: "bob" })).toBe("B");
+  });
+
+  it("combines given + family initials", () => {
+    expect(initialsFor({ givenName: "Robo", familyName: "Parker" })).toBe("RP");
+    expect(initialsFor({ givenName: "robo" })).toBe("R");
+  });
+
+  it("falls back to the email initial, then '?'", () => {
+    expect(initialsFor({ email: "zed@x.io" })).toBe("Z");
+    expect(initialsFor({})).toBe("?");
+    expect(initialsFor({ givenName: " ", email: "" })).toBe("?");
+  });
+});

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -12,7 +12,8 @@
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@base-ui/react": "^1.5.0",
@@ -61,6 +62,7 @@
     "@types/node": "^25.9.3",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "@vitest/coverage-v8": "4.1.8",
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.2.9",
     "eslint-plugin-react-hooks": "^7.0.0",

--- a/pwa/pnpm-lock.yaml
+++ b/pwa/pnpm-lock.yaml
@@ -145,6 +145,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
+      '@vitest/coverage-v8':
+        specifier: 4.1.8
+        version: 4.1.8(vitest@4.1.8)
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.7.0)
@@ -159,7 +162,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@25.9.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0))
+        version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0))
 
 packages:
 
@@ -273,6 +276,10 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@blocknote/core@0.51.4':
     resolution: {integrity: sha512-uR7/BlW6VVlCx/JzfGbkaLGz7O5uI3bu2tbNIdzGTfSloiEp8Qc14if36Dy7DDs+dVWfZgwds0jWiGfE3AzJiw==}
@@ -2275,6 +2282,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/coverage-v8@4.1.8':
+    resolution: {integrity: sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==}
+    peerDependencies:
+      '@vitest/browser': 4.1.8
+      vitest: 4.1.8
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.8':
     resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
 
@@ -2374,6 +2390,9 @@ packages:
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
+
+  ast-v8-to-istanbul@1.0.4:
+    resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
 
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
@@ -2981,6 +3000,9 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
@@ -3148,6 +3170,18 @@ packages:
   isomorphic.js@0.2.5:
     resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
@@ -3155,6 +3189,9 @@ packages:
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -3313,6 +3350,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -4552,6 +4596,8 @@ snapshots:
       use-sync-external-store: 1.6.0(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.17
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@blocknote/core@0.51.4(@types/hast@3.0.4)':
     dependencies:
@@ -6459,6 +6505,20 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
+  '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.8
+      ast-v8-to-istanbul: 1.0.4
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.2
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0))
+
   '@vitest/expect@4.1.8':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -6597,6 +6657,12 @@ snapshots:
   assertion-error@2.0.1: {}
 
   ast-types-flow@0.0.8: {}
+
+  ast-v8-to-istanbul@1.0.4:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   async-function@1.0.0: {}
 
@@ -7370,6 +7436,8 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
+  html-escaper@2.0.2: {}
+
   html-url-attributes@3.0.1: {}
 
   ignore@5.3.2: {}
@@ -7534,6 +7602,19 @@ snapshots:
 
   isomorphic.js@0.2.5: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   iterator.prototype@1.1.5:
     dependencies:
       define-data-property: 1.1.4
@@ -7544,6 +7625,8 @@ snapshots:
       set-function-name: 2.0.2
 
   jiti@2.7.0: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -7671,6 +7754,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.3:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.4
 
   markdown-table@3.0.4: {}
 
@@ -9033,7 +9126,7 @@ snapshots:
       jiti: 2.7.0
       lightningcss: 1.32.0
 
-  vitest@4.1.8(@types/node@25.9.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)):
+  vitest@4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)):
     dependencies:
       '@vitest/expect': 4.1.8
       '@vitest/mocker': 4.1.8(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0))
@@ -9057,6 +9150,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.3
+      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
     transitivePeerDependencies:
       - msw
 

--- a/pwa/vitest.config.ts
+++ b/pwa/vitest.config.ts
@@ -4,10 +4,40 @@ import { defineConfig } from "vitest/config";
 // Unit tests for the pure logic under pwa/lib (query parsing, validation
 // mapping, password-strength estimation, …). Component/integration coverage
 // stays in the Playwright e2e suite; this is the fast unit layer.
+//
+// Coverage gate (the PR floor): `pnpm test:coverage` enforces the thresholds
+// below over an explicit allowlist of pure-logic modules — the modules we've
+// committed to keeping unit-tested. When you add a new framework-free helper
+// under lib/, add it (and its `*.test.ts`) to `coverage.include` so the gate
+// keeps it honest. Hooks (`use*.ts`), API clients, and type-only modules are
+// intentionally out of scope here — their coverage lives in the e2e suite.
 export default defineConfig({
   test: {
     environment: "node",
     include: ["lib/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "text-summary"],
+      include: [
+        "lib/authRedirect.ts",
+        "lib/avatarPalette.ts",
+        "lib/currencies.ts",
+        "lib/landingDestination.ts",
+        "lib/notificationPrefs.ts",
+        "lib/notificationTypes.ts",
+        "lib/passwordStrength.ts",
+        "lib/relativeTime.ts",
+        "lib/searchQuery.ts",
+        "lib/userDisplay.ts",
+        "lib/violations.ts",
+      ],
+      thresholds: {
+        lines: 85,
+        statements: 85,
+        functions: 90,
+        branches: 75,
+      },
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Description

Reviews the test setup and fills the largest **automated-testing gap**, then establishes a **minimum-coverage floor for PRs**.

### Context
The API side is well covered (~83 PHPUnit suites). The thin spot was the PWA unit layer: of the framework-free modules under `pwa/lib`, only `searchQuery`, `passwordStrength`, and `violations` had Vitest tests. The rest of the pure logic — including security-relevant code — was untested.

### Tests added (79 unit tests pass)
- **`authRedirect`** — open-redirect sanitisation (`isSafeNextPath` / `safeNextPath` / `signinHrefForCurrent`); rejects `//host`, `/\host`, `javascript:`, off-origin URLs.
- **`landingDestination`** — post-login start-page resolution + stale/unknown-page fallbacks.
- **`relativeTime`** — relative formatting + Today/This-week/Earlier bucketing (deterministic via fake timers).
- **`currencies`** — ISO-4217 lookup, case-insensitivity, Intl + 2-digit fallbacks, list integrity.
- **`avatarPalette`** — deterministic palette pick + explicit/inherited/fallback color resolution.
- **`userDisplay`** — display-name and initials precedence rules.
- **`notificationPrefs` / `notificationTypes`** — matrix defaults, `allOnMatrix`, collection accessors, `metaFor` fallback.
- Expanded **`passwordStrength`** to exercise every strength bucket and character class (symbol/control/high-bit).

### Minimum coverage gate for PRs
- `pwa/vitest.config.ts` now runs **v8 coverage** over an explicit allowlist of the tested pure-logic modules with thresholds: **lines/statements ≥ 85%, functions ≥ 90%, branches ≥ 75%**.
- New `test:coverage` script; **CI** now runs `pnpm test:coverage` (was `pnpm test`), so a PR that drops a covered branch fails the *PWA Typecheck* check.
- Current coverage of the allowlist: **99% lines / 100% funcs / 96% branches** — comfortable margin above the floor.
- Policy documented in `.github/CONTRIBUTING.md` (new **Testing** section) and the PR template; the allowlist is the contributor touch-point for new helpers.

### Verification
Ran in a throwaway Node 22 container: `pnpm typecheck` (0 errors), `pnpm lint` (0 errors; pre-existing warnings only), and `pnpm test:coverage` (79 passing, thresholds met). The added `@vitest/coverage-v8` devDependency is reflected in `pnpm-lock.yaml` so the frozen-lockfile prod image build stays green.

## Type of Change
- [x] New feature (test infrastructure)

## Component
- [x] PWA (Next.js)
- [x] Documentation

## How Has This Been Tested?
`pnpm typecheck`, `pnpm lint`, and `pnpm test:coverage` all pass in a clean container; coverage thresholds enforced.

## Checklist
- [x] My code follows the project's conventions
- [x] I have added tests that prove my fix or feature works
- [x] New and existing tests pass locally (`pnpm test:coverage`)
- [x] New pure-logic helpers under `pwa/lib` are added to the coverage allowlist in `pwa/vitest.config.ts`
- [x] I have updated documentation if needed