### PR TITLE
refactor(api): extract duplicated mailer/export/auth logic into composed services

### DIFF
--- a/api/src/Security/AuthenticatedUserResolver.php
+++ b/api/src/Security/AuthenticatedUserResolver.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+use App\Entity\User;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+
+/**
+ * Resolves the authenticated {@see User} or rejects with a 401. The
+ * "stamp the current user as owner/author" creation processors
+ * ({@see \App\State\TaskOwnerProcessor}, {@see \App\State\CommentAuthorProcessor}, …)
+ * compose this resolver instead of each repeating the getUser() + instanceof
+ * guard, so the unauthenticated-request behaviour is defined in one place.
+ */
+final class AuthenticatedUserResolver
+{
+    public function __construct(
+        private readonly Security $security,
+    ) {
+    }
+
+    /**
+     * @param string $action fills "You must be authenticated to <action>."
+     *                       (e.g. "create a task")
+     */
+    public function requireUser(string $action): User
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new UnauthorizedHttpException('Bearer', sprintf('You must be authenticated to %s.', $action));
+        }
+
+        return $user;
+    }
+}

--- a/api/src/Service/AccountExportBuilder.php
+++ b/api/src/Service/AccountExportBuilder.php
@@ -4,9 +4,8 @@ namespace App\Service;
 
 use App\Entity\AccountExport;
 use App\Entity\MediaObject;
-use App\Entity\User;
+use App\Service\Export\ExportArchiveWriter;
 use Doctrine\ORM\EntityManagerInterface;
-use League\Flysystem\FilesystemOperator;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
@@ -36,8 +35,7 @@ final class AccountExportBuilder
     public function __construct(
         private EntityManagerInterface $em,
         private UserDataExporter $exporter,
-        #[Autowire(service: 'media.storage')]
-        private FilesystemOperator $mediaStorage,
+        private ExportArchiveWriter $archive,
         #[Autowire('%app.account_export_dir%')]
         private string $exportDir,
     ) {
@@ -74,13 +72,13 @@ final class AccountExportBuilder
 
         $account = $this->exporter->export($user);
         $account['exportedAt'] = (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM);
-        $account['attachments'] = array_values(array_map(static fn (MediaObject $m): array => [
+        $account['attachments'] = array_values(array_map(fn (MediaObject $m): array => [
             'id' => (string) $m->getId(),
             'kind' => $m->getKind(),
             'originalName' => $m->getOriginalName(),
             'mimeType' => $m->getMimeType(),
             'byteSize' => $m->getByteSize(),
-            'file' => self::attachmentFileName($m),
+            'file' => $this->archive->attachmentFileName($m),
         ], $media));
 
         $zip = new \ZipArchive();
@@ -89,17 +87,17 @@ final class AccountExportBuilder
         }
 
         try {
-            $this->addJson($zip, 'account.json', $account);
+            $this->archive->addJson($zip, 'account.json', $account);
 
             foreach ($media as $mediaObject) {
-                $this->addAttachment($zip, $mediaObject, $partsDir);
+                $this->archive->addAttachment($zip, $mediaObject, $partsDir);
             }
         } catch (\Throwable $e) {
             $zip->close();
             if (is_file($tmp)) {
                 unlink($tmp);
             }
-            $this->removeDir($partsDir);
+            $this->archive->removeDir($partsDir);
             throw $e;
         }
 
@@ -107,7 +105,7 @@ final class AccountExportBuilder
         // the staging directory must survive until here, then it's safe to
         // remove regardless of success.
         $closed = $zip->close();
-        $this->removeDir($partsDir);
+        $this->archive->removeDir($partsDir);
         if (!$closed) {
             if (is_file($tmp)) {
                 unlink($tmp);
@@ -119,88 +117,5 @@ final class AccountExportBuilder
         }
 
         return $file;
-    }
-
-    /**
-     * Stable in-archive filename for an attachment: media id prefix keeps
-     * names collision-free, the sanitized original name keeps them human.
-     */
-    public static function attachmentFileName(MediaObject $media): string
-    {
-        $name = basename($media->getOriginalName());
-        $sanitized = preg_replace('/[^\w.\- ]+/u', '_', $name);
-        $safe = (null !== $sanitized && '' !== trim($sanitized)) ? trim($sanitized) : 'file';
-
-        return sprintf('attachments/%s-%s', (string) $media->getId(), $safe);
-    }
-
-    /**
-     * @param array<int|string, mixed> $data
-     */
-    private function addJson(\ZipArchive $zip, string $name, array $data): void
-    {
-        $json = json_encode(
-            $data,
-            JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
-        );
-        if (!$zip->addFromString($name, $json)) {
-            throw new \RuntimeException(sprintf('Could not add "%s" to the export archive.', $name));
-        }
-    }
-
-    private function addAttachment(\ZipArchive $zip, MediaObject $media, string $partsDir): void
-    {
-        $path = $media->getVariantPath('original') ?? array_values($media->getVariants())[0] ?? null;
-        if (null === $path || !$this->mediaStorage->fileExists($path)) {
-            // A missing file shouldn't sink the whole export — the JSON
-            // manifest still records that the attachment existed.
-            return;
-        }
-
-        // Stream flysystem → a staged temp file, then hand the path to
-        // ZipArchive::addFile() so the bytes are read from disk at close()
-        // rather than buffered in memory. The media id is unique, so it's a
-        // safe temp filename.
-        $tempPath = $partsDir . '/' . (string) $media->getId();
-        $dest = fopen($tempPath, 'wb');
-        if (false === $dest) {
-            throw new \RuntimeException(sprintf('Could not stage attachment "%s" for export.', (string) $media->getId()));
-        }
-
-        $source = $this->mediaStorage->readStream($path);
-        $copied = stream_copy_to_stream($source, $dest);
-        if (\is_resource($source)) {
-            fclose($source);
-        }
-        fclose($dest);
-        if (false === $copied) {
-            // Couldn't read the bytes — skip rather than abort the export.
-            unlink($tempPath);
-            return;
-        }
-
-        if (!$zip->addFile($tempPath, self::attachmentFileName($media))) {
-            throw new \RuntimeException(sprintf('Could not add attachment "%s" to the export archive.', (string) $media->getId()));
-        }
-    }
-
-    /**
-     * Removes a staging directory and its (flat) contents. Best-effort — a
-     * leftover that survives a hard kill is reaped by AccountExportPruner.
-     */
-    private function removeDir(string $dir): void
-    {
-        if (!is_dir($dir)) {
-            return;
-        }
-        $entries = glob($dir . '/*');
-        if (false !== $entries) {
-            foreach ($entries as $entry) {
-                if (is_file($entry)) {
-                    unlink($entry);
-                }
-            }
-        }
-        rmdir($dir);
     }
 }

--- a/api/src/Service/AccountExportMailer.php
+++ b/api/src/Service/AccountExportMailer.php
@@ -3,9 +3,8 @@
 namespace App\Service;
 
 use App\Entity\AccountExport;
+use App\Service\Mail\MailDispatcher;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\Mailer\MailerInterface;
 
 /**
  * Sends the "your account export is ready" email once the worker has built
@@ -17,31 +16,25 @@ use Symfony\Component\Mailer\MailerInterface;
 final class AccountExportMailer
 {
     public function __construct(
-        private MailerInterface $mailer,
-        #[Autowire('%env(APP_FRONTEND_URL)%')]
-        private string $frontendUrl,
-        #[Autowire('%env(default::MAILER_FROM)%')]
-        private ?string $mailerFrom = null,
+        private readonly MailDispatcher $mail,
     ) {
     }
 
     public function sendExportReady(AccountExport $export, string $plainToken): void
     {
-        $from = (null !== $this->mailerFrom && '' !== $this->mailerFrom) ? $this->mailerFrom : 'no-reply@madori.test';
         $recipient = $export->getRequestedBy();
 
         $email = (new TemplatedEmail())
-            ->from($from)
             ->to($recipient->getEmail())
             ->subject('Your Madori data export is ready')
             ->htmlTemplate('emails/account_export.html.twig')
             ->textTemplate('emails/account_export.txt.twig')
             ->context([
                 'recipient' => $recipient,
-                'downloadUrl' => rtrim($this->frontendUrl, '/') . '/account-exports/' . $plainToken,
+                'downloadUrl' => $this->mail->frontendLink('/account-exports/' . $plainToken),
                 'expiresAt' => $export->getExpiresAt(),
             ]);
 
-        $this->mailer->send($email);
+        $this->mail->send($email);
     }
 }

--- a/api/src/Service/Export/ExportArchiveWriter.php
+++ b/api/src/Service/Export/ExportArchiveWriter.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Export;
+
+use App\Entity\MediaObject;
+use League\Flysystem\FilesystemOperator;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Shared zip-assembly primitives for the export builders
+ * ({@see \App\Service\SpaceExportBuilder} / {@see \App\Service\AccountExportBuilder}).
+ *
+ * The builders compose this writer (inject + call) instead of mixing in a trait,
+ * so the `media.storage` dependency lives here once rather than being an
+ * implicit `$this->mediaStorage` contract each builder has to satisfy.
+ */
+final class ExportArchiveWriter
+{
+    public function __construct(
+        #[Autowire(service: 'media.storage')]
+        private readonly FilesystemOperator $mediaStorage,
+    ) {
+    }
+
+    /**
+     * Stable in-archive filename for an attachment: media id prefix keeps
+     * names collision-free, the sanitized original name keeps them human.
+     */
+    public function attachmentFileName(MediaObject $media): string
+    {
+        $name = basename($media->getOriginalName());
+        $sanitized = preg_replace('/[^\w.\- ]+/u', '_', $name);
+        $safe = (null !== $sanitized && '' !== trim($sanitized)) ? trim($sanitized) : 'file';
+
+        return sprintf('attachments/%s-%s', (string) $media->getId(), $safe);
+    }
+
+    /**
+     * @param array<int|string, mixed> $data
+     */
+    public function addJson(\ZipArchive $zip, string $name, array $data): void
+    {
+        $json = json_encode(
+            $data,
+            JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+        );
+        if (!$zip->addFromString($name, $json)) {
+            throw new \RuntimeException(sprintf('Could not add "%s" to the export archive.', $name));
+        }
+    }
+
+    public function addAttachment(\ZipArchive $zip, MediaObject $media, string $partsDir): void
+    {
+        $path = $media->getVariantPath('original') ?? array_values($media->getVariants())[0] ?? null;
+        if (null === $path || !$this->mediaStorage->fileExists($path)) {
+            // A missing file shouldn't sink the whole export — the JSON
+            // still records that the attachment existed.
+            return;
+        }
+
+        // Stream flysystem → a staged temp file, then hand the path to
+        // ZipArchive::addFile() so the bytes are read from disk at close()
+        // rather than buffered in memory. The media id is unique, so it's a
+        // safe temp filename.
+        $tempPath = $partsDir . '/' . (string) $media->getId();
+        $dest = fopen($tempPath, 'wb');
+        if (false === $dest) {
+            throw new \RuntimeException(sprintf('Could not stage attachment "%s" for export.', (string) $media->getId()));
+        }
+
+        $source = $this->mediaStorage->readStream($path);
+        $copied = stream_copy_to_stream($source, $dest);
+        if (\is_resource($source)) {
+            fclose($source);
+        }
+        fclose($dest);
+        if (false === $copied) {
+            // Couldn't read the bytes — skip rather than abort the export.
+            unlink($tempPath);
+            return;
+        }
+
+        if (!$zip->addFile($tempPath, $this->attachmentFileName($media))) {
+            throw new \RuntimeException(sprintf('Could not add attachment "%s" to the export archive.', (string) $media->getId()));
+        }
+    }
+
+    /**
+     * Removes a staging directory and its (flat) contents. Best-effort — a
+     * leftover that survives a hard kill is reaped by the matching export pruner.
+     */
+    public function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $entries = glob($dir . '/*');
+        if (false !== $entries) {
+            foreach ($entries as $entry) {
+                if (is_file($entry)) {
+                    unlink($entry);
+                }
+            }
+        }
+        rmdir($dir);
+    }
+}

--- a/api/src/Service/InviteMailer.php
+++ b/api/src/Service/InviteMailer.php
@@ -3,8 +3,7 @@
 namespace App\Service;
 
 use App\Entity\UserInvite;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\Mailer\MailerInterface;
+use App\Service\Mail\MailDispatcher;
 use Symfony\Component\Mime\Email;
 
 /**
@@ -21,28 +20,18 @@ use Symfony\Component\Mime\Email;
 final class InviteMailer
 {
     public function __construct(
-        private MailerInterface $mailer,
-        #[Autowire('%env(APP_FRONTEND_URL)%')]
-        private string $frontendUrl,
-        #[Autowire('%env(default::MAILER_FROM)%')]
-        private ?string $mailerFrom = null,
+        private readonly MailDispatcher $mail,
     ) {
     }
 
     public function sendSignupLink(UserInvite $invite, string $plainToken, int $ttlDays): void
     {
-        $signupUrl = sprintf(
-            '%s/signup?invite=%s',
-            rtrim($this->frontendUrl, '/'),
-            $plainToken,
-        );
-        $from = (null !== $this->mailerFrom && '' !== $this->mailerFrom) ? $this->mailerFrom : 'no-reply@madori.test';
+        $signupUrl = $this->mail->frontendLink('/signup?invite=' . $plainToken);
 
         $targets = $this->collectTargetLabels($invite);
         $contextLine = $this->formatContextLine($targets);
 
         $message = (new Email())
-            ->from($from)
             ->to($invite->getEmail())
             ->subject('You\'ve been invited to join Madori')
             ->text(sprintf(
@@ -58,7 +47,7 @@ final class InviteMailer
                 $ttlDays,
             ));
 
-        $this->mailer->send($message);
+        $this->mail->send($message);
     }
 
     /**

--- a/api/src/Service/Mail/MailDispatcher.php
+++ b/api/src/Service/Mail/MailDispatcher.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Mail;
+
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Email;
+
+/**
+ * Shared collaborator for the transactional mailers. It owns the three things
+ * every mailer needs — the MailerInterface, the frontend base URL, and the
+ * MAILER_FROM fallback — so the concrete mailers compose it (inject + call)
+ * rather than inheriting a base class.
+ *
+ * {@see send()} stamps the From address when the message doesn't already carry
+ * one, so callers build their {@see Email}/TemplatedEmail without repeating the
+ * fallback; {@see frontendLink()} builds absolute links into the PWA.
+ */
+final class MailDispatcher
+{
+    public function __construct(
+        private readonly MailerInterface $mailer,
+        #[Autowire('%env(APP_FRONTEND_URL)%')]
+        private readonly string $frontendUrl,
+        #[Autowire('%env(default::MAILER_FROM)%')]
+        private readonly ?string $mailerFrom = null,
+    ) {
+    }
+
+    /**
+     * Sends $email, defaulting its From to the configured sender (or the dev
+     * fallback) when the caller hasn't set one.
+     */
+    public function send(Email $email): void
+    {
+        if ([] === $email->getFrom()) {
+            $email->from($this->senderAddress());
+        }
+
+        $this->mailer->send($email);
+    }
+
+    /**
+     * Absolute frontend URL for $path (a leading slash is expected), with any
+     * trailing slash on the configured base trimmed so the result is well-formed.
+     */
+    public function frontendLink(string $path = ''): string
+    {
+        return rtrim($this->frontendUrl, '/') . $path;
+    }
+
+    /**
+     * The From address, falling back to the dev default when MAILER_FROM is
+     * unset or empty.
+     */
+    private function senderAddress(): string
+    {
+        return (null !== $this->mailerFrom && '' !== $this->mailerFrom)
+            ? $this->mailerFrom
+            : 'no-reply@madori.test';
+    }
+}

--- a/api/src/Service/SpaceExportBuilder.php
+++ b/api/src/Service/SpaceExportBuilder.php
@@ -13,8 +13,8 @@ use App\Entity\SpaceExport;
 use App\Entity\Tag;
 use App\Entity\Task;
 use App\Entity\User;
+use App\Service\Export\ExportArchiveWriter;
 use Doctrine\ORM\EntityManagerInterface;
-use League\Flysystem\FilesystemOperator;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
@@ -42,8 +42,7 @@ final class SpaceExportBuilder
 {
     public function __construct(
         private EntityManagerInterface $em,
-        #[Autowire(service: 'media.storage')]
-        private FilesystemOperator $mediaStorage,
+        private ExportArchiveWriter $archive,
         #[Autowire('%app.space_export_dir%')]
         private string $exportDir,
     ) {
@@ -105,30 +104,30 @@ final class SpaceExportBuilder
             $pageComments = $this->commentsFor($pages, 'page');
             $discussionComments = $this->commentsFor($discussions, 'discussion');
 
-            $this->addJson($zip, 'space.json', $this->spaceData($export));
-            $this->addJson($zip, 'projects.json', array_map($this->projectData(...), $projects));
-            $this->addJson($zip, 'tasks.json', array_map(
+            $this->archive->addJson($zip, 'space.json', $this->spaceData($export));
+            $this->archive->addJson($zip, 'projects.json', array_map($this->projectData(...), $projects));
+            $this->archive->addJson($zip, 'tasks.json', array_map(
                 fn (Task $t): array => $this->taskData($t, $taskComments),
                 $tasks,
             ));
-            $this->addJson($zip, 'pages.json', array_map(
+            $this->archive->addJson($zip, 'pages.json', array_map(
                 fn (Page $p): array => $this->pageData($p, $pageComments),
                 $pages,
             ));
-            $this->addJson($zip, 'discussions.json', array_map(
+            $this->archive->addJson($zip, 'discussions.json', array_map(
                 fn (Discussion $d): array => $this->discussionData($d, $discussionComments),
                 $discussions,
             ));
 
             foreach ($media as $mediaObject) {
-                $this->addAttachment($zip, $mediaObject, $partsDir);
+                $this->archive->addAttachment($zip, $mediaObject, $partsDir);
             }
         } catch (\Throwable $e) {
             $zip->close();
             if (is_file($tmp)) {
                 unlink($tmp);
             }
-            $this->removeDir($partsDir);
+            $this->archive->removeDir($partsDir);
             throw $e;
         }
 
@@ -136,7 +135,7 @@ final class SpaceExportBuilder
         // the staging directory must survive until here, then it's safe to
         // remove regardless of success.
         $closed = $zip->close();
-        $this->removeDir($partsDir);
+        $this->archive->removeDir($partsDir);
         if (!$closed) {
             if (is_file($tmp)) {
                 unlink($tmp);
@@ -148,89 +147,6 @@ final class SpaceExportBuilder
         }
 
         return $file;
-    }
-
-    /**
-     * Stable in-archive filename for an attachment: media id prefix keeps
-     * names collision-free, the sanitized original name keeps them human.
-     */
-    public static function attachmentFileName(MediaObject $media): string
-    {
-        $name = basename($media->getOriginalName());
-        $sanitized = preg_replace('/[^\w.\- ]+/u', '_', $name);
-        $safe = (null !== $sanitized && '' !== trim($sanitized)) ? trim($sanitized) : 'file';
-
-        return sprintf('attachments/%s-%s', (string) $media->getId(), $safe);
-    }
-
-    /**
-     * @param array<int|string, mixed> $data
-     */
-    private function addJson(\ZipArchive $zip, string $name, array $data): void
-    {
-        $json = json_encode(
-            $data,
-            JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
-        );
-        if (!$zip->addFromString($name, $json)) {
-            throw new \RuntimeException(sprintf('Could not add "%s" to the export archive.', $name));
-        }
-    }
-
-    private function addAttachment(\ZipArchive $zip, MediaObject $media, string $partsDir): void
-    {
-        $path = $media->getVariantPath('original') ?? array_values($media->getVariants())[0] ?? null;
-        if (null === $path || !$this->mediaStorage->fileExists($path)) {
-            // A missing file shouldn't sink the whole export — the JSON
-            // still records that the attachment existed.
-            return;
-        }
-
-        // Stream flysystem → a staged temp file, then hand the path to
-        // ZipArchive::addFile() so the bytes are read from disk at close()
-        // rather than buffered in memory. The media id is unique, so it's a
-        // safe temp filename.
-        $tempPath = $partsDir . '/' . (string) $media->getId();
-        $dest = fopen($tempPath, 'wb');
-        if (false === $dest) {
-            throw new \RuntimeException(sprintf('Could not stage attachment "%s" for export.', (string) $media->getId()));
-        }
-
-        $source = $this->mediaStorage->readStream($path);
-        $copied = stream_copy_to_stream($source, $dest);
-        if (\is_resource($source)) {
-            fclose($source);
-        }
-        fclose($dest);
-        if (false === $copied) {
-            // Couldn't read the bytes — skip rather than abort the export.
-            unlink($tempPath);
-            return;
-        }
-
-        if (!$zip->addFile($tempPath, self::attachmentFileName($media))) {
-            throw new \RuntimeException(sprintf('Could not add attachment "%s" to the export archive.', (string) $media->getId()));
-        }
-    }
-
-    /**
-     * Removes a staging directory and its (flat) contents. Best-effort —
-     * a leftover that survives a hard kill is reaped by SpaceExportPruner.
-     */
-    private function removeDir(string $dir): void
-    {
-        if (!is_dir($dir)) {
-            return;
-        }
-        $entries = glob($dir . '/*');
-        if (false !== $entries) {
-            foreach ($entries as $entry) {
-                if (is_file($entry)) {
-                    unlink($entry);
-                }
-            }
-        }
-        rmdir($dir);
     }
 
     /**
@@ -306,9 +222,9 @@ final class SpaceExportBuilder
                 'name' => $v->getDefinition()?->getName(),
                 'value' => $v->getValue(),
             ], $task->getCustomFieldValues()->toArray()),
-            'attachments' => array_map(static fn (MediaObject $m): array => [
+            'attachments' => array_map(fn (MediaObject $m): array => [
                 'id' => (string) $m->getId(),
-                'file' => self::attachmentFileName($m),
+                'file' => $this->archive->attachmentFileName($m),
                 'originalName' => $m->getOriginalName(),
             ], $task->getAttachments()->toArray()),
             'comments' => $commentsByParent[(string) $task->getId()] ?? [],

--- a/api/src/Service/SpaceExportMailer.php
+++ b/api/src/Service/SpaceExportMailer.php
@@ -3,9 +3,8 @@
 namespace App\Service;
 
 use App\Entity\SpaceExport;
+use App\Service\Mail\MailDispatcher;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\Mailer\MailerInterface;
 
 /**
  * Sends the "your space export is ready" email once the worker has built
@@ -17,21 +16,15 @@ use Symfony\Component\Mailer\MailerInterface;
 final class SpaceExportMailer
 {
     public function __construct(
-        private MailerInterface $mailer,
-        #[Autowire('%env(APP_FRONTEND_URL)%')]
-        private string $frontendUrl,
-        #[Autowire('%env(default::MAILER_FROM)%')]
-        private ?string $mailerFrom = null,
+        private readonly MailDispatcher $mail,
     ) {
     }
 
     public function sendExportReady(SpaceExport $export, string $plainToken): void
     {
-        $from = (null !== $this->mailerFrom && '' !== $this->mailerFrom) ? $this->mailerFrom : 'no-reply@madori.test';
         $recipient = $export->getRequestedBy();
 
         $email = (new TemplatedEmail())
-            ->from($from)
             ->to($recipient->getEmail())
             ->subject(sprintf('Your export of "%s" is ready', $export->getSpace()->getName()))
             ->htmlTemplate('emails/space_export.html.twig')
@@ -39,10 +32,10 @@ final class SpaceExportMailer
             ->context([
                 'recipient' => $recipient,
                 'space' => $export->getSpace(),
-                'downloadUrl' => rtrim($this->frontendUrl, '/') . '/exports/' . $plainToken,
+                'downloadUrl' => $this->mail->frontendLink('/exports/' . $plainToken),
                 'expiresAt' => $export->getExpiresAt(),
             ]);
 
-        $this->mailer->send($email);
+        $this->mail->send($email);
     }
 }

--- a/api/src/Service/TwoFactorRecoveryMailer.php
+++ b/api/src/Service/TwoFactorRecoveryMailer.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace App\Service;
 
 use App\Entity\User;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\Mailer\MailerInterface;
+use App\Service\Mail\MailDispatcher;
 use Symfony\Component\Mime\Email;
 
 /**
@@ -27,17 +26,13 @@ use Symfony\Component\Mime\Email;
 final class TwoFactorRecoveryMailer
 {
     public function __construct(
-        private MailerInterface $mailer,
-        #[Autowire('%env(APP_FRONTEND_URL)%')]
-        private string $frontendUrl,
-        #[Autowire('%env(default::MAILER_FROM)%')]
-        private ?string $mailerFrom = null,
+        private readonly MailDispatcher $mail,
     ) {
     }
 
     public function sendBackupCodeUsed(User $user): void
     {
-        $accountUrl = $this->url('/account');
+        $accountUrl = $this->mail->frontendLink('/account');
         $this->dispatch(
             $user,
             'A recovery code was used on your Madori account',
@@ -56,7 +51,7 @@ final class TwoFactorRecoveryMailer
 
     public function sendDisabled(User $user): void
     {
-        $accountUrl = $this->url('/account');
+        $accountUrl = $this->mail->frontendLink('/account');
         $this->dispatch(
             $user,
             'Two-factor authentication was disabled',
@@ -75,7 +70,7 @@ final class TwoFactorRecoveryMailer
 
     public function sendReconfigured(User $user): void
     {
-        $accountUrl = $this->url('/account');
+        $accountUrl = $this->mail->frontendLink('/account');
         $this->dispatch(
             $user,
             'A new authenticator was enrolled for your account',
@@ -99,22 +94,12 @@ final class TwoFactorRecoveryMailer
             return;
         }
 
-        $from = (null !== $this->mailerFrom && '' !== $this->mailerFrom)
-            ? $this->mailerFrom
-            : 'no-reply@madori.test';
-
         $message = (new Email())
-            ->from($from)
             ->to($to)
             ->subject($subject)
             ->text($text)
             ->html($html);
 
-        $this->mailer->send($message);
-    }
-
-    private function url(string $path): string
-    {
-        return rtrim($this->frontendUrl, '/') . $path;
+        $this->mail->send($message);
     }
 }

--- a/api/src/Service/WaitlistAccessMailer.php
+++ b/api/src/Service/WaitlistAccessMailer.php
@@ -3,9 +3,8 @@
 namespace App\Service;
 
 use App\Entity\User;
+use App\Service\Mail\MailDispatcher;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\Mailer\MailerInterface;
 
 /**
  * Sends the "your account is ready" email when a waitlisted user is promoted
@@ -19,29 +18,22 @@ use Symfony\Component\Mailer\MailerInterface;
 final class WaitlistAccessMailer
 {
     public function __construct(
-        private MailerInterface $mailer,
-        #[Autowire('%env(APP_FRONTEND_URL)%')]
-        private string $frontendUrl,
-        #[Autowire('%env(default::MAILER_FROM)%')]
-        private ?string $mailerFrom = null,
+        private readonly MailDispatcher $mail,
     ) {
     }
 
     public function sendAccessGranted(User $user): void
     {
-        $from = (null !== $this->mailerFrom && '' !== $this->mailerFrom) ? $this->mailerFrom : 'no-reply@madori.test';
-
         $email = (new TemplatedEmail())
-            ->from($from)
             ->to($user->getEmail())
             ->subject('Your Madori account is ready')
             ->htmlTemplate('emails/waitlist_access.html.twig')
             ->textTemplate('emails/waitlist_access.txt.twig')
             ->context([
                 'recipient' => $user,
-                'signinUrl' => rtrim($this->frontendUrl, '/') . '/signin',
+                'signinUrl' => $this->mail->frontendLink('/signin'),
             ]);
 
-        $this->mailer->send($email);
+        $this->mail->send($email);
     }
 }

--- a/api/src/Service/WaitlistJoinedMailer.php
+++ b/api/src/Service/WaitlistJoinedMailer.php
@@ -3,9 +3,8 @@
 namespace App\Service;
 
 use App\Entity\User;
+use App\Service\Mail\MailDispatcher;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\Mailer\MailerInterface;
 
 /**
  * Sends the "you're on the waitlist" confirmation email at signup time while
@@ -21,18 +20,13 @@ use Symfony\Component\Mailer\MailerInterface;
 final class WaitlistJoinedMailer
 {
     public function __construct(
-        private MailerInterface $mailer,
-        #[Autowire('%env(default::MAILER_FROM)%')]
-        private ?string $mailerFrom = null,
+        private readonly MailDispatcher $mail,
     ) {
     }
 
     public function sendJoinedConfirmation(User $user): void
     {
-        $from = (null !== $this->mailerFrom && '' !== $this->mailerFrom) ? $this->mailerFrom : 'no-reply@madori.test';
-
         $email = (new TemplatedEmail())
-            ->from($from)
             ->to($user->getEmail())
             ->subject("You're on the Madori waitlist")
             ->htmlTemplate('emails/waitlist_joined.html.twig')
@@ -41,6 +35,6 @@ final class WaitlistJoinedMailer
                 'recipient' => $user,
             ]);
 
-        $this->mailer->send($email);
+        $this->mail->send($email);
     }
 }

--- a/api/src/State/CommentAuthorProcessor.php
+++ b/api/src/State/CommentAuthorProcessor.php
@@ -5,13 +5,11 @@ namespace App\State;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\Entity\Comment;
-use App\Entity\User;
+use App\Security\AuthenticatedUserResolver;
 use App\Service\CommentActivityNotifier;
 use App\Service\CommentMentionService;
 use App\Service\CommentMercurePublisher;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 /**
  * Stamps the comment with the currently authenticated user before
@@ -31,7 +29,7 @@ final class CommentAuthorProcessor implements ProcessorInterface
     public function __construct(
         #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
         private ProcessorInterface $persistProcessor,
-        private Security $security,
+        private AuthenticatedUserResolver $auth,
         private CommentMercurePublisher $publisher,
         private CommentMentionService $mentions,
         private CommentActivityNotifier $activity,
@@ -43,10 +41,7 @@ final class CommentAuthorProcessor implements ProcessorInterface
      */
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Comment
     {
-        $user = $this->security->getUser();
-        if (!$user instanceof User) {
-            throw new UnauthorizedHttpException('Bearer', 'You must be authenticated to comment.');
-        }
+        $user = $this->auth->requireUser('comment');
 
         $data->setAuthor($user);
 

--- a/api/src/State/DiscussionAuthorProcessor.php
+++ b/api/src/State/DiscussionAuthorProcessor.php
@@ -5,10 +5,8 @@ namespace App\State;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\Entity\Discussion;
-use App\Entity\User;
-use Symfony\Bundle\SecurityBundle\Security;
+use App\Security\AuthenticatedUserResolver;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 /**
  * Stamps the current user as the discussion author before persisting,
@@ -26,7 +24,7 @@ final class DiscussionAuthorProcessor implements ProcessorInterface
     public function __construct(
         #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
         private ProcessorInterface $persistProcessor,
-        private Security $security,
+        private AuthenticatedUserResolver $auth,
     ) {
     }
 
@@ -35,10 +33,7 @@ final class DiscussionAuthorProcessor implements ProcessorInterface
      */
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Discussion
     {
-        $user = $this->security->getUser();
-        if (!$user instanceof User) {
-            throw new UnauthorizedHttpException('Bearer', 'You must be authenticated to start a discussion.');
-        }
+        $user = $this->auth->requireUser('start a discussion');
 
         $data->setAuthor($user);
 

--- a/api/src/State/PageAuthorProcessor.php
+++ b/api/src/State/PageAuthorProcessor.php
@@ -5,10 +5,8 @@ namespace App\State;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\Entity\Page;
-use App\Entity\User;
-use Symfony\Bundle\SecurityBundle\Security;
+use App\Security\AuthenticatedUserResolver;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 /**
  * Stamps the creator on a new {@see Page} (#183). Mirrors the
@@ -26,7 +24,7 @@ final class PageAuthorProcessor implements ProcessorInterface
     public function __construct(
         #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
         private ProcessorInterface $persistProcessor,
-        private Security $security,
+        private AuthenticatedUserResolver $auth,
     ) {
     }
 
@@ -35,10 +33,7 @@ final class PageAuthorProcessor implements ProcessorInterface
      */
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Page
     {
-        $user = $this->security->getUser();
-        if (!$user instanceof User) {
-            throw new UnauthorizedHttpException('Bearer', 'You must be authenticated to create a page.');
-        }
+        $user = $this->auth->requireUser('create a page');
         $data->setCreatedBy($user);
 
         return $this->persistProcessor->process($data, $operation, $uriVariables, $context);

--- a/api/src/State/ProjectOwnerProcessor.php
+++ b/api/src/State/ProjectOwnerProcessor.php
@@ -5,11 +5,9 @@ namespace App\State;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\Entity\Project;
-use App\Entity\User;
 use App\Repository\SpaceRepository;
-use Symfony\Bundle\SecurityBundle\Security;
+use App\Security\AuthenticatedUserResolver;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 /**
  * Stamps the creator as owner of a new Project and adds them to the member
@@ -26,7 +24,7 @@ final class ProjectOwnerProcessor implements ProcessorInterface
     public function __construct(
         #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
         private ProcessorInterface $persistProcessor,
-        private Security $security,
+        private AuthenticatedUserResolver $auth,
         private SpaceRepository $spaceRepository,
     ) {
     }
@@ -36,10 +34,7 @@ final class ProjectOwnerProcessor implements ProcessorInterface
      */
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Project
     {
-        $user = $this->security->getUser();
-        if (!$user instanceof User) {
-            throw new UnauthorizedHttpException('Bearer', 'You must be authenticated to create a project.');
-        }
+        $user = $this->auth->requireUser('create a project');
 
         $data->setOwner($user);
 

--- a/api/src/State/PushSubscriptionOwnerProcessor.php
+++ b/api/src/State/PushSubscriptionOwnerProcessor.php
@@ -5,10 +5,8 @@ namespace App\State;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\Entity\PushSubscription;
-use App\Entity\User;
-use Symfony\Bundle\SecurityBundle\Security;
+use App\Security\AuthenticatedUserResolver;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 /**
  * Stamps the current user on a freshly-created PushSubscription before
@@ -27,7 +25,7 @@ final class PushSubscriptionOwnerProcessor implements ProcessorInterface
     public function __construct(
         #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
         private ProcessorInterface $persistProcessor,
-        private Security $security,
+        private AuthenticatedUserResolver $auth,
     ) {
     }
 
@@ -36,10 +34,7 @@ final class PushSubscriptionOwnerProcessor implements ProcessorInterface
      */
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): PushSubscription
     {
-        $user = $this->security->getUser();
-        if (!$user instanceof User) {
-            throw new UnauthorizedHttpException('Bearer', 'You must be authenticated to register a push subscription.');
-        }
+        $user = $this->auth->requireUser('register a push subscription');
 
         $data->setUser($user);
 

--- a/api/src/State/SegmentCreateProcessor.php
+++ b/api/src/State/SegmentCreateProcessor.php
@@ -5,10 +5,8 @@ namespace App\State;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\Entity\Segment;
-use App\Entity\User;
-use Symfony\Bundle\SecurityBundle\Security;
+use App\Security\AuthenticatedUserResolver;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 /**
  * Stamps the creating admin onto a new Segment, then hands off to the
@@ -24,7 +22,7 @@ final class SegmentCreateProcessor implements ProcessorInterface
     public function __construct(
         #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
         private ProcessorInterface $persistProcessor,
-        private Security $security,
+        private AuthenticatedUserResolver $auth,
     ) {
     }
 
@@ -33,10 +31,7 @@ final class SegmentCreateProcessor implements ProcessorInterface
      */
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Segment
     {
-        $user = $this->security->getUser();
-        if (!$user instanceof User) {
-            throw new UnauthorizedHttpException('Bearer', 'You must be authenticated to create a segment.');
-        }
+        $user = $this->auth->requireUser('create a segment');
 
         $data->setCreatedBy($user);
 

--- a/api/src/State/SpaceCreateProcessor.php
+++ b/api/src/State/SpaceCreateProcessor.php
@@ -7,11 +7,10 @@ use ApiPlatform\State\ProcessorInterface;
 use App\Entity\Space;
 use App\Entity\SpaceMembership;
 use App\Entity\User;
+use App\Security\AuthenticatedUserResolver;
 use App\Service\SpaceMemberAdder;
 use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 /**
  * Stamps the creator on a new Space and provisions an admin
@@ -39,7 +38,7 @@ final class SpaceCreateProcessor implements ProcessorInterface
     public function __construct(
         #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
         private ProcessorInterface $persistProcessor,
-        private Security $security,
+        private AuthenticatedUserResolver $auth,
         private EntityManagerInterface $em,
         private SpaceMemberAdder $memberAdder,
     ) {
@@ -50,10 +49,7 @@ final class SpaceCreateProcessor implements ProcessorInterface
      */
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Space
     {
-        $user = $this->security->getUser();
-        if (!$user instanceof User) {
-            throw new UnauthorizedHttpException('Bearer', 'You must be authenticated to create a space.');
-        }
+        $user = $this->auth->requireUser('create a space');
 
         $data->setCreatedBy($user);
         $data->setIsPersonal(false);

--- a/api/src/State/TagOwnerProcessor.php
+++ b/api/src/State/TagOwnerProcessor.php
@@ -5,10 +5,8 @@ namespace App\State;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\Entity\Tag;
-use App\Entity\User;
-use Symfony\Bundle\SecurityBundle\Security;
+use App\Security\AuthenticatedUserResolver;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 /**
  * Sets the owner of a new Tag to the currently authenticated user. Mirrors
@@ -24,7 +22,7 @@ final class TagOwnerProcessor implements ProcessorInterface
     public function __construct(
         #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
         private ProcessorInterface $persistProcessor,
-        private Security $security,
+        private AuthenticatedUserResolver $auth,
     ) {
     }
 
@@ -33,10 +31,7 @@ final class TagOwnerProcessor implements ProcessorInterface
      */
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Tag
     {
-        $user = $this->security->getUser();
-        if (!$user instanceof User) {
-            throw new UnauthorizedHttpException('Bearer', 'You must be authenticated to create a tag.');
-        }
+        $user = $this->auth->requireUser('create a tag');
 
         $data->setOwner($user);
 

--- a/api/src/State/TaskOwnerProcessor.php
+++ b/api/src/State/TaskOwnerProcessor.php
@@ -5,12 +5,10 @@ namespace App\State;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\Entity\Task;
-use App\Entity\User;
 use App\Repository\TaskRepository;
+use App\Security\AuthenticatedUserResolver;
 use App\Service\TaskActivityNotifier;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 /**
  * Sets the owner of a new Task to the currently authenticated user and
@@ -28,7 +26,7 @@ final class TaskOwnerProcessor implements ProcessorInterface
     public function __construct(
         #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
         private ProcessorInterface $persistProcessor,
-        private Security $security,
+        private AuthenticatedUserResolver $auth,
         private TaskRepository $tasks,
         private TaskActivityNotifier $activity,
     ) {
@@ -39,10 +37,7 @@ final class TaskOwnerProcessor implements ProcessorInterface
      */
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Task
     {
-        $user = $this->security->getUser();
-        if (!$user instanceof User) {
-            throw new UnauthorizedHttpException('Bearer', 'You must be authenticated to create a task.');
-        }
+        $user = $this->auth->requireUser('create a task');
 
         $data->setOwner($user);
 

--- a/api/src/State/UserGroupOwnerProcessor.php
+++ b/api/src/State/UserGroupOwnerProcessor.php
@@ -4,12 +4,10 @@ namespace App\State;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
-use App\Entity\User;
 use App\Entity\UserGroup;
 use App\Repository\UserGroupRepository;
-use Symfony\Bundle\SecurityBundle\Security;
+use App\Security\AuthenticatedUserResolver;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 /**
  * Stamps the creator as owner of a new UserGroup, adds them to the
@@ -27,7 +25,7 @@ final class UserGroupOwnerProcessor implements ProcessorInterface
     public function __construct(
         #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
         private ProcessorInterface $persistProcessor,
-        private Security $security,
+        private AuthenticatedUserResolver $auth,
         private UserGroupRepository $userGroupRepository,
     ) {
     }
@@ -37,10 +35,7 @@ final class UserGroupOwnerProcessor implements ProcessorInterface
      */
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): UserGroup
     {
-        $user = $this->security->getUser();
-        if (!$user instanceof User) {
-            throw new UnauthorizedHttpException('Bearer', 'You must be authenticated to create a group.');
-        }
+        $user = $this->auth->requireUser('create a group');
 
         $data->setOwner($user);
         $data->addMember($user);

--- a/pwa/pages/pages/[pageId].tsx
+++ b/pwa/pages/pages/[pageId].tsx
@@ -8,6 +8,8 @@ import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
 import { ENTRYPOINT } from "@/config/entrypoint";
 import { signinHrefForCurrent } from "@/lib/authRedirect";
 import { displayName } from "@/lib/userDisplay";
+import { formatRelative } from "@/lib/relativeTime";
+import { apiErrorMessage, readCollection } from "@/lib/apiClient";
 import MarkdownEditor from "@/components/editor/MarkdownEditor";
 import MarkdownView from "@/components/editor/MarkdownView";
 import UserAvatar, { type AvatarUser } from "@/components/user/UserAvatar";
@@ -48,36 +50,6 @@ interface ChildPage {
   id: string;
   title: string;
 }
-
-interface Collection<T> {
-  member?: T[];
-  "hydra:member"?: T[];
-}
-
-const RELATIVE = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
-const formatRelative = (iso: string): string => {
-  const ts = new Date(iso).getTime();
-  if (Number.isNaN(ts)) return "";
-  const diffSec = Math.round((ts - Date.now()) / 1000);
-  const abs = Math.abs(diffSec);
-  if (abs < 60) return RELATIVE.format(diffSec, "second");
-  if (abs < 3600) return RELATIVE.format(Math.round(diffSec / 60), "minute");
-  if (abs < 86400) return RELATIVE.format(Math.round(diffSec / 3600), "hour");
-  if (abs < 2592000) return RELATIVE.format(Math.round(diffSec / 86400), "day");
-  if (abs < 31536000)
-    return RELATIVE.format(Math.round(diffSec / 2592000), "month");
-  return RELATIVE.format(Math.round(diffSec / 31536000), "year");
-};
-
-const errorMessage = async (res: Response): Promise<string> => {
-  const data = await res.json().catch(() => ({}));
-  return (
-    data.detail ||
-    data.description ||
-    data["hydra:description"] ||
-    "Request failed."
-  );
-};
 
 const PageDetailView = () => {
   const { user, isAuthenticated, isLoading: authLoading } = useAuth();
@@ -155,12 +127,10 @@ const PageDetailView = () => {
         ),
       ]);
       if (childrenRes.ok) {
-        const collection: Collection<ChildPage> = await childrenRes.json();
-        setChildren(collection.member ?? collection["hydra:member"] ?? []);
+        setChildren(readCollection<ChildPage>(await childrenRes.json()));
       }
       if (commentsRes.ok) {
-        const collection: Collection<PageCommentRow> = await commentsRes.json();
-        setComments(collection.member ?? collection["hydra:member"] ?? []);
+        setComments(readCollection<PageCommentRow>(await commentsRes.json()));
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load.");
@@ -211,7 +181,7 @@ const PageDetailView = () => {
         body: JSON.stringify({ title: editTitle.trim(), body: editBody }),
       });
       if (!res.ok) {
-        throw new Error(await errorMessage(res));
+        throw new Error(await apiErrorMessage(res, "Request failed."));
       }
       setEditing(false);
       await load();
@@ -238,7 +208,7 @@ const PageDetailView = () => {
         credentials: "include",
       });
       if (!res.ok) {
-        throw new Error(await errorMessage(res));
+        throw new Error(await apiErrorMessage(res, "Request failed."));
       }
       await router.push("/pages");
     } catch (err) {
@@ -256,7 +226,7 @@ const PageDetailView = () => {
       headers: { "Content-Type": "application/ld+json" },
       body: JSON.stringify({ page: page["@id"], body }),
     });
-    if (!res.ok) throw new Error(await errorMessage(res));
+    if (!res.ok) throw new Error(await apiErrorMessage(res, "Request failed."));
     const created: PageCommentRow = await res.json();
     // Optimistic insert; the Mercure echo of this POST may also
     // arrive and tries to add the same IRI — dedupe defensively.
@@ -277,7 +247,7 @@ const PageDetailView = () => {
       headers: { "Content-Type": "application/merge-patch+json" },
       body: JSON.stringify({ body }),
     });
-    if (!res.ok) throw new Error(await errorMessage(res));
+    if (!res.ok) throw new Error(await apiErrorMessage(res, "Request failed."));
     const updated: PageCommentRow = await res.json();
     setComments((prev) =>
       prev.map((c) => (c["@id"] === updated["@id"] ? updated : c)),
@@ -292,7 +262,7 @@ const PageDetailView = () => {
       credentials: "include",
     });
     if (!res.ok) {
-      throw new Error(await errorMessage(res));
+      throw new Error(await apiErrorMessage(res, "Request failed."));
     }
     setComments((prev) => prev.filter((c) => c["@id"] !== comment["@id"]));
   };


### PR DESCRIPTION
## Description

Removes copy-paste duplication across the API (and one PWA page) by extracting shared logic into **injectable collaborator services** — composition, not inheritance or traits. No behaviour change.

Three new services replace duplication that was spread across many files:

| Service | Owns | Replaces duplication in |
|---|---|---|
| `App\Service\Mail\MailDispatcher` | `MailerInterface` + `MAILER_FROM` fallback + frontend-URL building; `send()` auto-stamps the From | 6 mailers (Space/Account export, Waitlist access/joined, Invite, 2FA recovery) |
| `App\Service\Export\ExportArchiveWriter` | `media.storage` + `addJson`/`addAttachment`/`removeDir`/`attachmentFileName` zip primitives | `SpaceExportBuilder`, `AccountExportBuilder` (had them verbatim) |
| `App\Security\AuthenticatedUserResolver` | `Security` + `requireUser(action): User` (401 on miss) | 10 owner/author creation processors |

The PWA change drops `pages/[pageId].tsx`'s inline re-implementations of `formatRelative`, the Hydra collection unwrap, and an `errorMessage` helper in favour of the existing `lib` helpers (`relativeTime.formatRelative`, `apiClient.readCollection`, `apiClient.apiErrorMessage`).

### Why

These patterns were copy-pasted across the codebase (e.g. every mailer repeated the `MAILER_FROM` fallback + `rtrim($frontendUrl)`; both export builders held ~150 identical lines; 10 processors repeated the same `getUser()` + `instanceof User` guard). Centralising them removes ~90 net lines and gives each behaviour a single home.

### Design note

Done as **composition over inheritance** per reviewer preference: consumers inject the collaborator (visible, individually mockable dependency) rather than extending a base class or mixing in a trait with an implicit `$this->property` contract. Two bonuses fell out: `MailDispatcher.send()` auto-stamps the From so mailers stopped repeating `->from(...)`, and the builders dropped their own `media.storage` dependency (the writer owns it).

`ApiTokenCreateProcessor` was intentionally **not** migrated to the resolver — it throws `AccessDeniedHttpException`, not the resolver's `UnauthorizedHttpException` 401.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor (no functional change)

## Component

- [x] API (PHP/Symfony)
- [x] PWA (Next.js)

## How Has This Been Tested?

No functional change — exception messages, From addresses, and export archive layout are preserved byte-for-byte. Relies on existing CI (PHPStan level 10 + strict rules, PHPCS, PWA typecheck, PHPUnit, E2E). No local PHP/Node toolchain was available in this environment, so local runs were not performed.

## Checklist

- [x] My code follows the project's conventions
- [ ] I have added tests that prove my fix or feature works
- [ ] New and existing tests pass locally
- [x] I have updated documentation if needed (no doc changes required — internal refactor)
