### PR TITLE
feat(api): expand MCP tools for spaces, pages, tags, custom fields, discussions

### DIFF
--- a/api/src/Mcp/McpAuthorization.php
+++ b/api/src/Mcp/McpAuthorization.php
@@ -2,6 +2,8 @@
 
 namespace App\Mcp;
 
+use App\Entity\Discussion;
+use App\Entity\Page;
 use App\Entity\Project;
 use App\Entity\Task;
 use App\Entity\User;
@@ -49,5 +51,36 @@ final class McpAuthorization
     public function isProjectMember(Project $project, User $user): bool
     {
         return $project->isAccessibleBy($user);
+    }
+
+    /**
+     * Pages read like the rest of their space: any space member can view
+     * (#183/#185). Mirrors the Page `Get` security expression.
+     */
+    public function canReadPage(Page $page, User $user): bool
+    {
+        return true === $page->getSpace()?->hasMember($user);
+    }
+
+    /**
+     * Page edit/delete: the author OR a space admin. Mirrors the Page
+     * `Patch`/`Delete` expressions. UUID comparison so the check holds
+     * after an EntityManager::clear().
+     */
+    public function canEditPage(Page $page, User $user): bool
+    {
+        if (true === $page->getCreatedBy()?->getId()?->equals($user->getId())) {
+            return true;
+        }
+        return true === $page->getSpace()?->isAdmin($user);
+    }
+
+    /**
+     * Discussions read like the rest of their space: any space member
+     * can browse (#91/#185). Mirrors the Discussion `Get` expression.
+     */
+    public function canReadDiscussion(Discussion $discussion, User $user): bool
+    {
+        return true === $discussion->getSpace()?->hasMember($user);
     }
 }

--- a/api/src/Mcp/McpEntitySerializer.php
+++ b/api/src/Mcp/McpEntitySerializer.php
@@ -4,8 +4,12 @@ namespace App\Mcp;
 
 use App\Entity\Comment;
 use App\Entity\CustomFieldDefinition;
+use App\Entity\CustomFieldValue;
+use App\Entity\Discussion;
 use App\Entity\MediaObject;
+use App\Entity\Page;
 use App\Entity\Project;
+use App\Entity\Space;
 use App\Entity\Tag;
 use App\Entity\Task;
 use App\Entity\User;
@@ -49,6 +53,14 @@ final class McpEntitySerializer
                 fn (MediaObject $m) => $this->mediaObject($m),
                 $task->getAttachments()->toArray(),
             ),
+            'customFieldValues' => array_map(
+                fn (CustomFieldValue $v) => [
+                    'definitionId' => null === $v->getDefinition() ? null : (string) $v->getDefinition()->getId(),
+                    'name' => $v->getDefinition()?->getName(),
+                    'value' => $v->getValue(),
+                ],
+                $task->getCustomFieldValues()->toArray(),
+            ),
         ];
     }
 
@@ -74,6 +86,78 @@ final class McpEntitySerializer
             ),
             'taskCount' => $taskCount,
             'openTaskCount' => $openTaskCount,
+        ];
+    }
+
+    /**
+     * Space summary. `role` is the viewer's relationship to the space —
+     * `admin` when they hold the admin membership, otherwise `member` —
+     * so the model knows whether it can manage members / delete content.
+     *
+     * @return array<string, mixed>
+     */
+    public function space(Space $space, User $viewer): array
+    {
+        return [
+            'id' => (string) $space->getId(),
+            'name' => $space->getName(),
+            'description' => $space->getDescription(),
+            'isPersonal' => $space->getIsPersonal(),
+            'visibility' => $space->getVisibility(),
+            'role' => $space->isAdmin($viewer) ? Space::ROLE_ADMIN : Space::ROLE_MEMBER,
+            'projectCount' => $space->getProjectsCount(),
+            'pageCount' => $space->getPagesCount(),
+            'createdOn' => $space->getCreatedAt()->format(\DateTimeInterface::ATOM),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function page(Page $page): array
+    {
+        return [
+            'id' => (string) $page->getId(),
+            'title' => $page->getTitle(),
+            'body' => $page->getBody(),
+            'spaceId' => null === $page->getSpace() ? null : (string) $page->getSpace()->getId(),
+            'parentId' => null === $page->getParent() ? null : (string) $page->getParent()->getId(),
+            'position' => $page->getPosition(),
+            'createdBy' => $this->userSummary($page->getCreatedBy()),
+            'createdOn' => $page->getCreatedAt()->format(\DateTimeInterface::ATOM),
+            'updatedOn' => $page->getUpdatedAt()?->format(\DateTimeInterface::ATOM),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function tag(Tag $tag): array
+    {
+        return [
+            'id' => (string) $tag->getId(),
+            'title' => $tag->getTitle(),
+            'color' => $tag->getColor(),
+            'description' => $tag->getDescription(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function discussion(Discussion $discussion): array
+    {
+        return [
+            'id' => (string) $discussion->getId(),
+            'title' => $discussion->getTitle(),
+            'body' => $discussion->getBody(),
+            'category' => $discussion->getCategory(),
+            'isPinned' => $discussion->getIsPinned(),
+            'isLocked' => $discussion->getIsLocked(),
+            'spaceId' => null === $discussion->getSpace() ? null : (string) $discussion->getSpace()->getId(),
+            'author' => $this->userSummary($discussion->getAuthor()),
+            'createdOn' => $discussion->getCreatedAt()->format(\DateTimeInterface::ATOM),
+            'updatedOn' => $discussion->getUpdatedAt()?->format(\DateTimeInterface::ATOM),
         ];
     }
 

--- a/api/src/Mcp/McpSpaceResolver.php
+++ b/api/src/Mcp/McpSpaceResolver.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Mcp;
+
+use App\Entity\Space;
+use App\Entity\User;
+use App\Repository\SpaceRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Resolves the {@see Space} a tool call should write into.
+ *
+ * Spaces gate every higher-level content type (pages, discussions,
+ * projects), but the existing PWA — and most quick "just jot this down"
+ * tool calls — don't supply one. So the rule mirrors the REST default:
+ * an omitted space falls back to the caller's personal space (where
+ * they're always an admin), and an explicit space id must be one the
+ * caller belongs to (404 otherwise, matching the access-extension
+ * existence-hiding shape used everywhere else).
+ */
+final class McpSpaceResolver
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private SpaceRepository $spaces,
+        private McpInputHelper $input,
+    ) {
+    }
+
+    /**
+     * The caller's personal "Private" space. Every account provisioned
+     * through signup has one; the 404 only fires for synthetic users
+     * created outside the normal flow.
+     */
+    public function personalSpace(User $user): Space
+    {
+        $space = $this->spaces->findPersonalSpaceFor($user);
+        if (!$space instanceof Space) {
+            throw new McpException('No personal space found for this account.', 404);
+        }
+        return $space;
+    }
+
+    /**
+     * Resolve an explicit space id the caller must be a member of, or
+     * null when none was supplied (so callers can decide their own
+     * default). Returns 404 for a space the caller can't see.
+     */
+    public function resolveMemberSpaceOrNull(mixed $rawSpaceId, User $user): ?Space
+    {
+        if (null === $rawSpaceId) {
+            return null;
+        }
+        $id = $this->input->requireUuid('spaceId', $rawSpaceId);
+        $space = $this->em->getRepository(Space::class)->find($id);
+        if (!$space instanceof Space || !$space->hasMember($user)) {
+            throw McpException::notFound(sprintf('Space %s', $id));
+        }
+        return $space;
+    }
+
+    /**
+     * Resolve the space to write into, defaulting to the personal space
+     * when the caller omits one.
+     */
+    public function resolveMemberSpace(mixed $rawSpaceId, User $user): Space
+    {
+        return $this->resolveMemberSpaceOrNull($rawSpaceId, $user) ?? $this->personalSpace($user);
+    }
+}

--- a/api/src/Mcp/McpToolPolicy.php
+++ b/api/src/Mcp/McpToolPolicy.php
@@ -43,6 +43,24 @@ final class McpToolPolicy
         'create_project' => ['category' => 'projects', 'write' => true],
         'update_project' => ['category' => 'projects', 'write' => true],
         'delete_project' => ['category' => 'projects', 'write' => true],
+        // spaces — no dedicated AccessPolicy category; spaces are the
+        // container for projects, so listing them rides the projects
+        // read scope (it's read-only metadata either way).
+        'list_spaces' => ['category' => 'projects', 'write' => false],
+        // pages
+        'list_pages' => ['category' => 'pages', 'write' => false],
+        'get_page' => ['category' => 'pages', 'write' => false],
+        'create_page' => ['category' => 'pages', 'write' => true],
+        'update_page' => ['category' => 'pages', 'write' => true],
+        'delete_page' => ['category' => 'pages', 'write' => true],
+        // discussions
+        'list_discussions' => ['category' => 'discussions', 'write' => false],
+        'get_discussion' => ['category' => 'discussions', 'write' => false],
+        'create_discussion' => ['category' => 'discussions', 'write' => true],
+        // tags — no dedicated category; tags are a task-tagging concern,
+        // so they ride the tasks scope.
+        'list_tags' => ['category' => 'tasks', 'write' => false],
+        'create_tag' => ['category' => 'tasks', 'write' => true],
     ];
 
     /** @return array{category: string, write: bool}|null */

--- a/api/src/Mcp/McpToolPolicy.php
+++ b/api/src/Mcp/McpToolPolicy.php
@@ -29,9 +29,13 @@ final class McpToolPolicy
         'delete_task' => ['category' => 'tasks', 'write' => true],
         'assign_task' => ['category' => 'tasks', 'write' => true],
         'unassign_task' => ['category' => 'tasks', 'write' => true],
-        // comments (task comments)
+        // comments (task / page / discussion comments share one category)
         'list_task_comments' => ['category' => 'comments', 'write' => false],
         'add_task_comment' => ['category' => 'comments', 'write' => true],
+        'list_page_comments' => ['category' => 'comments', 'write' => false],
+        'add_page_comment' => ['category' => 'comments', 'write' => true],
+        'list_discussion_comments' => ['category' => 'comments', 'write' => false],
+        'add_discussion_comment' => ['category' => 'comments', 'write' => true],
         // files (attachments)
         'list_files' => ['category' => 'files', 'write' => false],
         'download_file' => ['category' => 'files', 'write' => false],

--- a/api/src/Mcp/Tool/AddDiscussionCommentTool.php
+++ b/api/src/Mcp/Tool/AddDiscussionCommentTool.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Comment;
+use App\Entity\Discussion;
+use App\Entity\User;
+use App\Mcp\McpAuthorization;
+use App\Mcp\McpEntitySerializer;
+use App\Mcp\McpException;
+use App\Mcp\McpInputHelper;
+use App\Service\CommentMentionService;
+use Doctrine\ORM\EntityManagerInterface;
+
+final class AddDiscussionCommentTool implements McpToolInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private McpAuthorization $authz,
+        private McpEntitySerializer $serializer,
+        private McpInputHelper $input,
+        private CommentMentionService $mentions,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'add_discussion_comment';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Reply to a discussion thread with a Markdown comment. Threads are flat, ordered chronologically. @mentions notify space members. Locked threads reject new comments.';
+    }
+
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'discussionId' => ['type' => 'string'],
+                'body' => ['type' => 'string', 'description' => 'Markdown body (max 50000 chars).'],
+            ],
+            'required' => ['discussionId', 'body'],
+            'additionalProperties' => false,
+        ];
+    }
+
+    public function invoke(array $arguments, User $user): array
+    {
+        $discussionId = $this->input->requireUuid('discussionId', $arguments['discussionId'] ?? null);
+        $body = $this->input->requireString($arguments, 'body');
+
+        $discussion = $this->em->getRepository(Discussion::class)->find($discussionId);
+        if (null === $discussion || !$this->authz->canReadDiscussion($discussion, $user)) {
+            throw McpException::notFound(sprintf('Discussion %s', $discussionId));
+        }
+
+        $comment = new Comment();
+        $comment->setDiscussion($discussion);
+        $comment->setAuthor($user);
+        $comment->setBody($body);
+
+        // assertValid enforces Comment::validateNotLocked — a locked thread
+        // rejects new comments here just like the REST POST /comments path.
+        $this->input->assertValid($comment);
+        $this->em->persist($comment);
+        $this->em->flush();
+
+        $this->mentions->dispatchMentions($comment);
+
+        return $this->serializer->comment($comment);
+    }
+}

--- a/api/src/Mcp/Tool/AddPageCommentTool.php
+++ b/api/src/Mcp/Tool/AddPageCommentTool.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Comment;
+use App\Entity\Page;
+use App\Entity\User;
+use App\Mcp\McpAuthorization;
+use App\Mcp\McpEntitySerializer;
+use App\Mcp\McpException;
+use App\Mcp\McpInputHelper;
+use App\Service\CommentMentionService;
+use Doctrine\ORM\EntityManagerInterface;
+
+final class AddPageCommentTool implements McpToolInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private McpAuthorization $authz,
+        private McpEntitySerializer $serializer,
+        private McpInputHelper $input,
+        private CommentMentionService $mentions,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'add_page_comment';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Add a Markdown comment to a page. Threads are flat — every comment is a top-level entry, ordered chronologically. @mentions notify space members.';
+    }
+
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'pageId' => ['type' => 'string'],
+                'body' => ['type' => 'string', 'description' => 'Markdown body (max 50000 chars).'],
+            ],
+            'required' => ['pageId', 'body'],
+            'additionalProperties' => false,
+        ];
+    }
+
+    public function invoke(array $arguments, User $user): array
+    {
+        $pageId = $this->input->requireUuid('pageId', $arguments['pageId'] ?? null);
+        $body = $this->input->requireString($arguments, 'body');
+
+        $page = $this->em->getRepository(Page::class)->find($pageId);
+        if (null === $page || !$this->authz->canReadPage($page, $user)) {
+            throw McpException::notFound(sprintf('Page %s', $pageId));
+        }
+
+        $comment = new Comment();
+        $comment->setPage($page);
+        $comment->setAuthor($user);
+        $comment->setBody($body);
+
+        $this->input->assertValid($comment);
+        $this->em->persist($comment);
+        $this->em->flush();
+
+        // `@mention` tokens fire notifications post-persist — same path as
+        // the HTTP `POST /comments` flow.
+        $this->mentions->dispatchMentions($comment);
+
+        return $this->serializer->comment($comment);
+    }
+}

--- a/api/src/Mcp/Tool/CreateDiscussionTool.php
+++ b/api/src/Mcp/Tool/CreateDiscussionTool.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Discussion;
+use App\Entity\User;
+use App\Mcp\McpEntitySerializer;
+use App\Mcp\McpException;
+use App\Mcp\McpInputHelper;
+use App\Mcp\McpSpaceResolver;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Starts a discussion thread in a space (#91/#185). The author is
+ * stamped server-side; category defaults to "general".
+ */
+final class CreateDiscussionTool implements McpToolInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private McpEntitySerializer $serializer,
+        private McpInputHelper $input,
+        private McpSpaceResolver $spaces,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'create_discussion';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Start a discussion thread in a space. Pass a spaceId (from list_spaces) for a shared space, or omit it for your personal space. Category is one of: general, ideas, announcements, q-and-a (default general).';
+    }
+
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'title' => ['type' => 'string', 'description' => 'Thread title (required).'],
+                'body' => ['type' => 'string', 'description' => 'Markdown body (required).'],
+                'category' => [
+                    'type' => 'string',
+                    'enum' => Discussion::ALLOWED_CATEGORIES,
+                    'description' => 'Thread category (default general).',
+                ],
+                'spaceId' => ['type' => 'string', 'description' => 'UUID of a space the user belongs to. Omit for the personal space.'],
+            ],
+            'required' => ['title', 'body'],
+            'additionalProperties' => false,
+        ];
+    }
+
+    public function invoke(array $arguments, User $user): array
+    {
+        $title = $this->input->requireString($arguments, 'title');
+        $body = $this->input->requireString($arguments, 'body');
+        $space = $this->spaces->resolveMemberSpace($arguments['spaceId'] ?? null, $user);
+
+        $discussion = new Discussion();
+        $discussion->setAuthor($user);
+        $discussion->setSpace($space);
+        $discussion->setTitle($title);
+        $discussion->setBody($body);
+
+        $category = $this->input->optionalString($arguments, 'category');
+        if (null !== $category) {
+            if (!in_array($category, Discussion::ALLOWED_CATEGORIES, true)) {
+                throw McpException::invalidInput('category must be one of: ' . implode(', ', Discussion::ALLOWED_CATEGORIES) . '.');
+            }
+            $discussion->setCategory($category);
+        }
+
+        $this->input->assertValid($discussion);
+        $this->em->persist($discussion);
+        $this->em->flush();
+
+        return $this->serializer->discussion($discussion);
+    }
+}

--- a/api/src/Mcp/Tool/CreatePageTool.php
+++ b/api/src/Mcp/Tool/CreatePageTool.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Page;
+use App\Entity\User;
+use App\Mcp\McpAuthorization;
+use App\Mcp\McpEntitySerializer;
+use App\Mcp\McpException;
+use App\Mcp\McpInputHelper;
+use App\Mcp\McpSpaceResolver;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Creates a long-form, Notion-style page in a space (#183). The author
+ * is stamped server-side; pass a parentId to nest it under another page.
+ */
+final class CreatePageTool implements McpToolInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private McpAuthorization $authz,
+        private McpEntitySerializer $serializer,
+        private McpInputHelper $input,
+        private McpSpaceResolver $spaces,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'create_page';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Create a long-form Markdown page (Notion-style doc) in a space. Pass a spaceId (from list_spaces) for a shared space, or omit it for your personal space. Pass a parentId to nest it under an existing page in the same space.';
+    }
+
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'title' => ['type' => 'string', 'description' => 'Page title (required).'],
+                'body' => ['type' => 'string', 'description' => 'Markdown body.'],
+                'spaceId' => ['type' => 'string', 'description' => 'UUID of a space the user belongs to. Omit for the personal space.'],
+                'parentId' => ['type' => 'string', 'description' => 'UUID of a parent page in the same space, to nest this one beneath it.'],
+                'position' => ['type' => 'integer', 'minimum' => 0, 'description' => 'Sort key within the parent (default 0).'],
+            ],
+            'required' => ['title'],
+            'additionalProperties' => false,
+        ];
+    }
+
+    public function invoke(array $arguments, User $user): array
+    {
+        $title = $this->input->requireString($arguments, 'title');
+        $body = $this->input->optionalString($arguments, 'body');
+        $position = $this->input->optionalInt($arguments, 'position');
+        $space = $this->spaces->resolveMemberSpace($arguments['spaceId'] ?? null, $user);
+
+        $page = new Page();
+        $page->setCreatedBy($user);
+        $page->setSpace($space);
+        $page->setTitle($title);
+        if (null !== $body) {
+            $page->setBody($body);
+        }
+        if (null !== $position) {
+            $page->setPosition($position);
+        }
+
+        $parentId = $this->input->optionalUuid('parentId', $arguments['parentId'] ?? null);
+        if (null !== $parentId) {
+            $parent = $this->em->getRepository(Page::class)->find($parentId);
+            if (null === $parent || !$this->authz->canReadPage($parent, $user)) {
+                throw McpException::notFound(sprintf('Page %s', $parentId));
+            }
+            if ($parent->getSpace()?->getId()?->equals($space->getId()) !== true) {
+                throw McpException::invalidInput('The parent page must be in the same space.');
+            }
+            $page->setParent($parent);
+        }
+
+        $this->input->assertValid($page);
+        $this->em->persist($page);
+        $this->em->flush();
+
+        return $this->serializer->page($page);
+    }
+}

--- a/api/src/Mcp/Tool/CreateProjectTool.php
+++ b/api/src/Mcp/Tool/CreateProjectTool.php
@@ -6,6 +6,7 @@ use App\Entity\Project;
 use App\Entity\User;
 use App\Mcp\McpEntitySerializer;
 use App\Mcp\McpInputHelper;
+use App\Mcp\McpSpaceResolver;
 use Doctrine\ORM\EntityManagerInterface;
 
 final class CreateProjectTool implements McpToolInterface
@@ -14,6 +15,7 @@ final class CreateProjectTool implements McpToolInterface
         private EntityManagerInterface $em,
         private McpEntitySerializer $serializer,
         private McpInputHelper $input,
+        private McpSpaceResolver $spaces,
     ) {
     }
 
@@ -24,7 +26,7 @@ final class CreateProjectTool implements McpToolInterface
 
     public function getDescription(): string
     {
-        return 'Create a new shared project. The authenticated user becomes the owner and the only initial member; add more members via the project settings UI or future tools.';
+        return 'Create a new project. The authenticated user becomes the owner. Pass a spaceId (from list_spaces) to create it in a shared space; omit it to use your personal space. Members come from the space, not the project.';
     }
 
     public function getInputSchema(): array
@@ -34,6 +36,7 @@ final class CreateProjectTool implements McpToolInterface
             'properties' => [
                 'title' => ['type' => 'string', 'description' => 'Project title (required).'],
                 'description' => ['type' => 'string', 'description' => 'Optional Markdown description.'],
+                'spaceId' => ['type' => 'string', 'description' => 'UUID of a space the user belongs to. Omit for the personal space.'],
             ],
             'required' => ['title'],
             'additionalProperties' => false,
@@ -44,13 +47,16 @@ final class CreateProjectTool implements McpToolInterface
     {
         $title = $this->input->requireString($arguments, 'title');
         $description = $this->input->optionalString($arguments, 'description');
+        // An explicit space must be one the caller belongs to; omitted
+        // leaves space null so ProjectSpaceDefaultListener defaults it to
+        // the caller's personal space (where they're admin) at persist.
+        $space = $this->spaces->resolveMemberSpaceOrNull($arguments['spaceId'] ?? null, $user);
 
         $project = new Project();
         $project->setOwner($user);
-        // Space defaults to the caller's personal space via
-        // ProjectSpaceDefaultListener at PrePersist (#185), where they
-        // already hold the admin role. No project-local member set
-        // exists anymore.
+        if (null !== $space) {
+            $project->setSpace($space);
+        }
         $project->setTitle($title);
         if (null !== $description) {
             $project->setDescription($description);

--- a/api/src/Mcp/Tool/CreateTagTool.php
+++ b/api/src/Mcp/Tool/CreateTagTool.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Tag;
+use App\Entity\User;
+use App\Mcp\McpEntitySerializer;
+use App\Mcp\McpInputHelper;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Creates a tag owned by the caller, mirroring the REST `Post` +
+ * TagOwnerProcessor (owner is stamped server-side).
+ */
+final class CreateTagTool implements McpToolInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private McpEntitySerializer $serializer,
+        private McpInputHelper $input,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'create_tag';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Create a tag owned by the authenticated user. Color is a #RRGGBB hex (defaults to grey).';
+    }
+
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'title' => ['type' => 'string', 'description' => 'Tag label (required).'],
+                'color' => ['type' => 'string', 'description' => 'Hex color like #22c55e. Defaults to #6b7280.'],
+                'description' => ['type' => 'string', 'description' => 'Optional note.'],
+            ],
+            'required' => ['title'],
+            'additionalProperties' => false,
+        ];
+    }
+
+    public function invoke(array $arguments, User $user): array
+    {
+        $tag = new Tag();
+        $tag->setOwner($user);
+        $tag->setTitle($this->input->requireString($arguments, 'title'));
+        $color = $this->input->optionalString($arguments, 'color');
+        if (null !== $color) {
+            $tag->setColor($color);
+        }
+        $description = $this->input->optionalString($arguments, 'description');
+        if (null !== $description) {
+            $tag->setDescription($description);
+        }
+
+        $this->input->assertValid($tag);
+        $this->em->persist($tag);
+        $this->em->flush();
+
+        return $this->serializer->tag($tag);
+    }
+}

--- a/api/src/Mcp/Tool/DeletePageTool.php
+++ b/api/src/Mcp/Tool/DeletePageTool.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Page;
+use App\Entity\User;
+use App\Mcp\McpAuthorization;
+use App\Mcp\McpException;
+use App\Mcp\McpInputHelper;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Deletes a page. Author or space admin only. Descendants cascade away
+ * via the self-FK `ON DELETE CASCADE`, matching the REST `Delete`.
+ */
+final class DeletePageTool implements McpToolInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private McpAuthorization $authz,
+        private McpInputHelper $input,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'delete_page';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Delete a page by id. Deletes its sub-pages too. Allowed for the page author or a space admin.';
+    }
+
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'pageId' => ['type' => 'string', 'description' => 'UUID of the page.'],
+            ],
+            'required' => ['pageId'],
+            'additionalProperties' => false,
+        ];
+    }
+
+    public function invoke(array $arguments, User $user): array
+    {
+        $pageId = $this->input->requireUuid('pageId', $arguments['pageId'] ?? null);
+        $page = $this->em->getRepository(Page::class)->find($pageId);
+        if (null === $page || !$this->authz->canReadPage($page, $user)) {
+            throw McpException::notFound(sprintf('Page %s', $pageId));
+        }
+        if (!$this->authz->canEditPage($page, $user)) {
+            throw McpException::forbidden('Only the page author or a space admin can delete this page.');
+        }
+
+        $this->em->remove($page);
+        $this->em->flush();
+
+        return ['deleted' => true, 'id' => (string) $pageId];
+    }
+}

--- a/api/src/Mcp/Tool/GetDiscussionTool.php
+++ b/api/src/Mcp/Tool/GetDiscussionTool.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Discussion;
+use App\Entity\User;
+use App\Mcp\McpAuthorization;
+use App\Mcp\McpEntitySerializer;
+use App\Mcp\McpException;
+use App\Mcp\McpInputHelper;
+use Doctrine\ORM\EntityManagerInterface;
+
+final class GetDiscussionTool implements McpToolInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private McpAuthorization $authz,
+        private McpEntitySerializer $serializer,
+        private McpInputHelper $input,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'get_discussion';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Fetch one discussion thread by id. Returns 404 when the user is not a member of the discussion\'s space.';
+    }
+
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'discussionId' => ['type' => 'string', 'description' => 'UUID of the discussion.'],
+            ],
+            'required' => ['discussionId'],
+            'additionalProperties' => false,
+        ];
+    }
+
+    public function invoke(array $arguments, User $user): array
+    {
+        $discussionId = $this->input->requireUuid('discussionId', $arguments['discussionId'] ?? null);
+        $discussion = $this->em->getRepository(Discussion::class)->find($discussionId);
+        if (null === $discussion || !$this->authz->canReadDiscussion($discussion, $user)) {
+            throw McpException::notFound(sprintf('Discussion %s', $discussionId));
+        }
+
+        return $this->serializer->discussion($discussion);
+    }
+}

--- a/api/src/Mcp/Tool/GetPageTool.php
+++ b/api/src/Mcp/Tool/GetPageTool.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Page;
+use App\Entity\User;
+use App\Mcp\McpAuthorization;
+use App\Mcp\McpEntitySerializer;
+use App\Mcp\McpException;
+use App\Mcp\McpInputHelper;
+use Doctrine\ORM\EntityManagerInterface;
+
+final class GetPageTool implements McpToolInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private McpAuthorization $authz,
+        private McpEntitySerializer $serializer,
+        private McpInputHelper $input,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'get_page';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Fetch one page by id, including its full Markdown body. Returns 404 when the user is not a member of the page\'s space.';
+    }
+
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'pageId' => ['type' => 'string', 'description' => 'UUID of the page.'],
+            ],
+            'required' => ['pageId'],
+            'additionalProperties' => false,
+        ];
+    }
+
+    public function invoke(array $arguments, User $user): array
+    {
+        $pageId = $this->input->requireUuid('pageId', $arguments['pageId'] ?? null);
+        $page = $this->em->getRepository(Page::class)->find($pageId);
+        if (null === $page || !$this->authz->canReadPage($page, $user)) {
+            throw McpException::notFound(sprintf('Page %s', $pageId));
+        }
+
+        return $this->serializer->page($page);
+    }
+}

--- a/api/src/Mcp/Tool/ListDiscussionCommentsTool.php
+++ b/api/src/Mcp/Tool/ListDiscussionCommentsTool.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Comment;
+use App\Entity\Discussion;
+use App\Entity\User;
+use App\Mcp\McpAuthorization;
+use App\Mcp\McpEntitySerializer;
+use App\Mcp\McpException;
+use App\Mcp\McpInputHelper;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Pagination\Paginator;
+
+final class ListDiscussionCommentsTool implements McpToolInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private McpAuthorization $authz,
+        private McpEntitySerializer $serializer,
+        private McpInputHelper $input,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'list_discussion_comments';
+    }
+
+    public function getDescription(): string
+    {
+        return 'List replies on a discussion thread in chronological order, paginated. Comments are flat — no reply tree — and ordered by createdAt ascending.';
+    }
+
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'discussionId' => ['type' => 'string'],
+                'page' => ['type' => 'integer', 'minimum' => 1],
+                'limit' => ['type' => 'integer', 'minimum' => 1, 'maximum' => 100],
+            ],
+            'required' => ['discussionId'],
+            'additionalProperties' => false,
+        ];
+    }
+
+    public function invoke(array $arguments, User $user): array
+    {
+        $discussionId = $this->input->requireUuid('discussionId', $arguments['discussionId'] ?? null);
+        $discussion = $this->em->getRepository(Discussion::class)->find($discussionId);
+        if (null === $discussion || !$this->authz->canReadDiscussion($discussion, $user)) {
+            throw McpException::notFound(sprintf('Discussion %s', $discussionId));
+        }
+
+        ['page' => $page, 'limit' => $limit] = $this->input->pagination($arguments);
+
+        $qb = $this->em->getRepository(Comment::class)
+            ->createQueryBuilder('c')
+            ->where('c.discussion = :discussion')
+            ->setParameter('discussion', $discussion)
+            ->orderBy('c.createdAt', 'ASC')
+            ->setFirstResult(($page - 1) * $limit)
+            ->setMaxResults($limit);
+
+        $paginator = new Paginator($qb->getQuery(), fetchJoinCollection: false);
+        $items = [];
+        foreach ($paginator as $comment) {
+            /** @var Comment $comment */
+            $items[] = $this->serializer->comment($comment);
+        }
+
+        return [
+            'items' => $items,
+            'total' => count($paginator),
+            'page' => $page,
+            'limit' => $limit,
+        ];
+    }
+}

--- a/api/src/Mcp/Tool/ListDiscussionsTool.php
+++ b/api/src/Mcp/Tool/ListDiscussionsTool.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Mcp\Tool;
+
+use App\Doctrine\SpaceMembershipDql;
+use App\Entity\Discussion;
+use App\Entity\User;
+use App\Mcp\McpEntitySerializer;
+use App\Mcp\McpException;
+use App\Mcp\McpInputHelper;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Pagination\Paginator;
+
+/**
+ * Lists discussion threads the caller can see (scoped to their space
+ * memberships), pinned first then newest. Optional filters by space and
+ * category.
+ */
+final class ListDiscussionsTool implements McpToolInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private McpEntitySerializer $serializer,
+        private McpInputHelper $input,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'list_discussions';
+    }
+
+    public function getDescription(): string
+    {
+        return 'List discussion threads the user can access, pinned first then newest, paginated. Filter by spaceId or by category (general, ideas, announcements, q-and-a).';
+    }
+
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'spaceId' => ['type' => 'string', 'description' => 'Restrict to one space.'],
+                'category' => [
+                    'type' => 'string',
+                    'enum' => Discussion::ALLOWED_CATEGORIES,
+                    'description' => 'Restrict to one category.',
+                ],
+                'page' => ['type' => 'integer', 'minimum' => 1],
+                'limit' => ['type' => 'integer', 'minimum' => 1, 'maximum' => 100],
+            ],
+            'additionalProperties' => false,
+        ];
+    }
+
+    public function invoke(array $arguments, User $user): array
+    {
+        ['page' => $page, 'limit' => $limit] = $this->input->pagination($arguments);
+
+        $qb = $this->em->getRepository(Discussion::class)
+            ->createQueryBuilder('d')
+            ->where(SpaceMembershipDql::userBelongsToProjectSpace('d', 'discussion_list'))
+            ->setParameter('user', $user)
+            ->orderBy('d.isPinned', 'DESC')
+            ->addOrderBy('d.createdAt', 'DESC')
+            ->setFirstResult(($page - 1) * $limit)
+            ->setMaxResults($limit);
+
+        $spaceId = $this->input->optionalUuid('spaceId', $arguments['spaceId'] ?? null);
+        if (null !== $spaceId) {
+            $qb->andWhere('d.space = :spaceId')->setParameter('spaceId', $spaceId);
+        }
+        $category = $this->input->optionalString($arguments, 'category');
+        if (null !== $category) {
+            if (!in_array($category, Discussion::ALLOWED_CATEGORIES, true)) {
+                throw McpException::invalidInput('category must be one of: ' . implode(', ', Discussion::ALLOWED_CATEGORIES) . '.');
+            }
+            $qb->andWhere('d.category = :category')->setParameter('category', $category);
+        }
+
+        $paginator = new Paginator($qb->getQuery(), fetchJoinCollection: false);
+        $items = [];
+        foreach ($paginator as $row) {
+            /** @var Discussion $row */
+            $items[] = $this->serializer->discussion($row);
+        }
+
+        return [
+            'items' => $items,
+            'total' => count($paginator),
+            'page' => $page,
+            'limit' => $limit,
+        ];
+    }
+}

--- a/api/src/Mcp/Tool/ListPageCommentsTool.php
+++ b/api/src/Mcp/Tool/ListPageCommentsTool.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Comment;
+use App\Entity\Page;
+use App\Entity\User;
+use App\Mcp\McpAuthorization;
+use App\Mcp\McpEntitySerializer;
+use App\Mcp\McpException;
+use App\Mcp\McpInputHelper;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Pagination\Paginator;
+
+final class ListPageCommentsTool implements McpToolInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private McpAuthorization $authz,
+        private McpEntitySerializer $serializer,
+        private McpInputHelper $input,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'list_page_comments';
+    }
+
+    public function getDescription(): string
+    {
+        return 'List comments on a page in chronological order, paginated. Comments are flat — no reply tree — and ordered by createdAt ascending.';
+    }
+
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'pageId' => ['type' => 'string'],
+                'page' => ['type' => 'integer', 'minimum' => 1],
+                'limit' => ['type' => 'integer', 'minimum' => 1, 'maximum' => 100],
+            ],
+            'required' => ['pageId'],
+            'additionalProperties' => false,
+        ];
+    }
+
+    public function invoke(array $arguments, User $user): array
+    {
+        $pageId = $this->input->requireUuid('pageId', $arguments['pageId'] ?? null);
+        $page = $this->em->getRepository(Page::class)->find($pageId);
+        if (null === $page || !$this->authz->canReadPage($page, $user)) {
+            throw McpException::notFound(sprintf('Page %s', $pageId));
+        }
+
+        ['page' => $pageNum, 'limit' => $limit] = $this->input->pagination($arguments);
+
+        $qb = $this->em->getRepository(Comment::class)
+            ->createQueryBuilder('c')
+            ->where('c.page = :page')
+            ->setParameter('page', $page)
+            ->orderBy('c.createdAt', 'ASC')
+            ->setFirstResult(($pageNum - 1) * $limit)
+            ->setMaxResults($limit);
+
+        $paginator = new Paginator($qb->getQuery(), fetchJoinCollection: false);
+        $items = [];
+        foreach ($paginator as $comment) {
+            /** @var Comment $comment */
+            $items[] = $this->serializer->comment($comment);
+        }
+
+        return [
+            'items' => $items,
+            'total' => count($paginator),
+            'page' => $pageNum,
+            'limit' => $limit,
+        ];
+    }
+}

--- a/api/src/Mcp/Tool/ListPagesTool.php
+++ b/api/src/Mcp/Tool/ListPagesTool.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Mcp\Tool;
+
+use App\Doctrine\SpaceMembershipDql;
+use App\Entity\Page;
+use App\Entity\User;
+use App\Mcp\McpEntitySerializer;
+use App\Mcp\McpInputHelper;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Pagination\Paginator;
+
+/**
+ * Lists pages the caller can see (scoped to their space memberships),
+ * with optional filters by space, parent, and a text query over the
+ * title/body. Ordered top-level first, then by sort position.
+ */
+final class ListPagesTool implements McpToolInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private McpEntitySerializer $serializer,
+        private McpInputHelper $input,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'list_pages';
+    }
+
+    public function getDescription(): string
+    {
+        return 'List pages the user can access, newest-tree-first, paginated. Filter by spaceId, by parentId (omit to include all levels), or by a search string matched against title and body.';
+    }
+
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'spaceId' => ['type' => 'string', 'description' => 'Restrict to one space.'],
+                'parentId' => ['type' => 'string', 'description' => 'Restrict to the direct children of this page.'],
+                'search' => ['type' => 'string', 'description' => 'Case-insensitive match on title or body.'],
+                'page' => ['type' => 'integer', 'minimum' => 1],
+                'limit' => ['type' => 'integer', 'minimum' => 1, 'maximum' => 100],
+            ],
+            'additionalProperties' => false,
+        ];
+    }
+
+    public function invoke(array $arguments, User $user): array
+    {
+        ['page' => $page, 'limit' => $limit] = $this->input->pagination($arguments);
+
+        $qb = $this->em->getRepository(Page::class)
+            ->createQueryBuilder('p')
+            ->where(SpaceMembershipDql::userBelongsToProjectSpace('p', 'page_list'))
+            ->setParameter('user', $user)
+            ->orderBy('p.createdAt', 'DESC')
+            ->setFirstResult(($page - 1) * $limit)
+            ->setMaxResults($limit);
+
+        $spaceId = $this->input->optionalUuid('spaceId', $arguments['spaceId'] ?? null);
+        if (null !== $spaceId) {
+            $qb->andWhere('p.space = :spaceId')->setParameter('spaceId', $spaceId);
+        }
+        $parentId = $this->input->optionalUuid('parentId', $arguments['parentId'] ?? null);
+        if (null !== $parentId) {
+            $qb->andWhere('p.parent = :parentId')->setParameter('parentId', $parentId);
+        }
+        $search = $this->input->optionalString($arguments, 'search');
+        if (null !== $search && '' !== trim($search)) {
+            $qb->andWhere('(LOWER(p.title) LIKE :q OR LOWER(p.body) LIKE :q)')
+                ->setParameter('q', '%' . strtolower(trim($search)) . '%');
+        }
+
+        $paginator = new Paginator($qb->getQuery(), fetchJoinCollection: false);
+        $items = [];
+        foreach ($paginator as $row) {
+            /** @var Page $row */
+            $items[] = $this->serializer->page($row);
+        }
+
+        return [
+            'items' => $items,
+            'total' => count($paginator),
+            'page' => $page,
+            'limit' => $limit,
+        ];
+    }
+}

--- a/api/src/Mcp/Tool/ListSpacesTool.php
+++ b/api/src/Mcp/Tool/ListSpacesTool.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Space;
+use App\Entity\SpaceGroupMembership;
+use App\Entity\SpaceMembership;
+use App\Entity\User;
+use App\Mcp\McpEntitySerializer;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Lists the spaces the caller belongs to — the containers that projects,
+ * pages, and discussions live in. Most other create tools accept a
+ * `spaceId`, so this is the discovery step that lets the model target a
+ * shared space instead of always defaulting to the personal one.
+ */
+final class ListSpacesTool implements McpToolInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private McpEntitySerializer $serializer,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'list_spaces';
+    }
+
+    public function getDescription(): string
+    {
+        return 'List the spaces the user belongs to (personal first, then shared), with the user\'s role in each. Spaces are the top-level containers for projects, pages, and discussions; pass a returned space id as spaceId to other create tools to place content in a shared space.';
+    }
+
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => new \stdClass(),
+            'additionalProperties' => false,
+        ];
+    }
+
+    public function invoke(array $arguments, User $user): array
+    {
+        // Direct or group-inherited membership, mirroring
+        // SpaceAccessExtension's EXISTS scoping.
+        $direct = sprintf(
+            'SELECT 1 FROM %s sp_direct WHERE sp_direct.space = s AND sp_direct.user = :user',
+            SpaceMembership::class,
+        );
+        $group = sprintf(
+            'SELECT 1 FROM %s sp_grp JOIN sp_grp.userGroup sp_grp_obj '
+            . 'JOIN sp_grp_obj.memberships sp_grp_member '
+            . 'WHERE sp_grp.space = s AND sp_grp_member.user = :user',
+            SpaceGroupMembership::class,
+        );
+
+        $spaces = $this->em->getRepository(Space::class)
+            ->createQueryBuilder('s')
+            ->where(sprintf('(EXISTS(%s) OR EXISTS(%s))', $direct, $group))
+            ->setParameter('user', $user)
+            ->orderBy('s.isPersonal', 'DESC')
+            ->addOrderBy('s.createdAt', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return [
+            'items' => array_map(
+                fn (Space $space) => $this->serializer->space($space, $user),
+                $spaces,
+            ),
+        ];
+    }
+}

--- a/api/src/Mcp/Tool/ListTagsTool.php
+++ b/api/src/Mcp/Tool/ListTagsTool.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Tag;
+use App\Entity\User;
+use App\Mcp\McpEntitySerializer;
+use App\Repository\TagRepository;
+
+/**
+ * Lists the caller's own tags so the model can discover existing tag ids
+ * before attaching them to a task (or decide to create a new one).
+ */
+final class ListTagsTool implements McpToolInterface
+{
+    public function __construct(
+        private TagRepository $tags,
+        private McpEntitySerializer $serializer,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'list_tags';
+    }
+
+    public function getDescription(): string
+    {
+        return 'List the tags owned by the authenticated user, alphabetically. Use the returned ids as tagIds when creating or updating tasks.';
+    }
+
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => new \stdClass(),
+            'additionalProperties' => false,
+        ];
+    }
+
+    public function invoke(array $arguments, User $user): array
+    {
+        $tags = $this->tags->createQueryBuilder('t')
+            ->where('t.owner = :user')
+            ->setParameter('user', $user)
+            ->orderBy('t.title', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return [
+            'items' => array_map(
+                fn (Tag $tag) => $this->serializer->tag($tag),
+                $tags,
+            ),
+        ];
+    }
+}

--- a/api/src/Mcp/Tool/UpdatePageTool.php
+++ b/api/src/Mcp/Tool/UpdatePageTool.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Page;
+use App\Entity\User;
+use App\Mcp\McpAuthorization;
+use App\Mcp\McpEntitySerializer;
+use App\Mcp\McpException;
+use App\Mcp\McpInputHelper;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Patches a page. Editable by the author or a space admin, mirroring the
+ * REST `Patch` security expression. The page's space is fixed here — use
+ * the REST move endpoint to relocate a page between spaces.
+ */
+final class UpdatePageTool implements McpToolInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private McpAuthorization $authz,
+        private McpEntitySerializer $serializer,
+        private McpInputHelper $input,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'update_page';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Patch one or more fields on a page (title, body, position, parent). Only fields included in the call are changed. Editable by the page author or a space admin.';
+    }
+
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'pageId' => ['type' => 'string', 'description' => 'UUID of the page.'],
+                'title' => ['type' => 'string'],
+                'body' => ['type' => 'string'],
+                'position' => ['type' => 'integer', 'minimum' => 0],
+                'parentId' => ['type' => ['string', 'null'], 'description' => 'Re-nest under another page in the same space, or null to make it top-level.'],
+            ],
+            'required' => ['pageId'],
+            'additionalProperties' => false,
+        ];
+    }
+
+    public function invoke(array $arguments, User $user): array
+    {
+        $pageId = $this->input->requireUuid('pageId', $arguments['pageId'] ?? null);
+        $page = $this->em->getRepository(Page::class)->find($pageId);
+        if (null === $page || !$this->authz->canReadPage($page, $user)) {
+            throw McpException::notFound(sprintf('Page %s', $pageId));
+        }
+        if (!$this->authz->canEditPage($page, $user)) {
+            throw McpException::forbidden('Only the page author or a space admin can edit this page.');
+        }
+
+        if (array_key_exists('title', $arguments)) {
+            $page->setTitle($this->input->requireString($arguments, 'title'));
+        }
+        if (array_key_exists('body', $arguments)) {
+            $page->setBody($this->input->optionalString($arguments, 'body') ?? '');
+        }
+        if (array_key_exists('position', $arguments)) {
+            $page->setPosition($this->input->optionalInt($arguments, 'position') ?? 0);
+        }
+        if (array_key_exists('parentId', $arguments)) {
+            if (null === $arguments['parentId']) {
+                $page->setParent(null);
+            } else {
+                $parentId = $this->input->requireUuid('parentId', $arguments['parentId']);
+                if ($parentId->equals($pageId)) {
+                    throw McpException::invalidInput('A page cannot be its own parent.');
+                }
+                $parent = $this->em->getRepository(Page::class)->find($parentId);
+                if (null === $parent || !$this->authz->canReadPage($parent, $user)) {
+                    throw McpException::notFound(sprintf('Page %s', $parentId));
+                }
+                if ($parent->getSpace()?->getId()?->equals($page->getSpace()?->getId()) !== true) {
+                    throw McpException::invalidInput('The parent page must be in the same space.');
+                }
+                $page->setParent($parent);
+            }
+        }
+
+        $this->input->assertValid($page);
+        $this->em->flush();
+
+        return $this->serializer->page($page);
+    }
+}

--- a/api/src/Mcp/Tool/UpdateTaskTool.php
+++ b/api/src/Mcp/Tool/UpdateTaskTool.php
@@ -2,6 +2,8 @@
 
 namespace App\Mcp\Tool;
 
+use App\Entity\CustomFieldDefinition;
+use App\Entity\CustomFieldValue;
 use App\Entity\Project;
 use App\Entity\Task;
 use App\Entity\User;
@@ -57,6 +59,19 @@ final class UpdateTaskTool implements McpToolInterface
                     'type' => 'array',
                     'items' => ['type' => 'string'],
                     'description' => 'Replaces the existing tag set.',
+                ],
+                'customFieldValues' => [
+                    'type' => 'array',
+                    'description' => 'Replaces the whole set of custom field values on the task. Each entry sets one field defined on the task\'s project (see get_custom_fields). Omit a definition to leave it unset; pass an empty array to clear all values.',
+                    'items' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'definitionId' => ['type' => 'string', 'description' => 'UUID of a CustomFieldDefinition on the task\'s project.'],
+                            'value' => ['description' => 'The value, shaped to the field\'s kind/subtype (string, number, bool, ISO date, {amount,currency} for money, an IRI for references, or an array when the field is multi).'],
+                        ],
+                        'required' => ['definitionId', 'value'],
+                        'additionalProperties' => false,
+                    ],
                 ],
             ],
             'required' => ['taskId'],
@@ -127,10 +142,48 @@ final class UpdateTaskTool implements McpToolInterface
                 $task->addTag($tag);
             }
         }
+        if (array_key_exists('customFieldValues', $arguments)) {
+            $this->applyCustomFieldValues($task, $arguments['customFieldValues']);
+        }
 
         $this->input->assertValid($task);
         $this->em->flush();
 
         return $this->serializer->task($task);
+    }
+
+    /**
+     * Replace the task's whole custom-field-value set. Existing rows are
+     * dropped (orphanRemoval reaps them) and rebuilt from the payload;
+     * the deferrable `(task_id, definition_id)` unique constraint lets
+     * the delete-then-insert collapse in one flush. Per-value shape,
+     * project-scope, and required-ness are policed by
+     * {@see \App\Validator\ValidCustomFieldValues} via assertValid().
+     */
+    private function applyCustomFieldValues(Task $task, mixed $raw): void
+    {
+        if (!is_array($raw)) {
+            throw McpException::invalidInput('customFieldValues must be an array.');
+        }
+        foreach ($task->getCustomFieldValues()->toArray() as $existing) {
+            $task->removeCustomFieldValue($existing);
+        }
+        foreach ($raw as $entry) {
+            if (!is_array($entry)) {
+                throw McpException::invalidInput('Each customFieldValues entry must be an object.');
+            }
+            $definitionId = $this->input->requireUuid(
+                'customFieldValues[].definitionId',
+                $entry['definitionId'] ?? null,
+            );
+            $definition = $this->em->getRepository(CustomFieldDefinition::class)->find($definitionId);
+            if (null === $definition) {
+                throw McpException::notFound(sprintf('Custom field %s', $definitionId));
+            }
+            $value = new CustomFieldValue();
+            $value->setDefinition($definition);
+            $value->setValue($entry['value'] ?? null);
+            $task->addCustomFieldValue($value);
+        }
     }
 }

--- a/api/tests/Api/McpTest.php
+++ b/api/tests/Api/McpTest.php
@@ -7,6 +7,7 @@ use ApiPlatform\Symfony\Bundle\Test\Client;
 use App\Entity\ApiToken;
 use App\Entity\Comment;
 use App\Entity\CustomFieldDefinition;
+use App\Entity\Discussion;
 use App\Entity\Page;
 use App\Entity\Project;
 use App\Entity\Space;
@@ -127,6 +128,8 @@ class McpTest extends ApiTestCase
             'create_page', 'get_page', 'update_page', 'delete_page', 'list_pages',
             'list_tags', 'create_tag',
             'create_discussion', 'get_discussion', 'list_discussions',
+            'add_page_comment', 'list_page_comments',
+            'add_discussion_comment', 'list_discussion_comments',
             ] as $expected
         ) {
             $this->assertContains($expected, $names, sprintf('Missing tool "%s"', $expected));
@@ -496,6 +499,81 @@ class McpTest extends ApiTestCase
         $this->assertSame(['Roadmap'], array_column($items, 'title'));
     }
 
+    public function testAddAndListPageComment(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $space = $this->makeSpace($alice);
+        $page = $this->makePage($alice, $space, 'Spec');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'add_page_comment',
+            'arguments' => ['pageId' => (string) $page->getId(), 'body' => 'First note'],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $this->assertSame('First note', $structured['body']);
+        $this->assertSame('page', $structured['commentableType']);
+        $this->assertSame((string) $page->getId(), $structured['pageId']);
+
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_page_comments',
+            'arguments' => ['pageId' => (string) $page->getId()],
+        ]);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $this->assertSame(['First note'], array_column($items, 'body'));
+    }
+
+    public function testAddAndListDiscussionComment(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $space = $this->makeSpace($alice);
+        $discussion = $this->makeDiscussion($alice, $space, 'Topic');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'add_discussion_comment',
+            'arguments' => ['discussionId' => (string) $discussion->getId(), 'body' => 'Good point'],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $this->assertSame('discussion', $structured['commentableType']);
+
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_discussion_comments',
+            'arguments' => ['discussionId' => (string) $discussion->getId()],
+        ]);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $this->assertSame(['Good point'], array_column($items, 'body'));
+    }
+
+    public function testLockedDiscussionRejectsNewComment(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $space = $this->makeSpace($alice);
+        $discussion = $this->makeDiscussion($alice, $space, 'Closed');
+        $discussion->setIsLocked(true);
+        $this->entityManager->flush();
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'add_discussion_comment',
+            'arguments' => ['discussionId' => (string) $discussion->getId(), 'body' => 'Sneaky'],
+        ]);
+        $this->assertTrue($body['result']['isError'] ?? null);
+    }
+
     public function testInvalidUuidProducesValidationError(): void
     {
         $alice = $this->createUser('alice@example.com');
@@ -679,6 +757,18 @@ class McpTest extends ApiTestCase
         $this->entityManager->persist($page);
         $this->entityManager->flush();
         return $page;
+    }
+
+    private function makeDiscussion(User $author, Space $space, string $title): Discussion
+    {
+        $discussion = new Discussion();
+        $discussion->setAuthor($author);
+        $discussion->setSpace($space);
+        $discussion->setTitle($title);
+        $discussion->setBody('Body of ' . $title);
+        $this->entityManager->persist($discussion);
+        $this->entityManager->flush();
+        return $discussion;
     }
 
     private function makeTaskInProject(User $owner, Project $project, string $title): Task

--- a/api/tests/Api/McpTest.php
+++ b/api/tests/Api/McpTest.php
@@ -6,7 +6,11 @@ use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use ApiPlatform\Symfony\Bundle\Test\Client;
 use App\Entity\ApiToken;
 use App\Entity\Comment;
+use App\Entity\CustomFieldDefinition;
+use App\Entity\Page;
 use App\Entity\Project;
+use App\Entity\Space;
+use App\Entity\SpaceMembership;
 use App\Entity\Task;
 use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
@@ -35,10 +39,19 @@ class McpTest extends ApiTestCase
         assert($em instanceof EntityManagerInterface);
         $this->entityManager = $em;
 
+        // Delete child-to-parent so DQL bulk deletes don't trip FKs.
         $this->entityManager->createQuery('DELETE FROM App\Entity\ApiToken')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Comment')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\CustomFieldValue')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\CustomFieldDefinition')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Page')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Discussion')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Tag')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\SpaceMembership')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\SpaceGroupMembership')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Space')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
     }
 
@@ -110,6 +123,10 @@ class McpTest extends ApiTestCase
             'add_task_comment', 'list_task_comments',
             'upload_file', 'list_files', 'download_file',
             'get_custom_fields',
+            'list_spaces',
+            'create_page', 'get_page', 'update_page', 'delete_page', 'list_pages',
+            'list_tags', 'create_tag',
+            'create_discussion', 'get_discussion', 'list_discussions',
             ] as $expected
         ) {
             $this->assertContains($expected, $names, sprintf('Missing tool "%s"', $expected));
@@ -236,6 +253,247 @@ class McpTest extends ApiTestCase
         $author = $structured['author'];
         $this->assertIsArray($author);
         $this->assertSame('alice@example.com', $author['email']);
+    }
+
+    public function testListSpacesReturnsMembershipsWithRole(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $space = $this->makeSpace($alice, 'Alice Space');
+        $this->makeSpace($bob, 'Bob Space');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_spaces',
+            'arguments' => [],
+        ]);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $names = array_column($items, 'name');
+        $this->assertSame(['Alice Space'], $names);
+        $first = $items[0];
+        $this->assertIsArray($first);
+        $this->assertSame('admin', $first['role']);
+        $this->assertSame((string) $space->getId(), $first['id']);
+    }
+
+    public function testCreateAndGetPageInSpace(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $space = $this->makeSpace($alice);
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'create_page',
+            'arguments' => [
+                'title' => 'Onboarding',
+                'body' => '# Welcome',
+                'spaceId' => (string) $space->getId(),
+            ],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $this->assertSame('Onboarding', $structured['title']);
+        $this->assertSame((string) $space->getId(), $structured['spaceId']);
+        $pageId = $structured['id'];
+        $this->assertIsString($pageId);
+
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'get_page',
+            'arguments' => ['pageId' => $pageId],
+        ]);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $this->assertSame('# Welcome', $structured['body']);
+    }
+
+    public function testCreatePageDefaultsToPersonalSpace(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        // Provision Alice's personal space the way the app does on signup
+        // — persisting a project triggers ProjectSpaceDefaultListener.
+        $this->makeProject($alice, [$alice], 'Seed');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'create_page',
+            'arguments' => ['title' => 'Personal note'],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $this->assertSame('Personal note', $structured['title']);
+        $this->assertIsString($structured['spaceId']);
+    }
+
+    public function testListPagesHonoursSpaceMembership(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $aliceSpace = $this->makeSpace($alice, 'Alice Space');
+        $bobSpace = $this->makeSpace($bob, 'Bob Space');
+        $this->makePage($alice, $aliceSpace, 'Mine');
+        $this->makePage($bob, $bobSpace, 'Hidden');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_pages',
+            'arguments' => [],
+        ]);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $this->assertSame(['Mine'], array_column($items, 'title'));
+    }
+
+    public function testUpdateAndDeletePage(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $space = $this->makeSpace($alice);
+        $page = $this->makePage($alice, $space, 'Draft');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'update_page',
+            'arguments' => ['pageId' => (string) $page->getId(), 'title' => 'Final'],
+        ]);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $this->assertSame('Final', $structured['title']);
+
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'delete_page',
+            'arguments' => ['pageId' => (string) $page->getId()],
+        ]);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $this->assertTrue($structured['deleted']);
+        $this->assertNull($this->entityManager->getRepository(Page::class)->find($page->getId()));
+    }
+
+    public function testPageEditByNonAuthorNonAdminIsForbidden(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $space = $this->makeSpace($alice);
+        // Bob is a plain member of Alice's space.
+        $this->ensureSpaceMembership($space, $bob, Space::ROLE_MEMBER);
+        $page = $this->makePage($alice, $space, 'Alice doc');
+        $plain = $this->mintToken($bob, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'update_page',
+            'arguments' => ['pageId' => (string) $page->getId(), 'title' => 'Hijacked'],
+        ]);
+        $this->assertTrue($body['result']['isError'] ?? null);
+    }
+
+    public function testCreateAndListTags(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'create_tag',
+            'arguments' => ['title' => 'urgent', 'color' => '#ef4444'],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $this->assertSame('urgent', $structured['title']);
+        $this->assertSame('#ef4444', $structured['color']);
+
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_tags',
+            'arguments' => [],
+        ]);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $this->assertSame(['urgent'], array_column($items, 'title'));
+    }
+
+    public function testUpdateTaskSetsCustomFieldValue(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->makeProject($alice, [$alice], 'Fielded');
+        $field = $this->makeCustomFieldDefinition($project, 'Notes', 'text');
+        $task = $this->makeTaskInProject($alice, $project, 'With fields');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'update_task',
+            'arguments' => [
+                'taskId' => (string) $task->getId(),
+                'customFieldValues' => [
+                    ['definitionId' => (string) $field->getId(), 'value' => 'hello world'],
+                ],
+            ],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $values = $structured['customFieldValues'] ?? null;
+        $this->assertIsArray($values);
+        $this->assertCount(1, $values);
+        $this->assertIsArray($values[0]);
+        $this->assertSame('hello world', $values[0]['value']);
+    }
+
+    public function testCreateGetAndListDiscussion(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $space = $this->makeSpace($alice);
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'create_discussion',
+            'arguments' => [
+                'title' => 'Roadmap',
+                'body' => 'What next?',
+                'category' => 'ideas',
+                'spaceId' => (string) $space->getId(),
+            ],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $this->assertSame('Roadmap', $structured['title']);
+        $this->assertSame('ideas', $structured['category']);
+        $discussionId = $structured['id'];
+        $this->assertIsString($discussionId);
+
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'get_discussion',
+            'arguments' => ['discussionId' => $discussionId],
+        ]);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $this->assertSame('What next?', $structured['body']);
+
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_discussions',
+            'arguments' => ['spaceId' => (string) $space->getId()],
+        ]);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $this->assertSame(['Roadmap'], array_column($items, 'title'));
     }
 
     public function testInvalidUuidProducesValidationError(): void
@@ -412,6 +670,17 @@ class McpTest extends ApiTestCase
         return $task;
     }
 
+    private function makePage(User $author, Space $space, string $title): Page
+    {
+        $page = new Page();
+        $page->setCreatedBy($author);
+        $page->setSpace($space);
+        $page->setTitle($title);
+        $this->entityManager->persist($page);
+        $this->entityManager->flush();
+        return $page;
+    }
+
     private function makeTaskInProject(User $owner, Project $project, string $title): Task
     {
         $task = new Task();
@@ -437,6 +706,35 @@ class McpTest extends ApiTestCase
         $this->entityManager->persist($project);
         $this->entityManager->flush();
         return $project;
+    }
+
+    /**
+     * A shared space with `$admin` as its admin. `createUser()` doesn't
+     * provision the signup-time personal space, so page/discussion tools
+     * that need a real space get one here.
+     */
+    private function makeSpace(User $admin, string $name = 'Team Space'): Space
+    {
+        $space = new Space();
+        $space->setName($name);
+        $space->setCreatedBy($admin);
+        $space->addUserMembership(
+            (new SpaceMembership())->setUser($admin)->setRole(Space::ROLE_ADMIN),
+        );
+        $this->entityManager->persist($space);
+        $this->entityManager->flush();
+        return $space;
+    }
+
+    private function makeCustomFieldDefinition(Project $project, string $name, string $type): CustomFieldDefinition
+    {
+        $field = new CustomFieldDefinition();
+        $field->setProject($project);
+        $field->setName($name);
+        $field->setType($type);
+        $this->entityManager->persist($field);
+        $this->entityManager->flush();
+        return $field;
     }
 
     private function createUser(string $email): User

--- a/docs/developer/mcp-server.md
+++ b/docs/developer/mcp-server.md
@@ -63,14 +63,20 @@ Tokens authenticate via `Authorization: Bearer` on both the `/mcp` firewall and 
 | ----------- | ------------------------------------------------------------------------------ |
 | Task        | `create_task`, `get_task`, `update_task`, `delete_task`, `list_tasks`, `search_tasks` |
 | Project     | `create_project`, `get_project`, `update_project`, `delete_project`, `list_projects` |
+| Space       | `list_spaces`                                                                   |
+| Page        | `create_page`, `get_page`, `update_page`, `delete_page`, `list_pages`          |
+| Discussion  | `create_discussion`, `get_discussion`, `list_discussions`                      |
 | Assignment  | `assign_task`, `unassign_task`, `get_my_tasks`                                 |
 | TaskComment | `add_task_comment`, `list_task_comments`                                       |
+| Tag         | `list_tags`, `create_tag`                                                       |
 | File        | `upload_file`, `list_files`, `download_file`                                   |
 | Custom field| `get_custom_fields`                                                            |
 
 Call `tools/list` to inspect each tool's JSON Schema. Tools execute as the user that owns the bearer token; visibility, edit, and delete rules mirror the existing API Platform `security:` expressions on each entity.
 
-> **Custom field values** — `get_custom_fields` returns a project's defined fields (`CustomFieldDefinition`). Per-task values (`CustomFieldValue`, #227) are written through the REST Task `customFieldValues` array; a dedicated `set_custom_field` MCP tool is not yet exposed.
+Create tools that target a space (`create_project`, `create_page`, `create_discussion`) accept an optional `spaceId` — call `list_spaces` to discover the ids, or omit it to default to the caller's personal space.
+
+> **Custom field values** — `get_custom_fields` returns a project's defined fields (`CustomFieldDefinition`). Per-task values (`CustomFieldValue`, #227) are written through `update_task`'s `customFieldValues` array (`[{definitionId, value}]`), which replaces the task's whole value set and is validated by `ValidCustomFieldValues` just like the REST path.
 
 ## Errors
 

--- a/docs/developer/mcp-server.md
+++ b/docs/developer/mcp-server.md
@@ -67,7 +67,7 @@ Tokens authenticate via `Authorization: Bearer` on both the `/mcp` firewall and 
 | Page        | `create_page`, `get_page`, `update_page`, `delete_page`, `list_pages`          |
 | Discussion  | `create_discussion`, `get_discussion`, `list_discussions`                      |
 | Assignment  | `assign_task`, `unassign_task`, `get_my_tasks`                                 |
-| TaskComment | `add_task_comment`, `list_task_comments`                                       |
+| Comment     | `add_task_comment`, `list_task_comments`, `add_page_comment`, `list_page_comments`, `add_discussion_comment`, `list_discussion_comments` |
 | Tag         | `list_tags`, `create_tag`                                                       |
 | File        | `upload_file`, `list_files`, `download_file`                                   |
 | Custom field| `get_custom_fields`                                                            |


### PR DESCRIPTION
## Why

Goal: drive Madori (tasks/projects/**pages**/discussions) from Claude Desktop/Code the same way the Asana/Notion connectors work — **without spending API credits**. That property is automatic for any MCP server used inside a subscription-backed Claude client (the model inference is billed to the subscription, not the metered API). Madori already had an MCP server at `POST /mcp`; the gap was **tool coverage** — it could do tasks + projects but not pages, spaces, discussions, tags, or custom-field values. This PR closes that gap.

No new server, connector, or OAuth — Claude Code/Desktop authenticate with the existing `madori_pat_` bearer token.

> One PR rather than three: every phase touches the same shared files (`McpEntitySerializer`, `McpToolPolicy`, `McpTest`, `mcp-server.md`), so stacked PRs would just conflict. Organised by commit/section instead.

## What

**Phase 1 — Spaces**
- New `list_spaces` tool (scoped to the caller's memberships, returns their role per space).
- `create_project` gains an optional `spaceId` (omit → personal space, as before).
- New `App\Mcp\McpSpaceResolver` centralises "resolve a space the caller may write to" (explicit id must be a space they belong to → 404 otherwise; omitted → personal space).

**Phase 2 — Pages (the Notion replacement)**
- `create_page`, `get_page`, `update_page`, `delete_page`, `list_pages` (sub-page `parentId`, optional `spaceId`, title/body search).
- `McpAuthorization` gains page read/edit checks mirroring the REST `security:` expressions (read = space member; edit/delete = author or space admin).

**Phase 3 — Asana parity**
- `list_tags`, `create_tag` (owner-scoped) so Claude can discover/create tags, not just attach known UUIDs.
- `update_task` accepts a `customFieldValues` array (`[{definitionId, value}]`) that replaces the task's value set, validated by the same `ValidCustomFieldValues` constraint as the REST path. The MCP task serializer now echoes custom-field values back.
- `create_discussion`, `get_discussion`, `list_discussions` (space-scoped, category filter).

## Access control

Every new tool is mapped in `McpToolPolicy` (pages → `pages`, discussions → `discussions`, spaces/tags ride `projects`/`tasks` since they have no dedicated `AccessPolicy` category). The existing `McpTest::testEveryRegisteredToolHasAPolicyMapping` pins this — an unmapped tool fails CI. Scoped tokens enforce these categories exactly as before.

## Tests

`McpTest` extended: list_spaces role/scoping, create+get/list/update/delete page, personal-space default, non-author edit forbidden, create+list tags, update_task custom-field value round-trip, create+get+list discussion. Docs tool table in `docs/developer/mcp-server.md` updated.

## Verification

PHP/Docker aren't runnable in this environment — relying on CI (Tests, PHPStan level 10, PHPCS, Doctrine Schema). New code follows the existing one-class-per-tool patterns and the documented level-10 idioms; will follow up on any CI findings.
