### PR TITLE
Promote: MCP tool expansion + service refactor + coverage

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -42,7 +42,18 @@ Use lowercase `kebab-case` for branch names.
 Every PR must keep CI green, which includes the test suites:
 
 - **API** — PHPUnit (`bin/phpunit`). New endpoints, services, and behaviour
-  changes need tests under `api/tests/`.
+  changes need tests under `api/tests/`. A **minimum line-coverage floor** is
+  enforced on PRs: the *Tests* CI job runs the suite with coverage
+  (`XDEBUG_MODE=coverage … --coverage-clover`) and then
+  [`api/bin/coverage-check.php`](../api/bin/coverage-check.php) fails the build
+  if `api/src` line coverage drops below the floor (currently 70%; measured
+  ~75.5%). To check locally:
+
+  ```bash
+  docker compose exec -e XDEBUG_MODE=coverage php php -d memory_limit=-1 \
+    bin/phpunit --coverage-clover var/coverage.xml
+  docker compose exec php php bin/coverage-check.php var/coverage.xml 70
+  ```
 - **PWA** — Vitest over the framework-free logic in `pwa/lib`
   (`pnpm test`). A **minimum-coverage floor** is enforced on PRs via
   `pnpm test:coverage`: the modules listed in `coverage.include` in

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -46,13 +46,14 @@ Every PR must keep CI green, which includes the test suites:
   enforced on PRs: the *Tests* CI job runs the suite with coverage
   (`XDEBUG_MODE=coverage … --coverage-clover`) and then
   [`api/bin/coverage-check.php`](../api/bin/coverage-check.php) fails the build
-  if `api/src` line coverage drops below the floor (currently 70%; measured
-  ~75.5%). To check locally:
+  if `api/src` line coverage drops below the floor (currently 84%; measured
+  ~85%). Dev/test seeders under `src/DataFixtures` are excluded from coverage
+  (see `api/phpunit.xml.dist`). To check locally:
 
   ```bash
   docker compose exec -e XDEBUG_MODE=coverage php php -d memory_limit=-1 \
     bin/phpunit --coverage-clover var/coverage.xml
-  docker compose exec php php bin/coverage-check.php var/coverage.xml 70
+  docker compose exec php php bin/coverage-check.php var/coverage.xml 84
   ```
 - **PWA** — Vitest over the framework-free logic in `pwa/lib`
   (`pnpm test`). A **minimum-coverage floor** is enforced on PRs via

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -37,6 +37,25 @@ Use lowercase `kebab-case` for branch names.
 - **PHP**: Follow [Symfony coding standards](https://symfony.com/doc/current/contributing/code/standards.html)
 - **TypeScript/React**: Follow the existing patterns in the codebase
 
+### Testing
+
+Every PR must keep CI green, which includes the test suites:
+
+- **API** — PHPUnit (`bin/phpunit`). New endpoints, services, and behaviour
+  changes need tests under `api/tests/`.
+- **PWA** — Vitest over the framework-free logic in `pwa/lib`
+  (`pnpm test`). A **minimum-coverage floor** is enforced on PRs via
+  `pnpm test:coverage`: the modules listed in `coverage.include` in
+  [`pwa/vitest.config.ts`](../pwa/vitest.config.ts) must stay above the
+  configured thresholds (lines/statements ≥ 85%, functions ≥ 90%,
+  branches ≥ 75%). When you add a new pure-logic helper under `pwa/lib`,
+  add it (and its `*.test.ts`) to that allowlist so the gate keeps it
+  covered. Component/integration coverage lives in the Playwright **e2e**
+  suite rather than the unit layer.
+
+If your change is genuinely untestable in these layers (pure infra/config),
+say so in the PR description.
+
 See `docs/developer/branching-and-releases.md` for the full branching and release strategy.
 
 ## License

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,5 +25,6 @@
 
 - [ ] My code follows the project's conventions
 - [ ] I have added tests that prove my fix or feature works
-- [ ] New and existing tests pass locally
+- [ ] New and existing tests pass locally (PHPUnit / `pnpm test:coverage`)
+- [ ] New pure-logic helpers under `pwa/lib` are added to the coverage allowlist in `pwa/vitest.config.ts`
 - [ ] I have updated documentation if needed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,8 +264,12 @@ jobs:
       -
         name: PWA unit tests
         # Vitest over the pure logic in pwa/lib (query parsing, validation
-        # mapping, password strength). Component coverage stays in e2e.
-        run: docker compose exec -T pwa pnpm test
+        # mapping, password strength, auth-redirect sanitisation, …).
+        # `test:coverage` enforces the minimum-coverage floor declared in
+        # pwa/vitest.config.ts over the tested-module allowlist, so a PR
+        # that drops a covered branch fails here. Component coverage stays
+        # in the e2e suite.
+        run: docker compose exec -T pwa pnpm test:coverage
 
   e2e:
     name: E2E

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,13 +113,24 @@ jobs:
         name: Run migrations
         run: docker compose exec -T php bin/console -e test doctrine:migrations:migrate --no-interaction
       -
-        name: Run PHPUnit
+        name: Run PHPUnit (with coverage)
         # PHPUnit's deprecation tracker accumulates context across the whole
         # suite, so peak memory grows with test count. The default 128M was
         # tight even before; 512M then started tipping over as the suite
         # grew, so we run unbounded here — GitHub runners have GBs free and
         # the limit was only ever an accidental ceiling, not a real budget.
-        run: docker compose exec -T php php -d memory_limit=-1 bin/phpunit
+        #
+        # Coverage rides along on this single run: XDEBUG_MODE=coverage flips
+        # the (installed-but-off) Xdebug driver on for this process only, and
+        # --coverage-clover writes the report the floor gate reads next. One
+        # suite execution covers both the pass/fail signal and the floor.
+        run: docker compose exec -T -e XDEBUG_MODE=coverage php php -d memory_limit=-1 bin/phpunit --coverage-clover var/coverage.xml
+      -
+        name: Enforce coverage floor
+        # Fails the build when line coverage of api/src drops below the floor.
+        # The floor is a *minimum* regression guard (measured ~75.5%), not a
+        # target — ratchet the trailing floor argument up as coverage climbs.
+        run: docker compose exec -T php php bin/coverage-check.php var/coverage.xml 70
 
   phpstan:
     name: PHPStan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,10 +127,11 @@ jobs:
         run: docker compose exec -T -e XDEBUG_MODE=coverage php php -d memory_limit=-1 bin/phpunit --coverage-clover var/coverage.xml
       -
         name: Enforce coverage floor
-        # Fails the build when line coverage of api/src drops below the floor.
-        # The floor is a *minimum* regression guard (measured ~75.5%), not a
+        # Fails the build when line coverage of api/src drops below the floor
+        # (DataFixtures are excluded from coverage — see phpunit.xml.dist).
+        # The floor is a *minimum* regression guard (measured ~85%), not a
         # target — ratchet the trailing floor argument up as coverage climbs.
-        run: docker compose exec -T php php bin/coverage-check.php var/coverage.xml 70
+        run: docker compose exec -T php php bin/coverage-check.php var/coverage.xml 84
 
   phpstan:
     name: PHPStan

--- a/api/bin/coverage-check.php
+++ b/api/bin/coverage-check.php
@@ -1,0 +1,65 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Minimal PHP coverage-floor gate (no Composer dependency).
+ *
+ * Parses a Clover XML report and fails (exit 1) when line coverage falls
+ * below a floor. Wired into CI after PHPUnit runs with `--coverage-clover`.
+ * The floor is intentionally a *minimum* — a regression guard, not a target.
+ *
+ * Usage:
+ *   php bin/coverage-check.php <clover.xml> [minPercent]
+ *
+ * `minPercent` defaults to the COVERAGE_MIN env var, then to 70.
+ *
+ * "Line coverage" here is Clover's `coveredstatements / statements`, which
+ * matches the "Lines" figure PHPUnit's own `--coverage-text` summary prints.
+ */
+
+$cloverPath = $argv[1] ?? '';
+if ($cloverPath === '' || !is_file($cloverPath)) {
+    fwrite(STDERR, "coverage-check: clover report not found at '{$cloverPath}'\n");
+    fwrite(STDERR, "usage: php bin/coverage-check.php <clover.xml> [minPercent]\n");
+    exit(2);
+}
+
+$minRaw = $argv[2] ?? getenv('COVERAGE_MIN');
+$min = is_numeric($minRaw) ? (float) $minRaw : 70.0;
+
+$xml = @simplexml_load_file($cloverPath);
+if ($xml === false) {
+    fwrite(STDERR, "coverage-check: could not parse clover XML at '{$cloverPath}'\n");
+    exit(2);
+}
+
+// Project-level summary metrics (one node: /coverage/project/metrics).
+$metrics = $xml->xpath('/coverage/project/metrics');
+if ($metrics === false || $metrics === null || count($metrics) === 0) {
+    fwrite(STDERR, "coverage-check: no <project><metrics> node in clover report\n");
+    exit(2);
+}
+
+$summary = $metrics[0];
+$statements = (int) ($summary['statements'] ?? 0);
+$covered = (int) ($summary['coveredstatements'] ?? 0);
+
+if ($statements === 0) {
+    fwrite(STDERR, "coverage-check: zero statements reported — refusing to pass a hollow run\n");
+    exit(2);
+}
+
+$percent = $covered / $statements * 100;
+$rounded = round($percent, 2);
+
+printf("Line coverage: %.2f%% (%d/%d statements) — floor %.2f%%\n", $rounded, $covered, $statements, $min);
+
+if ($percent + 1e-9 < $min) {
+    fwrite(STDERR, sprintf("coverage-check: FAIL — %.2f%% is below the %.2f%% floor\n", $rounded, $min));
+    exit(1);
+}
+
+echo "coverage-check: OK\n";
+exit(0);

--- a/api/phpunit.xml.dist
+++ b/api/phpunit.xml.dist
@@ -27,6 +27,12 @@
         <include>
             <directory suffix=".php">src</directory>
         </include>
+        <exclude>
+            <!-- Dev/test data seeders, not production logic — they run during
+                 E2E fixture loading, not PHPUnit, so they only ever skew the
+                 coverage denominator. -->
+            <directory suffix=".php">src/DataFixtures</directory>
+        </exclude>
     </coverage>
 
     <listeners>

--- a/api/src/Mcp/McpAuthorization.php
+++ b/api/src/Mcp/McpAuthorization.php
@@ -2,6 +2,8 @@
 
 namespace App\Mcp;
 
+use App\Entity\Discussion;
+use App\Entity\Page;
 use App\Entity\Project;
 use App\Entity\Task;
 use App\Entity\User;
@@ -49,5 +51,36 @@ final class McpAuthorization
     public function isProjectMember(Project $project, User $user): bool
     {
         return $project->isAccessibleBy($user);
+    }
+
+    /**
+     * Pages read like the rest of their space: any space member can view
+     * (#183/#185). Mirrors the Page `Get` security expression.
+     */
+    public function canReadPage(Page $page, User $user): bool
+    {
+        return true === $page->getSpace()?->hasMember($user);
+    }
+
+    /**
+     * Page edit/delete: the author OR a space admin. Mirrors the Page
+     * `Patch`/`Delete` expressions. UUID comparison so the check holds
+     * after an EntityManager::clear().
+     */
+    public function canEditPage(Page $page, User $user): bool
+    {
+        if (true === $page->getCreatedBy()?->getId()?->equals($user->getId())) {
+            return true;
+        }
+        return true === $page->getSpace()?->isAdmin($user);
+    }
+
+    /**
+     * Discussions read like the rest of their space: any space member
+     * can browse (#91/#185). Mirrors the Discussion `Get` expression.
+     */
+    public function canReadDiscussion(Discussion $discussion, User $user): bool
+    {
+        return true === $discussion->getSpace()?->hasMember($user);
     }
 }

--- a/api/src/Mcp/McpEntitySerializer.php
+++ b/api/src/Mcp/McpEntitySerializer.php
@@ -4,8 +4,12 @@ namespace App\Mcp;
 
 use App\Entity\Comment;
 use App\Entity\CustomFieldDefinition;
+use App\Entity\CustomFieldValue;
+use App\Entity\Discussion;
 use App\Entity\MediaObject;
+use App\Entity\Page;
 use App\Entity\Project;
+use App\Entity\Space;
 use App\Entity\Tag;
 use App\Entity\Task;
 use App\Entity\User;
@@ -49,6 +53,14 @@ final class McpEntitySerializer
                 fn (MediaObject $m) => $this->mediaObject($m),
                 $task->getAttachments()->toArray(),
             ),
+            'customFieldValues' => array_map(
+                fn (CustomFieldValue $v) => [
+                    'definitionId' => null === $v->getDefinition() ? null : (string) $v->getDefinition()->getId(),
+                    'name' => $v->getDefinition()?->getName(),
+                    'value' => $v->getValue(),
+                ],
+                $task->getCustomFieldValues()->toArray(),
+            ),
         ];
     }
 
@@ -74,6 +86,78 @@ final class McpEntitySerializer
             ),
             'taskCount' => $taskCount,
             'openTaskCount' => $openTaskCount,
+        ];
+    }
+
+    /**
+     * Space summary. `role` is the viewer's relationship to the space —
+     * `admin` when they hold the admin membership, otherwise `member` —
+     * so the model knows whether it can manage members / delete content.
+     *
+     * @return array<string, mixed>
+     */
+    public function space(Space $space, User $viewer): array
+    {
+        return [
+            'id' => (string) $space->getId(),
+            'name' => $space->getName(),
+            'description' => $space->getDescription(),
+            'isPersonal' => $space->getIsPersonal(),
+            'visibility' => $space->getVisibility(),
+            'role' => $space->isAdmin($viewer) ? Space::ROLE_ADMIN : Space::ROLE_MEMBER,
+            'projectCount' => $space->getProjectsCount(),
+            'pageCount' => $space->getPagesCount(),
+            'createdOn' => $space->getCreatedAt()->format(\DateTimeInterface::ATOM),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function page(Page $page): array
+    {
+        return [
+            'id' => (string) $page->getId(),
+            'title' => $page->getTitle(),
+            'body' => $page->getBody(),
+            'spaceId' => null === $page->getSpace() ? null : (string) $page->getSpace()->getId(),
+            'parentId' => null === $page->getParent() ? null : (string) $page->getParent()->getId(),
+            'position' => $page->getPosition(),
+            'createdBy' => $this->userSummary($page->getCreatedBy()),
+            'createdOn' => $page->getCreatedAt()->format(\DateTimeInterface::ATOM),
+            'updatedOn' => $page->getUpdatedAt()?->format(\DateTimeInterface::ATOM),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function tag(Tag $tag): array
+    {
+        return [
+            'id' => (string) $tag->getId(),
+            'title' => $tag->getTitle(),
+            'color' => $tag->getColor(),
+            'description' => $tag->getDescription(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function discussion(Discussion $discussion): array
+    {
+        return [
+            'id' => (string) $discussion->getId(),
+            'title' => $discussion->getTitle(),
+            'body' => $discussion->getBody(),
+            'category' => $discussion->getCategory(),
+            'isPinned' => $discussion->getIsPinned(),
+            'isLocked' => $discussion->getIsLocked(),
+            'spaceId' => null === $discussion->getSpace() ? null : (string) $discussion->getSpace()->getId(),
+            'author' => $this->userSummary($discussion->getAuthor()),
+            'createdOn' => $discussion->getCreatedAt()->format(\DateTimeInterface::ATOM),
+            'updatedOn' => $discussion->getUpdatedAt()?->format(\DateTimeInterface::ATOM),
         ];
     }
 

--- a/api/src/Mcp/McpSpaceResolver.php
+++ b/api/src/Mcp/McpSpaceResolver.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Mcp;
+
+use App\Entity\Space;
+use App\Entity\User;
+use App\Repository\SpaceRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Resolves the {@see Space} a tool call should write into.
+ *
+ * Spaces gate every higher-level content type (pages, discussions,
+ * projects), but the existing PWA — and most quick "just jot this down"
+ * tool calls — don't supply one. So the rule mirrors the REST default:
+ * an omitted space falls back to the caller's personal space (where
+ * they're always an admin), and an explicit space id must be one the
+ * caller belongs to (404 otherwise, matching the access-extension
+ * existence-hiding shape used everywhere else).
+ */
+final class McpSpaceResolver
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private SpaceRepository $spaces,
+        private McpInputHelper $input,
+    ) {
+    }
+
+    /**
+     * The caller's personal "Private" space. Every account provisioned
+     * through signup has one; the 404 only fires for synthetic users
+     * created outside the normal flow.
+     */
+    public function personalSpace(User $user): Space
+    {
+        $space = $this->spaces->findPersonalSpaceFor($user);
+        if (!$space instanceof Space) {
+            throw new McpException('No personal space found for this account.', 404);
+        }
+        return $space;
+    }
+
+    /**
+     * Resolve an explicit space id the caller must be a member of, or
+     * null when none was supplied (so callers can decide their own
+     * default). Returns 404 for a space the caller can't see.
+     */
+    public function resolveMemberSpaceOrNull(mixed $rawSpaceId, User $user): ?Space
+    {
+        if (null === $rawSpaceId) {
+            return null;
+        }
+        $id = $this->input->requireUuid('spaceId', $rawSpaceId);
+        $space = $this->em->getRepository(Space::class)->find($id);
+        if (!$space instanceof Space || !$space->hasMember($user)) {
+            throw McpException::notFound(sprintf('Space %s', $id));
+        }
+        return $space;
+    }
+
+    /**
+     * Resolve the space to write into, defaulting to the personal space
+     * when the caller omits one.
+     */
+    public function resolveMemberSpace(mixed $rawSpaceId, User $user): Space
+    {
+        return $this->resolveMemberSpaceOrNull($rawSpaceId, $user) ?? $this->personalSpace($user);
+    }
+}

--- a/api/src/Mcp/McpToolPolicy.php
+++ b/api/src/Mcp/McpToolPolicy.php
@@ -43,6 +43,24 @@ final class McpToolPolicy
         'create_project' => ['category' => 'projects', 'write' => true],
         'update_project' => ['category' => 'projects', 'write' => true],
         'delete_project' => ['category' => 'projects', 'write' => true],
+        // spaces — no dedicated AccessPolicy category; spaces are the
+        // container for projects, so listing them rides the projects
+        // read scope (it's read-only metadata either way).
+        'list_spaces' => ['category' => 'projects', 'write' => false],
+        // pages
+        'list_pages' => ['category' => 'pages', 'write' => false],
+        'get_page' => ['category' => 'pages', 'write' => false],
+        'create_page' => ['category' => 'pages', 'write' => true],
+        'update_page' => ['category' => 'pages', 'write' => true],
+        'delete_page' => ['category' => 'pages', 'write' => true],
+        // discussions
+        'list_discussions' => ['category' => 'discussions', 'write' => false],
+        'get_discussion' => ['category' => 'discussions', 'write' => false],
+        'create_discussion' => ['category' => 'discussions', 'write' => true],
+        // tags — no dedicated category; tags are a task-tagging concern,
+        // so they ride the tasks scope.
+        'list_tags' => ['category' => 'tasks', 'write' => false],
+        'create_tag' => ['category' => 'tasks', 'write' => true],
     ];
 
     /** @return array{category: string, write: bool}|null */

--- a/api/src/Mcp/McpToolPolicy.php
+++ b/api/src/Mcp/McpToolPolicy.php
@@ -29,9 +29,13 @@ final class McpToolPolicy
         'delete_task' => ['category' => 'tasks', 'write' => true],
         'assign_task' => ['category' => 'tasks', 'write' => true],
         'unassign_task' => ['category' => 'tasks', 'write' => true],
-        // comments (task comments)
+        // comments (task / page / discussion comments share one category)
         'list_task_comments' => ['category' => 'comments', 'write' => false],
         'add_task_comment' => ['category' => 'comments', 'write' => true],
+        'list_page_comments' => ['category' => 'comments', 'write' => false],
+        'add_page_comment' => ['category' => 'comments', 'write' => true],
+        'list_discussion_comments' => ['category' => 'comments', 'write' => false],
+        'add_discussion_comment' => ['category' => 'comments', 'write' => true],
         // files (attachments)
         'list_files' => ['category' => 'files', 'write' => false],
         'download_file' => ['category' => 'files', 'write' => false],

--- a/api/src/Mcp/Tool/AddDiscussionCommentTool.php
+++ b/api/src/Mcp/Tool/AddDiscussionCommentTool.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Comment;
+use App\Entity\Discussion;
+use App\Entity\User;
+use App\Mcp\McpAuthorization;
+use App\Mcp\McpEntitySerializer;
+use App\Mcp\McpException;
+use App\Mcp\McpInputHelper;
+use App\Service\CommentMentionService;
+use Doctrine\ORM\EntityManagerInterface;
+
+final class AddDiscussionCommentTool implements McpToolInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private McpAuthorization $authz,
+        private McpEntitySerializer $serializer,
+        private McpInputHelper $input,
+        private CommentMentionService $mentions,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'add_discussion_comment';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Reply to a discussion thread with a Markdown comment. Threads are flat, ordered chronologically. @mentions notify space members. Locked threads reject new comments.';
+    }
+
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'discussionId' => ['type' => 'string'],
+                'body' => ['type' => 'string', 'description' => 'Markdown body (max 50000 chars).'],
+            ],
+            'required' => ['discussionId', 'body'],
+            'additionalProperties' => false,
+        ];
+    }
+
+    public function invoke(array $arguments, User $user): array
+    {
+        $discussionId = $this->input->requireUuid('discussionId', $arguments['discussionId'] ?? null);
+        $body = $this->input->requireString($arguments, 'body');
+
+        $discussion = $this->em->getRepository(Discussion::class)->find($discussionId);
+        if (null === $discussion || !$this->authz->canReadDiscussion($discussion, $user)) {
+            throw McpException::notFound(sprintf('Discussion %s', $discussionId));
+        }
+
+        $comment = new Comment();
+        $comment->setDiscussion($discussion);
+        $comment->setAuthor($user);
+        $comment->setBody($body);
+
+        // assertValid enforces Comment::validateNotLocked — a locked thread
+        // rejects new comments here just like the REST POST /comments path.
+        $this->input->assertValid($comment);
+        $this->em->persist($comment);
+        $this->em->flush();
+
+        $this->mentions->dispatchMentions($comment);
+
+        return $this->serializer->comment($comment);
+    }
+}

--- a/api/src/Mcp/Tool/AddPageCommentTool.php
+++ b/api/src/Mcp/Tool/AddPageCommentTool.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Comment;
+use App\Entity\Page;
+use App\Entity\User;
+use App\Mcp\McpAuthorization;
+use App\Mcp\McpEntitySerializer;
+use App\Mcp\McpException;
+use App\Mcp\McpInputHelper;
+use App\Service\CommentMentionService;
+use Doctrine\ORM\EntityManagerInterface;
+
+final class AddPageCommentTool implements McpToolInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private McpAuthorization $authz,
+        private McpEntitySerializer $serializer,
+        private McpInputHelper $input,
+        private CommentMentionService $mentions,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'add_page_comment';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Add a Markdown comment to a page. Threads are flat — every comment is a top-level entry, ordered chronologically. @mentions notify space members.';
+    }
+
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'pageId' => ['type' => 'string'],
+                'body' => ['type' => 'string', 'description' => 'Markdown body (max 50000 chars).'],
+            ],
+            'required' => ['pageId', 'body'],
+            'additionalProperties' => false,
+        ];
+    }
+
+    public function invoke(array $arguments, User $user): array
+    {
+        $pageId = $this->input->requireUuid('pageId', $arguments['pageId'] ?? null);
+        $body = $this->input->requireString($arguments, 'body');
+
+        $page = $this->em->getRepository(Page::class)->find($pageId);
+        if (null === $page || !$this->authz->canReadPage($page, $user)) {
+            throw McpException::notFound(sprintf('Page %s', $pageId));
+        }
+
+        $comment = new Comment();
+        $comment->setPage($page);
+        $comment->setAuthor($user);
+        $comment->setBody($body);
+
+        $this->input->assertValid($comment);
+        $this->em->persist($comment);
+        $this->em->flush();
+
+        // `@mention` tokens fire notifications post-persist — same path as
+        // the HTTP `POST /comments` flow.
+        $this->mentions->dispatchMentions($comment);
+
+        return $this->serializer->comment($comment);
+    }
+}

--- a/api/src/Mcp/Tool/CreateDiscussionTool.php
+++ b/api/src/Mcp/Tool/CreateDiscussionTool.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Discussion;
+use App\Entity\User;
+use App\Mcp\McpEntitySerializer;
+use App\Mcp\McpException;
+use App\Mcp\McpInputHelper;
+use App\Mcp\McpSpaceResolver;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Starts a discussion thread in a space (#91/#185). The author is
+ * stamped server-side; category defaults to "general".
+ */
+final class CreateDiscussionTool implements McpToolInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private McpEntitySerializer $serializer,
+        private McpInputHelper $input,
+        private McpSpaceResolver $spaces,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'create_discussion';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Start a discussion thread in a space. Pass a spaceId (from list_spaces) for a shared space, or omit it for your personal space. Category is one of: general, ideas, announcements, q-and-a (default general).';
+    }
+
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'title' => ['type' => 'string', 'description' => 'Thread title (required).'],
+                'body' => ['type' => 'string', 'description' => 'Markdown body (required).'],
+                'category' => [
+                    'type' => 'string',
+                    'enum' => Discussion::ALLOWED_CATEGORIES,
+                    'description' => 'Thread category (default general).',
+                ],
+                'spaceId' => ['type' => 'string', 'description' => 'UUID of a space the user belongs to. Omit for the personal space.'],
+            ],
+            'required' => ['title', 'body'],
+            'additionalProperties' => false,
+        ];
+    }
+
+    public function invoke(array $arguments, User $user): array
+    {
+        $title = $this->input->requireString($arguments, 'title');
+        $body = $this->input->requireString($arguments, 'body');
+        $space = $this->spaces->resolveMemberSpace($arguments['spaceId'] ?? null, $user);
+
+        $discussion = new Discussion();
+        $discussion->setAuthor($user);
+        $discussion->setSpace($space);
+        $discussion->setTitle($title);
+        $discussion->setBody($body);
+
+        $category = $this->input->optionalString($arguments, 'category');
+        if (null !== $category) {
+            if (!in_array($category, Discussion::ALLOWED_CATEGORIES, true)) {
+                throw McpException::invalidInput('category must be one of: ' . implode(', ', Discussion::ALLOWED_CATEGORIES) . '.');
+            }
+            $discussion->setCategory($category);
+        }
+
+        $this->input->assertValid($discussion);
+        $this->em->persist($discussion);
+        $this->em->flush();
+
+        return $this->serializer->discussion($discussion);
+    }
+}

--- a/api/src/Mcp/Tool/CreatePageTool.php
+++ b/api/src/Mcp/Tool/CreatePageTool.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Page;
+use App\Entity\User;
+use App\Mcp\McpAuthorization;
+use App\Mcp\McpEntitySerializer;
+use App\Mcp\McpException;
+use App\Mcp\McpInputHelper;
+use App\Mcp\McpSpaceResolver;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Creates a long-form, Notion-style page in a space (#183). The author
+ * is stamped server-side; pass a parentId to nest it under another page.
+ */
+final class CreatePageTool implements McpToolInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private McpAuthorization $authz,
+        private McpEntitySerializer $serializer,
+        private McpInputHelper $input,
+        private McpSpaceResolver $spaces,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'create_page';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Create a long-form Markdown page (Notion-style doc) in a space. Pass a spaceId (from list_spaces) for a shared space, or omit it for your personal space. Pass a parentId to nest it under an existing page in the same space.';
+    }
+
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'title' => ['type' => 'string', 'description' => 'Page title (required).'],
+                'body' => ['type' => 'string', 'description' => 'Markdown body.'],
+                'spaceId' => ['type' => 'string', 'description' => 'UUID of a space the user belongs to. Omit for the personal space.'],
+                'parentId' => ['type' => 'string', 'description' => 'UUID of a parent page in the same space, to nest this one beneath it.'],
+                'position' => ['type' => 'integer', 'minimum' => 0, 'description' => 'Sort key within the parent (default 0).'],
+            ],
+            'required' => ['title'],
+            'additionalProperties' => false,
+        ];
+    }
+
+    public function invoke(array $arguments, User $user): array
+    {
+        $title = $this->input->requireString($arguments, 'title');
+        $body = $this->input->optionalString($arguments, 'body');
+        $position = $this->input->optionalInt($arguments, 'position');
+        $space = $this->spaces->resolveMemberSpace($arguments['spaceId'] ?? null, $user);
+
+        $page = new Page();
+        $page->setCreatedBy($user);
+        $page->setSpace($space);
+        $page->setTitle($title);
+        if (null !== $body) {
+            $page->setBody($body);
+        }
+        if (null !== $position) {
+            $page->setPosition($position);
+        }
+
+        $parentId = $this->input->optionalUuid('parentId', $arguments['parentId'] ?? null);
+        if (null !== $parentId) {
+            $parent = $this->em->getRepository(Page::class)->find($parentId);
+            if (null === $parent || !$this->authz->canReadPage($parent, $user)) {
+                throw McpException::notFound(sprintf('Page %s', $parentId));
+            }
+            if ($parent->getSpace()?->getId()?->equals($space->getId()) !== true) {
+                throw McpException::invalidInput('The parent page must be in the same space.');
+            }
+            $page->setParent($parent);
+        }
+
+        $this->input->assertValid($page);
+        $this->em->persist($page);
+        $this->em->flush();
+
+        return $this->serializer->page($page);
+    }
+}

--- a/api/src/Mcp/Tool/CreateProjectTool.php
+++ b/api/src/Mcp/Tool/CreateProjectTool.php
@@ -6,6 +6,7 @@ use App\Entity\Project;
 use App\Entity\User;
 use App\Mcp\McpEntitySerializer;
 use App\Mcp\McpInputHelper;
+use App\Mcp\McpSpaceResolver;
 use Doctrine\ORM\EntityManagerInterface;
 
 final class CreateProjectTool implements McpToolInterface
@@ -14,6 +15,7 @@ final class CreateProjectTool implements McpToolInterface
         private EntityManagerInterface $em,
         private McpEntitySerializer $serializer,
         private McpInputHelper $input,
+        private McpSpaceResolver $spaces,
     ) {
     }
 
@@ -24,7 +26,7 @@ final class CreateProjectTool implements McpToolInterface
 
     public function getDescription(): string
     {
-        return 'Create a new shared project. The authenticated user becomes the owner and the only initial member; add more members via the project settings UI or future tools.';
+        return 'Create a new project. The authenticated user becomes the owner. Pass a spaceId (from list_spaces) to create it in a shared space; omit it to use your personal space. Members come from the space, not the project.';
     }
 
     public function getInputSchema(): array
@@ -34,6 +36,7 @@ final class CreateProjectTool implements McpToolInterface
             'properties' => [
                 'title' => ['type' => 'string', 'description' => 'Project title (required).'],
                 'description' => ['type' => 'string', 'description' => 'Optional Markdown description.'],
+                'spaceId' => ['type' => 'string', 'description' => 'UUID of a space the user belongs to. Omit for the personal space.'],
             ],
             'required' => ['title'],
             'additionalProperties' => false,
@@ -44,13 +47,16 @@ final class CreateProjectTool implements McpToolInterface
     {
         $title = $this->input->requireString($arguments, 'title');
         $description = $this->input->optionalString($arguments, 'description');
+        // An explicit space must be one the caller belongs to; omitted
+        // leaves space null so ProjectSpaceDefaultListener defaults it to
+        // the caller's personal space (where they're admin) at persist.
+        $space = $this->spaces->resolveMemberSpaceOrNull($arguments['spaceId'] ?? null, $user);
 
         $project = new Project();
         $project->setOwner($user);
-        // Space defaults to the caller's personal space via
-        // ProjectSpaceDefaultListener at PrePersist (#185), where they
-        // already hold the admin role. No project-local member set
-        // exists anymore.
+        if (null !== $space) {
+            $project->setSpace($space);
+        }
         $project->setTitle($title);
         if (null !== $description) {
             $project->setDescription($description);

--- a/api/src/Mcp/Tool/CreateTagTool.php
+++ b/api/src/Mcp/Tool/CreateTagTool.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Tag;
+use App\Entity\User;
+use App\Mcp\McpEntitySerializer;
+use App\Mcp\McpInputHelper;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Creates a tag owned by the caller, mirroring the REST `Post` +
+ * TagOwnerProcessor (owner is stamped server-side).
+ */
+final class CreateTagTool implements McpToolInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private McpEntitySerializer $serializer,
+        private McpInputHelper $input,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'create_tag';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Create a tag owned by the authenticated user. Color is a #RRGGBB hex (defaults to grey).';
+    }
+
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'title' => ['type' => 'string', 'description' => 'Tag label (required).'],
+                'color' => ['type' => 'string', 'description' => 'Hex color like #22c55e. Defaults to #6b7280.'],
+                'description' => ['type' => 'string', 'description' => 'Optional note.'],
+            ],
+            'required' => ['title'],
+            'additionalProperties' => false,
+        ];
+    }
+
+    public function invoke(array $arguments, User $user): array
+    {
+        $tag = new Tag();
+        $tag->setOwner($user);
+        $tag->setTitle($this->input->requireString($arguments, 'title'));
+        $color = $this->input->optionalString($arguments, 'color');
+        if (null !== $color) {
+            $tag->setColor($color);
+        }
+        $description = $this->input->optionalString($arguments, 'description');
+        if (null !== $description) {
+            $tag->setDescription($description);
+        }
+
+        $this->input->assertValid($tag);
+        $this->em->persist($tag);
+        $this->em->flush();
+
+        return $this->serializer->tag($tag);
+    }
+}

--- a/api/src/Mcp/Tool/DeletePageTool.php
+++ b/api/src/Mcp/Tool/DeletePageTool.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Page;
+use App\Entity\User;
+use App\Mcp\McpAuthorization;
+use App\Mcp\McpException;
+use App\Mcp\McpInputHelper;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Deletes a page. Author or space admin only. Descendants cascade away
+ * via the self-FK `ON DELETE CASCADE`, matching the REST `Delete`.
+ */
+final class DeletePageTool implements McpToolInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private McpAuthorization $authz,
+        private McpInputHelper $input,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'delete_page';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Delete a page by id. Deletes its sub-pages too. Allowed for the page author or a space admin.';
+    }
+
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'pageId' => ['type' => 'string', 'description' => 'UUID of the page.'],
+            ],
+            'required' => ['pageId'],
+            'additionalProperties' => false,
+        ];
+    }
+
+    public function invoke(array $arguments, User $user): array
+    {
+        $pageId = $this->input->requireUuid('pageId', $arguments['pageId'] ?? null);
+        $page = $this->em->getRepository(Page::class)->find($pageId);
+        if (null === $page || !$this->authz->canReadPage($page, $user)) {
+            throw McpException::notFound(sprintf('Page %s', $pageId));
+        }
+        if (!$this->authz->canEditPage($page, $user)) {
+            throw McpException::forbidden('Only the page author or a space admin can delete this page.');
+        }
+
+        $this->em->remove($page);
+        $this->em->flush();
+
+        return ['deleted' => true, 'id' => (string) $pageId];
+    }
+}

--- a/api/src/Mcp/Tool/GetDiscussionTool.php
+++ b/api/src/Mcp/Tool/GetDiscussionTool.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Discussion;
+use App\Entity\User;
+use App\Mcp\McpAuthorization;
+use App\Mcp\McpEntitySerializer;
+use App\Mcp\McpException;
+use App\Mcp\McpInputHelper;
+use Doctrine\ORM\EntityManagerInterface;
+
+final class GetDiscussionTool implements McpToolInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private McpAuthorization $authz,
+        private McpEntitySerializer $serializer,
+        private McpInputHelper $input,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'get_discussion';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Fetch one discussion thread by id. Returns 404 when the user is not a member of the discussion\'s space.';
+    }
+
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'discussionId' => ['type' => 'string', 'description' => 'UUID of the discussion.'],
+            ],
+            'required' => ['discussionId'],
+            'additionalProperties' => false,
+        ];
+    }
+
+    public function invoke(array $arguments, User $user): array
+    {
+        $discussionId = $this->input->requireUuid('discussionId', $arguments['discussionId'] ?? null);
+        $discussion = $this->em->getRepository(Discussion::class)->find($discussionId);
+        if (null === $discussion || !$this->authz->canReadDiscussion($discussion, $user)) {
+            throw McpException::notFound(sprintf('Discussion %s', $discussionId));
+        }
+
+        return $this->serializer->discussion($discussion);
+    }
+}

--- a/api/src/Mcp/Tool/GetPageTool.php
+++ b/api/src/Mcp/Tool/GetPageTool.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Page;
+use App\Entity\User;
+use App\Mcp\McpAuthorization;
+use App\Mcp\McpEntitySerializer;
+use App\Mcp\McpException;
+use App\Mcp\McpInputHelper;
+use Doctrine\ORM\EntityManagerInterface;
+
+final class GetPageTool implements McpToolInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private McpAuthorization $authz,
+        private McpEntitySerializer $serializer,
+        private McpInputHelper $input,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'get_page';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Fetch one page by id, including its full Markdown body. Returns 404 when the user is not a member of the page\'s space.';
+    }
+
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'pageId' => ['type' => 'string', 'description' => 'UUID of the page.'],
+            ],
+            'required' => ['pageId'],
+            'additionalProperties' => false,
+        ];
+    }
+
+    public function invoke(array $arguments, User $user): array
+    {
+        $pageId = $this->input->requireUuid('pageId', $arguments['pageId'] ?? null);
+        $page = $this->em->getRepository(Page::class)->find($pageId);
+        if (null === $page || !$this->authz->canReadPage($page, $user)) {
+            throw McpException::notFound(sprintf('Page %s', $pageId));
+        }
+
+        return $this->serializer->page($page);
+    }
+}

--- a/api/src/Mcp/Tool/ListDiscussionCommentsTool.php
+++ b/api/src/Mcp/Tool/ListDiscussionCommentsTool.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Comment;
+use App\Entity\Discussion;
+use App\Entity\User;
+use App\Mcp\McpAuthorization;
+use App\Mcp\McpEntitySerializer;
+use App\Mcp\McpException;
+use App\Mcp\McpInputHelper;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Pagination\Paginator;
+
+final class ListDiscussionCommentsTool implements McpToolInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private McpAuthorization $authz,
+        private McpEntitySerializer $serializer,
+        private McpInputHelper $input,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'list_discussion_comments';
+    }
+
+    public function getDescription(): string
+    {
+        return 'List replies on a discussion thread in chronological order, paginated. Comments are flat — no reply tree — and ordered by createdAt ascending.';
+    }
+
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'discussionId' => ['type' => 'string'],
+                'page' => ['type' => 'integer', 'minimum' => 1],
+                'limit' => ['type' => 'integer', 'minimum' => 1, 'maximum' => 100],
+            ],
+            'required' => ['discussionId'],
+            'additionalProperties' => false,
+        ];
+    }
+
+    public function invoke(array $arguments, User $user): array
+    {
+        $discussionId = $this->input->requireUuid('discussionId', $arguments['discussionId'] ?? null);
+        $discussion = $this->em->getRepository(Discussion::class)->find($discussionId);
+        if (null === $discussion || !$this->authz->canReadDiscussion($discussion, $user)) {
+            throw McpException::notFound(sprintf('Discussion %s', $discussionId));
+        }
+
+        ['page' => $page, 'limit' => $limit] = $this->input->pagination($arguments);
+
+        $qb = $this->em->getRepository(Comment::class)
+            ->createQueryBuilder('c')
+            ->where('c.discussion = :discussion')
+            ->setParameter('discussion', $discussion)
+            ->orderBy('c.createdAt', 'ASC')
+            ->setFirstResult(($page - 1) * $limit)
+            ->setMaxResults($limit);
+
+        $paginator = new Paginator($qb->getQuery(), fetchJoinCollection: false);
+        $items = [];
+        foreach ($paginator as $comment) {
+            /** @var Comment $comment */
+            $items[] = $this->serializer->comment($comment);
+        }
+
+        return [
+            'items' => $items,
+            'total' => count($paginator),
+            'page' => $page,
+            'limit' => $limit,
+        ];
+    }
+}

--- a/api/src/Mcp/Tool/ListDiscussionsTool.php
+++ b/api/src/Mcp/Tool/ListDiscussionsTool.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Mcp\Tool;
+
+use App\Doctrine\SpaceMembershipDql;
+use App\Entity\Discussion;
+use App\Entity\User;
+use App\Mcp\McpEntitySerializer;
+use App\Mcp\McpException;
+use App\Mcp\McpInputHelper;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Pagination\Paginator;
+
+/**
+ * Lists discussion threads the caller can see (scoped to their space
+ * memberships), pinned first then newest. Optional filters by space and
+ * category.
+ */
+final class ListDiscussionsTool implements McpToolInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private McpEntitySerializer $serializer,
+        private McpInputHelper $input,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'list_discussions';
+    }
+
+    public function getDescription(): string
+    {
+        return 'List discussion threads the user can access, pinned first then newest, paginated. Filter by spaceId or by category (general, ideas, announcements, q-and-a).';
+    }
+
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'spaceId' => ['type' => 'string', 'description' => 'Restrict to one space.'],
+                'category' => [
+                    'type' => 'string',
+                    'enum' => Discussion::ALLOWED_CATEGORIES,
+                    'description' => 'Restrict to one category.',
+                ],
+                'page' => ['type' => 'integer', 'minimum' => 1],
+                'limit' => ['type' => 'integer', 'minimum' => 1, 'maximum' => 100],
+            ],
+            'additionalProperties' => false,
+        ];
+    }
+
+    public function invoke(array $arguments, User $user): array
+    {
+        ['page' => $page, 'limit' => $limit] = $this->input->pagination($arguments);
+
+        $qb = $this->em->getRepository(Discussion::class)
+            ->createQueryBuilder('d')
+            ->where(SpaceMembershipDql::userBelongsToProjectSpace('d', 'discussion_list'))
+            ->setParameter('user', $user)
+            ->orderBy('d.isPinned', 'DESC')
+            ->addOrderBy('d.createdAt', 'DESC')
+            ->setFirstResult(($page - 1) * $limit)
+            ->setMaxResults($limit);
+
+        $spaceId = $this->input->optionalUuid('spaceId', $arguments['spaceId'] ?? null);
+        if (null !== $spaceId) {
+            $qb->andWhere('d.space = :spaceId')->setParameter('spaceId', $spaceId);
+        }
+        $category = $this->input->optionalString($arguments, 'category');
+        if (null !== $category) {
+            if (!in_array($category, Discussion::ALLOWED_CATEGORIES, true)) {
+                throw McpException::invalidInput('category must be one of: ' . implode(', ', Discussion::ALLOWED_CATEGORIES) . '.');
+            }
+            $qb->andWhere('d.category = :category')->setParameter('category', $category);
+        }
+
+        $paginator = new Paginator($qb->getQuery(), fetchJoinCollection: false);
+        $items = [];
+        foreach ($paginator as $row) {
+            /** @var Discussion $row */
+            $items[] = $this->serializer->discussion($row);
+        }
+
+        return [
+            'items' => $items,
+            'total' => count($paginator),
+            'page' => $page,
+            'limit' => $limit,
+        ];
+    }
+}

--- a/api/src/Mcp/Tool/ListPageCommentsTool.php
+++ b/api/src/Mcp/Tool/ListPageCommentsTool.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Comment;
+use App\Entity\Page;
+use App\Entity\User;
+use App\Mcp\McpAuthorization;
+use App\Mcp\McpEntitySerializer;
+use App\Mcp\McpException;
+use App\Mcp\McpInputHelper;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Pagination\Paginator;
+
+final class ListPageCommentsTool implements McpToolInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private McpAuthorization $authz,
+        private McpEntitySerializer $serializer,
+        private McpInputHelper $input,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'list_page_comments';
+    }
+
+    public function getDescription(): string
+    {
+        return 'List comments on a page in chronological order, paginated. Comments are flat — no reply tree — and ordered by createdAt ascending.';
+    }
+
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'pageId' => ['type' => 'string'],
+                'page' => ['type' => 'integer', 'minimum' => 1],
+                'limit' => ['type' => 'integer', 'minimum' => 1, 'maximum' => 100],
+            ],
+            'required' => ['pageId'],
+            'additionalProperties' => false,
+        ];
+    }
+
+    public function invoke(array $arguments, User $user): array
+    {
+        $pageId = $this->input->requireUuid('pageId', $arguments['pageId'] ?? null);
+        $page = $this->em->getRepository(Page::class)->find($pageId);
+        if (null === $page || !$this->authz->canReadPage($page, $user)) {
+            throw McpException::notFound(sprintf('Page %s', $pageId));
+        }
+
+        ['page' => $pageNum, 'limit' => $limit] = $this->input->pagination($arguments);
+
+        $qb = $this->em->getRepository(Comment::class)
+            ->createQueryBuilder('c')
+            ->where('c.page = :page')
+            ->setParameter('page', $page)
+            ->orderBy('c.createdAt', 'ASC')
+            ->setFirstResult(($pageNum - 1) * $limit)
+            ->setMaxResults($limit);
+
+        $paginator = new Paginator($qb->getQuery(), fetchJoinCollection: false);
+        $items = [];
+        foreach ($paginator as $comment) {
+            /** @var Comment $comment */
+            $items[] = $this->serializer->comment($comment);
+        }
+
+        return [
+            'items' => $items,
+            'total' => count($paginator),
+            'page' => $pageNum,
+            'limit' => $limit,
+        ];
+    }
+}

--- a/api/src/Mcp/Tool/ListPagesTool.php
+++ b/api/src/Mcp/Tool/ListPagesTool.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Mcp\Tool;
+
+use App\Doctrine\SpaceMembershipDql;
+use App\Entity\Page;
+use App\Entity\User;
+use App\Mcp\McpEntitySerializer;
+use App\Mcp\McpInputHelper;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Pagination\Paginator;
+
+/**
+ * Lists pages the caller can see (scoped to their space memberships),
+ * with optional filters by space, parent, and a text query over the
+ * title/body. Ordered top-level first, then by sort position.
+ */
+final class ListPagesTool implements McpToolInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private McpEntitySerializer $serializer,
+        private McpInputHelper $input,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'list_pages';
+    }
+
+    public function getDescription(): string
+    {
+        return 'List pages the user can access, newest-tree-first, paginated. Filter by spaceId, by parentId (omit to include all levels), or by a search string matched against title and body.';
+    }
+
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'spaceId' => ['type' => 'string', 'description' => 'Restrict to one space.'],
+                'parentId' => ['type' => 'string', 'description' => 'Restrict to the direct children of this page.'],
+                'search' => ['type' => 'string', 'description' => 'Case-insensitive match on title or body.'],
+                'page' => ['type' => 'integer', 'minimum' => 1],
+                'limit' => ['type' => 'integer', 'minimum' => 1, 'maximum' => 100],
+            ],
+            'additionalProperties' => false,
+        ];
+    }
+
+    public function invoke(array $arguments, User $user): array
+    {
+        ['page' => $page, 'limit' => $limit] = $this->input->pagination($arguments);
+
+        $qb = $this->em->getRepository(Page::class)
+            ->createQueryBuilder('p')
+            ->where(SpaceMembershipDql::userBelongsToProjectSpace('p', 'page_list'))
+            ->setParameter('user', $user)
+            ->orderBy('p.createdAt', 'DESC')
+            ->setFirstResult(($page - 1) * $limit)
+            ->setMaxResults($limit);
+
+        $spaceId = $this->input->optionalUuid('spaceId', $arguments['spaceId'] ?? null);
+        if (null !== $spaceId) {
+            $qb->andWhere('p.space = :spaceId')->setParameter('spaceId', $spaceId);
+        }
+        $parentId = $this->input->optionalUuid('parentId', $arguments['parentId'] ?? null);
+        if (null !== $parentId) {
+            $qb->andWhere('p.parent = :parentId')->setParameter('parentId', $parentId);
+        }
+        $search = $this->input->optionalString($arguments, 'search');
+        if (null !== $search && '' !== trim($search)) {
+            $qb->andWhere('(LOWER(p.title) LIKE :q OR LOWER(p.body) LIKE :q)')
+                ->setParameter('q', '%' . strtolower(trim($search)) . '%');
+        }
+
+        $paginator = new Paginator($qb->getQuery(), fetchJoinCollection: false);
+        $items = [];
+        foreach ($paginator as $row) {
+            /** @var Page $row */
+            $items[] = $this->serializer->page($row);
+        }
+
+        return [
+            'items' => $items,
+            'total' => count($paginator),
+            'page' => $page,
+            'limit' => $limit,
+        ];
+    }
+}

--- a/api/src/Mcp/Tool/ListSpacesTool.php
+++ b/api/src/Mcp/Tool/ListSpacesTool.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Space;
+use App\Entity\SpaceGroupMembership;
+use App\Entity\SpaceMembership;
+use App\Entity\User;
+use App\Mcp\McpEntitySerializer;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Lists the spaces the caller belongs to — the containers that projects,
+ * pages, and discussions live in. Most other create tools accept a
+ * `spaceId`, so this is the discovery step that lets the model target a
+ * shared space instead of always defaulting to the personal one.
+ */
+final class ListSpacesTool implements McpToolInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private McpEntitySerializer $serializer,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'list_spaces';
+    }
+
+    public function getDescription(): string
+    {
+        return 'List the spaces the user belongs to (personal first, then shared), with the user\'s role in each. Spaces are the top-level containers for projects, pages, and discussions; pass a returned space id as spaceId to other create tools to place content in a shared space.';
+    }
+
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => new \stdClass(),
+            'additionalProperties' => false,
+        ];
+    }
+
+    public function invoke(array $arguments, User $user): array
+    {
+        // Direct or group-inherited membership, mirroring
+        // SpaceAccessExtension's EXISTS scoping.
+        $direct = sprintf(
+            'SELECT 1 FROM %s sp_direct WHERE sp_direct.space = s AND sp_direct.user = :user',
+            SpaceMembership::class,
+        );
+        $group = sprintf(
+            'SELECT 1 FROM %s sp_grp JOIN sp_grp.userGroup sp_grp_obj '
+            . 'JOIN sp_grp_obj.memberships sp_grp_member '
+            . 'WHERE sp_grp.space = s AND sp_grp_member.user = :user',
+            SpaceGroupMembership::class,
+        );
+
+        $spaces = $this->em->getRepository(Space::class)
+            ->createQueryBuilder('s')
+            ->where(sprintf('(EXISTS(%s) OR EXISTS(%s))', $direct, $group))
+            ->setParameter('user', $user)
+            ->orderBy('s.isPersonal', 'DESC')
+            ->addOrderBy('s.createdAt', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return [
+            'items' => array_map(
+                fn (Space $space) => $this->serializer->space($space, $user),
+                $spaces,
+            ),
+        ];
+    }
+}

--- a/api/src/Mcp/Tool/ListTagsTool.php
+++ b/api/src/Mcp/Tool/ListTagsTool.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Tag;
+use App\Entity\User;
+use App\Mcp\McpEntitySerializer;
+use App\Repository\TagRepository;
+
+/**
+ * Lists the caller's own tags so the model can discover existing tag ids
+ * before attaching them to a task (or decide to create a new one).
+ */
+final class ListTagsTool implements McpToolInterface
+{
+    public function __construct(
+        private TagRepository $tags,
+        private McpEntitySerializer $serializer,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'list_tags';
+    }
+
+    public function getDescription(): string
+    {
+        return 'List the tags owned by the authenticated user, alphabetically. Use the returned ids as tagIds when creating or updating tasks.';
+    }
+
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => new \stdClass(),
+            'additionalProperties' => false,
+        ];
+    }
+
+    public function invoke(array $arguments, User $user): array
+    {
+        $tags = $this->tags->createQueryBuilder('t')
+            ->where('t.owner = :user')
+            ->setParameter('user', $user)
+            ->orderBy('t.title', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return [
+            'items' => array_map(
+                fn (Tag $tag) => $this->serializer->tag($tag),
+                $tags,
+            ),
+        ];
+    }
+}

--- a/api/src/Mcp/Tool/UpdatePageTool.php
+++ b/api/src/Mcp/Tool/UpdatePageTool.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Page;
+use App\Entity\User;
+use App\Mcp\McpAuthorization;
+use App\Mcp\McpEntitySerializer;
+use App\Mcp\McpException;
+use App\Mcp\McpInputHelper;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Patches a page. Editable by the author or a space admin, mirroring the
+ * REST `Patch` security expression. The page's space is fixed here — use
+ * the REST move endpoint to relocate a page between spaces.
+ */
+final class UpdatePageTool implements McpToolInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private McpAuthorization $authz,
+        private McpEntitySerializer $serializer,
+        private McpInputHelper $input,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'update_page';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Patch one or more fields on a page (title, body, position, parent). Only fields included in the call are changed. Editable by the page author or a space admin.';
+    }
+
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'pageId' => ['type' => 'string', 'description' => 'UUID of the page.'],
+                'title' => ['type' => 'string'],
+                'body' => ['type' => 'string'],
+                'position' => ['type' => 'integer', 'minimum' => 0],
+                'parentId' => ['type' => ['string', 'null'], 'description' => 'Re-nest under another page in the same space, or null to make it top-level.'],
+            ],
+            'required' => ['pageId'],
+            'additionalProperties' => false,
+        ];
+    }
+
+    public function invoke(array $arguments, User $user): array
+    {
+        $pageId = $this->input->requireUuid('pageId', $arguments['pageId'] ?? null);
+        $page = $this->em->getRepository(Page::class)->find($pageId);
+        if (null === $page || !$this->authz->canReadPage($page, $user)) {
+            throw McpException::notFound(sprintf('Page %s', $pageId));
+        }
+        if (!$this->authz->canEditPage($page, $user)) {
+            throw McpException::forbidden('Only the page author or a space admin can edit this page.');
+        }
+
+        if (array_key_exists('title', $arguments)) {
+            $page->setTitle($this->input->requireString($arguments, 'title'));
+        }
+        if (array_key_exists('body', $arguments)) {
+            $page->setBody($this->input->optionalString($arguments, 'body') ?? '');
+        }
+        if (array_key_exists('position', $arguments)) {
+            $page->setPosition($this->input->optionalInt($arguments, 'position') ?? 0);
+        }
+        if (array_key_exists('parentId', $arguments)) {
+            if (null === $arguments['parentId']) {
+                $page->setParent(null);
+            } else {
+                $parentId = $this->input->requireUuid('parentId', $arguments['parentId']);
+                if ($parentId->equals($pageId)) {
+                    throw McpException::invalidInput('A page cannot be its own parent.');
+                }
+                $parent = $this->em->getRepository(Page::class)->find($parentId);
+                if (null === $parent || !$this->authz->canReadPage($parent, $user)) {
+                    throw McpException::notFound(sprintf('Page %s', $parentId));
+                }
+                if ($parent->getSpace()?->getId()?->equals($page->getSpace()?->getId()) !== true) {
+                    throw McpException::invalidInput('The parent page must be in the same space.');
+                }
+                $page->setParent($parent);
+            }
+        }
+
+        $this->input->assertValid($page);
+        $this->em->flush();
+
+        return $this->serializer->page($page);
+    }
+}

--- a/api/src/Mcp/Tool/UpdateTaskTool.php
+++ b/api/src/Mcp/Tool/UpdateTaskTool.php
@@ -2,6 +2,8 @@
 
 namespace App\Mcp\Tool;
 
+use App\Entity\CustomFieldDefinition;
+use App\Entity\CustomFieldValue;
 use App\Entity\Project;
 use App\Entity\Task;
 use App\Entity\User;
@@ -57,6 +59,19 @@ final class UpdateTaskTool implements McpToolInterface
                     'type' => 'array',
                     'items' => ['type' => 'string'],
                     'description' => 'Replaces the existing tag set.',
+                ],
+                'customFieldValues' => [
+                    'type' => 'array',
+                    'description' => 'Replaces the whole set of custom field values on the task. Each entry sets one field defined on the task\'s project (see get_custom_fields). Omit a definition to leave it unset; pass an empty array to clear all values.',
+                    'items' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'definitionId' => ['type' => 'string', 'description' => 'UUID of a CustomFieldDefinition on the task\'s project.'],
+                            'value' => ['description' => 'The value, shaped to the field\'s kind/subtype (string, number, bool, ISO date, {amount,currency} for money, an IRI for references, or an array when the field is multi).'],
+                        ],
+                        'required' => ['definitionId', 'value'],
+                        'additionalProperties' => false,
+                    ],
                 ],
             ],
             'required' => ['taskId'],
@@ -127,10 +142,48 @@ final class UpdateTaskTool implements McpToolInterface
                 $task->addTag($tag);
             }
         }
+        if (array_key_exists('customFieldValues', $arguments)) {
+            $this->applyCustomFieldValues($task, $arguments['customFieldValues']);
+        }
 
         $this->input->assertValid($task);
         $this->em->flush();
 
         return $this->serializer->task($task);
+    }
+
+    /**
+     * Replace the task's whole custom-field-value set. Existing rows are
+     * dropped (orphanRemoval reaps them) and rebuilt from the payload;
+     * the deferrable `(task_id, definition_id)` unique constraint lets
+     * the delete-then-insert collapse in one flush. Per-value shape,
+     * project-scope, and required-ness are policed by
+     * {@see \App\Validator\ValidCustomFieldValues} via assertValid().
+     */
+    private function applyCustomFieldValues(Task $task, mixed $raw): void
+    {
+        if (!is_array($raw)) {
+            throw McpException::invalidInput('customFieldValues must be an array.');
+        }
+        foreach ($task->getCustomFieldValues()->toArray() as $existing) {
+            $task->removeCustomFieldValue($existing);
+        }
+        foreach ($raw as $entry) {
+            if (!is_array($entry)) {
+                throw McpException::invalidInput('Each customFieldValues entry must be an object.');
+            }
+            $definitionId = $this->input->requireUuid(
+                'customFieldValues[].definitionId',
+                $entry['definitionId'] ?? null,
+            );
+            $definition = $this->em->getRepository(CustomFieldDefinition::class)->find($definitionId);
+            if (null === $definition) {
+                throw McpException::notFound(sprintf('Custom field %s', $definitionId));
+            }
+            $value = new CustomFieldValue();
+            $value->setDefinition($definition);
+            $value->setValue($entry['value'] ?? null);
+            $task->addCustomFieldValue($value);
+        }
     }
 }

--- a/api/src/Security/AuthenticatedUserResolver.php
+++ b/api/src/Security/AuthenticatedUserResolver.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+use App\Entity\User;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+
+/**
+ * Resolves the authenticated {@see User} or rejects with a 401. The
+ * "stamp the current user as owner/author" creation processors
+ * ({@see \App\State\TaskOwnerProcessor}, {@see \App\State\CommentAuthorProcessor}, …)
+ * compose this resolver instead of each repeating the getUser() + instanceof
+ * guard, so the unauthenticated-request behaviour is defined in one place.
+ */
+final class AuthenticatedUserResolver
+{
+    public function __construct(
+        private readonly Security $security,
+    ) {
+    }
+
+    /**
+     * @param string $action fills "You must be authenticated to <action>."
+     *                       (e.g. "create a task")
+     */
+    public function requireUser(string $action): User
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new UnauthorizedHttpException('Bearer', sprintf('You must be authenticated to %s.', $action));
+        }
+
+        return $user;
+    }
+}

--- a/api/src/Service/AccountExportBuilder.php
+++ b/api/src/Service/AccountExportBuilder.php
@@ -4,9 +4,8 @@ namespace App\Service;
 
 use App\Entity\AccountExport;
 use App\Entity\MediaObject;
-use App\Entity\User;
+use App\Service\Export\ExportArchiveWriter;
 use Doctrine\ORM\EntityManagerInterface;
-use League\Flysystem\FilesystemOperator;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
@@ -36,8 +35,7 @@ final class AccountExportBuilder
     public function __construct(
         private EntityManagerInterface $em,
         private UserDataExporter $exporter,
-        #[Autowire(service: 'media.storage')]
-        private FilesystemOperator $mediaStorage,
+        private ExportArchiveWriter $archive,
         #[Autowire('%app.account_export_dir%')]
         private string $exportDir,
     ) {
@@ -74,13 +72,13 @@ final class AccountExportBuilder
 
         $account = $this->exporter->export($user);
         $account['exportedAt'] = (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM);
-        $account['attachments'] = array_values(array_map(static fn (MediaObject $m): array => [
+        $account['attachments'] = array_values(array_map(fn (MediaObject $m): array => [
             'id' => (string) $m->getId(),
             'kind' => $m->getKind(),
             'originalName' => $m->getOriginalName(),
             'mimeType' => $m->getMimeType(),
             'byteSize' => $m->getByteSize(),
-            'file' => self::attachmentFileName($m),
+            'file' => $this->archive->attachmentFileName($m),
         ], $media));
 
         $zip = new \ZipArchive();
@@ -89,17 +87,17 @@ final class AccountExportBuilder
         }
 
         try {
-            $this->addJson($zip, 'account.json', $account);
+            $this->archive->addJson($zip, 'account.json', $account);
 
             foreach ($media as $mediaObject) {
-                $this->addAttachment($zip, $mediaObject, $partsDir);
+                $this->archive->addAttachment($zip, $mediaObject, $partsDir);
             }
         } catch (\Throwable $e) {
             $zip->close();
             if (is_file($tmp)) {
                 unlink($tmp);
             }
-            $this->removeDir($partsDir);
+            $this->archive->removeDir($partsDir);
             throw $e;
         }
 
@@ -107,7 +105,7 @@ final class AccountExportBuilder
         // the staging directory must survive until here, then it's safe to
         // remove regardless of success.
         $closed = $zip->close();
-        $this->removeDir($partsDir);
+        $this->archive->removeDir($partsDir);
         if (!$closed) {
             if (is_file($tmp)) {
                 unlink($tmp);
@@ -119,88 +117,5 @@ final class AccountExportBuilder
         }
 
         return $file;
-    }
-
-    /**
-     * Stable in-archive filename for an attachment: media id prefix keeps
-     * names collision-free, the sanitized original name keeps them human.
-     */
-    public static function attachmentFileName(MediaObject $media): string
-    {
-        $name = basename($media->getOriginalName());
-        $sanitized = preg_replace('/[^\w.\- ]+/u', '_', $name);
-        $safe = (null !== $sanitized && '' !== trim($sanitized)) ? trim($sanitized) : 'file';
-
-        return sprintf('attachments/%s-%s', (string) $media->getId(), $safe);
-    }
-
-    /**
-     * @param array<int|string, mixed> $data
-     */
-    private function addJson(\ZipArchive $zip, string $name, array $data): void
-    {
-        $json = json_encode(
-            $data,
-            JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
-        );
-        if (!$zip->addFromString($name, $json)) {
-            throw new \RuntimeException(sprintf('Could not add "%s" to the export archive.', $name));
-        }
-    }
-
-    private function addAttachment(\ZipArchive $zip, MediaObject $media, string $partsDir): void
-    {
-        $path = $media->getVariantPath('original') ?? array_values($media->getVariants())[0] ?? null;
-        if (null === $path || !$this->mediaStorage->fileExists($path)) {
-            // A missing file shouldn't sink the whole export — the JSON
-            // manifest still records that the attachment existed.
-            return;
-        }
-
-        // Stream flysystem → a staged temp file, then hand the path to
-        // ZipArchive::addFile() so the bytes are read from disk at close()
-        // rather than buffered in memory. The media id is unique, so it's a
-        // safe temp filename.
-        $tempPath = $partsDir . '/' . (string) $media->getId();
-        $dest = fopen($tempPath, 'wb');
-        if (false === $dest) {
-            throw new \RuntimeException(sprintf('Could not stage attachment "%s" for export.', (string) $media->getId()));
-        }
-
-        $source = $this->mediaStorage->readStream($path);
-        $copied = stream_copy_to_stream($source, $dest);
-        if (\is_resource($source)) {
-            fclose($source);
-        }
-        fclose($dest);
-        if (false === $copied) {
-            // Couldn't read the bytes — skip rather than abort the export.
-            unlink($tempPath);
-            return;
-        }
-
-        if (!$zip->addFile($tempPath, self::attachmentFileName($media))) {
-            throw new \RuntimeException(sprintf('Could not add attachment "%s" to the export archive.', (string) $media->getId()));
-        }
-    }
-
-    /**
-     * Removes a staging directory and its (flat) contents. Best-effort — a
-     * leftover that survives a hard kill is reaped by AccountExportPruner.
-     */
-    private function removeDir(string $dir): void
-    {
-        if (!is_dir($dir)) {
-            return;
-        }
-        $entries = glob($dir . '/*');
-        if (false !== $entries) {
-            foreach ($entries as $entry) {
-                if (is_file($entry)) {
-                    unlink($entry);
-                }
-            }
-        }
-        rmdir($dir);
     }
 }

--- a/api/src/Service/AccountExportMailer.php
+++ b/api/src/Service/AccountExportMailer.php
@@ -3,9 +3,8 @@
 namespace App\Service;
 
 use App\Entity\AccountExport;
+use App\Service\Mail\MailDispatcher;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\Mailer\MailerInterface;
 
 /**
  * Sends the "your account export is ready" email once the worker has built
@@ -17,31 +16,25 @@ use Symfony\Component\Mailer\MailerInterface;
 final class AccountExportMailer
 {
     public function __construct(
-        private MailerInterface $mailer,
-        #[Autowire('%env(APP_FRONTEND_URL)%')]
-        private string $frontendUrl,
-        #[Autowire('%env(default::MAILER_FROM)%')]
-        private ?string $mailerFrom = null,
+        private readonly MailDispatcher $mail,
     ) {
     }
 
     public function sendExportReady(AccountExport $export, string $plainToken): void
     {
-        $from = (null !== $this->mailerFrom && '' !== $this->mailerFrom) ? $this->mailerFrom : 'no-reply@madori.test';
         $recipient = $export->getRequestedBy();
 
         $email = (new TemplatedEmail())
-            ->from($from)
             ->to($recipient->getEmail())
             ->subject('Your Madori data export is ready')
             ->htmlTemplate('emails/account_export.html.twig')
             ->textTemplate('emails/account_export.txt.twig')
             ->context([
                 'recipient' => $recipient,
-                'downloadUrl' => rtrim($this->frontendUrl, '/') . '/account-exports/' . $plainToken,
+                'downloadUrl' => $this->mail->frontendLink('/account-exports/' . $plainToken),
                 'expiresAt' => $export->getExpiresAt(),
             ]);
 
-        $this->mailer->send($email);
+        $this->mail->send($email);
     }
 }

--- a/api/src/Service/Export/ExportArchiveWriter.php
+++ b/api/src/Service/Export/ExportArchiveWriter.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Export;
+
+use App\Entity\MediaObject;
+use League\Flysystem\FilesystemOperator;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Shared zip-assembly primitives for the export builders
+ * ({@see \App\Service\SpaceExportBuilder} / {@see \App\Service\AccountExportBuilder}).
+ *
+ * The builders compose this writer (inject + call) instead of mixing in a trait,
+ * so the `media.storage` dependency lives here once rather than being an
+ * implicit `$this->mediaStorage` contract each builder has to satisfy.
+ */
+final class ExportArchiveWriter
+{
+    public function __construct(
+        #[Autowire(service: 'media.storage')]
+        private readonly FilesystemOperator $mediaStorage,
+    ) {
+    }
+
+    /**
+     * Stable in-archive filename for an attachment: media id prefix keeps
+     * names collision-free, the sanitized original name keeps them human.
+     */
+    public function attachmentFileName(MediaObject $media): string
+    {
+        $name = basename($media->getOriginalName());
+        $sanitized = preg_replace('/[^\w.\- ]+/u', '_', $name);
+        $safe = (null !== $sanitized && '' !== trim($sanitized)) ? trim($sanitized) : 'file';
+
+        return sprintf('attachments/%s-%s', (string) $media->getId(), $safe);
+    }
+
+    /**
+     * @param array<int|string, mixed> $data
+     */
+    public function addJson(\ZipArchive $zip, string $name, array $data): void
+    {
+        $json = json_encode(
+            $data,
+            JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+        );
+        if (!$zip->addFromString($name, $json)) {
+            throw new \RuntimeException(sprintf('Could not add "%s" to the export archive.', $name));
+        }
+    }
+
+    public function addAttachment(\ZipArchive $zip, MediaObject $media, string $partsDir): void
+    {
+        $path = $media->getVariantPath('original') ?? array_values($media->getVariants())[0] ?? null;
+        if (null === $path || !$this->mediaStorage->fileExists($path)) {
+            // A missing file shouldn't sink the whole export — the JSON
+            // still records that the attachment existed.
+            return;
+        }
+
+        // Stream flysystem → a staged temp file, then hand the path to
+        // ZipArchive::addFile() so the bytes are read from disk at close()
+        // rather than buffered in memory. The media id is unique, so it's a
+        // safe temp filename.
+        $tempPath = $partsDir . '/' . (string) $media->getId();
+        $dest = fopen($tempPath, 'wb');
+        if (false === $dest) {
+            throw new \RuntimeException(sprintf('Could not stage attachment "%s" for export.', (string) $media->getId()));
+        }
+
+        $source = $this->mediaStorage->readStream($path);
+        $copied = stream_copy_to_stream($source, $dest);
+        if (\is_resource($source)) {
+            fclose($source);
+        }
+        fclose($dest);
+        if (false === $copied) {
+            // Couldn't read the bytes — skip rather than abort the export.
+            unlink($tempPath);
+            return;
+        }
+
+        if (!$zip->addFile($tempPath, $this->attachmentFileName($media))) {
+            throw new \RuntimeException(sprintf('Could not add attachment "%s" to the export archive.', (string) $media->getId()));
+        }
+    }
+
+    /**
+     * Removes a staging directory and its (flat) contents. Best-effort — a
+     * leftover that survives a hard kill is reaped by the matching export pruner.
+     */
+    public function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $entries = glob($dir . '/*');
+        if (false !== $entries) {
+            foreach ($entries as $entry) {
+                if (is_file($entry)) {
+                    unlink($entry);
+                }
+            }
+        }
+        rmdir($dir);
+    }
+}

--- a/api/src/Service/InviteMailer.php
+++ b/api/src/Service/InviteMailer.php
@@ -3,8 +3,7 @@
 namespace App\Service;
 
 use App\Entity\UserInvite;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\Mailer\MailerInterface;
+use App\Service\Mail\MailDispatcher;
 use Symfony\Component\Mime\Email;
 
 /**
@@ -21,28 +20,18 @@ use Symfony\Component\Mime\Email;
 final class InviteMailer
 {
     public function __construct(
-        private MailerInterface $mailer,
-        #[Autowire('%env(APP_FRONTEND_URL)%')]
-        private string $frontendUrl,
-        #[Autowire('%env(default::MAILER_FROM)%')]
-        private ?string $mailerFrom = null,
+        private readonly MailDispatcher $mail,
     ) {
     }
 
     public function sendSignupLink(UserInvite $invite, string $plainToken, int $ttlDays): void
     {
-        $signupUrl = sprintf(
-            '%s/signup?invite=%s',
-            rtrim($this->frontendUrl, '/'),
-            $plainToken,
-        );
-        $from = (null !== $this->mailerFrom && '' !== $this->mailerFrom) ? $this->mailerFrom : 'no-reply@madori.test';
+        $signupUrl = $this->mail->frontendLink('/signup?invite=' . $plainToken);
 
         $targets = $this->collectTargetLabels($invite);
         $contextLine = $this->formatContextLine($targets);
 
         $message = (new Email())
-            ->from($from)
             ->to($invite->getEmail())
             ->subject('You\'ve been invited to join Madori')
             ->text(sprintf(
@@ -58,7 +47,7 @@ final class InviteMailer
                 $ttlDays,
             ));
 
-        $this->mailer->send($message);
+        $this->mail->send($message);
     }
 
     /**

--- a/api/src/Service/Mail/MailDispatcher.php
+++ b/api/src/Service/Mail/MailDispatcher.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Mail;
+
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Email;
+
+/**
+ * Shared collaborator for the transactional mailers. It owns the three things
+ * every mailer needs — the MailerInterface, the frontend base URL, and the
+ * MAILER_FROM fallback — so the concrete mailers compose it (inject + call)
+ * rather than inheriting a base class.
+ *
+ * {@see send()} stamps the From address when the message doesn't already carry
+ * one, so callers build their {@see Email}/TemplatedEmail without repeating the
+ * fallback; {@see frontendLink()} builds absolute links into the PWA.
+ */
+final class MailDispatcher
+{
+    public function __construct(
+        private readonly MailerInterface $mailer,
+        #[Autowire('%env(APP_FRONTEND_URL)%')]
+        private readonly string $frontendUrl,
+        #[Autowire('%env(default::MAILER_FROM)%')]
+        private readonly ?string $mailerFrom = null,
+    ) {
+    }
+
+    /**
+     * Sends $email, defaulting its From to the configured sender (or the dev
+     * fallback) when the caller hasn't set one.
+     */
+    public function send(Email $email): void
+    {
+        if ([] === $email->getFrom()) {
+            $email->from($this->senderAddress());
+        }
+
+        $this->mailer->send($email);
+    }
+
+    /**
+     * Absolute frontend URL for $path (a leading slash is expected), with any
+     * trailing slash on the configured base trimmed so the result is well-formed.
+     */
+    public function frontendLink(string $path = ''): string
+    {
+        return rtrim($this->frontendUrl, '/') . $path;
+    }
+
+    /**
+     * The From address, falling back to the dev default when MAILER_FROM is
+     * unset or empty.
+     */
+    private function senderAddress(): string
+    {
+        return (null !== $this->mailerFrom && '' !== $this->mailerFrom)
+            ? $this->mailerFrom
+            : 'no-reply@madori.test';
+    }
+}

--- a/api/src/Service/SpaceExportBuilder.php
+++ b/api/src/Service/SpaceExportBuilder.php
@@ -13,8 +13,8 @@ use App\Entity\SpaceExport;
 use App\Entity\Tag;
 use App\Entity\Task;
 use App\Entity\User;
+use App\Service\Export\ExportArchiveWriter;
 use Doctrine\ORM\EntityManagerInterface;
-use League\Flysystem\FilesystemOperator;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
@@ -42,8 +42,7 @@ final class SpaceExportBuilder
 {
     public function __construct(
         private EntityManagerInterface $em,
-        #[Autowire(service: 'media.storage')]
-        private FilesystemOperator $mediaStorage,
+        private ExportArchiveWriter $archive,
         #[Autowire('%app.space_export_dir%')]
         private string $exportDir,
     ) {
@@ -105,30 +104,30 @@ final class SpaceExportBuilder
             $pageComments = $this->commentsFor($pages, 'page');
             $discussionComments = $this->commentsFor($discussions, 'discussion');
 
-            $this->addJson($zip, 'space.json', $this->spaceData($export));
-            $this->addJson($zip, 'projects.json', array_map($this->projectData(...), $projects));
-            $this->addJson($zip, 'tasks.json', array_map(
+            $this->archive->addJson($zip, 'space.json', $this->spaceData($export));
+            $this->archive->addJson($zip, 'projects.json', array_map($this->projectData(...), $projects));
+            $this->archive->addJson($zip, 'tasks.json', array_map(
                 fn (Task $t): array => $this->taskData($t, $taskComments),
                 $tasks,
             ));
-            $this->addJson($zip, 'pages.json', array_map(
+            $this->archive->addJson($zip, 'pages.json', array_map(
                 fn (Page $p): array => $this->pageData($p, $pageComments),
                 $pages,
             ));
-            $this->addJson($zip, 'discussions.json', array_map(
+            $this->archive->addJson($zip, 'discussions.json', array_map(
                 fn (Discussion $d): array => $this->discussionData($d, $discussionComments),
                 $discussions,
             ));
 
             foreach ($media as $mediaObject) {
-                $this->addAttachment($zip, $mediaObject, $partsDir);
+                $this->archive->addAttachment($zip, $mediaObject, $partsDir);
             }
         } catch (\Throwable $e) {
             $zip->close();
             if (is_file($tmp)) {
                 unlink($tmp);
             }
-            $this->removeDir($partsDir);
+            $this->archive->removeDir($partsDir);
             throw $e;
         }
 
@@ -136,7 +135,7 @@ final class SpaceExportBuilder
         // the staging directory must survive until here, then it's safe to
         // remove regardless of success.
         $closed = $zip->close();
-        $this->removeDir($partsDir);
+        $this->archive->removeDir($partsDir);
         if (!$closed) {
             if (is_file($tmp)) {
                 unlink($tmp);
@@ -148,89 +147,6 @@ final class SpaceExportBuilder
         }
 
         return $file;
-    }
-
-    /**
-     * Stable in-archive filename for an attachment: media id prefix keeps
-     * names collision-free, the sanitized original name keeps them human.
-     */
-    public static function attachmentFileName(MediaObject $media): string
-    {
-        $name = basename($media->getOriginalName());
-        $sanitized = preg_replace('/[^\w.\- ]+/u', '_', $name);
-        $safe = (null !== $sanitized && '' !== trim($sanitized)) ? trim($sanitized) : 'file';
-
-        return sprintf('attachments/%s-%s', (string) $media->getId(), $safe);
-    }
-
-    /**
-     * @param array<int|string, mixed> $data
-     */
-    private function addJson(\ZipArchive $zip, string $name, array $data): void
-    {
-        $json = json_encode(
-            $data,
-            JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
-        );
-        if (!$zip->addFromString($name, $json)) {
-            throw new \RuntimeException(sprintf('Could not add "%s" to the export archive.', $name));
-        }
-    }
-
-    private function addAttachment(\ZipArchive $zip, MediaObject $media, string $partsDir): void
-    {
-        $path = $media->getVariantPath('original') ?? array_values($media->getVariants())[0] ?? null;
-        if (null === $path || !$this->mediaStorage->fileExists($path)) {
-            // A missing file shouldn't sink the whole export — the JSON
-            // still records that the attachment existed.
-            return;
-        }
-
-        // Stream flysystem → a staged temp file, then hand the path to
-        // ZipArchive::addFile() so the bytes are read from disk at close()
-        // rather than buffered in memory. The media id is unique, so it's a
-        // safe temp filename.
-        $tempPath = $partsDir . '/' . (string) $media->getId();
-        $dest = fopen($tempPath, 'wb');
-        if (false === $dest) {
-            throw new \RuntimeException(sprintf('Could not stage attachment "%s" for export.', (string) $media->getId()));
-        }
-
-        $source = $this->mediaStorage->readStream($path);
-        $copied = stream_copy_to_stream($source, $dest);
-        if (\is_resource($source)) {
-            fclose($source);
-        }
-        fclose($dest);
-        if (false === $copied) {
-            // Couldn't read the bytes — skip rather than abort the export.
-            unlink($tempPath);
-            return;
-        }
-
-        if (!$zip->addFile($tempPath, self::attachmentFileName($media))) {
-            throw new \RuntimeException(sprintf('Could not add attachment "%s" to the export archive.', (string) $media->getId()));
-        }
-    }
-
-    /**
-     * Removes a staging directory and its (flat) contents. Best-effort —
-     * a leftover that survives a hard kill is reaped by SpaceExportPruner.
-     */
-    private function removeDir(string $dir): void
-    {
-        if (!is_dir($dir)) {
-            return;
-        }
-        $entries = glob($dir . '/*');
-        if (false !== $entries) {
-            foreach ($entries as $entry) {
-                if (is_file($entry)) {
-                    unlink($entry);
-                }
-            }
-        }
-        rmdir($dir);
     }
 
     /**
@@ -306,9 +222,9 @@ final class SpaceExportBuilder
                 'name' => $v->getDefinition()?->getName(),
                 'value' => $v->getValue(),
             ], $task->getCustomFieldValues()->toArray()),
-            'attachments' => array_map(static fn (MediaObject $m): array => [
+            'attachments' => array_map(fn (MediaObject $m): array => [
                 'id' => (string) $m->getId(),
-                'file' => self::attachmentFileName($m),
+                'file' => $this->archive->attachmentFileName($m),
                 'originalName' => $m->getOriginalName(),
             ], $task->getAttachments()->toArray()),
             'comments' => $commentsByParent[(string) $task->getId()] ?? [],

--- a/api/src/Service/SpaceExportMailer.php
+++ b/api/src/Service/SpaceExportMailer.php
@@ -3,9 +3,8 @@
 namespace App\Service;
 
 use App\Entity\SpaceExport;
+use App\Service\Mail\MailDispatcher;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\Mailer\MailerInterface;
 
 /**
  * Sends the "your space export is ready" email once the worker has built
@@ -17,21 +16,15 @@ use Symfony\Component\Mailer\MailerInterface;
 final class SpaceExportMailer
 {
     public function __construct(
-        private MailerInterface $mailer,
-        #[Autowire('%env(APP_FRONTEND_URL)%')]
-        private string $frontendUrl,
-        #[Autowire('%env(default::MAILER_FROM)%')]
-        private ?string $mailerFrom = null,
+        private readonly MailDispatcher $mail,
     ) {
     }
 
     public function sendExportReady(SpaceExport $export, string $plainToken): void
     {
-        $from = (null !== $this->mailerFrom && '' !== $this->mailerFrom) ? $this->mailerFrom : 'no-reply@madori.test';
         $recipient = $export->getRequestedBy();
 
         $email = (new TemplatedEmail())
-            ->from($from)
             ->to($recipient->getEmail())
             ->subject(sprintf('Your export of "%s" is ready', $export->getSpace()->getName()))
             ->htmlTemplate('emails/space_export.html.twig')
@@ -39,10 +32,10 @@ final class SpaceExportMailer
             ->context([
                 'recipient' => $recipient,
                 'space' => $export->getSpace(),
-                'downloadUrl' => rtrim($this->frontendUrl, '/') . '/exports/' . $plainToken,
+                'downloadUrl' => $this->mail->frontendLink('/exports/' . $plainToken),
                 'expiresAt' => $export->getExpiresAt(),
             ]);
 
-        $this->mailer->send($email);
+        $this->mail->send($email);
     }
 }

--- a/api/src/Service/TwoFactorRecoveryMailer.php
+++ b/api/src/Service/TwoFactorRecoveryMailer.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace App\Service;
 
 use App\Entity\User;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\Mailer\MailerInterface;
+use App\Service\Mail\MailDispatcher;
 use Symfony\Component\Mime\Email;
 
 /**
@@ -27,17 +26,13 @@ use Symfony\Component\Mime\Email;
 final class TwoFactorRecoveryMailer
 {
     public function __construct(
-        private MailerInterface $mailer,
-        #[Autowire('%env(APP_FRONTEND_URL)%')]
-        private string $frontendUrl,
-        #[Autowire('%env(default::MAILER_FROM)%')]
-        private ?string $mailerFrom = null,
+        private readonly MailDispatcher $mail,
     ) {
     }
 
     public function sendBackupCodeUsed(User $user): void
     {
-        $accountUrl = $this->url('/account');
+        $accountUrl = $this->mail->frontendLink('/account');
         $this->dispatch(
             $user,
             'A recovery code was used on your Madori account',
@@ -56,7 +51,7 @@ final class TwoFactorRecoveryMailer
 
     public function sendDisabled(User $user): void
     {
-        $accountUrl = $this->url('/account');
+        $accountUrl = $this->mail->frontendLink('/account');
         $this->dispatch(
             $user,
             'Two-factor authentication was disabled',
@@ -75,7 +70,7 @@ final class TwoFactorRecoveryMailer
 
     public function sendReconfigured(User $user): void
     {
-        $accountUrl = $this->url('/account');
+        $accountUrl = $this->mail->frontendLink('/account');
         $this->dispatch(
             $user,
             'A new authenticator was enrolled for your account',
@@ -99,22 +94,12 @@ final class TwoFactorRecoveryMailer
             return;
         }
 
-        $from = (null !== $this->mailerFrom && '' !== $this->mailerFrom)
-            ? $this->mailerFrom
-            : 'no-reply@madori.test';
-
         $message = (new Email())
-            ->from($from)
             ->to($to)
             ->subject($subject)
             ->text($text)
             ->html($html);
 
-        $this->mailer->send($message);
-    }
-
-    private function url(string $path): string
-    {
-        return rtrim($this->frontendUrl, '/') . $path;
+        $this->mail->send($message);
     }
 }

--- a/api/src/Service/WaitlistAccessMailer.php
+++ b/api/src/Service/WaitlistAccessMailer.php
@@ -3,9 +3,8 @@
 namespace App\Service;
 
 use App\Entity\User;
+use App\Service\Mail\MailDispatcher;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\Mailer\MailerInterface;
 
 /**
  * Sends the "your account is ready" email when a waitlisted user is promoted
@@ -19,29 +18,22 @@ use Symfony\Component\Mailer\MailerInterface;
 final class WaitlistAccessMailer
 {
     public function __construct(
-        private MailerInterface $mailer,
-        #[Autowire('%env(APP_FRONTEND_URL)%')]
-        private string $frontendUrl,
-        #[Autowire('%env(default::MAILER_FROM)%')]
-        private ?string $mailerFrom = null,
+        private readonly MailDispatcher $mail,
     ) {
     }
 
     public function sendAccessGranted(User $user): void
     {
-        $from = (null !== $this->mailerFrom && '' !== $this->mailerFrom) ? $this->mailerFrom : 'no-reply@madori.test';
-
         $email = (new TemplatedEmail())
-            ->from($from)
             ->to($user->getEmail())
             ->subject('Your Madori account is ready')
             ->htmlTemplate('emails/waitlist_access.html.twig')
             ->textTemplate('emails/waitlist_access.txt.twig')
             ->context([
                 'recipient' => $user,
-                'signinUrl' => rtrim($this->frontendUrl, '/') . '/signin',
+                'signinUrl' => $this->mail->frontendLink('/signin'),
             ]);
 
-        $this->mailer->send($email);
+        $this->mail->send($email);
     }
 }

--- a/api/src/Service/WaitlistJoinedMailer.php
+++ b/api/src/Service/WaitlistJoinedMailer.php
@@ -3,9 +3,8 @@
 namespace App\Service;
 
 use App\Entity\User;
+use App\Service\Mail\MailDispatcher;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\Mailer\MailerInterface;
 
 /**
  * Sends the "you're on the waitlist" confirmation email at signup time while
@@ -21,18 +20,13 @@ use Symfony\Component\Mailer\MailerInterface;
 final class WaitlistJoinedMailer
 {
     public function __construct(
-        private MailerInterface $mailer,
-        #[Autowire('%env(default::MAILER_FROM)%')]
-        private ?string $mailerFrom = null,
+        private readonly MailDispatcher $mail,
     ) {
     }
 
     public function sendJoinedConfirmation(User $user): void
     {
-        $from = (null !== $this->mailerFrom && '' !== $this->mailerFrom) ? $this->mailerFrom : 'no-reply@madori.test';
-
         $email = (new TemplatedEmail())
-            ->from($from)
             ->to($user->getEmail())
             ->subject("You're on the Madori waitlist")
             ->htmlTemplate('emails/waitlist_joined.html.twig')
@@ -41,6 +35,6 @@ final class WaitlistJoinedMailer
                 'recipient' => $user,
             ]);
 
-        $this->mailer->send($email);
+        $this->mail->send($email);
     }
 }

--- a/api/src/State/CommentAuthorProcessor.php
+++ b/api/src/State/CommentAuthorProcessor.php
@@ -5,13 +5,11 @@ namespace App\State;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\Entity\Comment;
-use App\Entity\User;
+use App\Security\AuthenticatedUserResolver;
 use App\Service\CommentActivityNotifier;
 use App\Service\CommentMentionService;
 use App\Service\CommentMercurePublisher;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 /**
  * Stamps the comment with the currently authenticated user before
@@ -31,7 +29,7 @@ final class CommentAuthorProcessor implements ProcessorInterface
     public function __construct(
         #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
         private ProcessorInterface $persistProcessor,
-        private Security $security,
+        private AuthenticatedUserResolver $auth,
         private CommentMercurePublisher $publisher,
         private CommentMentionService $mentions,
         private CommentActivityNotifier $activity,
@@ -43,10 +41,7 @@ final class CommentAuthorProcessor implements ProcessorInterface
      */
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Comment
     {
-        $user = $this->security->getUser();
-        if (!$user instanceof User) {
-            throw new UnauthorizedHttpException('Bearer', 'You must be authenticated to comment.');
-        }
+        $user = $this->auth->requireUser('comment');
 
         $data->setAuthor($user);
 

--- a/api/src/State/DiscussionAuthorProcessor.php
+++ b/api/src/State/DiscussionAuthorProcessor.php
@@ -5,10 +5,8 @@ namespace App\State;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\Entity\Discussion;
-use App\Entity\User;
-use Symfony\Bundle\SecurityBundle\Security;
+use App\Security\AuthenticatedUserResolver;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 /**
  * Stamps the current user as the discussion author before persisting,
@@ -26,7 +24,7 @@ final class DiscussionAuthorProcessor implements ProcessorInterface
     public function __construct(
         #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
         private ProcessorInterface $persistProcessor,
-        private Security $security,
+        private AuthenticatedUserResolver $auth,
     ) {
     }
 
@@ -35,10 +33,7 @@ final class DiscussionAuthorProcessor implements ProcessorInterface
      */
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Discussion
     {
-        $user = $this->security->getUser();
-        if (!$user instanceof User) {
-            throw new UnauthorizedHttpException('Bearer', 'You must be authenticated to start a discussion.');
-        }
+        $user = $this->auth->requireUser('start a discussion');
 
         $data->setAuthor($user);
 

--- a/api/src/State/PageAuthorProcessor.php
+++ b/api/src/State/PageAuthorProcessor.php
@@ -5,10 +5,8 @@ namespace App\State;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\Entity\Page;
-use App\Entity\User;
-use Symfony\Bundle\SecurityBundle\Security;
+use App\Security\AuthenticatedUserResolver;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 /**
  * Stamps the creator on a new {@see Page} (#183). Mirrors the
@@ -26,7 +24,7 @@ final class PageAuthorProcessor implements ProcessorInterface
     public function __construct(
         #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
         private ProcessorInterface $persistProcessor,
-        private Security $security,
+        private AuthenticatedUserResolver $auth,
     ) {
     }
 
@@ -35,10 +33,7 @@ final class PageAuthorProcessor implements ProcessorInterface
      */
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Page
     {
-        $user = $this->security->getUser();
-        if (!$user instanceof User) {
-            throw new UnauthorizedHttpException('Bearer', 'You must be authenticated to create a page.');
-        }
+        $user = $this->auth->requireUser('create a page');
         $data->setCreatedBy($user);
 
         return $this->persistProcessor->process($data, $operation, $uriVariables, $context);

--- a/api/src/State/ProjectOwnerProcessor.php
+++ b/api/src/State/ProjectOwnerProcessor.php
@@ -5,11 +5,9 @@ namespace App\State;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\Entity\Project;
-use App\Entity\User;
 use App\Repository\SpaceRepository;
-use Symfony\Bundle\SecurityBundle\Security;
+use App\Security\AuthenticatedUserResolver;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 /**
  * Stamps the creator as owner of a new Project and adds them to the member
@@ -26,7 +24,7 @@ final class ProjectOwnerProcessor implements ProcessorInterface
     public function __construct(
         #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
         private ProcessorInterface $persistProcessor,
-        private Security $security,
+        private AuthenticatedUserResolver $auth,
         private SpaceRepository $spaceRepository,
     ) {
     }
@@ -36,10 +34,7 @@ final class ProjectOwnerProcessor implements ProcessorInterface
      */
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Project
     {
-        $user = $this->security->getUser();
-        if (!$user instanceof User) {
-            throw new UnauthorizedHttpException('Bearer', 'You must be authenticated to create a project.');
-        }
+        $user = $this->auth->requireUser('create a project');
 
         $data->setOwner($user);
 

--- a/api/src/State/PushSubscriptionOwnerProcessor.php
+++ b/api/src/State/PushSubscriptionOwnerProcessor.php
@@ -5,10 +5,8 @@ namespace App\State;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\Entity\PushSubscription;
-use App\Entity\User;
-use Symfony\Bundle\SecurityBundle\Security;
+use App\Security\AuthenticatedUserResolver;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 /**
  * Stamps the current user on a freshly-created PushSubscription before
@@ -27,7 +25,7 @@ final class PushSubscriptionOwnerProcessor implements ProcessorInterface
     public function __construct(
         #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
         private ProcessorInterface $persistProcessor,
-        private Security $security,
+        private AuthenticatedUserResolver $auth,
     ) {
     }
 
@@ -36,10 +34,7 @@ final class PushSubscriptionOwnerProcessor implements ProcessorInterface
      */
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): PushSubscription
     {
-        $user = $this->security->getUser();
-        if (!$user instanceof User) {
-            throw new UnauthorizedHttpException('Bearer', 'You must be authenticated to register a push subscription.');
-        }
+        $user = $this->auth->requireUser('register a push subscription');
 
         $data->setUser($user);
 

--- a/api/src/State/SegmentCreateProcessor.php
+++ b/api/src/State/SegmentCreateProcessor.php
@@ -5,10 +5,8 @@ namespace App\State;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\Entity\Segment;
-use App\Entity\User;
-use Symfony\Bundle\SecurityBundle\Security;
+use App\Security\AuthenticatedUserResolver;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 /**
  * Stamps the creating admin onto a new Segment, then hands off to the
@@ -24,7 +22,7 @@ final class SegmentCreateProcessor implements ProcessorInterface
     public function __construct(
         #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
         private ProcessorInterface $persistProcessor,
-        private Security $security,
+        private AuthenticatedUserResolver $auth,
     ) {
     }
 
@@ -33,10 +31,7 @@ final class SegmentCreateProcessor implements ProcessorInterface
      */
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Segment
     {
-        $user = $this->security->getUser();
-        if (!$user instanceof User) {
-            throw new UnauthorizedHttpException('Bearer', 'You must be authenticated to create a segment.');
-        }
+        $user = $this->auth->requireUser('create a segment');
 
         $data->setCreatedBy($user);
 

--- a/api/src/State/SpaceCreateProcessor.php
+++ b/api/src/State/SpaceCreateProcessor.php
@@ -7,11 +7,10 @@ use ApiPlatform\State\ProcessorInterface;
 use App\Entity\Space;
 use App\Entity\SpaceMembership;
 use App\Entity\User;
+use App\Security\AuthenticatedUserResolver;
 use App\Service\SpaceMemberAdder;
 use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 /**
  * Stamps the creator on a new Space and provisions an admin
@@ -39,7 +38,7 @@ final class SpaceCreateProcessor implements ProcessorInterface
     public function __construct(
         #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
         private ProcessorInterface $persistProcessor,
-        private Security $security,
+        private AuthenticatedUserResolver $auth,
         private EntityManagerInterface $em,
         private SpaceMemberAdder $memberAdder,
     ) {
@@ -50,10 +49,7 @@ final class SpaceCreateProcessor implements ProcessorInterface
      */
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Space
     {
-        $user = $this->security->getUser();
-        if (!$user instanceof User) {
-            throw new UnauthorizedHttpException('Bearer', 'You must be authenticated to create a space.');
-        }
+        $user = $this->auth->requireUser('create a space');
 
         $data->setCreatedBy($user);
         $data->setIsPersonal(false);

--- a/api/src/State/TagOwnerProcessor.php
+++ b/api/src/State/TagOwnerProcessor.php
@@ -5,10 +5,8 @@ namespace App\State;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\Entity\Tag;
-use App\Entity\User;
-use Symfony\Bundle\SecurityBundle\Security;
+use App\Security\AuthenticatedUserResolver;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 /**
  * Sets the owner of a new Tag to the currently authenticated user. Mirrors
@@ -24,7 +22,7 @@ final class TagOwnerProcessor implements ProcessorInterface
     public function __construct(
         #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
         private ProcessorInterface $persistProcessor,
-        private Security $security,
+        private AuthenticatedUserResolver $auth,
     ) {
     }
 
@@ -33,10 +31,7 @@ final class TagOwnerProcessor implements ProcessorInterface
      */
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Tag
     {
-        $user = $this->security->getUser();
-        if (!$user instanceof User) {
-            throw new UnauthorizedHttpException('Bearer', 'You must be authenticated to create a tag.');
-        }
+        $user = $this->auth->requireUser('create a tag');
 
         $data->setOwner($user);
 

--- a/api/src/State/TaskOwnerProcessor.php
+++ b/api/src/State/TaskOwnerProcessor.php
@@ -5,12 +5,10 @@ namespace App\State;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\Entity\Task;
-use App\Entity\User;
 use App\Repository\TaskRepository;
+use App\Security\AuthenticatedUserResolver;
 use App\Service\TaskActivityNotifier;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 /**
  * Sets the owner of a new Task to the currently authenticated user and
@@ -28,7 +26,7 @@ final class TaskOwnerProcessor implements ProcessorInterface
     public function __construct(
         #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
         private ProcessorInterface $persistProcessor,
-        private Security $security,
+        private AuthenticatedUserResolver $auth,
         private TaskRepository $tasks,
         private TaskActivityNotifier $activity,
     ) {
@@ -39,10 +37,7 @@ final class TaskOwnerProcessor implements ProcessorInterface
      */
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Task
     {
-        $user = $this->security->getUser();
-        if (!$user instanceof User) {
-            throw new UnauthorizedHttpException('Bearer', 'You must be authenticated to create a task.');
-        }
+        $user = $this->auth->requireUser('create a task');
 
         $data->setOwner($user);
 

--- a/api/src/State/UserGroupOwnerProcessor.php
+++ b/api/src/State/UserGroupOwnerProcessor.php
@@ -4,12 +4,10 @@ namespace App\State;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
-use App\Entity\User;
 use App\Entity\UserGroup;
 use App\Repository\UserGroupRepository;
-use Symfony\Bundle\SecurityBundle\Security;
+use App\Security\AuthenticatedUserResolver;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 /**
  * Stamps the creator as owner of a new UserGroup, adds them to the
@@ -27,7 +25,7 @@ final class UserGroupOwnerProcessor implements ProcessorInterface
     public function __construct(
         #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
         private ProcessorInterface $persistProcessor,
-        private Security $security,
+        private AuthenticatedUserResolver $auth,
         private UserGroupRepository $userGroupRepository,
     ) {
     }
@@ -37,10 +35,7 @@ final class UserGroupOwnerProcessor implements ProcessorInterface
      */
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): UserGroup
     {
-        $user = $this->security->getUser();
-        if (!$user instanceof User) {
-            throw new UnauthorizedHttpException('Bearer', 'You must be authenticated to create a group.');
-        }
+        $user = $this->auth->requireUser('create a group');
 
         $data->setOwner($user);
         $data->addMember($user);

--- a/api/tests/Api/CustomFieldDefinitionReorderEdgeTest.php
+++ b/api/tests/Api/CustomFieldDefinitionReorderEdgeTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\CustomField\CustomFieldKind;
+use App\Entity\CustomFieldDefinition;
+use App\Entity\Project;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Edge-branch coverage for App\Controller\CustomFieldDefinitionReorderController.
+ * The base CustomFieldDefinitionReorderTest covers admin happy-path,
+ * non-admin 404, incomplete + duplicate payloads. This adds: unknown /
+ * malformed project id, missing `order` key, malformed IRI, and an IRI
+ * that belongs to another project.
+ */
+class CustomFieldDefinitionReorderEdgeTest extends ApiTestCase
+{
+    use SpaceMembershipFixture;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\CustomFieldDefinition')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testUnknownProjectIs404(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/projects/00000000-0000-0000-0000-000000000000/custom_field_definitions/reorder', [
+            'json' => ['order' => []],
+        ]);
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testInvalidProjectIdIs404(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/projects/not-a-uuid/custom_field_definitions/reorder', [
+            'json' => ['order' => []],
+        ]);
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testMissingOrderKeyIs400(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/projects/' . $project->getId() . '/custom_field_definitions/reorder', [
+            'json' => ['nope' => []],
+        ]);
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    public function testMalformedIriIs400(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $this->seedField($project, 'Alpha', 0);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/projects/' . $project->getId() . '/custom_field_definitions/reorder', [
+            'json' => ['order' => ['/custom_field_definitions/not-a-uuid']],
+        ]);
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    public function testIriFromAnotherProjectIs400(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $projectA = $this->createProject($alice, 'Alpha project');
+        $projectB = $this->createProject($alice, 'Beta project');
+        // One field on each project.
+        $this->seedField($projectA, 'Local', 0);
+        $foreign = $this->seedField($projectB, 'Foreign', 0);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        // Reorder project A but list project B's field — rejected (not part
+        // of this project / contiguity guard).
+        $client->request('POST', '/projects/' . $projectA->getId() . '/custom_field_definitions/reorder', [
+            'json' => ['order' => ['/custom_field_definitions/' . $foreign->getId()]],
+        ]);
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    private function createProject(User $owner, string $title): Project
+    {
+        $project = new Project();
+        $project->setOwner($owner);
+        $project->setTitle($title);
+        $this->addProjectMember($project, $owner);
+        $this->entityManager->persist($project);
+        $this->entityManager->flush();
+        return $project;
+    }
+
+    private function createUser(string $email): User
+    {
+        $container = static::getContainer();
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+        return $user;
+    }
+
+    private function seedField(Project $project, string $name, int $position): CustomFieldDefinition
+    {
+        $field = new CustomFieldDefinition();
+        $field->setProject($project)
+            ->setName($name)
+            ->setKind(CustomFieldKind::TEXT->value)
+            ->setSubtype('text')
+            ->setConfig(['multi' => false])
+            ->setPosition($position);
+        $this->entityManager->persist($field);
+        $this->entityManager->flush();
+        return $field;
+    }
+}

--- a/api/tests/Api/CustomFieldFooterEdgeTest.php
+++ b/api/tests/Api/CustomFieldFooterEdgeTest.php
@@ -1,0 +1,233 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\CustomField\CustomFieldKind;
+use App\Entity\CustomFieldDefinition;
+use App\Entity\CustomFieldValue;
+use App\Entity\Project;
+use App\Entity\Task;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Extra branch coverage for {@see \App\Controller\CustomFieldFooterController}
+ * that CustomFieldFooterTest doesn't reach: the `?overdue=`, `?dueDate[...]`
+ * and `?search=` task-filter arms, plus min/max numeric aggregation.
+ */
+class CustomFieldFooterEdgeTest extends ApiTestCase
+{
+    use SpaceMembershipFixture;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\CustomFieldValue')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\CustomFieldDefinition')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testOutsiderGets404(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $this->seedNumericField($project, 'Estimate', footerKind: 'sum');
+
+        $client = static::createClient();
+        $client->loginUser($bob);
+        $client->request('GET', '/projects/' . $project->getId() . '/custom_field_footers');
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testOverdueFilterRestrictsAggregation(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $field = $this->seedNumericField($project, 'Estimate', footerKind: 'sum');
+
+        // Overdue task (past due, not completed) counts; future task doesn't.
+        $overdue = $this->seedTaskWithValue($alice, $project, $field, 3);
+        $overdue->setDueDate(new \DateTimeImmutable('-2 days'));
+        $future = $this->seedTaskWithValue($alice, $project, $field, 5);
+        $future->setDueDate(new \DateTimeImmutable('+5 days'));
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/projects/' . $project->getId() . '/custom_field_footers?overdue=true');
+        $this->assertResponseIsSuccessful();
+        $first = $this->firstFooter($client);
+        $this->assertEqualsCanonicalizing(3, $first['value']);
+    }
+
+    public function testDueDateBoundFilter(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $field = $this->seedNumericField($project, 'Estimate', footerKind: 'sum');
+
+        $early = $this->seedTaskWithValue($alice, $project, $field, 3);
+        $early->setDueDate(new \DateTimeImmutable('2026-01-01'));
+        $late = $this->seedTaskWithValue($alice, $project, $field, 5);
+        $late->setDueDate(new \DateTimeImmutable('2026-12-31'));
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        // Only the early task is due on/before mid-year → sum is 3.
+        $client->request(
+            'GET',
+            '/projects/' . $project->getId() . '/custom_field_footers?dueDate[before]=2026-06-01',
+        );
+        $this->assertResponseIsSuccessful();
+        $first = $this->firstFooter($client);
+        $this->assertEqualsCanonicalizing(3, $first['value']);
+    }
+
+    public function testSearchFilterRestrictsAggregation(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $field = $this->seedNumericField($project, 'Estimate', footerKind: 'sum');
+
+        $matching = $this->seedTaskWithValue($alice, $project, $field, 3);
+        $matching->setTitle('Pineapple harvest');
+        $other = $this->seedTaskWithValue($alice, $project, $field, 5);
+        $other->setTitle('Mango delivery');
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request(
+            'GET',
+            '/projects/' . $project->getId() . '/custom_field_footers?search=pineapple',
+        );
+        $this->assertResponseIsSuccessful();
+        $first = $this->firstFooter($client);
+        $this->assertEqualsCanonicalizing(3, $first['value']);
+    }
+
+    public function testMinAndMaxAggregation(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $minField = $this->seedNumericField($project, 'Low', footerKind: 'min');
+        $maxField = $this->seedNumericField($project, 'High', footerKind: 'max');
+
+        $this->seedTaskWithValues($alice, $project, [[$minField, 4], [$maxField, 4]]);
+        $this->seedTaskWithValues($alice, $project, [[$minField, 9], [$maxField, 9]]);
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/projects/' . $project->getId() . '/custom_field_footers');
+        $this->assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+        $footers = $body['footers'] ?? null;
+        $this->assertIsArray($footers);
+        $byName = array_column($footers, null, 'name');
+        $low = $byName['Low'] ?? null;
+        $this->assertIsArray($low);
+        $this->assertEqualsCanonicalizing(4, $low['value']);
+        $high = $byName['High'] ?? null;
+        $this->assertIsArray($high);
+        $this->assertEqualsCanonicalizing(9, $high['value']);
+    }
+
+    /**
+     * @return array<int|string, mixed>
+     */
+    private function firstFooter(Client $client): array
+    {
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+        $footers = $body['footers'] ?? null;
+        $this->assertIsArray($footers);
+        $first = $footers[0] ?? null;
+        $this->assertIsArray($first);
+        return $first;
+    }
+
+    private function createProject(User $owner, string $title): Project
+    {
+        $project = new Project();
+        $project->setOwner($owner);
+        $project->setTitle($title);
+        $this->addProjectMember($project, $owner);
+        $this->entityManager->persist($project);
+        $this->entityManager->flush();
+        return $project;
+    }
+
+    private function createUser(string $email): User
+    {
+        $container = static::getContainer();
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+        return $user;
+    }
+
+    private function seedNumericField(Project $project, string $name, ?string $footerKind): CustomFieldDefinition
+    {
+        $field = new CustomFieldDefinition();
+        $field->setProject($project)
+            ->setName($name)
+            ->setKind(CustomFieldKind::NUMERIC->value)
+            ->setSubtype('float')
+            ->setConfig(['multi' => false]);
+        if (null !== $footerKind) {
+            $field->setFooter(['kind' => $footerKind]);
+        }
+        $this->entityManager->persist($field);
+        $this->entityManager->flush();
+        return $field;
+    }
+
+    private function seedTaskWithValue(User $owner, Project $project, CustomFieldDefinition $field, mixed $value): Task
+    {
+        return $this->seedTaskWithValues($owner, $project, [[$field, $value]]);
+    }
+
+    /**
+     * @param list<array{0: CustomFieldDefinition, 1: mixed}> $pairs
+     */
+    private function seedTaskWithValues(User $owner, Project $project, array $pairs): Task
+    {
+        $task = new Task();
+        $task->setOwner($owner);
+        $task->setProject($project);
+        $task->setTitle('Task');
+        $this->entityManager->persist($task);
+        foreach ($pairs as [$field, $value]) {
+            $cfv = new CustomFieldValue();
+            $cfv->setTask($task);
+            $cfv->setDefinition($field);
+            $cfv->setValue($value);
+            $this->entityManager->persist($cfv);
+        }
+        return $task;
+    }
+}

--- a/api/tests/Api/McpExtraToolsTest.php
+++ b/api/tests/Api/McpExtraToolsTest.php
@@ -1,0 +1,447 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Entity\ApiToken;
+use App\Entity\Comment;
+use App\Entity\MediaObject;
+use App\Entity\Project;
+use App\Entity\Space;
+use App\Entity\Task;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Coverage for the file-oriented MCP tools (upload_file, list_files,
+ * download_file) plus additional update_task / get_my_tasks /
+ * list_task_comments branches and validation-error paths. These exercise
+ * {@see \App\Mcp\McpInputHelper} and {@see \App\Mcp\McpEntitySerializer}
+ * surfaces the other MCP tests don't reach.
+ *
+ * upload_file round-trips real bytes through ImageUploadService into the
+ * `media.storage` filesystem, so download_file can read them straight
+ * back — no manual storage wiring needed. list_files is additionally
+ * exercised against a Space by attaching a seeded MediaObject via the EM.
+ *
+ * Test fixtures must be persisted *before* the first call to
+ * {@see static::createClient()} — that boots the test kernel and any
+ * entities staged through `$this->entityManager` afterwards arrive
+ * detached, producing "A new entity was found" cascades.
+ */
+class McpExtraToolsTest extends ApiTestCase
+{
+    use SpaceMembershipFixture;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\ApiToken')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Comment')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testUploadFileToTaskReturnsMediaObject(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->makeTask($alice, 'Has an attachment');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'upload_file',
+            'arguments' => [
+                'entityType' => 'task',
+                'entityId' => (string) $task->getId(),
+                'fileName' => 'notes.txt',
+                'content' => base64_encode("Hello from MCP.\n"),
+            ],
+        ]);
+
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $this->assertSame('notes.txt', $structured['name']);
+        $this->assertSame('attachment', $structured['kind']);
+        $this->assertIsString($structured['id']);
+        $this->assertNotSame('', $structured['id']);
+    }
+
+    public function testUploadFileMissingRequiredArgIsError(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->makeTask($alice, 'Target');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        // Omit the required `content` field to trip McpInputHelper::requireString.
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'upload_file',
+            'arguments' => [
+                'entityType' => 'task',
+                'entityId' => (string) $task->getId(),
+                'fileName' => 'notes.txt',
+            ],
+        ]);
+
+        $this->assertTrue($body['result']['isError'] ?? null);
+        $content = $body['result']['content'] ?? null;
+        $this->assertIsArray($content);
+        $this->assertIsArray($content[0]);
+        $this->assertIsString($content[0]['text']);
+        $this->assertStringContainsString('content', $content[0]['text']);
+    }
+
+    public function testListFilesOnTaskReturnsUploadedFile(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->makeTask($alice, 'Files here');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $upload = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'upload_file',
+            'arguments' => [
+                'entityType' => 'task',
+                'entityId' => (string) $task->getId(),
+                'fileName' => 'report.txt',
+                'content' => base64_encode("body\n"),
+            ],
+        ]);
+        $this->assertFalse($upload['result']['isError'] ?? null);
+
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_files',
+            'arguments' => [
+                'entityType' => 'task',
+                'entityId' => (string) $task->getId(),
+            ],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $names = array_column($items, 'name');
+        $this->assertContains('report.txt', $names);
+    }
+
+    public function testListFilesOnSpaceReturnsSeededAttachment(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        // A project pins its creator's personal space via the listener.
+        $project = $this->makeProject($alice, [$alice], 'Space holder');
+        $space = $project->getSpace();
+        $this->assertNotNull($space);
+        $media = $this->seedAttachment($alice, 'shared.pdf');
+        $space->addAttachment($media);
+        $this->entityManager->flush();
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_files',
+            'arguments' => [
+                'entityType' => 'space',
+                'entityId' => (string) $space->getId(),
+            ],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $names = array_column($items, 'name');
+        $this->assertContains('shared.pdf', $names);
+    }
+
+    public function testDownloadFileReturnsBase64Content(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->makeTask($alice, 'Downloadable');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $payload = "Round-trip me.\n";
+        $upload = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'upload_file',
+            'arguments' => [
+                'entityType' => 'task',
+                'entityId' => (string) $task->getId(),
+                'fileName' => 'rt.txt',
+                'content' => base64_encode($payload),
+            ],
+        ]);
+        $this->assertFalse($upload['result']['isError'] ?? null);
+        $uploaded = $upload['result']['structuredContent'] ?? null;
+        $this->assertIsArray($uploaded);
+        $fileId = $uploaded['id'] ?? null;
+        $this->assertIsString($fileId);
+
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'download_file',
+            'arguments' => ['fileId' => $fileId],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $this->assertSame('rt.txt', $structured['name']);
+        $returned = $structured['content'] ?? null;
+        $this->assertIsString($returned);
+        $this->assertSame($payload, base64_decode($returned, true));
+    }
+
+    public function testDownloadFileUnknownIdIsError(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        // A well-formed but non-existent UUID — exercises the not-found branch.
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'download_file',
+            'arguments' => ['fileId' => '00000000-0000-7000-8000-000000000000'],
+        ]);
+        $this->assertTrue($body['result']['isError'] ?? null);
+        $content = $body['result']['content'] ?? null;
+        $this->assertIsArray($content);
+        $this->assertIsArray($content[0]);
+        $this->assertIsString($content[0]['text']);
+        $this->assertStringContainsString('not found', $content[0]['text']);
+    }
+
+    public function testUpdateTaskSetsAndClearsDueDate(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->makeTask($alice, 'Schedule me');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'update_task',
+            'arguments' => [
+                'taskId' => (string) $task->getId(),
+                'dueDate' => '2026-12-31T09:00:00+00:00',
+            ],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $dueDate = $structured['dueDate'] ?? null;
+        $this->assertIsString($dueDate);
+        $this->assertStringContainsString('2026-12-31', $dueDate);
+
+        // Passing null clears it again.
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'update_task',
+            'arguments' => [
+                'taskId' => (string) $task->getId(),
+                'dueDate' => null,
+            ],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $this->assertNull($structured['dueDate']);
+    }
+
+    public function testGetMyTasksReturnsMultipleAssignedTasks(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $first = $this->makeTask($alice, 'First mine');
+        $first->addAssignee($alice);
+        $second = $this->makeTask($alice, 'Second mine');
+        $second->addAssignee($alice);
+        $this->makeTask($alice, 'Not assigned');
+        $this->entityManager->flush();
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'get_my_tasks',
+            'arguments' => [],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $titles = array_column($items, 'title');
+        $this->assertContains('First mine', $titles);
+        $this->assertContains('Second mine', $titles);
+        $this->assertNotContains('Not assigned', $titles);
+    }
+
+    public function testListTaskCommentsReturnsAllComments(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->makeTask($alice, 'Threaded');
+        $this->makeComment($task, $alice, 'Earliest note');
+        $this->makeComment($task, $alice, 'Middle note');
+        $this->makeComment($task, $alice, 'Latest note');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_task_comments',
+            'arguments' => ['taskId' => (string) $task->getId()],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $bodies = array_column($items, 'body');
+        $this->assertContains('Earliest note', $bodies);
+        $this->assertContains('Middle note', $bodies);
+        $this->assertContains('Latest note', $bodies);
+
+        // Each comment carries an author summary from McpEntitySerializer.
+        $first = $items[0] ?? null;
+        $this->assertIsArray($first);
+        $author = $first['author'] ?? null;
+        $this->assertIsArray($author);
+        $this->assertSame('alice@example.com', $author['email']);
+    }
+
+    /**
+     * Returns the JSON-RPC response body. Every site that uses this
+     * helper goes through {@see assertResponseIsSuccessful()} and
+     * checks a `result`, so the shape is widened to `array<string, mixed>`
+     * on result (deep nesting is narrowed per-callsite with explicit
+     * `assertIsArray()` / `assertArrayHasKey()` calls).
+     *
+     * @param array<string, mixed> $params
+     * @return array{
+     *   jsonrpc: string,
+     *   id?: int|string,
+     *   result: array<string, mixed>,
+     *   error?: array{code: int, message: string, data?: mixed}
+     * }
+     */
+    private function callMcp(Client $client, string $bearer, string $method, array $params = []): array
+    {
+        $client->request('POST', '/mcp', [
+            'json' => [
+                'jsonrpc' => '2.0',
+                'id' => mt_rand(1, 99999),
+                'method' => $method,
+                'params' => $params,
+            ],
+            'headers' => ['Authorization' => 'Bearer ' . $bearer],
+        ]);
+        $this->assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        /**
+         * @var array{
+         *   jsonrpc: string,
+         *   id?: int|string,
+         *   result: array<string, mixed>,
+         *   error?: array{code: int, message: string, data?: mixed}
+         * } $body
+         */
+        $body = $response->toArray();
+        return $body;
+    }
+
+    /**
+     * @param array<string, mixed>|null $accessPolicy
+     */
+    private function mintToken(
+        User $user,
+        string $name,
+        ?\DateTimeImmutable $expiresAt = null,
+        ?array $accessPolicy = null,
+    ): string {
+        $plain = ApiToken::PLAINTEXT_PREFIX . bin2hex(random_bytes(16));
+        $token = new ApiToken();
+        $token->setUser($user);
+        $token->setName($name);
+        $token->setTokenHash(hash('sha256', $plain));
+        $token->setExpiresAt($expiresAt);
+        $token->setAccessPolicy($accessPolicy);
+        $this->entityManager->persist($token);
+        $this->entityManager->flush();
+        return $plain;
+    }
+
+    private function makeTask(User $owner, string $title): Task
+    {
+        $task = new Task();
+        $task->setOwner($owner);
+        $task->setTitle($title);
+        $this->entityManager->persist($task);
+        $this->entityManager->flush();
+        return $task;
+    }
+
+    private function makeComment(Task $task, User $author, string $body): Comment
+    {
+        $comment = new Comment();
+        $comment->setTask($task);
+        $comment->setAuthor($author);
+        $comment->setBody($body);
+        $this->entityManager->persist($comment);
+        $this->entityManager->flush();
+        return $comment;
+    }
+
+    /**
+     * @param User[] $members
+     */
+    private function makeProject(User $owner, array $members, string $title): Project
+    {
+        $project = new Project();
+        $project->setOwner($owner);
+        $project->setTitle($title);
+        foreach ($members as $member) {
+            $this->addProjectMember($project, $member);
+        }
+        $this->entityManager->persist($project);
+        $this->entityManager->flush();
+        return $project;
+    }
+
+    private function seedAttachment(User $owner, string $name): MediaObject
+    {
+        $media = new MediaObject();
+        $media->setOwner($owner);
+        $media->setKind(MediaObject::KIND_ATTACHMENT);
+        $media->setVariants(['original' => 'attachments/seeded-' . $name]);
+        $media->setOriginalName($name);
+        $media->setMimeType('application/pdf');
+        $media->setByteSize(1024);
+        $this->entityManager->persist($media);
+        $this->entityManager->flush();
+        return $media;
+    }
+
+    private function createUser(string $email): User
+    {
+        $container = static::getContainer();
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+        return $user;
+    }
+}

--- a/api/tests/Api/McpReadToolsTest.php
+++ b/api/tests/Api/McpReadToolsTest.php
@@ -1,0 +1,323 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Entity\ApiToken;
+use App\Entity\Comment;
+use App\Entity\Project;
+use App\Entity\Task;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Additional coverage for the under-tested read-oriented MCP tools
+ * (list_tasks, get_my_tasks, search_tasks, list_task_comments,
+ * get_project, get_custom_fields) plus extra update_task branches.
+ * Drives each via the JSON-RPC `tools/call` endpoint and asserts the
+ * structured response shape.
+ *
+ * Test fixtures must be persisted *before* the first call to
+ * {@see static::createClient()} — that boots the test kernel and any
+ * entities you've staged through `$this->entityManager` afterwards
+ * arrive detached, producing "A new entity was found" cascades.
+ */
+class McpReadToolsTest extends ApiTestCase
+{
+    use SpaceMembershipFixture;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\ApiToken')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Comment')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testListTasksReturnsItemsAndFilters(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $this->makeTask($alice, 'Open task');
+        $done = $this->makeTask($alice, 'Done task');
+        $done->setCompletedOn(new \DateTimeImmutable());
+        $this->entityManager->flush();
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_tasks',
+            'arguments' => [],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $titles = array_column($items, 'title');
+        $this->assertContains('Open task', $titles);
+        $this->assertContains('Done task', $titles);
+
+        // `status=open` narrows to the unfinished task only.
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_tasks',
+            'arguments' => ['status' => 'open'],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $titles = array_column($items, 'title');
+        $this->assertContains('Open task', $titles);
+        $this->assertNotContains('Done task', $titles);
+    }
+
+    public function testGetMyTasksReturnsAssignedItems(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->makeTask($alice, 'Assigned to me');
+        $task->addAssignee($alice);
+        $this->entityManager->flush();
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'get_my_tasks',
+            'arguments' => [],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $titles = array_column($items, 'title');
+        $this->assertContains('Assigned to me', $titles);
+    }
+
+    public function testSearchTasksFindsByQuery(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $this->makeTask($alice, 'A distinctiveword appears here');
+        $this->makeTask($alice, 'Unrelated chore');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'search_tasks',
+            'arguments' => ['query' => 'distinctiveword'],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $titles = array_column($items, 'title');
+        $this->assertContains('A distinctiveword appears here', $titles);
+        $this->assertNotContains('Unrelated chore', $titles);
+    }
+
+    public function testListTaskCommentsReturnsComment(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->makeTask($alice, 'Has comments');
+        $this->makeComment($task, $alice, 'First comment body');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_task_comments',
+            'arguments' => ['taskId' => (string) $task->getId()],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $bodies = array_column($items, 'body');
+        $this->assertContains('First comment body', $bodies);
+    }
+
+    public function testGetProjectReturnsTitle(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->makeProject($alice, [$alice], 'Roadmap');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'get_project',
+            'arguments' => ['projectId' => (string) $project->getId()],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $this->assertSame('Roadmap', $structured['title']);
+    }
+
+    public function testGetCustomFieldsReturnsShape(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->makeProject($alice, [$alice], 'With fields');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'get_custom_fields',
+            'arguments' => ['projectId' => (string) $project->getId()],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+    }
+
+    public function testUpdateTaskTitleAndDescription(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->makeTask($alice, 'Old title');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'update_task',
+            'arguments' => [
+                'taskId' => (string) $task->getId(),
+                'title' => 'New title',
+                'description' => 'A fresh description',
+            ],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $this->assertSame('New title', $structured['title']);
+        $this->assertSame('A fresh description', $structured['description']);
+    }
+
+    /**
+     * Returns the JSON-RPC response body. Every site that uses this
+     * helper goes through {@see assertResponseIsSuccessful()} and
+     * checks a `result`, so the shape is widened to `array<string, mixed>`
+     * on result (deep nesting is narrowed per-callsite with explicit
+     * `assertIsArray()` / `assertArrayHasKey()` calls).
+     *
+     * @param array<string, mixed> $params
+     * @return array{
+     *   jsonrpc: string,
+     *   id?: int|string,
+     *   result: array<string, mixed>,
+     *   error?: array{code: int, message: string, data?: mixed}
+     * }
+     */
+    private function callMcp(Client $client, string $bearer, string $method, array $params = []): array
+    {
+        $client->request('POST', '/mcp', [
+            'json' => [
+                'jsonrpc' => '2.0',
+                'id' => mt_rand(1, 99999),
+                'method' => $method,
+                'params' => $params,
+            ],
+            'headers' => ['Authorization' => 'Bearer ' . $bearer],
+        ]);
+        $this->assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        /**
+         * @var array{
+         *   jsonrpc: string,
+         *   id?: int|string,
+         *   result: array<string, mixed>,
+         *   error?: array{code: int, message: string, data?: mixed}
+         * } $body
+         */
+        $body = $response->toArray();
+        return $body;
+    }
+
+    /**
+     * @param array<string, mixed>|null $accessPolicy
+     */
+    private function mintToken(
+        User $user,
+        string $name,
+        ?\DateTimeImmutable $expiresAt = null,
+        ?array $accessPolicy = null,
+    ): string {
+        $plain = ApiToken::PLAINTEXT_PREFIX . bin2hex(random_bytes(16));
+        $token = new ApiToken();
+        $token->setUser($user);
+        $token->setName($name);
+        $token->setTokenHash(hash('sha256', $plain));
+        $token->setExpiresAt($expiresAt);
+        $token->setAccessPolicy($accessPolicy);
+        $this->entityManager->persist($token);
+        $this->entityManager->flush();
+        return $plain;
+    }
+
+    private function makeTask(User $owner, string $title): Task
+    {
+        $task = new Task();
+        $task->setOwner($owner);
+        $task->setTitle($title);
+        $this->entityManager->persist($task);
+        $this->entityManager->flush();
+        return $task;
+    }
+
+    private function makeComment(Task $task, User $author, string $body): Comment
+    {
+        $comment = new Comment();
+        $comment->setTask($task);
+        $comment->setAuthor($author);
+        $comment->setBody($body);
+        $this->entityManager->persist($comment);
+        $this->entityManager->flush();
+        return $comment;
+    }
+
+    /**
+     * @param User[] $members
+     */
+    private function makeProject(User $owner, array $members, string $title): Project
+    {
+        $project = new Project();
+        $project->setOwner($owner);
+        $project->setTitle($title);
+        foreach ($members as $member) {
+            $this->addProjectMember($project, $member);
+        }
+        $this->entityManager->persist($project);
+        $this->entityManager->flush();
+        return $project;
+    }
+
+    private function createUser(string $email): User
+    {
+        $container = static::getContainer();
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+        return $user;
+    }
+}

--- a/api/tests/Api/McpTest.php
+++ b/api/tests/Api/McpTest.php
@@ -7,6 +7,7 @@ use ApiPlatform\Symfony\Bundle\Test\Client;
 use App\Entity\ApiToken;
 use App\Entity\Comment;
 use App\Entity\CustomFieldDefinition;
+use App\Entity\Discussion;
 use App\Entity\Page;
 use App\Entity\Project;
 use App\Entity\Space;
@@ -127,6 +128,8 @@ class McpTest extends ApiTestCase
             'create_page', 'get_page', 'update_page', 'delete_page', 'list_pages',
             'list_tags', 'create_tag',
             'create_discussion', 'get_discussion', 'list_discussions',
+            'add_page_comment', 'list_page_comments',
+            'add_discussion_comment', 'list_discussion_comments',
             ] as $expected
         ) {
             $this->assertContains($expected, $names, sprintf('Missing tool "%s"', $expected));
@@ -496,6 +499,81 @@ class McpTest extends ApiTestCase
         $this->assertSame(['Roadmap'], array_column($items, 'title'));
     }
 
+    public function testAddAndListPageComment(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $space = $this->makeSpace($alice);
+        $page = $this->makePage($alice, $space, 'Spec');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'add_page_comment',
+            'arguments' => ['pageId' => (string) $page->getId(), 'body' => 'First note'],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $this->assertSame('First note', $structured['body']);
+        $this->assertSame('page', $structured['commentableType']);
+        $this->assertSame((string) $page->getId(), $structured['pageId']);
+
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_page_comments',
+            'arguments' => ['pageId' => (string) $page->getId()],
+        ]);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $this->assertSame(['First note'], array_column($items, 'body'));
+    }
+
+    public function testAddAndListDiscussionComment(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $space = $this->makeSpace($alice);
+        $discussion = $this->makeDiscussion($alice, $space, 'Topic');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'add_discussion_comment',
+            'arguments' => ['discussionId' => (string) $discussion->getId(), 'body' => 'Good point'],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $this->assertSame('discussion', $structured['commentableType']);
+
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_discussion_comments',
+            'arguments' => ['discussionId' => (string) $discussion->getId()],
+        ]);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $this->assertSame(['Good point'], array_column($items, 'body'));
+    }
+
+    public function testLockedDiscussionRejectsNewComment(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $space = $this->makeSpace($alice);
+        $discussion = $this->makeDiscussion($alice, $space, 'Closed');
+        $discussion->setIsLocked(true);
+        $this->entityManager->flush();
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'add_discussion_comment',
+            'arguments' => ['discussionId' => (string) $discussion->getId(), 'body' => 'Sneaky'],
+        ]);
+        $this->assertTrue($body['result']['isError'] ?? null);
+    }
+
     public function testInvalidUuidProducesValidationError(): void
     {
         $alice = $this->createUser('alice@example.com');
@@ -679,6 +757,18 @@ class McpTest extends ApiTestCase
         $this->entityManager->persist($page);
         $this->entityManager->flush();
         return $page;
+    }
+
+    private function makeDiscussion(User $author, Space $space, string $title): Discussion
+    {
+        $discussion = new Discussion();
+        $discussion->setAuthor($author);
+        $discussion->setSpace($space);
+        $discussion->setTitle($title);
+        $discussion->setBody('Body of ' . $title);
+        $this->entityManager->persist($discussion);
+        $this->entityManager->flush();
+        return $discussion;
     }
 
     private function makeTaskInProject(User $owner, Project $project, string $title): Task

--- a/api/tests/Api/McpTest.php
+++ b/api/tests/Api/McpTest.php
@@ -6,7 +6,11 @@ use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use ApiPlatform\Symfony\Bundle\Test\Client;
 use App\Entity\ApiToken;
 use App\Entity\Comment;
+use App\Entity\CustomFieldDefinition;
+use App\Entity\Page;
 use App\Entity\Project;
+use App\Entity\Space;
+use App\Entity\SpaceMembership;
 use App\Entity\Task;
 use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
@@ -35,10 +39,19 @@ class McpTest extends ApiTestCase
         assert($em instanceof EntityManagerInterface);
         $this->entityManager = $em;
 
+        // Delete child-to-parent so DQL bulk deletes don't trip FKs.
         $this->entityManager->createQuery('DELETE FROM App\Entity\ApiToken')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Comment')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\CustomFieldValue')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\CustomFieldDefinition')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Page')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Discussion')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Tag')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\SpaceMembership')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\SpaceGroupMembership')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Space')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
     }
 
@@ -110,6 +123,10 @@ class McpTest extends ApiTestCase
             'add_task_comment', 'list_task_comments',
             'upload_file', 'list_files', 'download_file',
             'get_custom_fields',
+            'list_spaces',
+            'create_page', 'get_page', 'update_page', 'delete_page', 'list_pages',
+            'list_tags', 'create_tag',
+            'create_discussion', 'get_discussion', 'list_discussions',
             ] as $expected
         ) {
             $this->assertContains($expected, $names, sprintf('Missing tool "%s"', $expected));
@@ -236,6 +253,247 @@ class McpTest extends ApiTestCase
         $author = $structured['author'];
         $this->assertIsArray($author);
         $this->assertSame('alice@example.com', $author['email']);
+    }
+
+    public function testListSpacesReturnsMembershipsWithRole(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $space = $this->makeSpace($alice, 'Alice Space');
+        $this->makeSpace($bob, 'Bob Space');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_spaces',
+            'arguments' => [],
+        ]);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $names = array_column($items, 'name');
+        $this->assertSame(['Alice Space'], $names);
+        $first = $items[0];
+        $this->assertIsArray($first);
+        $this->assertSame('admin', $first['role']);
+        $this->assertSame((string) $space->getId(), $first['id']);
+    }
+
+    public function testCreateAndGetPageInSpace(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $space = $this->makeSpace($alice);
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'create_page',
+            'arguments' => [
+                'title' => 'Onboarding',
+                'body' => '# Welcome',
+                'spaceId' => (string) $space->getId(),
+            ],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $this->assertSame('Onboarding', $structured['title']);
+        $this->assertSame((string) $space->getId(), $structured['spaceId']);
+        $pageId = $structured['id'];
+        $this->assertIsString($pageId);
+
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'get_page',
+            'arguments' => ['pageId' => $pageId],
+        ]);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $this->assertSame('# Welcome', $structured['body']);
+    }
+
+    public function testCreatePageDefaultsToPersonalSpace(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        // Provision Alice's personal space the way the app does on signup
+        // — persisting a project triggers ProjectSpaceDefaultListener.
+        $this->makeProject($alice, [$alice], 'Seed');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'create_page',
+            'arguments' => ['title' => 'Personal note'],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $this->assertSame('Personal note', $structured['title']);
+        $this->assertIsString($structured['spaceId']);
+    }
+
+    public function testListPagesHonoursSpaceMembership(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $aliceSpace = $this->makeSpace($alice, 'Alice Space');
+        $bobSpace = $this->makeSpace($bob, 'Bob Space');
+        $this->makePage($alice, $aliceSpace, 'Mine');
+        $this->makePage($bob, $bobSpace, 'Hidden');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_pages',
+            'arguments' => [],
+        ]);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $this->assertSame(['Mine'], array_column($items, 'title'));
+    }
+
+    public function testUpdateAndDeletePage(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $space = $this->makeSpace($alice);
+        $page = $this->makePage($alice, $space, 'Draft');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'update_page',
+            'arguments' => ['pageId' => (string) $page->getId(), 'title' => 'Final'],
+        ]);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $this->assertSame('Final', $structured['title']);
+
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'delete_page',
+            'arguments' => ['pageId' => (string) $page->getId()],
+        ]);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $this->assertTrue($structured['deleted']);
+        $this->assertNull($this->entityManager->getRepository(Page::class)->find($page->getId()));
+    }
+
+    public function testPageEditByNonAuthorNonAdminIsForbidden(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $space = $this->makeSpace($alice);
+        // Bob is a plain member of Alice's space.
+        $this->ensureSpaceMembership($space, $bob, Space::ROLE_MEMBER);
+        $page = $this->makePage($alice, $space, 'Alice doc');
+        $plain = $this->mintToken($bob, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'update_page',
+            'arguments' => ['pageId' => (string) $page->getId(), 'title' => 'Hijacked'],
+        ]);
+        $this->assertTrue($body['result']['isError'] ?? null);
+    }
+
+    public function testCreateAndListTags(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'create_tag',
+            'arguments' => ['title' => 'urgent', 'color' => '#ef4444'],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $this->assertSame('urgent', $structured['title']);
+        $this->assertSame('#ef4444', $structured['color']);
+
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_tags',
+            'arguments' => [],
+        ]);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $this->assertSame(['urgent'], array_column($items, 'title'));
+    }
+
+    public function testUpdateTaskSetsCustomFieldValue(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->makeProject($alice, [$alice], 'Fielded');
+        $field = $this->makeCustomFieldDefinition($project, 'Notes', 'text');
+        $task = $this->makeTaskInProject($alice, $project, 'With fields');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'update_task',
+            'arguments' => [
+                'taskId' => (string) $task->getId(),
+                'customFieldValues' => [
+                    ['definitionId' => (string) $field->getId(), 'value' => 'hello world'],
+                ],
+            ],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $values = $structured['customFieldValues'] ?? null;
+        $this->assertIsArray($values);
+        $this->assertCount(1, $values);
+        $this->assertIsArray($values[0]);
+        $this->assertSame('hello world', $values[0]['value']);
+    }
+
+    public function testCreateGetAndListDiscussion(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $space = $this->makeSpace($alice);
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'create_discussion',
+            'arguments' => [
+                'title' => 'Roadmap',
+                'body' => 'What next?',
+                'category' => 'ideas',
+                'spaceId' => (string) $space->getId(),
+            ],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $this->assertSame('Roadmap', $structured['title']);
+        $this->assertSame('ideas', $structured['category']);
+        $discussionId = $structured['id'];
+        $this->assertIsString($discussionId);
+
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'get_discussion',
+            'arguments' => ['discussionId' => $discussionId],
+        ]);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $this->assertSame('What next?', $structured['body']);
+
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_discussions',
+            'arguments' => ['spaceId' => (string) $space->getId()],
+        ]);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $this->assertSame(['Roadmap'], array_column($items, 'title'));
     }
 
     public function testInvalidUuidProducesValidationError(): void
@@ -412,6 +670,17 @@ class McpTest extends ApiTestCase
         return $task;
     }
 
+    private function makePage(User $author, Space $space, string $title): Page
+    {
+        $page = new Page();
+        $page->setCreatedBy($author);
+        $page->setSpace($space);
+        $page->setTitle($title);
+        $this->entityManager->persist($page);
+        $this->entityManager->flush();
+        return $page;
+    }
+
     private function makeTaskInProject(User $owner, Project $project, string $title): Task
     {
         $task = new Task();
@@ -437,6 +706,35 @@ class McpTest extends ApiTestCase
         $this->entityManager->persist($project);
         $this->entityManager->flush();
         return $project;
+    }
+
+    /**
+     * A shared space with `$admin` as its admin. `createUser()` doesn't
+     * provision the signup-time personal space, so page/discussion tools
+     * that need a real space get one here.
+     */
+    private function makeSpace(User $admin, string $name = 'Team Space'): Space
+    {
+        $space = new Space();
+        $space->setName($name);
+        $space->setCreatedBy($admin);
+        $space->addUserMembership(
+            (new SpaceMembership())->setUser($admin)->setRole(Space::ROLE_ADMIN),
+        );
+        $this->entityManager->persist($space);
+        $this->entityManager->flush();
+        return $space;
+    }
+
+    private function makeCustomFieldDefinition(Project $project, string $name, string $type): CustomFieldDefinition
+    {
+        $field = new CustomFieldDefinition();
+        $field->setProject($project);
+        $field->setName($name);
+        $field->setType($type);
+        $this->entityManager->persist($field);
+        $this->entityManager->flush();
+        return $field;
     }
 
     private function createUser(string $email): User

--- a/api/tests/Api/McpToolBranchesTest.php
+++ b/api/tests/Api/McpToolBranchesTest.php
@@ -1,0 +1,589 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Entity\ApiToken;
+use App\Entity\MediaObject;
+use App\Entity\Project;
+use App\Entity\Task;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Branch coverage for the MCP server that the existing suites
+ * ({@see McpTest}, {@see McpReadToolsTest}, {@see McpExtraToolsTest})
+ * don't exercise:
+ *  - {@see \App\Mcp\Tool\ListTasksTool} filter args (projectId, search,
+ *    dueBefore, pagination) + an unreachable projectId.
+ *  - {@see \App\Mcp\Tool\UpdateTaskTool} assigneeIds / projectId / tagIds
+ *    branches and the entity-validation (422) path.
+ *  - {@see \App\Mcp\Tool\DownloadFileTool} forbidden-file + malformed-id
+ *    branches.
+ *  - {@see \App\Mcp\McpInputHelper} type-coercion edge cases (missing
+ *    required arg, wrong JSON type, out-of-range enum).
+ *  - {@see \App\Controller\McpController} malformed JSON-RPC envelopes.
+ *
+ * Test fixtures must be persisted *before* the first call to
+ * {@see static::createClient()} — that boots the test kernel and any
+ * entities staged through `$this->entityManager` afterwards arrive
+ * detached, producing "A new entity was found" cascades.
+ */
+class McpToolBranchesTest extends ApiTestCase
+{
+    use SpaceMembershipFixture;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\ApiToken')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Comment')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    // ---- ListTasksTool filter branches ----------------------------------
+
+    public function testListTasksFiltersByProjectId(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->makeProject($alice, [$alice], 'Scoped');
+        $this->makeTaskInProject($alice, $project, 'In project');
+        $this->makeTask($alice, 'Standalone');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_tasks',
+            'arguments' => ['projectId' => (string) $project->getId()],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $titles = array_column($items, 'title');
+        $this->assertContains('In project', $titles);
+        $this->assertNotContains('Standalone', $titles);
+    }
+
+    public function testListTasksFiltersBySearch(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $this->makeTask($alice, 'Quarterly planning meeting');
+        $this->makeTask($alice, 'Water the plants');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_tasks',
+            'arguments' => ['search' => 'quarterly'],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $titles = array_column($items, 'title');
+        $this->assertContains('Quarterly planning meeting', $titles);
+        $this->assertNotContains('Water the plants', $titles);
+    }
+
+    public function testListTasksFiltersByDueBefore(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $soon = $this->makeTask($alice, 'Due soon');
+        $soon->setDueDate(new \DateTimeImmutable('2026-01-01T00:00:00+00:00'));
+        $later = $this->makeTask($alice, 'Due later');
+        $later->setDueDate(new \DateTimeImmutable('2027-01-01T00:00:00+00:00'));
+        $this->entityManager->flush();
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_tasks',
+            'arguments' => ['dueBefore' => '2026-06-01T00:00:00+00:00'],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $titles = array_column($items, 'title');
+        $this->assertContains('Due soon', $titles);
+        $this->assertNotContains('Due later', $titles);
+    }
+
+    public function testListTasksPaginates(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $this->makeTask($alice, 'First');
+        $this->makeTask($alice, 'Second');
+        $this->makeTask($alice, 'Third');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_tasks',
+            'arguments' => ['page' => 1, 'limit' => 2],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        // The page is clamped to the requested limit even though three exist.
+        $this->assertCount(2, $items);
+        $this->assertSame(3, $structured['total']);
+        $this->assertSame(1, $structured['page']);
+        $this->assertSame(2, $structured['limit']);
+    }
+
+    public function testListTasksUnreachableProjectReturnsEmpty(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        // A project alice can't see — filtering by it yields no rows (no error).
+        $hidden = $this->makeProject($bob, [$bob], 'Hidden');
+        $this->makeTask($alice, 'Visible to alice');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_tasks',
+            'arguments' => ['projectId' => (string) $hidden->getId()],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'] ?? null;
+        $this->assertIsArray($items);
+        $this->assertSame([], $items);
+        $this->assertSame(0, $structured['total']);
+    }
+
+    // ---- UpdateTaskTool branches ----------------------------------------
+
+    public function testUpdateTaskReplacesAssignees(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $project = $this->makeProject($alice, [$alice, $bob], 'Team');
+        $task = $this->makeTaskInProject($alice, $project, 'Joint');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'update_task',
+            'arguments' => [
+                'taskId' => (string) $task->getId(),
+                'assigneeIds' => [(string) $bob->getId()],
+            ],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $assignees = $structured['assignees'] ?? null;
+        $this->assertIsArray($assignees);
+        $emails = array_column($assignees, 'email');
+        $this->assertContains('bob@example.com', $emails);
+    }
+
+    public function testUpdateTaskMovesToProject(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->makeProject($alice, [$alice], 'Destination');
+        $task = $this->makeTask($alice, 'Detached');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'update_task',
+            'arguments' => [
+                'taskId' => (string) $task->getId(),
+                'projectId' => (string) $project->getId(),
+            ],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $project = $structured['project'] ?? null;
+        $this->assertIsArray($project);
+        $this->assertSame('Destination', $project['title']);
+    }
+
+    public function testUpdateTaskUnreachableProjectIsError(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $hidden = $this->makeProject($bob, [$bob], 'Hidden');
+        $task = $this->makeTask($alice, 'Mine');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'update_task',
+            'arguments' => [
+                'taskId' => (string) $task->getId(),
+                'projectId' => (string) $hidden->getId(),
+            ],
+        ]);
+        $this->assertTrue($body['result']['isError'] ?? null);
+        $content = $body['result']['content'] ?? null;
+        $this->assertIsArray($content);
+        $this->assertIsArray($content[0]);
+        $this->assertIsString($content[0]['text']);
+        $this->assertStringContainsString('not found', $content[0]['text']);
+    }
+
+    public function testUpdateTaskInvalidAssigneeFailsValidation(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        // bob is neither the owner nor a member of any shared project, so
+        // ValidAssignees rejects him → entity validation (422) branch.
+        $task = $this->makeTask($alice, 'Standalone');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'update_task',
+            'arguments' => [
+                'taskId' => (string) $task->getId(),
+                'assigneeIds' => [(string) $bob->getId()],
+            ],
+        ]);
+        $this->assertTrue($body['result']['isError'] ?? null);
+        $content = $body['result']['content'] ?? null;
+        $this->assertIsArray($content);
+        $this->assertIsArray($content[0]);
+        $this->assertIsString($content[0]['text']);
+        $this->assertStringContainsString('assignees', $content[0]['text']);
+    }
+
+    public function testUpdateTaskUnknownTagIsError(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->makeTask($alice, 'Tag me');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        // A well-formed UUID that doesn't resolve to a tag the caller owns.
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'update_task',
+            'arguments' => [
+                'taskId' => (string) $task->getId(),
+                'tagIds' => ['00000000-0000-7000-8000-000000000000'],
+            ],
+        ]);
+        $this->assertTrue($body['result']['isError'] ?? null);
+        $content = $body['result']['content'] ?? null;
+        $this->assertIsArray($content);
+        $this->assertIsArray($content[0]);
+        $this->assertIsString($content[0]['text']);
+        $this->assertStringContainsString('not found', $content[0]['text']);
+    }
+
+    // ---- DownloadFileTool branches --------------------------------------
+
+    public function testDownloadFileForbiddenAttachmentIsError(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        // bob's private attachment — alice is neither uploader nor a member
+        // of any task/space using it, so canAccess() is false → not found.
+        $media = $this->seedAttachment($bob, 'secret.pdf');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'download_file',
+            'arguments' => ['fileId' => (string) $media->getId()],
+        ]);
+        $this->assertTrue($body['result']['isError'] ?? null);
+        $content = $body['result']['content'] ?? null;
+        $this->assertIsArray($content);
+        $this->assertIsArray($content[0]);
+        $this->assertIsString($content[0]['text']);
+        $this->assertStringContainsString('not found', $content[0]['text']);
+    }
+
+    public function testDownloadFileMalformedIdIsValidationError(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'download_file',
+            'arguments' => ['fileId' => 'not-a-uuid'],
+        ]);
+        $this->assertTrue($body['result']['isError'] ?? null);
+        $content = $body['result']['content'] ?? null;
+        $this->assertIsArray($content);
+        $this->assertIsArray($content[0]);
+        $this->assertIsString($content[0]['text']);
+        $this->assertStringContainsString('UUID', $content[0]['text']);
+    }
+
+    // ---- McpInputHelper edge cases --------------------------------------
+
+    public function testMissingRequiredArgIsError(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        // update_task without taskId → requireUuid sees null → invalid input.
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'update_task',
+            'arguments' => ['title' => 'No id supplied'],
+        ]);
+        $this->assertTrue($body['result']['isError'] ?? null);
+        $content = $body['result']['content'] ?? null;
+        $this->assertIsArray($content);
+        $this->assertIsArray($content[0]);
+        $this->assertIsString($content[0]['text']);
+        $this->assertStringContainsString('taskId', $content[0]['text']);
+    }
+
+    public function testWrongJsonTypeForArrayArgIsError(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        // tagIds is a number, not an array → optionalStringArray rejects it.
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_tasks',
+            'arguments' => ['tagIds' => 42],
+        ]);
+        $this->assertTrue($body['result']['isError'] ?? null);
+        $content = $body['result']['content'] ?? null;
+        $this->assertIsArray($content);
+        $this->assertIsArray($content[0]);
+        $this->assertIsString($content[0]['text']);
+        $this->assertStringContainsString('array', $content[0]['text']);
+    }
+
+    public function testOutOfRangeEnumIsError(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        // status outside {open, completed} → invalid input branch.
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_tasks',
+            'arguments' => ['status' => 'archived'],
+        ]);
+        $this->assertTrue($body['result']['isError'] ?? null);
+        $content = $body['result']['content'] ?? null;
+        $this->assertIsArray($content);
+        $this->assertIsArray($content[0]);
+        $this->assertIsString($content[0]['text']);
+        $this->assertStringContainsString('open', $content[0]['text']);
+    }
+
+    // ---- McpController malformed-envelope branches ----------------------
+
+    public function testMissingMethodReturnsInvalidRequest(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        $client->request('POST', '/mcp', [
+            'json' => ['jsonrpc' => '2.0', 'id' => 7],
+            'headers' => ['Authorization' => 'Bearer ' . $plain],
+        ]);
+        $this->assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+        $error = $body['error'] ?? null;
+        $this->assertIsArray($error);
+        $this->assertSame(-32600, $error['code']);
+        $this->assertIsString($error['message']);
+        $this->assertStringContainsString('method', $error['message']);
+    }
+
+    public function testToolsCallWithNonObjectParamsIsError(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        // params is a string, not an object → handleToolsCall raises McpException.
+        $client->request('POST', '/mcp', [
+            'json' => ['jsonrpc' => '2.0', 'id' => 8, 'method' => 'tools/call', 'params' => 'oops'],
+            'headers' => ['Authorization' => 'Bearer ' . $plain],
+        ]);
+        $this->assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+        $result = $body['result'] ?? null;
+        $this->assertIsArray($result);
+        $this->assertTrue($result['isError'] ?? null);
+        $content = $result['content'] ?? null;
+        $this->assertIsArray($content);
+        $this->assertIsArray($content[0]);
+        $this->assertIsString($content[0]['text']);
+        $this->assertStringContainsString('object', $content[0]['text']);
+    }
+
+    public function testParseErrorOnMalformedJson(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $plain = $this->mintToken($alice, 'CLI');
+
+        $client = static::createClient();
+        // Raw, un-parseable body → decode() returns null → -32700 parse error.
+        $client->request('POST', '/mcp', [
+            'body' => '{ this is not valid json',
+            'headers' => [
+                'Authorization' => 'Bearer ' . $plain,
+                'Content-Type' => 'application/json',
+            ],
+        ]);
+        $this->assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+        $error = $body['error'] ?? null;
+        $this->assertIsArray($error);
+        $this->assertSame(-32700, $error['code']);
+    }
+
+    /**
+     * Returns the JSON-RPC response body. Every site that uses this
+     * helper goes through {@see assertResponseIsSuccessful()} and
+     * checks a `result`, so the shape is widened to `array<string, mixed>`
+     * on result (deep nesting is narrowed per-callsite with explicit
+     * `assertIsArray()` / `assertArrayHasKey()` calls).
+     *
+     * @param array<string, mixed> $params
+     * @return array{
+     *   jsonrpc: string,
+     *   id?: int|string,
+     *   result: array<string, mixed>,
+     *   error?: array{code: int, message: string, data?: mixed}
+     * }
+     */
+    private function callMcp(Client $client, string $bearer, string $method, array $params = []): array
+    {
+        $client->request('POST', '/mcp', [
+            'json' => [
+                'jsonrpc' => '2.0',
+                'id' => mt_rand(1, 99999),
+                'method' => $method,
+                'params' => $params,
+            ],
+            'headers' => ['Authorization' => 'Bearer ' . $bearer],
+        ]);
+        $this->assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        /**
+         * @var array{
+         *   jsonrpc: string,
+         *   id?: int|string,
+         *   result: array<string, mixed>,
+         *   error?: array{code: int, message: string, data?: mixed}
+         * } $body
+         */
+        $body = $response->toArray();
+        return $body;
+    }
+
+    private function mintToken(User $user, string $name): string
+    {
+        $plain = ApiToken::PLAINTEXT_PREFIX . bin2hex(random_bytes(16));
+        $token = new ApiToken();
+        $token->setUser($user);
+        $token->setName($name);
+        $token->setTokenHash(hash('sha256', $plain));
+        $this->entityManager->persist($token);
+        $this->entityManager->flush();
+        return $plain;
+    }
+
+    private function makeTask(User $owner, string $title): Task
+    {
+        $task = new Task();
+        $task->setOwner($owner);
+        $task->setTitle($title);
+        $this->entityManager->persist($task);
+        $this->entityManager->flush();
+        return $task;
+    }
+
+    private function makeTaskInProject(User $owner, Project $project, string $title): Task
+    {
+        $task = new Task();
+        $task->setOwner($owner);
+        $task->setProject($project);
+        $task->setTitle($title);
+        $this->entityManager->persist($task);
+        $this->entityManager->flush();
+        return $task;
+    }
+
+    /**
+     * @param User[] $members
+     */
+    private function makeProject(User $owner, array $members, string $title): Project
+    {
+        $project = new Project();
+        $project->setOwner($owner);
+        $project->setTitle($title);
+        foreach ($members as $member) {
+            $this->addProjectMember($project, $member);
+        }
+        $this->entityManager->persist($project);
+        $this->entityManager->flush();
+        return $project;
+    }
+
+    private function seedAttachment(User $owner, string $name): MediaObject
+    {
+        $media = new MediaObject();
+        $media->setOwner($owner);
+        $media->setKind(MediaObject::KIND_ATTACHMENT);
+        $media->setVariants(['original' => 'attachments/seeded-' . $name]);
+        $media->setOriginalName($name);
+        $media->setMimeType('application/pdf');
+        $media->setByteSize(1024);
+        $this->entityManager->persist($media);
+        $this->entityManager->flush();
+        return $media;
+    }
+
+    private function createUser(string $email): User
+    {
+        $container = static::getContainer();
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+        return $user;
+    }
+}

--- a/api/tests/Api/MediaObjectDownloadEdgeTest.php
+++ b/api/tests/Api/MediaObjectDownloadEdgeTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\MediaObject;
+use App\Entity\Space;
+use App\Entity\SpaceMembership;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use League\Flysystem\FilesystemOperator;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Extra branch coverage for {@see \App\Controller\MediaObjectDownloadController}
+ * that MediaObjectDownloadTest doesn't reach: the space-attachment
+ * readability arm (member downloads, non-member 404) and the
+ * no-variant-path 404 fallback.
+ */
+class MediaObjectDownloadEdgeTest extends ApiTestCase
+{
+    private EntityManagerInterface $entityManager;
+    private FilesystemOperator $storage;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $container = static::getContainer();
+        $em = $container->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+        $this->storage = $container->get('media.storage');
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\SpaceMembership')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\MediaObject')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Space')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testSpaceMemberCanDownloadSpaceAttachment(): void
+    {
+        $owner = $this->createUser('owner@example.com');
+        $member = $this->createUser('member@example.com');
+        $space = $this->createSpace($owner, [$member]);
+
+        // Uploaded by the owner, attached to the space; a different member
+        // who didn't upload it can still download via space membership.
+        $media = $this->seedAttachment($owner, 'shared.pdf', 'SHAREDBYTES');
+        $space->addAttachment($media);
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($member);
+        $client->request('GET', '/media-objects/' . $media->getId() . '/download');
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testNonSpaceMemberCannotDownloadSpaceAttachment(): void
+    {
+        $owner = $this->createUser('owner@example.com');
+        $stranger = $this->createUser('stranger@example.com');
+        $space = $this->createSpace($owner, []);
+
+        $media = $this->seedAttachment($owner, 'secret.pdf', 'SECRET');
+        $space->addAttachment($media);
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($stranger);
+        $client->request('GET', '/media-objects/' . $media->getId() . '/download');
+        // 404 (not 403) so the endpoint can't enumerate MediaObject ids.
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testMediaWithoutVariantPathReturns404(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        // Owner has access, but the MediaObject has no stored variant, so
+        // the controller can't resolve a path to stream → 404.
+        $media = new MediaObject();
+        $media->setOwner($alice);
+        $media->setKind(MediaObject::KIND_ATTACHMENT);
+        $media->setVariants([]);
+        $media->setOriginalName('empty.pdf');
+        $media->setMimeType('application/pdf');
+        $media->setByteSize(0);
+        $this->entityManager->persist($media);
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/media-objects/' . $media->getId() . '/download');
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    private function seedAttachment(User $owner, string $name, string $bytes): MediaObject
+    {
+        $path = 'attachments/edge-' . bin2hex(random_bytes(4)) . '-' . $name;
+        $this->storage->write($path, $bytes);
+
+        $media = new MediaObject();
+        $media->setOwner($owner);
+        $media->setKind(MediaObject::KIND_ATTACHMENT);
+        $media->setVariants(['original' => $path]);
+        $media->setOriginalName($name);
+        $media->setMimeType('application/pdf');
+        $media->setByteSize(strlen($bytes));
+        $this->entityManager->persist($media);
+        $this->entityManager->flush();
+        return $media;
+    }
+
+    /**
+     * @param User[] $extraMembers
+     */
+    private function createSpace(User $owner, array $extraMembers): Space
+    {
+        $space = new Space();
+        $space->setName('Shared space');
+        $space->setCreatedBy($owner);
+        $this->entityManager->persist($space);
+
+        $admin = (new SpaceMembership())
+            ->setUser($owner)
+            ->setRole(Space::ROLE_ADMIN);
+        $space->addUserMembership($admin);
+        $this->entityManager->persist($admin);
+
+        foreach ($extraMembers as $m) {
+            $membership = (new SpaceMembership())
+                ->setUser($m)
+                ->setRole(Space::ROLE_MEMBER);
+            $space->addUserMembership($membership);
+            $this->entityManager->persist($membership);
+        }
+
+        $this->entityManager->flush();
+        return $space;
+    }
+
+    private function createUser(string $email): User
+    {
+        $container = static::getContainer();
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/api/tests/Api/PageActivityTest.php
+++ b/api/tests/Api/PageActivityTest.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\Page;
+use App\Entity\Space;
+use App\Entity\SpaceMembership;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Coverage for App\Controller\PageActivityController — `GET /pages/{id}/activity`
+ * (#183). Mirrors the Task/Project activity controllers: any space member can
+ * read the audit feed; non-members and unknown ids get 404 (existence-hiding).
+ */
+class PageActivityTest extends ApiTestCase
+{
+    use SpaceMembershipFixture;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Comment')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Page')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Space')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\ActivityLog')->execute();
+    }
+
+    public function testMemberSeesActivityAfterPageEdit(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $space = $this->createSpace($alice);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        // Create + edit the page over the wire so Gedmo's listener fires.
+        $client->request('POST', '/pages', [
+            'json' => [
+                'space' => '/spaces/' . $space->getId(),
+                'title' => 'Runbook',
+                'body' => 'First draft.',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $created = $response->toArray();
+        $pageId = $created['id'];
+        $this->assertIsString($pageId);
+
+        $client->request('PATCH', '/pages/' . $pageId, [
+            'json' => ['title' => 'Runbook v2'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $client->request('GET', '/pages/' . $pageId . '/activity');
+        $this->assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+
+        $this->assertSame(2, $body['totalItems']);
+        $items = $body['items'] ?? null;
+        $this->assertIsArray($items);
+        $this->assertCount(2, $items);
+        $latest = $items[0] ?? null;
+        $this->assertIsArray($latest);
+        $this->assertSame('update', $latest['action']);
+        $actors = $body['actors'] ?? null;
+        $this->assertIsArray($actors);
+        $this->assertArrayHasKey('/users/' . $alice->getId(), $actors);
+    }
+
+    public function testActivityPaginates(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $space = $this->createSpace($alice);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        $client->request('POST', '/pages', [
+            'json' => [
+                'space' => '/spaces/' . $space->getId(),
+                'title' => 'Pageable',
+                'body' => 'Body',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $pageId = $response->toArray()['id'];
+        $this->assertIsString($pageId);
+
+        for ($i = 1; $i <= 4; $i++) {
+            $client->request('PATCH', '/pages/' . $pageId, [
+                'json' => ['title' => 'Pageable v' . $i],
+                'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            ]);
+        }
+
+        $client->request('GET', '/pages/' . $pageId . '/activity?page=1&itemsPerPage=2');
+        $this->assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+        $this->assertSame(5, $body['totalItems']);
+        $items = $body['items'] ?? null;
+        $this->assertIsArray($items);
+        $this->assertCount(2, $items);
+    }
+
+    public function testStrangerCannotReadActivity(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $stranger = $this->createUser('stranger@example.com');
+        $space = $this->createSpace($alice);
+        $page = $this->seedPage($alice, $space, 'Hidden');
+
+        $client = static::createClient();
+        $client->loginUser($stranger);
+        $client->request('GET', '/pages/' . $page->getId() . '/activity');
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testUnknownPageIs404(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $client = static::createClient();
+        $client->loginUser($alice);
+        // Well-formed UUID that doesn't resolve to a page.
+        $client->request('GET', '/pages/00000000-0000-0000-0000-000000000000/activity');
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testInvalidIdIs404(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/pages/not-a-uuid/activity');
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    private function seedPage(User $author, Space $space, string $title, string $body = 'Body'): Page
+    {
+        $page = new Page();
+        $page->setSpace($space);
+        $page->setCreatedBy($author);
+        $page->setTitle($title);
+        $page->setBody($body);
+        $this->entityManager->persist($page);
+        $this->entityManager->flush();
+        return $page;
+    }
+
+    private function createSpace(User $owner, string $name = 'Test space'): Space
+    {
+        $space = new Space();
+        $space->setName($name);
+        $space->setCreatedBy($owner);
+        $this->entityManager->persist($space);
+
+        $admin = (new SpaceMembership())
+            ->setUser($owner)
+            ->setRole(Space::ROLE_ADMIN);
+        $space->addUserMembership($admin);
+        $this->entityManager->persist($admin);
+        $this->entityManager->flush();
+        return $space;
+    }
+
+    private function createUser(string $email): User
+    {
+        $container = static::getContainer();
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/api/tests/Api/RecurrenceValidationTest.php
+++ b/api/tests/Api/RecurrenceValidationTest.php
@@ -1,0 +1,306 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\Task;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Focused coverage of {@see \App\Validator\ValidRecurrenceValidator} branches
+ * — byDay, monthly weekday mode, and the `ends` end-conditions — beyond the
+ * frequency/interval/due-date cases already in {@see TaskTest}.
+ */
+class RecurrenceValidationTest extends ApiTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Notification')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Comment')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testValidWeeklyByDayRecurrenceIsAccepted(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks', [
+            'json' => [
+                'title' => 'Weekly standup',
+                'dueDate' => '2026-06-01T08:00:00+00:00',
+                'recurrenceRule' => [
+                    'frequency' => 'weekly',
+                    'interval' => 1,
+                    'byDay' => ['MO', 'WE', 'FR'],
+                ],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+    }
+
+    public function testValidMonthlyWeekdayRecurrenceIsAccepted(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks', [
+            'json' => [
+                'title' => 'Last Friday of the month',
+                'dueDate' => '2026-06-26T08:00:00+00:00',
+                'recurrenceRule' => [
+                    'frequency' => 'monthly',
+                    'interval' => 1,
+                    'monthlyMode' => 'weekday',
+                    'byDay' => ['FR'],
+                    'bySetPos' => -1,
+                ],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+    }
+
+    public function testValidEndsCountRecurrenceIsAccepted(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks', [
+            'json' => [
+                'title' => 'Three dailies',
+                'dueDate' => '2026-06-01T08:00:00+00:00',
+                'recurrenceRule' => [
+                    'frequency' => 'daily',
+                    'interval' => 1,
+                    'ends' => ['type' => 'count', 'count' => 3],
+                ],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+    }
+
+    public function testValidEndsUntilRecurrenceIsAccepted(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks', [
+            'json' => [
+                'title' => 'Until summer ends',
+                'dueDate' => '2026-06-01T08:00:00+00:00',
+                'recurrenceRule' => [
+                    'frequency' => 'weekly',
+                    'interval' => 2,
+                    'ends' => ['type' => 'until', 'until' => '2026-09-21'],
+                ],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+    }
+
+    public function testPatchToValidRecurrenceIsAccepted(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $task = $this->createTask($alice, 'Will recur');
+        $task->setDueDate(new \DateTimeImmutable('2026-06-01T08:00:00+00:00'));
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/tasks/' . $task->getId(), [
+            'json' => [
+                'recurrenceRule' => ['frequency' => 'monthly', 'interval' => 1],
+            ],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $reloaded = $this->reloadTaskByTitle('Will recur');
+        $this->assertSame(
+            ['frequency' => 'monthly', 'interval' => 1],
+            $reloaded->getRecurrenceRule(),
+        );
+    }
+
+    public function testMissingFrequencyIsRejected(): void
+    {
+        // No `frequency` key → invalid shape branch.
+        $this->assertRecurrenceRejected(['interval' => 1]);
+    }
+
+    public function testNonIntegerIntervalIsRejected(): void
+    {
+        // `interval` must be an int; a string trips the invalid-shape branch.
+        $this->assertRecurrenceRejected(['frequency' => 'daily', 'interval' => '1']);
+    }
+
+    public function testInvalidByDayTokenIsRejected(): void
+    {
+        $this->assertRecurrenceRejected([
+            'frequency' => 'weekly',
+            'interval' => 1,
+            'byDay' => ['XX'],
+        ]);
+    }
+
+    public function testNonArrayByDayIsRejected(): void
+    {
+        $this->assertRecurrenceRejected([
+            'frequency' => 'weekly',
+            'interval' => 1,
+            'byDay' => 'MO',
+        ]);
+    }
+
+    public function testInvalidMonthlyModeIsRejected(): void
+    {
+        $this->assertRecurrenceRejected([
+            'frequency' => 'monthly',
+            'interval' => 1,
+            'monthlyMode' => 'lunar',
+        ]);
+    }
+
+    public function testMonthlyWeekdayMissingBySetPosIsRejected(): void
+    {
+        // weekday mode requires a single byDay AND a valid bySetPos.
+        $this->assertRecurrenceRejected([
+            'frequency' => 'monthly',
+            'interval' => 1,
+            'monthlyMode' => 'weekday',
+            'byDay' => ['FR'],
+        ]);
+    }
+
+    public function testMonthlyWeekdayOutOfRangeBySetPosIsRejected(): void
+    {
+        $this->assertRecurrenceRejected([
+            'frequency' => 'monthly',
+            'interval' => 1,
+            'monthlyMode' => 'weekday',
+            'byDay' => ['FR'],
+            'bySetPos' => 6,
+        ]);
+    }
+
+    public function testEndsCountZeroIsRejected(): void
+    {
+        $this->assertRecurrenceRejected([
+            'frequency' => 'daily',
+            'interval' => 1,
+            'ends' => ['type' => 'count', 'count' => 0],
+        ]);
+    }
+
+    public function testEndsUntilMalformedDateIsRejected(): void
+    {
+        $this->assertRecurrenceRejected([
+            'frequency' => 'daily',
+            'interval' => 1,
+            'ends' => ['type' => 'until', 'until' => '21-09-2026'],
+        ]);
+    }
+
+    public function testEndsUnknownTypeIsRejected(): void
+    {
+        $this->assertRecurrenceRejected([
+            'frequency' => 'daily',
+            'interval' => 1,
+            'ends' => ['type' => 'forever'],
+        ]);
+    }
+
+    public function testNonArrayEndsIsRejected(): void
+    {
+        $this->assertRecurrenceRejected([
+            'frequency' => 'daily',
+            'interval' => 1,
+            'ends' => 'never',
+        ]);
+    }
+
+    /**
+     * POSTs a task carrying $rule (with a due date so only the rule shape can
+     * trip the validator) and asserts a 422.
+     *
+     * @param array<string, mixed> $rule
+     */
+    private function assertRecurrenceRejected(array $rule): void
+    {
+        $alice = $this->createUser('alice@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks', [
+            'json' => [
+                'title' => 'Invalid recurrence',
+                'dueDate' => '2026-06-01T08:00:00+00:00',
+                'recurrenceRule' => $rule,
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    private function createUser(string $email): User
+    {
+        $container = static::getContainer();
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+
+    private function createTask(User $owner, string $title): Task
+    {
+        $task = new Task();
+        $task->setOwner($owner);
+        $task->setTitle($title);
+
+        $this->entityManager->persist($task);
+        $this->entityManager->flush();
+
+        return $task;
+    }
+
+    private function reloadTaskByTitle(string $title): Task
+    {
+        $this->entityManager->clear();
+        $task = $this->entityManager->getRepository(Task::class)->findOneBy(['title' => $title]);
+        assert($task instanceof Task);
+        return $task;
+    }
+}

--- a/api/tests/Api/SearchFilterTest.php
+++ b/api/tests/Api/SearchFilterTest.php
@@ -1,0 +1,306 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\Discussion;
+use App\Entity\Project;
+use App\Entity\Space;
+use App\Entity\SpaceMembership;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Functional coverage for the Postgres full-text-search collection
+ * filters {@see \App\Filter\ProjectSearchFilter} and
+ * {@see \App\Filter\DiscussionSearchFilter}.
+ *
+ * Both filters expose `?search={q}` (their `PARAMETER` constant) on the
+ * Project / Discussion collections, run it through `websearch_to_tsquery`
+ * via the `SEARCH_VECTOR_MATCH` DQL function, and order by `ts_rank`
+ * (`SEARCH_VECTOR_RANK`) unless `?sort=recent` is supplied. Rows are
+ * space-scoped by the access extensions, so the corpus is seeded inside
+ * a space the requesting user belongs to.
+ */
+class SearchFilterTest extends ApiTestCase
+{
+    use SpaceMembershipFixture;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Discussion')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Space')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testProjectSearchMatchesTitleWordOnly(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        // Projects land in the creator's personal space, of which the
+        // creator is the sole admin — so they're visible to Alice.
+        $this->createProject($alice, 'Marketing launch checklist', 'Plan the campaign');
+        $this->createProject($alice, 'Engineering backlog', 'Refactor the parser');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        // `search` is ProjectSearchFilter::PARAMETER.
+        $client->request('GET', '/projects?search=Marketing');
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains(['totalItems' => 1]);
+
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+        $members = $body['member'] ?? null;
+        $this->assertIsArray($members);
+        $this->assertCount(1, $members);
+        $first = $members[0] ?? null;
+        $this->assertIsArray($first);
+        $this->assertSame('Marketing launch checklist', $first['title'] ?? null);
+    }
+
+    public function testProjectSearchMatchesDescriptionWord(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $this->createProject($alice, 'Marketing launch checklist', 'Plan the campaign');
+        $this->createProject($alice, 'Engineering backlog', 'Refactor the parser');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        // "parser" only appears in the second project's description.
+        $client->request('GET', '/projects?search=parser');
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains(['totalItems' => 1]);
+
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+        $members = $body['member'] ?? null;
+        $this->assertIsArray($members);
+        $this->assertCount(1, $members);
+        $first = $members[0] ?? null;
+        $this->assertIsArray($first);
+        $this->assertSame('Engineering backlog', $first['title'] ?? null);
+    }
+
+    public function testProjectSearchNonMatchingTermReturnsNothing(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $this->createProject($alice, 'Marketing launch checklist', 'Plan the campaign');
+        $this->createProject($alice, 'Engineering backlog', 'Refactor the parser');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        $client->request('GET', '/projects?search=zzzznomatch');
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains(['totalItems' => 0]);
+    }
+
+    public function testProjectSearchRelevanceAndRecentSortsBothSucceed(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $this->createProject($alice, 'Marketing launch alpha', 'shared keyword corpus');
+        $this->createProject($alice, 'Marketing launch beta', 'shared keyword corpus');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        // Default ordering is by relevance (ts_rank). Both projects share
+        // the search term, so the matched set is the same in either mode.
+        $client->request('GET', '/projects?search=Marketing&sort=relevance');
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains(['totalItems' => 2]);
+
+        // `sort=recent` swaps the order to createdOn DESC (see
+        // ProjectSearchFilter); the matched set is unchanged.
+        $client->request('GET', '/projects?search=Marketing&sort=recent');
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains(['totalItems' => 2]);
+
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+        $members = $body['member'] ?? null;
+        $this->assertIsArray($members);
+        $this->assertCount(2, $members);
+    }
+
+    public function testDiscussionSearchMatchesTitleWordOnly(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $space = $this->createSpace($alice, 'Backend');
+        $this->seedDiscussion($alice, $space, 'Pricing question for launch', 'How much will it cost');
+        $this->seedDiscussion($alice, $space, 'Idea: switch to pnpm', 'Quick win on installs');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        // `search` is DiscussionSearchFilter::PARAMETER.
+        $client->request('GET', '/discussions?search=Pricing');
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains(['totalItems' => 1]);
+
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+        $members = $body['member'] ?? null;
+        $this->assertIsArray($members);
+        $this->assertCount(1, $members);
+        $first = $members[0] ?? null;
+        $this->assertIsArray($first);
+        $this->assertSame('Pricing question for launch', $first['title'] ?? null);
+    }
+
+    public function testDiscussionSearchMatchesBodyWord(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $space = $this->createSpace($alice, 'Backend');
+        $this->seedDiscussion($alice, $space, 'Pricing question for launch', 'How much will it cost');
+        $this->seedDiscussion($alice, $space, 'Idea: switch to pnpm', 'Quick win on installs');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        // "installs" only appears in the second discussion's body.
+        $client->request('GET', '/discussions?search=installs');
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains(['totalItems' => 1]);
+
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+        $members = $body['member'] ?? null;
+        $this->assertIsArray($members);
+        $this->assertCount(1, $members);
+        $first = $members[0] ?? null;
+        $this->assertIsArray($first);
+        $this->assertSame('Idea: switch to pnpm', $first['title'] ?? null);
+    }
+
+    public function testDiscussionSearchNonMatchingTermReturnsNothing(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $space = $this->createSpace($alice, 'Backend');
+        $this->seedDiscussion($alice, $space, 'Pricing question for launch', 'How much will it cost');
+        $this->seedDiscussion($alice, $space, 'Idea: switch to pnpm', 'Quick win on installs');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        $client->request('GET', '/discussions?search=zzzznomatch');
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains(['totalItems' => 0]);
+    }
+
+    public function testDiscussionSearchKeepsPinnedThreadFirst(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $space = $this->createSpace($alice, 'Backend');
+        // Two threads share the "launch" term; the pinned one must lead
+        // regardless of relevance ranking (see DiscussionSearchFilter,
+        // which orders isPinned DESC before the rank tiebreaker).
+        $this->seedDiscussion($alice, $space, 'Unpinned launch note', 'launch launch launch detail');
+        $this->seedDiscussion($alice, $space, 'Pinned launch note', 'launch summary', true);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        $client->request('GET', '/discussions?search=launch');
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains(['totalItems' => 2]);
+
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+        $members = $body['member'] ?? null;
+        $this->assertIsArray($members);
+        $this->assertCount(2, $members);
+        $first = $members[0] ?? null;
+        $this->assertIsArray($first);
+        $this->assertSame('Pinned launch note', $first['title'] ?? null);
+    }
+
+    private function createProject(User $owner, string $title, string $description): Project
+    {
+        $project = new Project();
+        $project->setOwner($owner);
+        $project->setTitle($title);
+        $project->setDescription($description);
+
+        // ProjectSpaceDefaultListener fills Project.space with the
+        // owner's personal space at PrePersist, so the owner can see it.
+        $this->entityManager->persist($project);
+        $this->entityManager->flush();
+
+        return $project;
+    }
+
+    private function createSpace(User $admin, string $name): Space
+    {
+        $space = new Space();
+        $space->setName($name);
+        $space->setCreatedBy($admin);
+        $this->entityManager->persist($space);
+        $membership = (new SpaceMembership())
+            ->setUser($admin)
+            ->setRole(Space::ROLE_ADMIN);
+        $space->addUserMembership($membership);
+        $this->entityManager->persist($membership);
+        $this->entityManager->flush();
+        return $space;
+    }
+
+    private function seedDiscussion(
+        User $author,
+        Space $space,
+        string $title,
+        string $body,
+        bool $pinned = false,
+    ): Discussion {
+        $disc = new Discussion();
+        $disc->setSpace($space);
+        $disc->setAuthor($author);
+        $disc->setTitle($title);
+        $disc->setBody($body);
+        $disc->setCategory('general');
+        $disc->setIsPinned($pinned);
+        $this->entityManager->persist($disc);
+        $this->entityManager->flush();
+        return $disc;
+    }
+
+    /**
+     * @param string[] $roles
+     */
+    private function createUser(string $email, array $roles = ['ROLE_USER']): User
+    {
+        $container = static::getContainer();
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles($roles);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/api/tests/Api/SegmentMemberControllerTest.php
+++ b/api/tests/Api/SegmentMemberControllerTest.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Entity\Segment;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Edge/error branches of {@see \App\Controller\SegmentMemberController}
+ * that SegmentTest doesn't reach: non-admin forbidden, unknown segment,
+ * unknown email, the re-POST mode flip, DELETE of an unknown member, and
+ * the preview breakdown shape.
+ */
+class SegmentMemberControllerTest extends ApiTestCase
+{
+    use JsonBodyAssertions;
+
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->em = $em;
+        $this->em->createQuery('DELETE FROM App\Entity\SegmentMembership')->execute();
+        $this->em->createQuery('DELETE FROM App\Entity\Segment')->execute();
+        $this->em->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testNonAdminForbidden(): void
+    {
+        $plain = $this->makeUser('plain@example.com');
+        $segment = $this->makeSegment('beta');
+
+        $client = static::createClient();
+        $client->loginUser($plain);
+
+        $client->request('POST', '/segments/' . $segment->getId() . '/members', [
+            'json' => ['email' => 'plain@example.com', 'mode' => 'include'],
+        ]);
+        $this->assertResponseStatusCodeSame(403);
+
+        $client->request('GET', '/segments/' . $segment->getId() . '/preview');
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testUnknownSegmentReturns404(): void
+    {
+        $admin = $this->makeUser('admin@example.com', ['ROLE_ADMIN']);
+        $client = static::createClient();
+        $client->loginUser($admin);
+
+        $client->request('POST', '/segments/01919999-9999-7999-9999-999999999999/members', [
+            'json' => ['email' => 'admin@example.com', 'mode' => 'include'],
+        ]);
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testUnknownEmailReturns404(): void
+    {
+        $admin = $this->makeUser('admin@example.com', ['ROLE_ADMIN']);
+        $segment = $this->makeSegment('beta');
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+
+        $client->request('POST', '/segments/' . $segment->getId() . '/members', [
+            'json' => ['email' => 'nobody@example.com', 'mode' => 'include'],
+        ]);
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testInvalidModeReturns422(): void
+    {
+        $admin = $this->makeUser('admin@example.com', ['ROLE_ADMIN']);
+        $segment = $this->makeSegment('beta');
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+
+        $client->request('POST', '/segments/' . $segment->getId() . '/members', [
+            'json' => ['email' => 'admin@example.com', 'mode' => 'maybe'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testRePostFlipsMode(): void
+    {
+        $admin = $this->makeUser('admin@example.com', ['ROLE_ADMIN']);
+        $target = $this->makeUser('target@example.com');
+        $segment = $this->makeSegment('beta');
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+
+        // First POST creates the override → 201 "added".
+        $client->request('POST', '/segments/' . $segment->getId() . '/members', [
+            'json' => ['email' => 'target@example.com', 'mode' => 'include'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+        $body = $this->body($client);
+        $this->assertSame('added', $this->stringField($body, 'status'));
+        $this->assertSame('include', $this->stringField($body, 'mode'));
+
+        // Re-POST with a new mode updates in place → 200 "updated".
+        $client->request('POST', '/segments/' . $segment->getId() . '/members', [
+            'json' => ['email' => 'target@example.com', 'mode' => 'exclude'],
+        ]);
+        $this->assertResponseStatusCodeSame(200);
+        $body = $this->body($client);
+        $this->assertSame('updated', $this->stringField($body, 'status'));
+        $this->assertSame('exclude', $this->stringField($body, 'mode'));
+    }
+
+    public function testRemoveUnknownMemberReturns404(): void
+    {
+        $admin = $this->makeUser('admin@example.com', ['ROLE_ADMIN']);
+        $other = $this->makeUser('other@example.com');
+        $segment = $this->makeSegment('beta');
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+
+        // A real user that has no override on this segment.
+        $client->request('DELETE', '/segments/' . $segment->getId() . '/members/' . $other->getId());
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testPreviewBreakdownShape(): void
+    {
+        $admin = $this->makeUser('admin@example.com', ['ROLE_ADMIN']);
+        $segment = $this->makeSegment('beta', rollout: 100);
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+
+        $client->request('GET', '/segments/' . $segment->getId() . '/preview');
+        $this->assertResponseIsSuccessful();
+
+        $body = $this->body($client);
+        $this->assertTrue($this->boolField($body, 'enabled'));
+        $this->assertSame(100, $this->intField($body, 'rolloutPercentage'));
+
+        $reach = $this->arrayField($body, 'reach');
+        $this->assertArrayHasKey('total', $reach);
+        $this->assertArrayHasKey('manualIncludes', $reach);
+        $this->assertArrayHasKey('byRole', $reach);
+        $this->assertArrayHasKey('byRollout', $reach);
+        $this->assertArrayHasKey('manualExcludes', $reach);
+    }
+
+    /**
+     * @return array<int|string, mixed>
+     */
+    private function body(Client $client): array
+    {
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        return $response->toArray(false);
+    }
+
+    private function makeSegment(string $key, int $rollout = 0): Segment
+    {
+        $segment = new Segment();
+        $segment->setKey($key);
+        $segment->setName(ucfirst($key));
+        $segment->setRolloutPercentage($rollout);
+        $this->em->persist($segment);
+        $this->em->flush();
+        return $segment;
+    }
+
+    /**
+     * @param list<string> $roles
+     */
+    private function makeUser(string $email, array $roles = []): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles($roles);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $this->em->persist($user);
+        $this->em->flush();
+        return $user;
+    }
+}

--- a/api/tests/Api/UserGroupMemberEdgeTest.php
+++ b/api/tests/Api/UserGroupMemberEdgeTest.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Entity\User;
+use App\Entity\UserGroup;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Edge/error branches of {@see \App\Controller\UserGroupMemberController}
+ * not covered by UserGroupTest: the add-by-email invite branch for an
+ * unknown address, add-already-member 409, the missing-email 400,
+ * removing a user who isn't a member (404), and the non-member-leave
+ * existence-hiding 404.
+ */
+class UserGroupMemberEdgeTest extends ApiTestCase
+{
+    use JsonBodyAssertions;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\GroupInvite')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\UserInvite')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\UserGroup')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testAddUnknownEmailCreatesInvite(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $group = $this->createGroup($alice, 'Solo', [$alice]);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/groups/' . $group->getId() . '/members', [
+            'json' => ['email' => 'newcomer@example.com'],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(200);
+        $body = $this->body($client);
+        $this->assertSame('invited', $this->stringField($body, 'status'));
+        $this->assertSame('newcomer@example.com', $this->stringField($body, 'email'));
+        $this->assertArrayHasKey('inviteId', $body);
+        $this->assertArrayHasKey('expiresAt', $body);
+    }
+
+    public function testAddAlreadyMemberReturns409(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $group = $this->createGroup($alice, 'Shared', [$alice, $bob]);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/groups/' . $group->getId() . '/members', [
+            'json' => ['email' => 'bob@example.com'],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(409);
+    }
+
+    public function testAddMemberWithMissingEmailReturns400(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $group = $this->createGroup($alice, 'Solo', [$alice]);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/groups/' . $group->getId() . '/members', [
+            'json' => ['email' => '  '],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    public function testAddMemberWithInvalidEmailReturns422(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $group = $this->createGroup($alice, 'Solo', [$alice]);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/groups/' . $group->getId() . '/members', [
+            'json' => ['email' => 'not-an-email'],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testRemoveUserWhoIsNotAMemberReturns404(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $outsider = $this->createUser('outsider@example.com');
+        $group = $this->createGroup($alice, 'Solo', [$alice]);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        // A real user that isn't part of the group.
+        $client->request('DELETE', '/groups/' . $group->getId() . '/members/' . $outsider->getId());
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testNonMemberLeaveReturns404(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $outsider = $this->createUser('outsider@example.com');
+        $group = $this->createGroup($alice, 'Solo', [$alice]);
+
+        $client = static::createClient();
+        $client->loginUser($outsider);
+        // Existence-hiding: a non-member probing /leave gets a 404.
+        $client->request('POST', '/groups/' . $group->getId() . '/leave');
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    /**
+     * @return array<int|string, mixed>
+     */
+    private function body(Client $client): array
+    {
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        return $response->toArray(false);
+    }
+
+    private function createUser(string $email): User
+    {
+        $container = static::getContainer();
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+
+    /**
+     * @param User[] $members
+     */
+    private function createGroup(User $owner, string $title, array $members): UserGroup
+    {
+        $group = new UserGroup();
+        $group->setOwner($owner);
+        $group->setTitle($title);
+        $slug = trim((string) preg_replace('/[^a-z0-9]+/', '-', strtolower($title)), '-');
+        $group->setSlug('' === $slug ? 'group' : $slug);
+        foreach ($members as $member) {
+            $group->addMember($member);
+        }
+
+        $this->entityManager->persist($group);
+        $this->entityManager->flush();
+
+        return $group;
+    }
+}

--- a/api/tests/Api/UserInviteControllerEdgeTest.php
+++ b/api/tests/Api/UserInviteControllerEdgeTest.php
@@ -1,0 +1,244 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\GroupInvite;
+use App\Entity\User;
+use App\Entity\UserGroup;
+use App\Entity\UserInvite;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Edge-branch coverage for App\Controller\UserInviteController — the
+ * resend endpoint (token rotation), unknown-invite / cross-group 404s,
+ * and the non-owner / stranger authorization branches that the base
+ * UserInviteTest doesn't exercise.
+ */
+class UserInviteControllerEdgeTest extends ApiTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\GroupInvite')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\UserInvite')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\UserGroup')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->entityManager->close();
+        self::ensureKernelShutdown();
+        parent::tearDown();
+    }
+
+    public function testOwnerCanResendAndTokenRotates(): void
+    {
+        $owner = $this->createUser('alice@example.com');
+        $group = $this->createGroup($owner, 'Backend', [$owner]);
+        $this->inviteEmail($owner, $group, 'newcomer@example.com');
+
+        $invite = $this->entityManager->getRepository(GroupInvite::class)->findAll()[0];
+        $oldHash = $invite->getUserInvite()->getTokenHash();
+
+        $client = static::createClient();
+        $client->loginUser($owner);
+        $client->request('POST', sprintf(
+            '/groups/%s/invites/%s/resend',
+            $group->getId(),
+            $invite->getId(),
+        ), ['headers' => ['Content-Type' => 'application/json']]);
+
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains(['status' => 'resent', 'email' => 'newcomer@example.com']);
+
+        $this->entityManager->clear();
+        $reloaded = $this->entityManager->getRepository(UserInvite::class)
+            ->findOneBy(['email' => 'newcomer@example.com']);
+        $this->assertNotNull($reloaded);
+        // Token rotated → new authoritative link.
+        $this->assertNotSame($oldHash, $reloaded->getTokenHash());
+    }
+
+    public function testResendUnknownInviteIs404(): void
+    {
+        $owner = $this->createUser('alice@example.com');
+        $group = $this->createGroup($owner, 'Backend', [$owner]);
+
+        $client = static::createClient();
+        $client->loginUser($owner);
+        $client->request('POST', sprintf(
+            '/groups/%s/invites/%s/resend',
+            $group->getId(),
+            '00000000-0000-0000-0000-000000000000',
+        ), ['headers' => ['Content-Type' => 'application/json']]);
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testResendInviteFromAnotherGroupIs404(): void
+    {
+        $owner = $this->createUser('alice@example.com');
+        $groupA = $this->createGroup($owner, 'Alpha', [$owner]);
+        $groupB = $this->createGroup($owner, 'Beta', [$owner]);
+        // Invite attached to group A only.
+        $this->inviteEmail($owner, $groupA, 'newcomer@example.com');
+        $invite = $this->entityManager->getRepository(GroupInvite::class)->findAll()[0];
+
+        $client = static::createClient();
+        $client->loginUser($owner);
+        // Address the group-A invite under group B's path → mismatch 404.
+        $client->request('POST', sprintf(
+            '/groups/%s/invites/%s/resend',
+            $groupB->getId(),
+            $invite->getId(),
+        ), ['headers' => ['Content-Type' => 'application/json']]);
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testNonOwnerMemberCannotResend(): void
+    {
+        $owner = $this->createUser('alice@example.com');
+        $member = $this->createUser('bob@example.com');
+        $group = $this->createGroup($owner, 'Shared', [$owner, $member]);
+        $this->inviteEmail($owner, $group, 'newcomer@example.com');
+        $invite = $this->entityManager->getRepository(GroupInvite::class)->findAll()[0];
+
+        $client = static::createClient();
+        $client->loginUser($member);
+        $client->request('POST', sprintf(
+            '/groups/%s/invites/%s/resend',
+            $group->getId(),
+            $invite->getId(),
+        ), ['headers' => ['Content-Type' => 'application/json']]);
+
+        // Non-owner member of the group → 403 (existence not hidden).
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testStrangerListingInvitesIs404(): void
+    {
+        $owner = $this->createUser('alice@example.com');
+        $stranger = $this->createUser('stranger@example.com');
+        $group = $this->createGroup($owner, 'Backend', [$owner]);
+
+        $client = static::createClient();
+        $client->loginUser($stranger);
+        $client->request('GET', '/groups/' . $group->getId() . '/invites');
+        // Non-member → existence hidden as 404.
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testRevokeUnknownInviteIs404(): void
+    {
+        $owner = $this->createUser('alice@example.com');
+        $group = $this->createGroup($owner, 'Backend', [$owner]);
+
+        $client = static::createClient();
+        $client->loginUser($owner);
+        $client->request('DELETE', sprintf(
+            '/groups/%s/invites/%s',
+            $group->getId(),
+            '00000000-0000-0000-0000-000000000000',
+        ));
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testRevokeOnUnknownGroupIs404(): void
+    {
+        $owner = $this->createUser('alice@example.com');
+        $this->createGroup($owner, 'Backend', [$owner]);
+
+        $client = static::createClient();
+        $client->loginUser($owner);
+        $client->request('DELETE', sprintf(
+            '/groups/%s/invites/%s',
+            '00000000-0000-0000-0000-000000000000',
+            '00000000-0000-0000-0000-000000000001',
+        ));
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    /**
+     * Build a UserInvite + GroupInvite directly (mirrors UserInviteTest).
+     */
+    private function inviteEmail(User $owner, UserGroup $group, string $email): string
+    {
+        $plainToken = bin2hex(random_bytes(32));
+        $tokenHash = hash('sha256', $plainToken);
+        $expiresAt = new \DateTimeImmutable('+14 days');
+
+        $invite = $this->entityManager->getRepository(UserInvite::class)
+            ->findOneBy(['email' => $email]);
+        if (null === $invite) {
+            $invite = new UserInvite($email, $tokenHash, $expiresAt);
+            $this->entityManager->persist($invite);
+        } else {
+            $invite->setTokenHash($tokenHash);
+            $invite->setExpiresAt($expiresAt);
+        }
+
+        $existing = $this->entityManager->getRepository(GroupInvite::class)
+            ->findOneBy(['userInvite' => $invite, 'group' => $group]);
+        if (null === $existing) {
+            new GroupInvite($invite, $group, $owner);
+        }
+
+        $this->entityManager->flush();
+
+        return $plainToken;
+    }
+
+    /**
+     * @param string[] $roles
+     */
+    private function createUser(string $email, array $roles = ['ROLE_USER']): User
+    {
+        $container = static::getContainer();
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles($roles);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+
+    /**
+     * @param User[] $members
+     */
+    private function createGroup(User $owner, string $title, array $members): UserGroup
+    {
+        $group = new UserGroup();
+        $group->setOwner($owner);
+        $group->setTitle($title);
+        $base = trim((string) preg_replace('/[^a-z0-9]+/', '-', strtolower($title)), '-');
+        $group->setSlug(('' === $base ? 'group' : $base) . '-' . (++self::$slugCounter));
+        foreach ($members as $member) {
+            $group->addMember($member);
+        }
+
+        $this->entityManager->persist($group);
+        $this->entityManager->flush();
+
+        return $group;
+    }
+
+    private static int $slugCounter = 0;
+}

--- a/api/tests/Command/AccountExportPruneCommandTest.php
+++ b/api/tests/Command/AccountExportPruneCommandTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Tests\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class AccountExportPruneCommandTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = self::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->em = $em;
+        $this->em->createQuery('DELETE FROM App\Entity\AccountExport')->execute();
+    }
+
+    public function testRunsOnEmptyDatabase(): void
+    {
+        $kernel = self::$kernel;
+        assert(null !== $kernel);
+        $application = new Application($kernel);
+        $tester = new CommandTester($application->find('app:account-exports:prune'));
+        $tester->execute([]);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('Deleted 0', $tester->getDisplay());
+    }
+}

--- a/api/tests/Command/DispatchNotificationDigestCommandTest.php
+++ b/api/tests/Command/DispatchNotificationDigestCommandTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Tests\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class DispatchNotificationDigestCommandTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = self::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->em = $em;
+        $this->em->createQuery('DELETE FROM App\Entity\Notification')->execute();
+    }
+
+    public function testRunsOnEmptyDatabase(): void
+    {
+        $kernel = self::$kernel;
+        assert(null !== $kernel);
+        $application = new Application($kernel);
+        $tester = new CommandTester($application->find('app:notifications:dispatch-digest'));
+        $tester->execute(['--period' => 'hourly']);
+
+        $tester->assertCommandIsSuccessful();
+    }
+}

--- a/api/tests/Command/DispatchTaskRemindersCommandTest.php
+++ b/api/tests/Command/DispatchTaskRemindersCommandTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Tests\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class DispatchTaskRemindersCommandTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = self::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->em = $em;
+        $this->em->createQuery('DELETE FROM App\Entity\Task')->execute();
+    }
+
+    public function testRunsOnEmptyDatabase(): void
+    {
+        $kernel = self::$kernel;
+        assert(null !== $kernel);
+        $application = new Application($kernel);
+        $tester = new CommandTester($application->find('app:tasks:reminders:dispatch'));
+        $tester->execute([]);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('notification', $tester->getDisplay());
+    }
+}

--- a/api/tests/Command/SegmentCommandCoverageTest.php
+++ b/api/tests/Command/SegmentCommandCoverageTest.php
@@ -1,0 +1,272 @@
+<?php
+
+namespace App\Tests\Command;
+
+use App\Entity\Segment;
+use App\Entity\SegmentMembership;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Coverage for the `app:segment` action branches not exercised by
+ * {@see SegmentCommandTest}: list, show, enable, disable, roles (valid),
+ * exclude, remove, delete, plus the obvious error paths (unknown action,
+ * unknown key, missing key, missing args, duplicate-create).
+ */
+class SegmentCommandCoverageTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = self::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->em = $em;
+        $this->em->createQuery('DELETE FROM App\Entity\SegmentMembership')->execute();
+        $this->em->createQuery('DELETE FROM App\Entity\Segment')->execute();
+        $this->em->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testCreateViaCommandThenShow(): void
+    {
+        // "create" with name + purpose + roles options on a fresh key.
+        $tester = $this->invoke([
+            'action' => 'create',
+            'args' => ['rollout-cohort'],
+            '--name' => 'Rollout cohort',
+            '--purpose' => Segment::PURPOSE_ROLLOUT,
+            '--roles' => 'ROLE_ADMIN,ROLE_USER',
+        ]);
+        $tester->assertCommandIsSuccessful();
+        $display = $tester->getDisplay();
+        // create() ends by calling show(), so the definition list renders.
+        $this->assertStringContainsString('ROLE_SEGMENT_ROLLOUT_COHORT', $display);
+
+        $segment = $this->reload('rollout-cohort');
+        $this->assertSame('Rollout cohort', $segment->getName());
+        $this->assertSame(Segment::PURPOSE_ROLLOUT, $segment->getPurpose());
+        $this->assertSame(['ROLE_ADMIN', 'ROLE_USER'], $segment->getIncludedRoles());
+    }
+
+    public function testShowAction(): void
+    {
+        $this->seedSegment('beta');
+        $tester = $this->invoke(['action' => 'show', 'args' => ['beta']]);
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('ROLE_SEGMENT_BETA', $tester->getDisplay());
+    }
+
+    public function testListAction(): void
+    {
+        $this->seedSegment('alpha');
+        $this->seedSegment('beta');
+
+        $tester = $this->invoke(['action' => 'list', 'args' => []]);
+        $tester->assertCommandIsSuccessful();
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('alpha', $display);
+        $this->assertStringContainsString('beta', $display);
+    }
+
+    public function testListActionWithNoSegments(): void
+    {
+        $tester = $this->invoke(['action' => 'list', 'args' => []]);
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('No segments yet', $tester->getDisplay());
+    }
+
+    public function testEnableAndDisableActions(): void
+    {
+        $this->seedSegment('toggle');
+
+        $this->invoke(['action' => 'disable', 'args' => ['toggle']])->assertCommandIsSuccessful();
+        $this->assertFalse($this->reload('toggle')->isEnabled());
+
+        $this->invoke(['action' => 'enable', 'args' => ['toggle']])->assertCommandIsSuccessful();
+        $this->assertTrue($this->reload('toggle')->isEnabled());
+    }
+
+    public function testRolloutZeroClearsPercentage(): void
+    {
+        $segment = $this->seedSegment('grad');
+        $segment->setRolloutPercentage(40);
+        $this->em->flush();
+
+        $this->invoke(['action' => 'rollout', 'args' => ['grad', '0']])->assertCommandIsSuccessful();
+        // 0% is stored as null per setRollout().
+        $this->assertNull($this->reload('grad')->getRolloutPercentage());
+    }
+
+    public function testRolesActionSetsValidRoles(): void
+    {
+        $this->seedSegment('beta');
+        $this->invoke(['action' => 'roles', 'args' => ['beta', 'ROLE_ADMIN,role_user']])
+            ->assertCommandIsSuccessful();
+        // parseRoles upper-cases + dedupes.
+        $this->assertSame(['ROLE_ADMIN', 'ROLE_USER'], $this->reload('beta')->getIncludedRoles());
+    }
+
+    public function testExcludeCreatesManualExcludeOverride(): void
+    {
+        $segment = $this->seedSegment('beta');
+        $this->makeUser('excluded@example.com');
+
+        $this->invoke(['action' => 'exclude', 'args' => ['beta', 'excluded@example.com']])
+            ->assertCommandIsSuccessful();
+
+        $membership = $this->em->getRepository(SegmentMembership::class)
+            ->findOneBy(['segment' => $segment]);
+        assert($membership instanceof SegmentMembership);
+        $this->assertSame(SegmentMembership::MODE_EXCLUDE, $membership->getMode());
+    }
+
+    public function testRemoveDropsOverride(): void
+    {
+        $segment = $this->seedSegment('beta');
+        $this->makeUser('member@example.com');
+
+        $this->invoke(['action' => 'add', 'args' => ['beta', 'member@example.com']])
+            ->assertCommandIsSuccessful();
+        $this->assertNotNull(
+            $this->em->getRepository(SegmentMembership::class)->findOneBy(['segment' => $segment]),
+        );
+
+        $this->invoke(['action' => 'remove', 'args' => ['beta', 'member@example.com']])
+            ->assertCommandIsSuccessful();
+        $this->em->clear();
+        $reloaded = $this->em->getRepository(Segment::class)->findOneByKey('beta');
+        assert($reloaded instanceof Segment);
+        $this->assertNull(
+            $this->em->getRepository(SegmentMembership::class)->findOneBy(['segment' => $reloaded]),
+        );
+    }
+
+    public function testAddWithUnknownEmailFails(): void
+    {
+        $this->seedSegment('beta');
+        // No matching user → nothing changed → FAILURE.
+        $tester = $this->invoke(['action' => 'add', 'args' => ['beta', 'ghost@example.com']]);
+        $this->assertNotSame(0, $tester->getStatusCode());
+    }
+
+    public function testAddWithoutEmailsIsInvalid(): void
+    {
+        $this->seedSegment('beta');
+        $tester = $this->invoke(['action' => 'add', 'args' => ['beta']]);
+        $this->assertNotSame(0, $tester->getStatusCode());
+    }
+
+    public function testRemoveWithoutOverrideFails(): void
+    {
+        $this->seedSegment('beta');
+        $this->makeUser('member@example.com');
+        // User exists but has no override → nothing removed → FAILURE.
+        $tester = $this->invoke(['action' => 'remove', 'args' => ['beta', 'member@example.com']]);
+        $this->assertNotSame(0, $tester->getStatusCode());
+    }
+
+    public function testDeleteAction(): void
+    {
+        $this->seedSegment('gone');
+        $this->invoke(['action' => 'delete', 'args' => ['gone']])->assertCommandIsSuccessful();
+
+        $this->em->clear();
+        $this->assertNull($this->em->getRepository(Segment::class)->findOneByKey('gone'));
+    }
+
+    public function testUnknownActionIsRejected(): void
+    {
+        $tester = $this->invoke(['action' => 'frobnicate', 'args' => []]);
+        $this->assertNotSame(0, $tester->getStatusCode());
+    }
+
+    public function testUnknownKeyFails(): void
+    {
+        $tester = $this->invoke(['action' => 'show', 'args' => ['no-such-key']]);
+        $this->assertNotSame(0, $tester->getStatusCode());
+        $this->assertStringContainsString('No segment with key', $tester->getDisplay());
+    }
+
+    public function testMissingKeyIsInvalid(): void
+    {
+        $tester = $this->invoke(['action' => 'show', 'args' => []]);
+        $this->assertNotSame(0, $tester->getStatusCode());
+    }
+
+    public function testRolloutMissingValueIsInvalid(): void
+    {
+        $this->seedSegment('grad');
+        $tester = $this->invoke(['action' => 'rollout', 'args' => ['grad']]);
+        $this->assertNotSame(0, $tester->getStatusCode());
+    }
+
+    public function testRolloutOutOfRangeIsInvalid(): void
+    {
+        $this->seedSegment('grad');
+        $tester = $this->invoke(['action' => 'rollout', 'args' => ['grad', '150']]);
+        $this->assertNotSame(0, $tester->getStatusCode());
+    }
+
+    public function testCreateDuplicateKeyFails(): void
+    {
+        $this->seedSegment('beta');
+        $tester = $this->invoke(['action' => 'create', 'args' => ['beta']]);
+        $this->assertNotSame(0, $tester->getStatusCode());
+    }
+
+    public function testCreateWithoutKeyIsInvalid(): void
+    {
+        $tester = $this->invoke(['action' => 'create', 'args' => []]);
+        $this->assertNotSame(0, $tester->getStatusCode());
+    }
+
+    /**
+     * @param array<string, string|list<string>> $input
+     */
+    private function invoke(array $input): CommandTester
+    {
+        $kernel = self::$kernel;
+        assert(null !== $kernel);
+        $application = new Application($kernel);
+        $tester = new CommandTester($application->find('app:segment'));
+        $tester->execute($input);
+        return $tester;
+    }
+
+    private function seedSegment(string $key): Segment
+    {
+        $segment = new Segment();
+        $segment->setKey($key);
+        $segment->setName($key);
+        $this->em->persist($segment);
+        $this->em->flush();
+        return $segment;
+    }
+
+    private function makeUser(string $email): User
+    {
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $this->em->persist($user);
+        $this->em->flush();
+        return $user;
+    }
+
+    private function reload(string $key): Segment
+    {
+        $this->em->clear();
+        $segment = $this->em->getRepository(Segment::class)->findOneByKey($key);
+        assert($segment instanceof Segment);
+        return $segment;
+    }
+}

--- a/api/tests/Command/SpaceExportPruneCommandTest.php
+++ b/api/tests/Command/SpaceExportPruneCommandTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Tests\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class SpaceExportPruneCommandTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = self::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->em = $em;
+        $this->em->createQuery('DELETE FROM App\Entity\SpaceExport')->execute();
+    }
+
+    public function testRunsOnEmptyDatabase(): void
+    {
+        $kernel = self::$kernel;
+        assert(null !== $kernel);
+        $application = new Application($kernel);
+        $tester = new CommandTester($application->find('app:space-exports:prune'));
+        $tester->execute([]);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('Deleted 0', $tester->getDisplay());
+    }
+}

--- a/api/tests/Command/UsageReportCommandTest.php
+++ b/api/tests/Command/UsageReportCommandTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Tests\Command;
+
+use App\Entity\User;
+use App\Entity\UserUsageSnapshot;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+class UsageReportCommandTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = self::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->em = $em;
+        $this->em->createQuery('DELETE FROM App\Entity\UserUsageSnapshot')->execute();
+        $this->em->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testEmptyDatabaseWarnsNoSnapshots(): void
+    {
+        $tester = $this->invoke();
+        $tester->assertCommandIsSuccessful();
+
+        $this->assertStringContainsString('No usage snapshots', $tester->getDisplay());
+    }
+
+    public function testListsUserWithSnapshot(): void
+    {
+        $user = $this->makeUser('usage@example.com');
+
+        $snapshot = new UserUsageSnapshot();
+        $snapshot->setUser($user);
+        $snapshot->setCapturedOn(new \DateTimeImmutable('today', new \DateTimeZone('UTC')));
+        $snapshot->setDiskBytes(2048);
+        $snapshot->setDbBytesEst(1024);
+        $snapshot->setApiCalls(10);
+        $snapshot->setMcpCalls(5);
+        $this->em->persist($snapshot);
+        $this->em->flush();
+
+        $tester = $this->invoke();
+        $tester->assertCommandIsSuccessful();
+
+        $this->assertStringContainsString('usage@example.com', $tester->getDisplay());
+    }
+
+    private function invoke(): CommandTester
+    {
+        $kernel = self::$kernel;
+        assert(null !== $kernel);
+        $application = new Application($kernel);
+        $tester = new CommandTester($application->find('app:usage:report'));
+        $tester->execute([]);
+        return $tester;
+    }
+
+    private function makeUser(string $email): User
+    {
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $this->em->persist($user);
+        $this->em->flush();
+        return $user;
+    }
+}

--- a/api/tests/Command/UsageSnapshotCommandTest.php
+++ b/api/tests/Command/UsageSnapshotCommandTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Tests\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class UsageSnapshotCommandTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = self::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->em = $em;
+        $this->em->createQuery('DELETE FROM App\Entity\UserUsageSnapshot')->execute();
+        $this->em->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testRunsWithNoOptions(): void
+    {
+        $this->invoke([])->assertCommandIsSuccessful();
+    }
+
+    public function testRunsWithDateOption(): void
+    {
+        $this->invoke(['--date' => '2026-06-10'])->assertCommandIsSuccessful();
+    }
+
+    public function testInvalidDateFails(): void
+    {
+        $tester = $this->invoke(['--date' => 'not-a-date']);
+
+        $this->assertNotSame(0, $tester->getStatusCode());
+        $this->assertStringContainsString('Invalid', $tester->getDisplay());
+    }
+
+    /**
+     * @param array<string, string> $input
+     */
+    private function invoke(array $input): CommandTester
+    {
+        $kernel = self::$kernel;
+        assert(null !== $kernel);
+        $application = new Application($kernel);
+        $tester = new CommandTester($application->find('app:usage:snapshot'));
+        $tester->execute($input);
+        return $tester;
+    }
+}

--- a/api/tests/CustomField/DateStrategyTest.php
+++ b/api/tests/CustomField/DateStrategyTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace App\Tests\CustomField;
+
+use App\CustomField\Footer\FooterKind;
+use App\CustomField\Type\Date\DateStrategy;
+use App\CustomField\Type\Date\DateTimeStrategy;
+use App\CustomField\Type\Date\TimeStrategy;
+use App\Entity\CustomFieldDefinition;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Coverage for the date-flavoured strategies and their shared abstract
+ * base (#227). Direct construction — no kernel, no DB. Complements
+ * TypeStrategiesTest by exercising the multi walk, config bounds, the
+ * search-text projection, and the per-subtype scalar overrides.
+ */
+final class DateStrategyTest extends TestCase
+{
+    public function testKeysAndCapabilities(): void
+    {
+        $date = new DateStrategy();
+        $time = new TimeStrategy();
+        $datetime = new DateTimeStrategy();
+
+        $this->assertSame('date.date', $date->key());
+        $this->assertSame('date.time', $time->key());
+        $this->assertSame('date.datetime', $datetime->key());
+
+        foreach ([$date, $time, $datetime] as $s) {
+            $this->assertTrue($s->supportsMulti());
+            $this->assertSame(
+                [FooterKind::MIN->value, FooterKind::MAX->value, FooterKind::COUNT->value],
+                $s->supportedAggregations(),
+            );
+        }
+    }
+
+    public function testDateRangeBounds(): void
+    {
+        $date = new DateStrategy();
+        $def = new CustomFieldDefinition();
+
+        $config = ['min' => '2026-01-01', 'max' => '2026-12-31'];
+        $this->assertCount(0, $date->validateValue('2026-06-15', $config, $def));
+        $this->assertCount(1, $date->validateValue('2025-12-31', $config, $def)); // before min
+        $this->assertCount(1, $date->validateValue('2027-01-01', $config, $def)); // after max
+        // Calendar overflow is rejected by the round-trip parse guard.
+        $this->assertCount(1, $date->validateValue('2026-02-30', [], $def));
+        // Non-string scalar.
+        $this->assertCount(1, $date->validateValue(20260615, [], $def));
+    }
+
+    public function testDateConfigValidation(): void
+    {
+        $date = new DateStrategy();
+
+        $this->assertEmpty($date->validateConfig([]));
+        $this->assertEmpty($date->validateConfig(['min' => '2026-01-01', 'max' => '2026-12-31']));
+        // Unparseable bound.
+        $this->assertNotEmpty($date->validateConfig(['min' => 'not-a-date']));
+        // Non-string bound.
+        $this->assertNotEmpty($date->validateConfig(['max' => 123]));
+        // min after max.
+        $this->assertNotEmpty($date->validateConfig(['min' => '2026-12-31', 'max' => '2026-01-01']));
+        // multi flag is honoured by the shared multi-config check.
+        $this->assertEmpty($date->validateConfig(['multi' => true]));
+        $this->assertNotEmpty($date->validateConfig(['multi' => 'yes']));
+    }
+
+    public function testDateMultiWalk(): void
+    {
+        $date = new DateStrategy();
+        $def = new CustomFieldDefinition();
+        $multi = ['multi' => true];
+
+        $this->assertCount(0, $date->validateValue(['2026-01-01', '2026-02-02'], $multi, $def));
+        // One bad element -> one violation.
+        $this->assertCount(1, $date->validateValue(['2026-01-01', 'nope'], $multi, $def));
+        // Non-list under multi -> single top-level violation.
+        $this->assertCount(1, $date->validateValue('2026-01-01', $multi, $def));
+        // Associative map under multi -> shape violation.
+        $this->assertCount(1, $date->validateValue(['a' => '2026-01-01'], $multi, $def));
+    }
+
+    public function testDateSearchText(): void
+    {
+        $date = new DateStrategy();
+
+        $this->assertNull($date->searchText(null, []));
+        $this->assertSame('2026-06-15', $date->searchText('2026-06-15', []));
+        // Invalid string projects nothing.
+        $this->assertNull($date->searchText('garbage', []));
+        // Multi: only the parseable elements survive.
+        $this->assertSame(
+            '2026-01-01 2026-02-02',
+            $date->searchText(['2026-01-01', 'bad', '2026-02-02'], ['multi' => true]),
+        );
+        $this->assertNull($date->searchText(['bad'], ['multi' => true]));
+    }
+
+    public function testTimeStrictFormatMessage(): void
+    {
+        $time = new TimeStrategy();
+        $def = new CustomFieldDefinition();
+
+        $this->assertCount(0, $time->validateValue('09:30', [], $def));
+        // Missing leading zero gets the subtype-specific message branch.
+        $this->assertCount(1, $time->validateValue('9:30', [], $def));
+        // Out-of-range hour rejected by the round-trip parse.
+        $this->assertCount(1, $time->validateValue('25:00', [], $def));
+        // Non-string falls through to the abstract base path.
+        $this->assertCount(1, $time->validateValue(930, [], $def));
+
+        // In-range bound honoured.
+        $config = ['min' => '08:00', 'max' => '17:00'];
+        $this->assertCount(0, $time->validateValue('12:00', $config, $def));
+        $this->assertCount(1, $time->validateValue('07:59', $config, $def));
+    }
+
+    public function testDateTimeIsoTolerance(): void
+    {
+        $datetime = new DateTimeStrategy();
+        $def = new CustomFieldDefinition();
+
+        $this->assertCount(0, $datetime->validateValue('2026-05-12T14:30:00+02:00', [], $def));
+        // JS toISOString shape (Z + fractional seconds) tolerated.
+        $this->assertCount(0, $datetime->validateValue('2026-05-12T14:30:00.000Z', [], $def));
+        // Space separator (no offset) rejected.
+        $this->assertCount(1, $datetime->validateValue('2026-05-12 14:30:00', [], $def));
+        // Non-string falls through to the abstract base path.
+        $this->assertCount(1, $datetime->validateValue(42, [], $def));
+    }
+
+    public function testDateTimeNormalize(): void
+    {
+        $datetime = new DateTimeStrategy();
+
+        $this->assertNull($datetime->normalize(null, []));
+        // Z + fractional seconds normalized to an explicit offset.
+        $this->assertSame(
+            '2026-05-12T14:30:00+00:00',
+            $datetime->normalize('2026-05-12T14:30:00.000Z', []),
+        );
+        // Multi normalizes each element; non-strings pass through.
+        $this->assertSame(
+            ['2026-05-12T14:30:00+00:00', 5],
+            $datetime->normalize(['2026-05-12T14:30:00.000Z', 5], ['multi' => true]),
+        );
+        // Multi with non-array input is returned unchanged.
+        $this->assertSame('x', $datetime->normalize('x', ['multi' => true]));
+    }
+}

--- a/api/tests/CustomField/FooterAggregatorTest.php
+++ b/api/tests/CustomField/FooterAggregatorTest.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace App\Tests\CustomField;
+
+use App\CustomField\CustomFieldTypeRegistry;
+use App\CustomField\Footer\FooterAggregator;
+use App\CustomField\Footer\FooterKind;
+use App\CustomField\Type\Boolean\BooleanStrategy;
+use App\CustomField\Type\Date\DateStrategy;
+use App\CustomField\Type\Numeric\FloatStrategy;
+use App\CustomField\Type\Numeric\IntStrategy;
+use App\CustomField\Type\Numeric\MoneyStrategy;
+use App\Entity\CustomFieldDefinition;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Coverage for FooterAggregator's row-assembly + dispatch logic (#227).
+ *
+ * The SQL aggregation paths (sum/avg/min/max over custom_field_value)
+ * are integration-tested against a live Postgres in the API suite. Here
+ * we cover the parts that run without ever issuing a query:
+ *   - skip rows with no footer / an invalid footer.kind / an aggregation
+ *     the strategy doesn't support;
+ *   - the empty-task-set short-circuit in compute() (count -> 0,
+ *     everything else -> null).
+ *
+ * The {@see Connection} is mocked and must never be touched — passing an
+ * empty task-id list keeps every path off the database.
+ */
+final class FooterAggregatorTest extends TestCase
+{
+    private function registry(): CustomFieldTypeRegistry
+    {
+        return new CustomFieldTypeRegistry([
+            new BooleanStrategy(),
+            new IntStrategy(),
+            new FloatStrategy(),
+            new MoneyStrategy(),
+            new DateStrategy(),
+        ]);
+    }
+
+    private function aggregator(Connection $connection): FooterAggregator
+    {
+        return new FooterAggregator($connection, $this->registry());
+    }
+
+    /**
+     * @param array{kind: string, label?: string}|null $footer
+     */
+    private function definition(string $kind, string $subtype, ?array $footer): CustomFieldDefinition
+    {
+        $def = new CustomFieldDefinition();
+        $def->setKind($kind);
+        $def->setSubtype($subtype);
+        if (null !== $footer) {
+            $def->setFooter($footer);
+        }
+        return $def;
+    }
+
+    public function testSkipsDefinitionsWithoutAFooter(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->never())->method('executeQuery');
+
+        $rows = $this->aggregator($connection)->aggregate(
+            [$this->definition('numeric', 'int', null)],
+            [],
+        );
+
+        $this->assertSame([], $rows);
+    }
+
+    public function testSkipsInvalidFooterKind(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->never())->method('executeQuery');
+
+        $rows = $this->aggregator($connection)->aggregate(
+            [$this->definition('numeric', 'int', ['kind' => 'bogus'])],
+            [],
+        );
+
+        $this->assertSame([], $rows);
+    }
+
+    public function testSkipsAggregationNotSupportedByStrategy(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->never())->method('executeQuery');
+
+        // Booleans only support COUNT — asking for SUM is dropped.
+        $rows = $this->aggregator($connection)->aggregate(
+            [$this->definition('boolean', 'boolean', ['kind' => FooterKind::SUM->value])],
+            [],
+        );
+
+        $this->assertSame([], $rows);
+    }
+
+    public function testSkipsUnknownTypeKey(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->never())->method('executeQuery');
+
+        // 'numeric.decimal' isn't a registered strategy -> dropped.
+        $rows = $this->aggregator($connection)->aggregate(
+            [$this->definition('numeric', 'decimal', ['kind' => FooterKind::SUM->value])],
+            [],
+        );
+
+        $this->assertSame([], $rows);
+    }
+
+    public function testEmptyTaskSetCountIsZero(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->never())->method('executeQuery');
+
+        $rows = $this->aggregator($connection)->aggregate(
+            [$this->definition('numeric', 'int', ['kind' => FooterKind::COUNT->value, 'label' => 'Filled'])],
+            [],
+        );
+
+        $this->assertCount(1, $rows);
+        $this->assertSame(FooterKind::COUNT->value, $rows[0]['kind']);
+        $this->assertSame('Filled', $rows[0]['label']);
+        $this->assertSame(0, $rows[0]['value']);
+    }
+
+    public function testEmptyTaskSetNonCountIsNull(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->never())->method('executeQuery');
+
+        $rows = $this->aggregator($connection)->aggregate(
+            [
+                $this->definition('numeric', 'int', ['kind' => FooterKind::SUM->value]),
+                $this->definition('numeric', 'float', ['kind' => FooterKind::AVG->value]),
+                $this->definition('numeric', 'money', ['kind' => FooterKind::MAX->value]),
+                $this->definition('date', 'date', ['kind' => FooterKind::MIN->value]),
+            ],
+            [],
+        );
+
+        $this->assertCount(4, $rows);
+        foreach ($rows as $row) {
+            $this->assertNull($row['value']);
+        }
+    }
+
+    public function testMissingLabelIsNull(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->never())->method('executeQuery');
+
+        $rows = $this->aggregator($connection)->aggregate(
+            [$this->definition('numeric', 'int', ['kind' => FooterKind::COUNT->value])],
+            [],
+        );
+
+        $this->assertCount(1, $rows);
+        $this->assertNull($rows[0]['label']);
+    }
+}

--- a/api/tests/CustomField/MoneyStrategyTest.php
+++ b/api/tests/CustomField/MoneyStrategyTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Tests\CustomField;
+
+use App\CustomField\Footer\FooterKind;
+use App\CustomField\Type\Numeric\MoneyStrategy;
+use App\Entity\CustomFieldDefinition;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Coverage for numeric.money (#227). Direct construction — no kernel,
+ * no DB. Complements TypeStrategiesTest's happy-path checks with the
+ * config branches, the min/max amount bounds, and the search/normalize
+ * edge cases.
+ */
+final class MoneyStrategyTest extends TestCase
+{
+    public function testKeyAndCapabilities(): void
+    {
+        $s = new MoneyStrategy();
+
+        $this->assertSame('numeric.money', $s->key());
+        $this->assertFalse($s->supportsMulti());
+        $this->assertSame(
+            [
+                FooterKind::SUM->value,
+                FooterKind::AVG->value,
+                FooterKind::MIN->value,
+                FooterKind::MAX->value,
+                FooterKind::COUNT->value,
+            ],
+            $s->supportedAggregations(),
+        );
+    }
+
+    public function testConfigValidation(): void
+    {
+        $s = new MoneyStrategy();
+
+        // Currency required + must be known.
+        $this->assertNotEmpty($s->validateConfig([]));
+        $this->assertNotEmpty($s->validateConfig(['currency' => '']));
+        $this->assertNotEmpty($s->validateConfig(['currency' => 123]));
+        $this->assertNotEmpty($s->validateConfig(['currency' => 'XXX']));
+        $this->assertEmpty($s->validateConfig(['currency' => 'USD']));
+        // Lower-case is accepted (uppercased before the existence check).
+        $this->assertEmpty($s->validateConfig(['currency' => 'usd']));
+
+        // min/max must be integers (minor units).
+        $this->assertNotEmpty($s->validateConfig(['currency' => 'USD', 'min' => 1.5]));
+        $this->assertNotEmpty($s->validateConfig(['currency' => 'USD', 'max' => 'x']));
+        // min > max.
+        $this->assertNotEmpty($s->validateConfig(['currency' => 'USD', 'min' => 100, 'max' => 10]));
+        $this->assertEmpty($s->validateConfig(['currency' => 'USD', 'min' => 10, 'max' => 100]));
+    }
+
+    public function testValueShapeAndCurrencyPin(): void
+    {
+        $s = new MoneyStrategy();
+        $def = new CustomFieldDefinition();
+        $config = ['currency' => 'USD'];
+
+        $this->assertCount(0, $s->validateValue(['amount' => 100, 'currency' => 'USD'], $config, $def));
+        // Non-array value.
+        $this->assertCount(1, $s->validateValue('100', $config, $def));
+        // Non-integer amount.
+        $this->assertNotEmpty($s->validateValue(['amount' => 1.5, 'currency' => 'USD'], $config, $def));
+        // Missing currency.
+        $this->assertNotEmpty($s->validateValue(['amount' => 100], $config, $def));
+        // Unknown currency code.
+        $this->assertNotEmpty($s->validateValue(['amount' => 100, 'currency' => 'XXX'], $config, $def));
+        // Mismatch against the pinned field currency.
+        $this->assertNotEmpty($s->validateValue(['amount' => 100, 'currency' => 'EUR'], $config, $def));
+    }
+
+    public function testAmountBounds(): void
+    {
+        $s = new MoneyStrategy();
+        $def = new CustomFieldDefinition();
+        $config = ['currency' => 'USD', 'min' => 0, 'max' => 1000];
+
+        $this->assertCount(0, $s->validateValue(['amount' => 500, 'currency' => 'USD'], $config, $def));
+        $this->assertNotEmpty($s->validateValue(['amount' => -1, 'currency' => 'USD'], $config, $def));
+        $this->assertNotEmpty($s->validateValue(['amount' => 1001, 'currency' => 'USD'], $config, $def));
+    }
+
+    public function testNormalize(): void
+    {
+        $s = new MoneyStrategy();
+        $config = ['currency' => 'USD'];
+
+        $this->assertSame(
+            ['amount' => 1000, 'currency' => 'USD'],
+            $s->normalize(['amount' => '1000', 'currency' => 'usd'], $config),
+        );
+        // Non-array passes through unchanged.
+        $this->assertSame('x', $s->normalize('x', $config));
+        // Non-numeric amount + non-string currency are left as-is.
+        $this->assertSame(
+            ['amount' => null, 'currency' => 5],
+            $s->normalize(['amount' => null, 'currency' => 5], $config),
+        );
+    }
+
+    public function testSearchText(): void
+    {
+        $s = new MoneyStrategy();
+        $config = ['currency' => 'USD'];
+
+        $this->assertSame('1000 USD', $s->searchText(['amount' => 1000, 'currency' => 'USD'], $config));
+        // Non-array -> null.
+        $this->assertNull($s->searchText('1000', $config));
+        // Malformed shape -> null.
+        $this->assertNull($s->searchText(['amount' => 'x', 'currency' => 'USD'], $config));
+        $this->assertNull($s->searchText(['amount' => 1000, 'currency' => 5], $config));
+    }
+}

--- a/api/tests/CustomField/ReferenceStrategyTest.php
+++ b/api/tests/CustomField/ReferenceStrategyTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Tests\CustomField;
+
+use App\CustomField\Footer\FooterKind;
+use App\CustomField\Type\Reference\ProjectReferenceStrategy;
+use App\CustomField\Type\Reference\TaskReferenceStrategy;
+use App\CustomField\Type\Reference\UserReferenceStrategy;
+use App\Entity\CustomFieldDefinition;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Coverage for the reference strategies' non-DB branches (#227).
+ *
+ * The DB-resolution path (IRI -> repository lookup -> space-scope check)
+ * is exercised end-to-end by TaskCustomFieldValueTest's integration
+ * suite, which needs a real EntityManager + fixtures. Here we cover
+ * everything that runs *before* the repository is touched — key/kind,
+ * capabilities, multi-shape rejection, non-string and bad-IRI scalars,
+ * and the search-text null branches — with a mocked EntityManager that
+ * is never invoked.
+ */
+final class ReferenceStrategyTest extends TestCase
+{
+    private function em(): EntityManagerInterface
+    {
+        return $this->createMock(EntityManagerInterface::class);
+    }
+
+    public function testKeysAndCapabilities(): void
+    {
+        $user = new UserReferenceStrategy($this->em());
+        $task = new TaskReferenceStrategy($this->em());
+        $project = new ProjectReferenceStrategy($this->em());
+
+        $this->assertSame('reference.user', $user->key());
+        $this->assertSame('reference.task', $task->key());
+        $this->assertSame('reference.project', $project->key());
+
+        foreach ([$user, $task, $project] as $s) {
+            $this->assertTrue($s->supportsMulti());
+            // References don't aggregate beyond count.
+            $this->assertSame([FooterKind::COUNT->value], $s->supportedAggregations());
+        }
+    }
+
+    public function testRejectsNonStringScalar(): void
+    {
+        $user = new UserReferenceStrategy($this->em());
+        $def = new CustomFieldDefinition(); // no space -> scope check skipped
+
+        // Non-string value never reaches the repository.
+        $this->assertCount(1, $user->validateValue(42, [], $def));
+    }
+
+    public function testRejectsMalformedIri(): void
+    {
+        $user = new UserReferenceStrategy($this->em());
+        $def = new CustomFieldDefinition();
+
+        // Wrong prefix -> extractUuid bails before any lookup.
+        $this->assertCount(1, $user->validateValue('/tasks/00000000-0000-0000-0000-000000000000', [], $def));
+        // Right prefix, non-UUID tail.
+        $this->assertCount(1, $user->validateValue('/users/not-a-uuid', [], $def));
+    }
+
+    public function testMultiShapeRejection(): void
+    {
+        $user = new UserReferenceStrategy($this->em());
+        $def = new CustomFieldDefinition();
+        $multi = ['multi' => true];
+
+        // Non-list under multi -> single shape violation, no lookup.
+        $this->assertCount(1, $user->validateValue('/users/00000000-0000-0000-0000-000000000000', $multi, $def));
+        // Associative map under multi -> shape violation.
+        $this->assertCount(1, $user->validateValue(['k' => '/users/x'], $multi, $def));
+    }
+
+    public function testSearchTextNullBranches(): void
+    {
+        $user = new UserReferenceStrategy($this->em());
+
+        $this->assertNull($user->searchText(null, []));
+        // Non-string single value resolves to null without a lookup.
+        $this->assertNull($user->searchText(42, []));
+        // Malformed IRI -> labelFor returns null without a lookup.
+        $this->assertNull($user->searchText('/tasks/abc', []));
+        // Multi with no resolvable elements -> null.
+        $this->assertNull($user->searchText([42, '/bad/iri'], ['multi' => true]));
+    }
+}

--- a/api/tests/CustomField/TextStrategyTest.php
+++ b/api/tests/CustomField/TextStrategyTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Tests\CustomField;
+
+use App\CustomField\Footer\FooterKind;
+use App\CustomField\Type\Text\RichTextStrategy;
+use App\CustomField\Type\Text\TextStrategy;
+use App\CustomField\Type\Text\UrlStrategy;
+use App\Entity\CustomFieldDefinition;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Coverage for the text-flavoured strategies and their shared abstract
+ * base (#227). Direct construction — no kernel, no DB. Complements
+ * TypeStrategiesTest by exercising config bounds, normalization, the
+ * search projection, and the URL scheme override.
+ */
+final class TextStrategyTest extends TestCase
+{
+    public function testKeysAndCapabilities(): void
+    {
+        $text = new TextStrategy();
+        $url = new UrlStrategy();
+        $rich = new RichTextStrategy();
+
+        $this->assertSame('text.text', $text->key());
+        $this->assertSame('text.url', $url->key());
+        $this->assertSame('text.rich_text', $rich->key());
+
+        foreach ([$text, $url, $rich] as $s) {
+            $this->assertTrue($s->supportsMulti());
+            $this->assertSame([FooterKind::COUNT->value], $s->supportedAggregations());
+        }
+    }
+
+    public function testConfigBounds(): void
+    {
+        $text = new TextStrategy();
+
+        $this->assertEmpty($text->validateConfig([]));
+        $this->assertEmpty($text->validateConfig(['minLength' => 1, 'maxLength' => 5, 'pattern' => '^[a-z]+$']));
+
+        // minLength must be a non-negative integer.
+        $this->assertNotEmpty($text->validateConfig(['minLength' => -1]));
+        $this->assertNotEmpty($text->validateConfig(['minLength' => 'x']));
+        // maxLength must be a positive integer.
+        $this->assertNotEmpty($text->validateConfig(['maxLength' => 0]));
+        $this->assertNotEmpty($text->validateConfig(['maxLength' => 'x']));
+        // min > max.
+        $this->assertNotEmpty($text->validateConfig(['minLength' => 5, 'maxLength' => 2]));
+        // pattern must be a string and a valid regex.
+        $this->assertNotEmpty($text->validateConfig(['pattern' => 123]));
+        $this->assertNotEmpty($text->validateConfig(['pattern' => '[']));
+    }
+
+    public function testValueLengthAndPattern(): void
+    {
+        $text = new TextStrategy();
+        $def = new CustomFieldDefinition();
+
+        $config = ['minLength' => 3, 'maxLength' => 5, 'pattern' => '^[a-z]+$'];
+        $this->assertCount(0, $text->validateValue('abc', $config, $def));
+        $this->assertCount(1, $text->validateValue('ab', $config, $def));      // too short
+        $this->assertCount(1, $text->validateValue('abcdef', $config, $def));  // too long
+        $this->assertCount(1, $text->validateValue('ABC', $config, $def));     // pattern miss
+        // Non-string scalar.
+        $this->assertCount(1, $text->validateValue(42, [], $def));
+    }
+
+    public function testNormalizeTrims(): void
+    {
+        $text = new TextStrategy();
+
+        $this->assertNull($text->normalize(null, []));
+        $this->assertSame('hello', $text->normalize('  hello  ', []));
+        // Non-string single passes through.
+        $this->assertSame(7, $text->normalize(7, []));
+        // Multi trims each element; non-array passes through.
+        $this->assertSame(['a', 'b'], $text->normalize([' a ', ' b '], ['multi' => true]));
+        $this->assertSame('x', $text->normalize('x', ['multi' => true]));
+    }
+
+    public function testSearchText(): void
+    {
+        $text = new TextStrategy();
+
+        $this->assertNull($text->searchText(null, []));
+        $this->assertSame('hi', $text->searchText('  hi  ', []));
+        // Whitespace-only -> nothing searchable.
+        $this->assertNull($text->searchText('   ', []));
+        // Non-string -> null.
+        $this->assertNull($text->searchText(5, []));
+        // Multi: empties dropped, rest joined.
+        $this->assertSame('a b', $text->searchText([' a ', '', ' b '], ['multi' => true]));
+        $this->assertNull($text->searchText(['', '  '], ['multi' => true]));
+    }
+
+    public function testUrlSchemeValidation(): void
+    {
+        $url = new UrlStrategy();
+        $def = new CustomFieldDefinition();
+
+        $this->assertCount(0, $url->validateValue('https://example.com', [], $def));
+        $this->assertCount(0, $url->validateValue('http://example.com', [], $def));
+        $this->assertCount(0, $url->validateValue('mailto:alice@example.com', [], $def));
+        // Disallowed scheme.
+        $this->assertCount(1, $url->validateValue('ftp://example.com', [], $def));
+        // Not a URL at all.
+        $this->assertCount(1, $url->validateValue('not a url', [], $def));
+        // Empty/whitespace short-circuits the URL check (only base rules apply,
+        // which are satisfied here -> no violation).
+        $this->assertCount(0, $url->validateValue('   ', [], $def));
+    }
+
+    public function testRichTextBehavesLikeText(): void
+    {
+        $rich = new RichTextStrategy();
+        $def = new CustomFieldDefinition();
+
+        $this->assertCount(0, $rich->validateValue('**bold**', [], $def));
+        $this->assertSame('hello', $rich->searchText(' hello ', ['multi' => false]));
+    }
+}

--- a/api/tests/Entity/UserUsageCounterTest.php
+++ b/api/tests/Entity/UserUsageCounterTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Tests\Entity;
+
+use App\Entity\User;
+use App\Entity\UserUsageCounter;
+use PHPUnit\Framework\TestCase;
+
+class UserUsageCounterTest extends TestCase
+{
+    public function testDefaultsToTodayUtcWithZeroCount(): void
+    {
+        $counter = new UserUsageCounter();
+
+        $this->assertNull($counter->getId());
+        $this->assertSame(0, $counter->getCount());
+        $this->assertSame('', $counter->getMetric());
+        // Constructor pins the bucket to "today" in UTC.
+        $this->assertSame(
+            (new \DateTimeImmutable('today', new \DateTimeZone('UTC')))->format('Y-m-d'),
+            $counter->getDay()->format('Y-m-d'),
+        );
+    }
+
+    public function testAccessorsRoundTrip(): void
+    {
+        $user = new User();
+        $user->setEmail('counter@example.com');
+
+        $day = new \DateTimeImmutable('2026-06-10', new \DateTimeZone('UTC'));
+        $counter = new UserUsageCounter();
+        $counter->setUser($user);
+        $counter->setDay($day);
+        $counter->setMetric('api_call');
+        $counter->setCount(42);
+
+        $this->assertSame($user, $counter->getUser());
+        $this->assertSame($day, $counter->getDay());
+        $this->assertSame('api_call', $counter->getMetric());
+        $this->assertSame(42, $counter->getCount());
+    }
+
+    public function testSettersAreFluent(): void
+    {
+        $counter = new UserUsageCounter();
+
+        $this->assertSame($counter, $counter->setMetric('mcp_call'));
+        $this->assertSame($counter, $counter->setCount(1));
+        $this->assertSame($counter, $counter->setDay(new \DateTimeImmutable('2026-01-01')));
+    }
+}

--- a/docs/developer/mcp-server.md
+++ b/docs/developer/mcp-server.md
@@ -63,14 +63,20 @@ Tokens authenticate via `Authorization: Bearer` on both the `/mcp` firewall and 
 | ----------- | ------------------------------------------------------------------------------ |
 | Task        | `create_task`, `get_task`, `update_task`, `delete_task`, `list_tasks`, `search_tasks` |
 | Project     | `create_project`, `get_project`, `update_project`, `delete_project`, `list_projects` |
+| Space       | `list_spaces`                                                                   |
+| Page        | `create_page`, `get_page`, `update_page`, `delete_page`, `list_pages`          |
+| Discussion  | `create_discussion`, `get_discussion`, `list_discussions`                      |
 | Assignment  | `assign_task`, `unassign_task`, `get_my_tasks`                                 |
 | TaskComment | `add_task_comment`, `list_task_comments`                                       |
+| Tag         | `list_tags`, `create_tag`                                                       |
 | File        | `upload_file`, `list_files`, `download_file`                                   |
 | Custom field| `get_custom_fields`                                                            |
 
 Call `tools/list` to inspect each tool's JSON Schema. Tools execute as the user that owns the bearer token; visibility, edit, and delete rules mirror the existing API Platform `security:` expressions on each entity.
 
-> **Custom field values** — `get_custom_fields` returns a project's defined fields (`CustomFieldDefinition`). Per-task values (`CustomFieldValue`, #227) are written through the REST Task `customFieldValues` array; a dedicated `set_custom_field` MCP tool is not yet exposed.
+Create tools that target a space (`create_project`, `create_page`, `create_discussion`) accept an optional `spaceId` — call `list_spaces` to discover the ids, or omit it to default to the caller's personal space.
+
+> **Custom field values** — `get_custom_fields` returns a project's defined fields (`CustomFieldDefinition`). Per-task values (`CustomFieldValue`, #227) are written through `update_task`'s `customFieldValues` array (`[{definitionId, value}]`), which replaces the task's whole value set and is validated by `ValidCustomFieldValues` just like the REST path.
 
 ## Errors
 

--- a/docs/developer/mcp-server.md
+++ b/docs/developer/mcp-server.md
@@ -67,7 +67,7 @@ Tokens authenticate via `Authorization: Bearer` on both the `/mcp` firewall and 
 | Page        | `create_page`, `get_page`, `update_page`, `delete_page`, `list_pages`          |
 | Discussion  | `create_discussion`, `get_discussion`, `list_discussions`                      |
 | Assignment  | `assign_task`, `unassign_task`, `get_my_tasks`                                 |
-| TaskComment | `add_task_comment`, `list_task_comments`                                       |
+| Comment     | `add_task_comment`, `list_task_comments`, `add_page_comment`, `list_page_comments`, `add_discussion_comment`, `list_discussion_comments` |
 | Tag         | `list_tags`, `create_tag`                                                       |
 | File        | `upload_file`, `list_files`, `download_file`                                   |
 | Custom field| `get_custom_fields`                                                            |

--- a/pwa/.gitignore
+++ b/pwa/.gitignore
@@ -4,6 +4,7 @@
 /node_modules
 /.pnp
 .pnp.js
+/.pnpm-store
 
 # testing
 /coverage

--- a/pwa/lib/authRedirect.test.ts
+++ b/pwa/lib/authRedirect.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { isSafeNextPath, safeNextPath, signinHrefForCurrent } from "./authRedirect";
+
+describe("isSafeNextPath", () => {
+  it("accepts a plain root-relative path", () => {
+    expect(isSafeNextPath("/projects")).toBe(true);
+    expect(isSafeNextPath("/tasks?status=open#top")).toBe(true);
+  });
+
+  it("rejects non-strings and empty strings", () => {
+    expect(isSafeNextPath(undefined)).toBe(false);
+    expect(isSafeNextPath(null)).toBe(false);
+    expect(isSafeNextPath(42)).toBe(false);
+    expect(isSafeNextPath("")).toBe(false);
+  });
+
+  it("rejects values that don't start with a single slash", () => {
+    expect(isSafeNextPath("projects")).toBe(false);
+    expect(isSafeNextPath("https://evil.com")).toBe(false);
+    expect(isSafeNextPath("javascript:alert(1)")).toBe(false);
+    expect(isSafeNextPath("data:text/html,x")).toBe(false);
+  });
+
+  it("rejects protocol-relative and backslash-smuggled hosts", () => {
+    expect(isSafeNextPath("//evil.com/x")).toBe(false);
+    expect(isSafeNextPath("/\\evil.com/x")).toBe(false);
+  });
+});
+
+describe("safeNextPath", () => {
+  it("returns the normalised path for a safe candidate", () => {
+    expect(safeNextPath("/tasks?status=open")).toBe("/tasks?status=open");
+    expect(safeNextPath("/a/b#frag")).toBe("/a/b#frag");
+  });
+
+  it("falls back to /projects for hostile or invalid input", () => {
+    expect(safeNextPath("//evil.com")).toBe("/projects");
+    expect(safeNextPath("https://evil.com/x")).toBe("/projects");
+    expect(safeNextPath(undefined)).toBe("/projects");
+    expect(safeNextPath("")).toBe("/projects");
+  });
+
+  it("honours a custom fallback", () => {
+    expect(safeNextPath(undefined, "/settings/profile")).toBe("/settings/profile");
+    expect(safeNextPath("//evil.com", "/home")).toBe("/home");
+  });
+});
+
+describe("signinHrefForCurrent", () => {
+  it("preserves a safe current path as ?next=", () => {
+    expect(signinHrefForCurrent("/projects/123")).toBe(
+      "/signin?next=%2Fprojects%2F123",
+    );
+  });
+
+  it("encodes query strings in the preserved path", () => {
+    expect(signinHrefForCurrent("/tasks?status=open")).toBe(
+      `/signin?next=${encodeURIComponent("/tasks?status=open")}`,
+    );
+  });
+
+  it("returns plain /signin for unsafe paths", () => {
+    expect(signinHrefForCurrent(undefined)).toBe("/signin");
+    expect(signinHrefForCurrent("//evil.com")).toBe("/signin");
+  });
+
+  it("does not loop back onto the auth pages themselves", () => {
+    expect(signinHrefForCurrent("/signin")).toBe("/signin");
+    expect(signinHrefForCurrent("/signin?next=/x")).toBe("/signin");
+    expect(signinHrefForCurrent("/signup")).toBe("/signin");
+  });
+});

--- a/pwa/lib/avatarPalette.test.ts
+++ b/pwa/lib/avatarPalette.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  AVATAR_PALETTE,
+  deterministicPaletteColor,
+  resolveGroupColor,
+  resolveSpaceColor,
+} from "./avatarPalette";
+
+describe("deterministicPaletteColor", () => {
+  it("returns the first palette entry for an empty seed", () => {
+    expect(deterministicPaletteColor("")).toBe(AVATAR_PALETTE[0]);
+  });
+
+  it("is stable for the same seed", () => {
+    expect(deterministicPaletteColor("team-alpha")).toBe(
+      deterministicPaletteColor("team-alpha"),
+    );
+  });
+
+  it("always returns a value from the palette", () => {
+    for (const seed of ["a", "longer-seed", "🙂", "Group 42"]) {
+      expect(AVATAR_PALETTE).toContain(deterministicPaletteColor(seed));
+    }
+  });
+});
+
+describe("resolveSpaceColor", () => {
+  it("prefers an explicit color", () => {
+    expect(
+      resolveSpaceColor({ color: "#123456", createdBy: { personalizedColor: "#abcdef" } }),
+    ).toBe("#123456");
+  });
+
+  it("inherits the creator's personalized color", () => {
+    expect(
+      resolveSpaceColor({ color: null, createdBy: { personalizedColor: "#abcdef" } }),
+    ).toBe("#abcdef");
+  });
+
+  it("falls back to the first palette entry", () => {
+    expect(resolveSpaceColor({ color: null, createdBy: null })).toBe(AVATAR_PALETTE[0]);
+    expect(resolveSpaceColor({ color: null, createdBy: {} })).toBe(AVATAR_PALETTE[0]);
+  });
+});
+
+describe("resolveGroupColor", () => {
+  it("prefers an explicit color, then owner color, then fallback", () => {
+    expect(resolveGroupColor({ color: "#111111" })).toBe("#111111");
+    expect(resolveGroupColor({ owner: { personalizedColor: "#222222" } })).toBe("#222222");
+    expect(resolveGroupColor({})).toBe(AVATAR_PALETTE[0]);
+    expect(resolveGroupColor({ color: null, owner: { personalizedColor: null } })).toBe(
+      AVATAR_PALETTE[0],
+    );
+  });
+});

--- a/pwa/lib/currencies.test.ts
+++ b/pwa/lib/currencies.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { CURRENCIES, currencyFractionDigits, findCurrency } from "./currencies";
+
+describe("findCurrency", () => {
+  it("looks up a known code case-insensitively", () => {
+    expect(findCurrency("USD")?.name).toBe("US Dollar");
+    expect(findCurrency("usd")?.code).toBe("USD");
+  });
+
+  it("returns undefined for an unknown code", () => {
+    expect(findCurrency("ZZZ")).toBeUndefined();
+  });
+});
+
+describe("currencyFractionDigits", () => {
+  it("returns the curated digits for known codes", () => {
+    expect(currencyFractionDigits("USD")).toBe(2);
+    expect(currencyFractionDigits("JPY")).toBe(0);
+    expect(currencyFractionDigits("KWD")).toBe(3);
+    expect(currencyFractionDigits("jpy")).toBe(0); // case-insensitive
+  });
+
+  it("falls back to Intl for a valid code outside the curated list", () => {
+    // TND (Tunisian Dinar) is a real 3-digit currency we don't curate.
+    expect(currencyFractionDigits("TND")).toBe(3);
+  });
+
+  it("falls back to 2 for an ill-formed code that Intl rejects", () => {
+    // A 2-letter code is not a well-formed ISO-4217 currency → Intl throws.
+    expect(currencyFractionDigits("US")).toBe(2);
+  });
+});
+
+describe("CURRENCIES list integrity", () => {
+  it("has unique, upper-case 3-letter codes", () => {
+    const codes = CURRENCIES.map((c) => c.code);
+    expect(new Set(codes).size).toBe(codes.length);
+    for (const code of codes) {
+      expect(code).toMatch(/^[A-Z]{3}$/);
+    }
+  });
+
+  it("only carries non-negative fraction digits", () => {
+    for (const c of CURRENCIES) {
+      expect(c.fractionDigits).toBeGreaterThanOrEqual(0);
+    }
+  });
+});

--- a/pwa/lib/landingDestination.test.ts
+++ b/pwa/lib/landingDestination.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_LANDING,
+  landingPathFor,
+  readLanding,
+} from "./landingDestination";
+
+describe("readLanding", () => {
+  it("returns the default when preferences are missing or malformed", () => {
+    expect(readLanding(undefined)).toEqual(DEFAULT_LANDING);
+    expect(readLanding(null)).toEqual(DEFAULT_LANDING);
+    // @ts-expect-error — exercising the runtime guard against a bad shape.
+    expect(readLanding({ landing: "nope" })).toEqual(DEFAULT_LANDING);
+  });
+
+  it("passes through a recognised page", () => {
+    expect(readLanding({ landing: { page: "tasks", spaceId: null } })).toEqual({
+      page: "tasks",
+      spaceId: null,
+    });
+  });
+
+  it("falls back to the default page for an unknown page value", () => {
+    expect(
+      // @ts-expect-error — stale/unknown page from an older client.
+      readLanding({ landing: { page: "bogus", spaceId: null } }),
+    ).toEqual(DEFAULT_LANDING);
+  });
+
+  it("keeps spaceId only for the 'space' page", () => {
+    expect(readLanding({ landing: { page: "space", spaceId: "abc" } })).toEqual({
+      page: "space",
+      spaceId: "abc",
+    });
+    // A spaceId riding on a non-space page is normalised away.
+    expect(
+      readLanding({ landing: { page: "tasks", spaceId: "abc" } }),
+    ).toEqual({ page: "tasks", spaceId: null });
+  });
+
+  it("defaults a missing spaceId on the space page to null", () => {
+    expect(
+      // @ts-expect-error — spaceId omitted entirely.
+      readLanding({ landing: { page: "space" } }),
+    ).toEqual({ page: "space", spaceId: null });
+  });
+});
+
+describe("landingPathFor", () => {
+  it("maps each page to its route", () => {
+    expect(landingPathFor({ page: "tasks", spaceId: null })).toBe("/tasks");
+    expect(landingPathFor({ page: "notifications", spaceId: null })).toBe(
+      "/notifications",
+    );
+    expect(landingPathFor({ page: "spaces", spaceId: null })).toBe("/spaces");
+    expect(landingPathFor({ page: "space", spaceId: "x" })).toBe("/projects");
+  });
+
+  it("falls back to the default route for an unrecognised page", () => {
+    // @ts-expect-error — defends against a value outside the union.
+    expect(landingPathFor({ page: "bogus", spaceId: null })).toBe("/projects");
+  });
+});

--- a/pwa/lib/notificationPrefs.test.ts
+++ b/pwa/lib/notificationPrefs.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  allOnMatrix,
+  DEFAULT_NOTIFICATION_MATRIX,
+  NOTIFICATION_ROWS,
+} from "./notificationPrefs";
+
+describe("notification preference defaults", () => {
+  it("has a default-matrix entry for every row", () => {
+    for (const row of NOTIFICATION_ROWS) {
+      expect(DEFAULT_NOTIFICATION_MATRIX[row.key]).toBeDefined();
+    }
+    expect(Object.keys(DEFAULT_NOTIFICATION_MATRIX).sort()).toEqual(
+      NOTIFICATION_ROWS.map((r) => r.key).sort(),
+    );
+  });
+
+  it("uses unique row keys", () => {
+    const keys = NOTIFICATION_ROWS.map((r) => r.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});
+
+describe("allOnMatrix", () => {
+  it("turns every row on for both channels", () => {
+    const matrix = allOnMatrix();
+    expect(Object.keys(matrix).sort()).toEqual(
+      NOTIFICATION_ROWS.map((r) => r.key).sort(),
+    );
+    for (const channel of Object.values(matrix)) {
+      expect(channel).toEqual({ inApp: true, email: true });
+    }
+  });
+});

--- a/pwa/lib/notificationTypes.test.ts
+++ b/pwa/lib/notificationTypes.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  collectionMembers,
+  collectionTotal,
+  metaFor,
+  NOTIFICATION_META,
+} from "./notificationTypes";
+
+describe("collectionMembers", () => {
+  it("reads the plain `member` key", () => {
+    expect(collectionMembers({ member: [{ id: "1" } as never] })).toHaveLength(1);
+  });
+
+  it("falls back to the JSON-LD `hydra:member` key, then []", () => {
+    expect(collectionMembers({ "hydra:member": [{ id: "1" } as never] })).toHaveLength(1);
+    expect(collectionMembers({})).toEqual([]);
+  });
+});
+
+describe("collectionTotal", () => {
+  it("reads totalItems, then hydra:totalItems, then 0", () => {
+    expect(collectionTotal({ totalItems: 5 })).toBe(5);
+    expect(collectionTotal({ "hydra:totalItems": 7 })).toBe(7);
+    expect(collectionTotal({})).toBe(0);
+  });
+});
+
+describe("metaFor", () => {
+  it("returns the matching meta for a known type", () => {
+    expect(metaFor("mention")).toBe(NOTIFICATION_META.mention);
+    expect(metaFor("status").label).toBe("STATUS");
+  });
+
+  it("returns the UPDATE fallback for an unknown type", () => {
+    expect(metaFor("totally-unknown").label).toBe("UPDATE");
+  });
+});

--- a/pwa/lib/passwordStrength.test.ts
+++ b/pwa/lib/passwordStrength.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   estimatePasswordStrength,
+  STRENGTH_MEDIUM,
+  STRENGTH_STRONG,
   STRENGTH_VERY_STRONG,
   STRENGTH_VERY_WEAK,
+  STRENGTH_WEAK,
 } from "./passwordStrength";
 
 describe("estimatePasswordStrength", () => {
@@ -25,5 +28,25 @@ describe("estimatePasswordStrength", () => {
     const weak = estimatePasswordStrength("password");
     const stronger = estimatePasswordStrength("P@ssw0rd!2024xyz");
     expect(stronger).toBeGreaterThan(weak);
+  });
+
+  it("walks every intermediate bucket as entropy climbs", () => {
+    // All-distinct lowercase keeps pool fixed at 26, so entropy is exactly
+    // length * log2(26) ≈ length * 4.7004 — no ICU/locale dependence. The
+    // chosen lengths land squarely inside each band's return branch.
+    expect(estimatePasswordStrength("abcdefghijklmn")).toBe(STRENGTH_WEAK); // 14 → ≈65.8 (60–80)
+    expect(estimatePasswordStrength("abcdefghijklmnopqr")).toBe(STRENGTH_MEDIUM); // 18 → ≈84.6 (80–100)
+    expect(estimatePasswordStrength("abcdefghijklmnopqrstuv")).toBe(STRENGTH_STRONG); // 22 → ≈103.4 (100–120)
+  });
+
+  it("accounts for symbol, control, and high-bit character classes", () => {
+    // These inputs route through the `symbol`, `control`, and `other`
+    // (high-bit) arms of the class-detection loop. We only assert the
+    // result is a valid 0–4 score — enough to exercise each branch without
+    // pinning a boundary-sensitive bucket.
+    for (const pw of ["!@#$%^&*()_+", "\x01\x02abcdEFG1", "éàüœ®©abc12"]) {
+      const score = estimatePasswordStrength(pw);
+      expect([0, 1, 2, 3, 4]).toContain(score);
+    }
   });
 });

--- a/pwa/lib/relativeTime.test.ts
+++ b/pwa/lib/relativeTime.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { formatRelative, isRecent, timeGroup } from "./relativeTime";
+
+// Pin "now" so Date.now()-relative output is deterministic.
+const NOW = new Date("2026-06-14T12:00:00.000Z");
+const minutes = (n: number) => n * 60_000;
+const hours = (n: number) => n * 3_600_000;
+const days = (n: number) => n * 86_400_000;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("isRecent", () => {
+  it("is true within the window and false outside it", () => {
+    expect(isRecent(new Date(NOW.getTime() - minutes(1)), minutes(5))).toBe(true);
+    expect(isRecent(new Date(NOW.getTime() - minutes(10)), minutes(5))).toBe(false);
+  });
+
+  it("accepts an ISO string as well as a Date", () => {
+    expect(isRecent(new Date(NOW.getTime() - minutes(1)).toISOString(), minutes(5))).toBe(true);
+  });
+
+  it("is false for an unparseable timestamp", () => {
+    expect(isRecent("not-a-date", minutes(5))).toBe(false);
+  });
+});
+
+describe("formatRelative", () => {
+  it("returns empty string for an invalid date", () => {
+    expect(formatRelative("not-a-date")).toBe("");
+  });
+
+  it("buckets past timestamps into the right unit", () => {
+    expect(formatRelative(new Date(NOW.getTime() - 30_000))).toMatch(/second|now/i);
+    expect(formatRelative(new Date(NOW.getTime() - minutes(5)))).toMatch(/minute/);
+    expect(formatRelative(new Date(NOW.getTime() - hours(3)))).toMatch(/hour/);
+    expect(formatRelative(new Date(NOW.getTime() - days(2)))).toMatch(/day/);
+    expect(formatRelative(new Date(NOW.getTime() - days(45)))).toMatch(/month/);
+    expect(formatRelative(new Date(NOW.getTime() - days(400)))).toMatch(/year/);
+  });
+
+  it("handles future timestamps too", () => {
+    expect(formatRelative(new Date(NOW.getTime() + minutes(5)))).toMatch(/minute/);
+  });
+});
+
+describe("timeGroup", () => {
+  it("buckets into Today / This week / Earlier", () => {
+    expect(timeGroup(new Date(NOW.getTime() - hours(2)))).toBe("Today");
+    expect(timeGroup(new Date(NOW.getTime() - days(3)))).toBe("This week");
+    expect(timeGroup(new Date(NOW.getTime() - days(30)))).toBe("Earlier");
+  });
+
+  it("treats an invalid timestamp as Earlier", () => {
+    expect(timeGroup("not-a-date")).toBe("Earlier");
+  });
+});

--- a/pwa/lib/userDisplay.test.ts
+++ b/pwa/lib/userDisplay.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { displayName, initialsFor } from "./userDisplay";
+
+describe("displayName", () => {
+  it("prefers a trimmed nickname", () => {
+    expect(displayName({ nickname: "  Bob  ", givenName: "Robert", email: "r@x.io" })).toBe("Bob");
+  });
+
+  it("falls back to given + family name", () => {
+    expect(displayName({ givenName: "Robo", familyName: "Parker" })).toBe("Robo Parker");
+    expect(displayName({ givenName: "Robo" })).toBe("Robo");
+    expect(displayName({ familyName: "Parker" })).toBe("Parker");
+  });
+
+  it("falls back to email, then Unknown", () => {
+    expect(displayName({ email: "r@x.io" })).toBe("r@x.io");
+    expect(displayName({})).toBe("Unknown");
+    expect(displayName({ nickname: "   ", givenName: " ", email: "  " })).toBe("Unknown");
+  });
+});
+
+describe("initialsFor", () => {
+  it("uses the first nickname character, upper-cased", () => {
+    expect(initialsFor({ nickname: "bob" })).toBe("B");
+  });
+
+  it("combines given + family initials", () => {
+    expect(initialsFor({ givenName: "Robo", familyName: "Parker" })).toBe("RP");
+    expect(initialsFor({ givenName: "robo" })).toBe("R");
+  });
+
+  it("falls back to the email initial, then '?'", () => {
+    expect(initialsFor({ email: "zed@x.io" })).toBe("Z");
+    expect(initialsFor({})).toBe("?");
+    expect(initialsFor({ givenName: " ", email: "" })).toBe("?");
+  });
+});

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -12,7 +12,8 @@
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@base-ui/react": "^1.5.0",
@@ -61,6 +62,7 @@
     "@types/node": "^25.9.3",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "@vitest/coverage-v8": "4.1.8",
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.2.9",
     "eslint-plugin-react-hooks": "^7.0.0",

--- a/pwa/pages/pages/[pageId].tsx
+++ b/pwa/pages/pages/[pageId].tsx
@@ -8,6 +8,8 @@ import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
 import { ENTRYPOINT } from "@/config/entrypoint";
 import { signinHrefForCurrent } from "@/lib/authRedirect";
 import { displayName } from "@/lib/userDisplay";
+import { formatRelative } from "@/lib/relativeTime";
+import { apiErrorMessage, readCollection } from "@/lib/apiClient";
 import MarkdownEditor from "@/components/editor/MarkdownEditor";
 import MarkdownView from "@/components/editor/MarkdownView";
 import UserAvatar, { type AvatarUser } from "@/components/user/UserAvatar";
@@ -48,36 +50,6 @@ interface ChildPage {
   id: string;
   title: string;
 }
-
-interface Collection<T> {
-  member?: T[];
-  "hydra:member"?: T[];
-}
-
-const RELATIVE = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
-const formatRelative = (iso: string): string => {
-  const ts = new Date(iso).getTime();
-  if (Number.isNaN(ts)) return "";
-  const diffSec = Math.round((ts - Date.now()) / 1000);
-  const abs = Math.abs(diffSec);
-  if (abs < 60) return RELATIVE.format(diffSec, "second");
-  if (abs < 3600) return RELATIVE.format(Math.round(diffSec / 60), "minute");
-  if (abs < 86400) return RELATIVE.format(Math.round(diffSec / 3600), "hour");
-  if (abs < 2592000) return RELATIVE.format(Math.round(diffSec / 86400), "day");
-  if (abs < 31536000)
-    return RELATIVE.format(Math.round(diffSec / 2592000), "month");
-  return RELATIVE.format(Math.round(diffSec / 31536000), "year");
-};
-
-const errorMessage = async (res: Response): Promise<string> => {
-  const data = await res.json().catch(() => ({}));
-  return (
-    data.detail ||
-    data.description ||
-    data["hydra:description"] ||
-    "Request failed."
-  );
-};
 
 const PageDetailView = () => {
   const { user, isAuthenticated, isLoading: authLoading } = useAuth();
@@ -155,12 +127,10 @@ const PageDetailView = () => {
         ),
       ]);
       if (childrenRes.ok) {
-        const collection: Collection<ChildPage> = await childrenRes.json();
-        setChildren(collection.member ?? collection["hydra:member"] ?? []);
+        setChildren(readCollection<ChildPage>(await childrenRes.json()));
       }
       if (commentsRes.ok) {
-        const collection: Collection<PageCommentRow> = await commentsRes.json();
-        setComments(collection.member ?? collection["hydra:member"] ?? []);
+        setComments(readCollection<PageCommentRow>(await commentsRes.json()));
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load.");
@@ -211,7 +181,7 @@ const PageDetailView = () => {
         body: JSON.stringify({ title: editTitle.trim(), body: editBody }),
       });
       if (!res.ok) {
-        throw new Error(await errorMessage(res));
+        throw new Error(await apiErrorMessage(res, "Request failed."));
       }
       setEditing(false);
       await load();
@@ -238,7 +208,7 @@ const PageDetailView = () => {
         credentials: "include",
       });
       if (!res.ok) {
-        throw new Error(await errorMessage(res));
+        throw new Error(await apiErrorMessage(res, "Request failed."));
       }
       await router.push("/pages");
     } catch (err) {
@@ -256,7 +226,7 @@ const PageDetailView = () => {
       headers: { "Content-Type": "application/ld+json" },
       body: JSON.stringify({ page: page["@id"], body }),
     });
-    if (!res.ok) throw new Error(await errorMessage(res));
+    if (!res.ok) throw new Error(await apiErrorMessage(res, "Request failed."));
     const created: PageCommentRow = await res.json();
     // Optimistic insert; the Mercure echo of this POST may also
     // arrive and tries to add the same IRI — dedupe defensively.
@@ -277,7 +247,7 @@ const PageDetailView = () => {
       headers: { "Content-Type": "application/merge-patch+json" },
       body: JSON.stringify({ body }),
     });
-    if (!res.ok) throw new Error(await errorMessage(res));
+    if (!res.ok) throw new Error(await apiErrorMessage(res, "Request failed."));
     const updated: PageCommentRow = await res.json();
     setComments((prev) =>
       prev.map((c) => (c["@id"] === updated["@id"] ? updated : c)),
@@ -292,7 +262,7 @@ const PageDetailView = () => {
       credentials: "include",
     });
     if (!res.ok) {
-      throw new Error(await errorMessage(res));
+      throw new Error(await apiErrorMessage(res, "Request failed."));
     }
     setComments((prev) => prev.filter((c) => c["@id"] !== comment["@id"]));
   };

--- a/pwa/pnpm-lock.yaml
+++ b/pwa/pnpm-lock.yaml
@@ -145,6 +145,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
+      '@vitest/coverage-v8':
+        specifier: 4.1.8
+        version: 4.1.8(vitest@4.1.8)
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.7.0)
@@ -159,7 +162,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@25.9.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0))
+        version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0))
 
 packages:
 
@@ -273,6 +276,10 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@blocknote/core@0.51.4':
     resolution: {integrity: sha512-uR7/BlW6VVlCx/JzfGbkaLGz7O5uI3bu2tbNIdzGTfSloiEp8Qc14if36Dy7DDs+dVWfZgwds0jWiGfE3AzJiw==}
@@ -2275,6 +2282,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/coverage-v8@4.1.8':
+    resolution: {integrity: sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==}
+    peerDependencies:
+      '@vitest/browser': 4.1.8
+      vitest: 4.1.8
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.8':
     resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
 
@@ -2374,6 +2390,9 @@ packages:
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
+
+  ast-v8-to-istanbul@1.0.4:
+    resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
 
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
@@ -2981,6 +3000,9 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
@@ -3148,6 +3170,18 @@ packages:
   isomorphic.js@0.2.5:
     resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
@@ -3155,6 +3189,9 @@ packages:
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -3313,6 +3350,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -4552,6 +4596,8 @@ snapshots:
       use-sync-external-store: 1.6.0(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.17
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@blocknote/core@0.51.4(@types/hast@3.0.4)':
     dependencies:
@@ -6459,6 +6505,20 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
+  '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.8
+      ast-v8-to-istanbul: 1.0.4
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.2
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0))
+
   '@vitest/expect@4.1.8':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -6597,6 +6657,12 @@ snapshots:
   assertion-error@2.0.1: {}
 
   ast-types-flow@0.0.8: {}
+
+  ast-v8-to-istanbul@1.0.4:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   async-function@1.0.0: {}
 
@@ -7370,6 +7436,8 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
+  html-escaper@2.0.2: {}
+
   html-url-attributes@3.0.1: {}
 
   ignore@5.3.2: {}
@@ -7534,6 +7602,19 @@ snapshots:
 
   isomorphic.js@0.2.5: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   iterator.prototype@1.1.5:
     dependencies:
       define-data-property: 1.1.4
@@ -7544,6 +7625,8 @@ snapshots:
       set-function-name: 2.0.2
 
   jiti@2.7.0: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -7671,6 +7754,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.3:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.4
 
   markdown-table@3.0.4: {}
 
@@ -9033,7 +9126,7 @@ snapshots:
       jiti: 2.7.0
       lightningcss: 1.32.0
 
-  vitest@4.1.8(@types/node@25.9.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)):
+  vitest@4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)):
     dependencies:
       '@vitest/expect': 4.1.8
       '@vitest/mocker': 4.1.8(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0))
@@ -9057,6 +9150,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.3
+      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
     transitivePeerDependencies:
       - msw
 

--- a/pwa/vitest.config.ts
+++ b/pwa/vitest.config.ts
@@ -4,10 +4,40 @@ import { defineConfig } from "vitest/config";
 // Unit tests for the pure logic under pwa/lib (query parsing, validation
 // mapping, password-strength estimation, …). Component/integration coverage
 // stays in the Playwright e2e suite; this is the fast unit layer.
+//
+// Coverage gate (the PR floor): `pnpm test:coverage` enforces the thresholds
+// below over an explicit allowlist of pure-logic modules — the modules we've
+// committed to keeping unit-tested. When you add a new framework-free helper
+// under lib/, add it (and its `*.test.ts`) to `coverage.include` so the gate
+// keeps it honest. Hooks (`use*.ts`), API clients, and type-only modules are
+// intentionally out of scope here — their coverage lives in the e2e suite.
 export default defineConfig({
   test: {
     environment: "node",
     include: ["lib/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "text-summary"],
+      include: [
+        "lib/authRedirect.ts",
+        "lib/avatarPalette.ts",
+        "lib/currencies.ts",
+        "lib/landingDestination.ts",
+        "lib/notificationPrefs.ts",
+        "lib/notificationTypes.ts",
+        "lib/passwordStrength.ts",
+        "lib/relativeTime.ts",
+        "lib/searchQuery.ts",
+        "lib/userDisplay.ts",
+        "lib/violations.ts",
+      ],
+      thresholds: {
+        lines: 85,
+        statements: 85,
+        functions: 90,
+        branches: 75,
+      },
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Promote `main` → `production`

Deploys everything currently on `main` and ahead of `production`. Merging this PR triggers the auto-deploy workflow (maintenance page up → pre-deploy DB+media backup → container swap → health check → maintenance page down).

> **Merge with a merge commit** (not squash) so `production` stays fast-forwardable, per the branching guide.

### What ships

**MCP tool expansion ([#465](https://github.com/roboparker/Aura/pull/465))** — the headline change. The integrated MCP server now covers the full content surface so an AI assistant (Claude Desktop/Code) can drive Madori on the user's subscription:
- Spaces: `list_spaces` + `spaceId` targeting on `create_project` / `create_page` / `create_discussion`
- Pages: `create` / `get` / `update` / `delete` / `list`
- Discussions: `create` / `get` / `list`
- Tags: `list` / `create`
- Custom field values written via `update_task`
- Comments: add + list on tasks, pages, and discussions (with @mentions + locked-thread enforcement)

**Refactor ([#464](https://github.com/roboparker/Aura/pull/464))** — extracted duplicated mailer / export / auth logic into composed services.

**Test coverage ([#463](https://github.com/roboparker/Aura/pull/463))** — lifted PHP line coverage to ~85% and added CI coverage floors (PHP + PWA).

### Risk

API-additive (new MCP tools, no schema migrations in #465). No DB migration in this batch beyond what's already on `main`. Rollback = re-run the deploy workflow with a previous `image_tag` SHA.
