### PR TITLE
fix: stop worker crash-loop on read-only var/media mount

### DIFF
--- a/api/frankenphp/docker-entrypoint.sh
+++ b/api/frankenphp/docker-entrypoint.sh
@@ -37,8 +37,21 @@ if [ "$1" = 'frankenphp' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ]; then
 		fi
 	fi
 
-	setfacl -R -m u:www-data:rwX -m u:"$(whoami)":rwX var
-	setfacl -dR -m u:www-data:rwX -m u:"$(whoami)":rwX var
+	# www-data must own writes under var/. Walk var/ but prune var/media: the
+	# worker mounts it read-only for the backup pass, and setfacl on a
+	# read-only mount fails — under `set -e` that crash-loops the entrypoint.
+	# The web container keeps media writable and gets its ACLs in the guarded
+	# pass below.
+	find var -path var/media -prune -o -print0 \
+		| xargs -0 setfacl -m u:www-data:rwX -m u:"$(whoami)":rwX
+	find var -path var/media -prune -o -type d -print0 \
+		| xargs -0 setfacl -d -m u:www-data:rwX -m u:"$(whoami)":rwX
+
+	# Apply the same ACLs to var/media only when it is writable, so the web
+	# container's read-write upload mount is covered while the worker's
+	# read-only mount is skipped (failures ignored as a belt-and-braces guard).
+	setfacl -R -m u:www-data:rwX -m u:"$(whoami)":rwX var/media 2>/dev/null || true
+	setfacl -dR -m u:www-data:rwX -m u:"$(whoami)":rwX var/media 2>/dev/null || true
 
 	echo 'PHP app ready!'
 fi


### PR DESCRIPTION
## Problem

The worker container was stuck in a restart loop. The shared image entrypoint (`api/frankenphp/docker-entrypoint.sh`) runs:

```sh
setfacl -R -m u:www-data:rwX -m u:"$(whoami)":rwX var
```

This recurses into `var/media`, which the **worker** mounts read-only (`media_data:/app/var/media:ro`, used only for the backup tar pass). `setfacl` fails on a read-only filesystem, and because the script runs under `set -e`, the entrypoint aborts before `messenger:consume` ever starts. The container then crash-loops, so no background jobs (notification emails, reminders, digests, exports) or scheduled tasks run.

This affects every deploy that mounts `var/media` read-only on the worker — including production.

## Fix

- Walk `var/` but **prune `var/media`** from the recursive ACL pass, so a read-only media mount can't abort the entrypoint.
- Apply the media ACLs in a separate **guarded pass** (`2>/dev/null || true`) that succeeds when media is writable and no-ops when it isn't.

Net effect: the **web container** (media read-write) still gets its upload ACLs exactly as before; the **worker** (media read-only) skips them instead of crashing.

## Verification

Rebuilt the image locally and recreated the worker — it now boots to `Up (healthy)` and immediately drained the backlog of missed scheduled jobs, including a **successful backup pass** that reads from the read-only media mount, confirming the read-only behavior is preserved.