### PR TITLE
fix(pwa): stop flex-row content overflow by letting truncation shrink

### DIFF
--- a/pwa/components/common/SpaceSwitcher.tsx
+++ b/pwa/components/common/SpaceSwitcher.tsx
@@ -76,7 +76,7 @@ const SpaceSwitcher = () => {
             isPersonal={activeSpace.isPersonal}
             size="sm"
           />
-          <span className="truncate flex-1 text-left font-medium">
+          <span className="min-w-0 truncate flex-1 text-left font-medium">
             {activeSpace.name}
           </span>
           <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
@@ -114,7 +114,7 @@ const SpaceSwitcher = () => {
                 isPersonal={space.isPersonal}
                 size="sm"
               />
-              <span className="truncate flex-1">{space.name}</span>
+              <span className="min-w-0 truncate flex-1">{space.name}</span>
             </DropdownMenuItem>
           );
         })}

--- a/pwa/components/search/SearchOverlay.tsx
+++ b/pwa/components/search/SearchOverlay.tsx
@@ -186,7 +186,7 @@ const SearchOverlay = () => {
               onClick={() => runQuery(trimmed)}
             >
               <SearchIcon className="h-4 w-4 text-muted-foreground" />
-              <span className="flex-1 truncate">
+              <span className="min-w-0 flex-1 truncate">
                 Search for <span className="font-medium text-foreground">{trimmed}</span>
               </span>
               <CornerDownLeft className="h-3.5 w-3.5 text-muted-foreground" />
@@ -252,7 +252,7 @@ const SearchOverlay = () => {
                     onClick={() => runQuery(r.q)}
                   >
                     <SearchIcon className="h-3.5 w-3.5 text-muted-foreground" />
-                    <span className="flex-1 truncate font-mono text-xs">{r.q}</span>
+                    <span className="min-w-0 flex-1 truncate font-mono text-xs">{r.q}</span>
                     {typeof r.count === "number" && (
                       <span className="text-[11px] text-muted-foreground">{r.count} results</span>
                     )}

--- a/pwa/components/tasks/AssigneesCombobox.tsx
+++ b/pwa/components/tasks/AssigneesCombobox.tsx
@@ -201,7 +201,7 @@ const AssigneesCombobox = ({
             {(u: AssigneeOption) => (
               <ComboboxItem key={u["@id"]} value={u}>
                 <UserAvatar user={u} size="sm" className="h-5 w-5" />
-                <span className="flex-1 truncate">{displayName(u)}</span>
+                <span className="min-w-0 flex-1 truncate">{displayName(u)}</span>
                 <span className="text-xs text-muted-foreground truncate">
                   {u.email}
                 </span>

--- a/pwa/components/tasks/value-editors.tsx
+++ b/pwa/components/tasks/value-editors.tsx
@@ -514,7 +514,7 @@ const SelectValue = ({
             {(o: SelectOption) => (
               <ComboboxItem key={o.key} value={o}>
                 <OptionDot option={o} />
-                <span className="flex-1 truncate">{o.label}</span>
+                <span className="min-w-0 flex-1 truncate">{o.label}</span>
               </ComboboxItem>
             )}
           </ComboboxList>
@@ -544,7 +544,7 @@ const SelectValue = ({
           {(o: SelectOption) => (
             <ComboboxItem key={o.key} value={o}>
               <OptionDot option={o} />
-              <span className="flex-1 truncate">{o.label}</span>
+              <span className="min-w-0 flex-1 truncate">{o.label}</span>
             </ComboboxItem>
           )}
         </ComboboxList>
@@ -616,7 +616,7 @@ const ReferenceValue = (props: ValueEditorProps) => {
             {(o: RefOption) => (
               <ComboboxItem key={o.iri} value={o}>
                 {o.user && <UserAvatar user={o.user} size="sm" className="h-5 w-5" />}
-                <span className="flex-1 truncate">{o.label}</span>
+                <span className="min-w-0 flex-1 truncate">{o.label}</span>
               </ComboboxItem>
             )}
           </ComboboxList>
@@ -649,7 +649,7 @@ const ReferenceValue = (props: ValueEditorProps) => {
           {(o: RefOption) => (
             <ComboboxItem key={o.iri} value={o}>
               {o.user && <UserAvatar user={o.user} size="sm" className="h-5 w-5" />}
-              <span className="flex-1 truncate">{o.label}</span>
+              <span className="min-w-0 flex-1 truncate">{o.label}</span>
             </ComboboxItem>
           )}
         </ComboboxList>

--- a/pwa/pages/spaces/[id].tsx
+++ b/pwa/pages/spaces/[id].tsx
@@ -646,7 +646,7 @@ const SpaceDetail = () => {
                                     user={toAvatarUser(m.user)}
                                     size="sm"
                                   />
-                                  <span className="text-sm font-medium truncate flex-1">
+                                  <span className="min-w-0 text-sm font-medium truncate flex-1">
                                     {displayName(m.user)}
                                     {isSelf && (
                                       <span className="ml-1 text-xs text-muted-foreground">


### PR DESCRIPTION
Adds `min-w-0` to `flex-1 truncate` children across the space switcher, ⌘K search overlay, assignee/select option lists, and space member rows.

Without `min-w-0` a flex item keeps `min-width: auto` (its content width), so `truncate` can never ellipsize — long names/queries overflowed the row and pushed sibling controls out. Purely additive: no visual change when content already fits.

Verified: PWA typecheck + ESLint clean.