### PR TITLE
feat(api): add profile + security account scopes to API token access policy

### DIFF
--- a/api/src/EventListener/AccessPolicyListener.php
+++ b/api/src/EventListener/AccessPolicyListener.php
@@ -27,7 +27,14 @@ use Symfony\Component\Uid\Uuid;
  *    viewable; writes (create) require the category to be 'edit'.
  *  - Any other content category (`/comments`, `/notifications`, `/media-objects`):
  *    governed wholesale by the category level.
- *  - Non-content endpoints (app shell, `/api/me`, `/spaces`, `/groups`, auth):
+ *  - Account surfaces (`profile`: /api/me + /me/preferences; `security`: /me/2fa,
+ *    /me/sessions, /me/deactivate|delete|export, /auth/change-password +
+ *    email-change): the category gates READ visibility (none = blocked). Every
+ *    write here is account-sensitive and stays blocked regardless of level (and
+ *    is independently step-up-gated). Only enforced when the actor's policy
+ *    actually defines the category — impersonation never does, so impersonated
+ *    reads of these surfaces keep working.
+ *  - Other non-content endpoints (app shell, `/spaces`, `/groups`, auth):
  *    reads allowed so the UI loads + a session can be ended; ALL writes
  *    blocked, so nothing outside granted content can be mutated (including the
  *    actor's own preferences / token settings).
@@ -75,6 +82,37 @@ final class AccessPolicyListener
     {
     }
 
+    /**
+     * Classify an account-management path into its gating category, or null if
+     * the path isn't an account surface. Keyed on the first two segments since
+     * profile + security both live under the shared `/me`, `/api/me`, `/auth`
+     * prefixes that first-segment routing can't separate.
+     */
+    private function accountCategory(string $first, ?string $second): ?string
+    {
+        if ('api' === $first && 'me' === $second) {
+            return 'profile';
+        }
+
+        if ('me' === $first) {
+            return match ($second) {
+                'preferences' => 'profile',
+                '2fa', 'sessions', 'deactivate', 'delete', 'export' => 'security',
+                default => null,
+            };
+        }
+
+        if ('auth' === $first) {
+            return match ($second) {
+                'change-password' => 'security',
+                'request-email-change', 'confirm-email-change', 'revert-email-change' => 'profile',
+                default => null,
+            };
+        }
+
+        return null;
+    }
+
     public function __invoke(RequestEvent $event): void
     {
         if (!$event->isMainRequest()) {
@@ -98,6 +136,24 @@ final class AccessPolicyListener
 
         $segments = explode('/', ltrim($request->getPathInfo(), '/'));
         $first = $segments[0];
+
+        // Account surfaces (profile / security). Enforced only when the actor's
+        // policy actually models the category — impersonation omits these, so
+        // its reads of /me fall through to the read-allowed default below.
+        $accountCategory = $this->accountCategory($first, $segments[1] ?? null);
+        if (null !== $accountCategory && $policy->definesCategory($accountCategory)) {
+            if (!$isRead) {
+                // Every account write is sensitive (also step-up-gated): blocked
+                // at any level. Future non-sensitive writes would relax here.
+                throw $this->denied($accountCategory);
+            }
+            if (AccessPolicy::NONE === $policy->categoryLevel($accountCategory)) {
+                throw $this->denied($accountCategory);
+            }
+
+            return;
+        }
+
         $category = self::PREFIX_TO_CATEGORY[$first] ?? null;
 
         if (null === $category) {

--- a/api/src/Security/Access/AccessPolicy.php
+++ b/api/src/Security/Access/AccessPolicy.php
@@ -34,6 +34,11 @@ final class AccessPolicy
         'comments',
         'notifications',
         'files',
+        // Account surfaces (token actors only — not impersonation, which uses
+        // User::IMPERSONATION_CATEGORIES). 'profile' gates /api/me + /me/preferences;
+        // 'security' gates /me/2fa, /me/sessions, account lifecycle, change-password.
+        'profile',
+        'security',
     ];
 
     public const ITEM_TYPES = ['project', 'page', 'task', 'discussion'];
@@ -60,6 +65,18 @@ final class AccessPolicy
     public static function categoryForItemType(string $type): ?string
     {
         return self::ITEM_TYPE_CATEGORY[$type] ?? null;
+    }
+
+    /**
+     * Whether this policy explicitly carries a level for the category, as
+     * opposed to it merely defaulting to 'none'. Lets the enforcement listener
+     * distinguish a token that models a category (enforce it) from an actor
+     * whose model omits it entirely — e.g. impersonation, which never carries
+     * 'profile'/'security' — so omitted categories keep their prior behavior.
+     */
+    public function definesCategory(string $category): bool
+    {
+        return array_key_exists($category, $this->categories);
     }
 
     /** The level for a whole category. */

--- a/api/tests/Api/ApiTokenAccessPolicyTest.php
+++ b/api/tests/Api/ApiTokenAccessPolicyTest.php
@@ -98,6 +98,62 @@ class ApiTokenAccessPolicyTest extends ApiTestCase
         $this->assertJsonContains(['totalItems' => 1]);
     }
 
+    public function testProfileNoneBlocksAccountRead(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bearer = $this->mintToken($alice, ['categories' => ['profile' => 'none'], 'items' => []]);
+
+        $client = static::createClient();
+        $client->request('GET', '/api/me', ['headers' => $this->authHeaders($bearer)]);
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testProfileViewAllowsAccountReadButWritesStayBlocked(): void
+    {
+        // Mint both tokens before createClient() reboots the kernel (which
+        // would detach $alice from the EntityManager mid-test).
+        $alice = $this->createUser('alice@example.com');
+        $view = $this->mintToken($alice, ['categories' => ['profile' => 'view'], 'items' => []]);
+        $edit = $this->mintToken($alice, ['categories' => ['profile' => 'edit'], 'items' => []]);
+
+        $client = static::createClient();
+        $client->request('GET', '/api/me', ['headers' => $this->authHeaders($view)]);
+        $this->assertResponseIsSuccessful();
+
+        // Even at 'edit', preference writes are account-sensitive and stay blocked.
+        $client->request('PATCH', '/me/preferences', [
+            'json' => ['timezone' => 'UTC'],
+            'headers' => $this->authHeaders($edit),
+        ]);
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testSecurityCategoryGatesAccountSurface(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $none = $this->mintToken($alice, ['categories' => ['security' => 'none'], 'items' => []]);
+        $view = $this->mintToken($alice, ['categories' => ['security' => 'view'], 'items' => []]);
+
+        $client = static::createClient();
+        $client->request('GET', '/me/sessions', ['headers' => $this->authHeaders($none)]);
+        $this->assertResponseStatusCodeSame(403);
+
+        $client->request('GET', '/me/sessions', ['headers' => $this->authHeaders($view)]);
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testTokenOmittingAccountCategoryKeepsPriorReadBehavior(): void
+    {
+        // Backward-compat + impersonation safety: a policy that doesn't model
+        // profile/security leaves account reads allowed as before.
+        $alice = $this->createUser('alice@example.com');
+        $bearer = $this->mintToken($alice, ['categories' => ['tasks' => 'view'], 'items' => []]);
+
+        $client = static::createClient();
+        $client->request('GET', '/api/me', ['headers' => $this->authHeaders($bearer)]);
+        $this->assertResponseIsSuccessful();
+    }
+
     /**
      * @return array<string, string>
      */

--- a/pwa/components/settings/CreateApiTokenDialog.tsx
+++ b/pwa/components/settings/CreateApiTokenDialog.tsx
@@ -35,17 +35,26 @@ const NODES: PermissionNode[] = [
   {
     key: "content",
     label: "Content",
-    description: "tasks, projects, pages, discussions, comments",
+    description: "tasks, projects, pages, discussions, comments, files",
     children: [
       { key: "tasks", label: "Tasks" },
       { key: "projects", label: "Projects" },
       { key: "pages", label: "Pages" },
       { key: "discussions", label: "Discussions" },
       { key: "comments", label: "Comments" },
+      { key: "files", label: "Files" },
     ],
   },
-  { key: "notifications", label: "Notifications" },
-  { key: "files", label: "Files" },
+  {
+    key: "settings",
+    label: "Settings",
+    description: "notifications, profile, security",
+    children: [
+      { key: "notifications", label: "Notifications" },
+      { key: "profile", label: "Profile" },
+      { key: "security", label: "Security" },
+    ],
+  },
 ];
 
 const ALL_CATEGORIES = [
@@ -56,6 +65,8 @@ const ALL_CATEGORIES = [
   "comments",
   "notifications",
   "files",
+  "profile",
+  "security",
 ];
 
 // When a token is restricted, start everything at read-only — a useful,
@@ -145,7 +156,7 @@ const CreateApiTokenDialog = ({
             </DialogHeader>
             <div className="flex items-center gap-2 rounded-md border bg-muted/40 p-2">
               <code
-                className="flex-1 truncate font-mono text-sm"
+                className="min-w-0 flex-1 truncate font-mono text-sm"
                 data-testid="api-token-plaintext"
               >
                 {created.plainToken}


### PR DESCRIPTION
Extends the token `AccessPolicy` with two account-surface categories so a scoped token can be limited to (or kept out of) the owner's profile and security pages — same none/view/edit model as content.

- `AccessPolicy`: add `profile` + `security` + a `definesCategory` guard.
- `AccessPolicyListener`: classify `/api/me` + `/me/preferences` (profile) and `/me/2fa`, `/me/sessions`, lifecycle, change-password/email-change (security). Gates READ visibility; every account write stays blocked at any level (also step-up-gated). Enforced only when the policy defines the category, so **impersonated `/me` reads keep working**.
- Token create dialog: regroup tree into Content (incl. Files) + Settings (Notifications, Profile, Security); fix created-token overflow.

Verified: PHPUnit (8 access-policy tests + impersonation regressions), PHPStan L10, PHPCS, PWA typecheck.