### PR TITLE
feat(pwa): explicit per-section Save on settings panels

### DIFF
--- a/e2e/tests/settings.spec.js
+++ b/e2e/tests/settings.spec.js
@@ -112,7 +112,8 @@ test.describe("Settings", () => {
     await expect(mentionsEmail).toHaveAttribute("aria-checked", "true");
     await mentionsEmail.click();
     await expect(mentionsEmail).toHaveAttribute("aria-checked", "false");
-    // Wait for the autosave to land before reloading.
+    // Explicit per-section save: commit the change, then wait for it to land.
+    await page.getByTestId("settings-delivery-save").click();
     await expect(page.getByTestId("settings-save-saved")).toBeVisible();
 
     await page.reload();
@@ -130,6 +131,9 @@ test.describe("Settings", () => {
     await tz.click();
     await tz.fill("London");
     await page.getByRole("option", { name: /London/ }).first().click();
+    // Explicit per-section save before reloading.
+    await page.getByTestId("settings-workspace-save").click();
+    await expect(page.getByTestId("settings-save-saved")).toBeVisible();
 
     await page.reload();
     await expect(page.getByTestId("settings-timezone-input")).toHaveValue(

--- a/pwa/components/settings/ImpersonationConsent.tsx
+++ b/pwa/components/settings/ImpersonationConsent.tsx
@@ -5,10 +5,10 @@ import {
   type ImpersonationCategory,
   type ImpersonationLevel,
 } from "@/contexts/AuthContext";
-import { usePreferencePersist } from "@/lib/usePreferencePersist";
+import { useSettingsSection } from "@/lib/useSettingsSection";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
-import SaveIndicator from "@/components/settings/SaveIndicator";
+import SectionSaveBar from "@/components/settings/SectionSaveBar";
 import ImpersonationItemExceptions from "@/components/settings/ImpersonationItemExceptions";
 import PermissionTree, {
   type PermissionLevel,
@@ -60,12 +60,21 @@ const DEFAULT_ACCESS: Record<ImpersonationCategory, ImpersonationLevel> = {
  */
 const ImpersonationConsent = () => {
   const { user } = useAuth();
-  const { persist, saveStatus, saveError } = usePreferencePersist();
 
   const enabled = user?.preferences?.canBeImpersonated ?? false;
   const access = useMemo(
     () => ({ ...DEFAULT_ACCESS, ...(user?.preferences?.impersonationAccess ?? {}) }),
     [user?.preferences?.impersonationAccess],
+  );
+
+  // Master toggle + the access matrix buffer together behind one Save. The
+  // per-item overrides below keep their own immediate save.
+  const consent = useSettingsSection(
+    { canBeImpersonated: enabled, impersonationAccess: access },
+    (next) => ({
+      canBeImpersonated: next.canBeImpersonated,
+      impersonationAccess: next.impersonationAccess,
+    }),
   );
 
   return (
@@ -86,28 +95,27 @@ const ImpersonationConsent = () => {
             leave it off and no one can impersonate your account.
           </p>
         </div>
-        <div className="flex shrink-0 items-center gap-2 pt-0.5">
-          <SaveIndicator status={saveStatus} />
-          <Switch
-            id="impersonation-consent"
-            checked={enabled}
-            onCheckedChange={(checked) =>
-              void persist({ canBeImpersonated: checked })
-            }
-            aria-label="Allow admin impersonation"
-          />
-        </div>
+        <Switch
+          id="impersonation-consent"
+          className="mt-0.5 shrink-0"
+          checked={consent.draft.canBeImpersonated}
+          onCheckedChange={(checked) =>
+            consent.setDraft({ ...consent.draft, canBeImpersonated: checked })
+          }
+          aria-label="Allow admin impersonation"
+        />
       </div>
 
-      {enabled ? (
+      {consent.draft.canBeImpersonated ? (
         <div className="rounded-md border p-3">
           <PermissionTree
             levels={LEVELS}
             nodes={NODES}
-            values={access as Record<string, string>}
+            values={consent.draft.impersonationAccess as Record<string, string>}
             masterLabel="What admins can access"
             onChange={(next) =>
-              void persist({
+              consent.setDraft({
+                ...consent.draft,
                 impersonationAccess: next as Record<
                   ImpersonationCategory,
                   ImpersonationLevel
@@ -127,9 +135,14 @@ const ImpersonationConsent = () => {
         </div>
       ) : null}
 
-      {saveStatus === "error" && saveError ? (
-        <p className="text-sm text-destructive">{saveError}</p>
-      ) : null}
+      <SectionSaveBar
+        dirty={consent.dirty}
+        status={consent.saveStatus}
+        error={consent.saveError}
+        onSave={() => void consent.save()}
+        onDiscard={consent.discard}
+        testId="settings-impersonation-save"
+      />
     </div>
   );
 };

--- a/pwa/components/settings/SectionSaveBar.tsx
+++ b/pwa/components/settings/SectionSaveBar.tsx
@@ -1,0 +1,59 @@
+import { Button } from "@/components/ui/button";
+import SaveIndicator from "@/components/settings/SaveIndicator";
+import type { SaveStatus } from "@/lib/usePreferencePersist";
+
+interface SectionSaveBarProps {
+  dirty: boolean;
+  status: SaveStatus;
+  error?: string | null;
+  onSave: () => void;
+  onDiscard: () => void;
+  /** Test hook applied to the Save button (`{testId}`) + Discard (`{testId}-discard`). */
+  testId?: string;
+}
+
+/**
+ * Save / Discard footer for an explicit-save Settings card. Buttons are
+ * disabled while clean or mid-save; the transient SaveIndicator pill shows the
+ * saving/saved transition, and an inline message surfaces save errors.
+ */
+const SectionSaveBar = ({
+  dirty,
+  status,
+  error,
+  onSave,
+  onDiscard,
+  testId,
+}: SectionSaveBarProps) => {
+  const busy = status === "saving";
+
+  return (
+    <div className="mt-4 flex items-center justify-end gap-3 border-t pt-3">
+      {status === "error" && error ? (
+        <span className="mr-auto text-xs text-destructive">{error}</span>
+      ) : null}
+      <SaveIndicator status={status} />
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={onDiscard}
+        disabled={!dirty || busy}
+        data-testid={testId ? `${testId}-discard` : undefined}
+      >
+        Discard
+      </Button>
+      <Button
+        type="button"
+        size="sm"
+        onClick={onSave}
+        disabled={!dirty || busy}
+        data-testid={testId}
+      >
+        Save changes
+      </Button>
+    </div>
+  );
+};
+
+export default SectionSaveBar;

--- a/pwa/lib/useSettingsSection.ts
+++ b/pwa/lib/useSettingsSection.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+import type { UserPreferences } from "@/contexts/AuthContext";
+import { usePreferencePersist } from "@/lib/usePreferencePersist";
+
+/**
+ * Per-section explicit-save state for a Settings card. Holds a local draft
+ * seeded from the persisted value, exposes a `dirty` flag, and only writes to
+ * `PATCH /me/preferences` when `save()` is called — the buffered counterpart
+ * to the auto-saving controls. Each call owns its own `usePreferencePersist`
+ * instance, so the save status/error reported here are scoped to this section.
+ *
+ * The draft re-syncs whenever the persisted value changes (initial load, a
+ * successful save, or an external update) so `dirty` stays accurate.
+ */
+export function useSettingsSection<T>(
+  serverValue: T,
+  toPatch: (draft: T) => Partial<UserPreferences>,
+) {
+  const { persist, saveStatus, saveError } = usePreferencePersist();
+  const serverKey = JSON.stringify(serverValue);
+  const [draft, setDraft] = useState<T>(serverValue);
+
+  useEffect(() => {
+    setDraft(JSON.parse(serverKey) as T);
+  }, [serverKey]);
+
+  const dirty = JSON.stringify(draft) !== serverKey;
+
+  return {
+    draft,
+    setDraft,
+    dirty,
+    saveStatus,
+    saveError,
+    save: () => persist(toPatch(draft)),
+    discard: () => setDraft(JSON.parse(serverKey) as T),
+  };
+}

--- a/pwa/pages/settings/notifications.tsx
+++ b/pwa/pages/settings/notifications.tsx
@@ -1,12 +1,13 @@
 import { useAuth } from "@/contexts/AuthContext";
 import { usePreferencePersist } from "@/lib/usePreferencePersist";
+import { useSettingsSection } from "@/lib/useSettingsSection";
 import { DEFAULT_NOTIFICATION_MATRIX } from "@/lib/notificationPrefs";
 import SettingsShell from "@/components/settings/SettingsShell";
 import SaveIndicator from "@/components/settings/SaveIndicator";
+import SectionSaveBar from "@/components/settings/SectionSaveBar";
 import NotificationMatrix from "@/components/settings/NotificationMatrix";
 import EmailDigestControl from "@/components/settings/EmailDigestControl";
 import QuietHoursControl from "@/components/settings/QuietHoursControl";
-import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
@@ -14,7 +15,6 @@ import { Switch } from "@/components/ui/switch";
 
 const NotificationsPage = () => {
   const { user } = useAuth();
-  const { persist, saveStatus, saveError } = usePreferencePersist();
   const prefs = user?.preferences;
   const disabled = !user;
 
@@ -31,28 +31,46 @@ const NotificationsPage = () => {
     end: "07:00",
   };
 
+  // Delivery matrix — its own buffered save.
+  const delivery = useSettingsSection(matrix, (next) => ({
+    notificationMatrix: next,
+  }));
+
+  // Email digest + quiet hours share one card and save together.
+  const emailQuiet = useSettingsSection({ digest, quietHours }, (next) => ({
+    emailDigest: next.digest,
+    // notificationFrequency is the canonical cadence the backend reads; keep
+    // it in sync with the digest mode.
+    notificationFrequency: next.digest.mode,
+    quietHours: next.quietHours,
+  }));
+
+  // The push toggle is a single browser-permission affordance — kept immediate.
+  const push = usePreferencePersist();
+
   return (
     <SettingsShell
       active="notifications"
       title="Notifications"
       description="Pick which Madori events reach you, and where."
-      actions={<SaveIndicator status={saveStatus} />}
     >
-      {saveError && (
-        <Alert variant="destructive" data-testid="settings-error">
-          <AlertDescription>{saveError}</AlertDescription>
-        </Alert>
-      )}
-
       <Card data-testid="settings-notifications">
         <CardHeader>
           <CardTitle>Delivery</CardTitle>
         </CardHeader>
         <CardContent>
           <NotificationMatrix
-            value={matrix}
+            value={delivery.draft}
             disabled={disabled}
-            onChange={(next) => void persist({ notificationMatrix: next })}
+            onChange={delivery.setDraft}
+          />
+          <SectionSaveBar
+            dirty={delivery.dirty}
+            status={delivery.saveStatus}
+            error={delivery.saveError}
+            onSave={() => void delivery.save()}
+            onDiscard={delivery.discard}
+            testId="settings-delivery-save"
           />
         </CardContent>
       </Card>
@@ -63,20 +81,28 @@ const NotificationsPage = () => {
         </CardHeader>
         <CardContent className="space-y-6">
           <EmailDigestControl
-            value={digest}
+            value={emailQuiet.draft.digest}
             disabled={disabled}
             onChange={(next) =>
-              // notificationFrequency is the canonical cadence the backend
-              // reads; keep it in sync with the digest mode.
-              void persist({ emailDigest: next, notificationFrequency: next.mode })
+              emailQuiet.setDraft({ ...emailQuiet.draft, digest: next })
             }
           />
           <Separator />
           <QuietHoursControl
-            value={quietHours}
+            value={emailQuiet.draft.quietHours}
             timezone={prefs?.timezone ?? "UTC"}
             disabled={disabled}
-            onChange={(next) => void persist({ quietHours: next })}
+            onChange={(next) =>
+              emailQuiet.setDraft({ ...emailQuiet.draft, quietHours: next })
+            }
+          />
+          <SectionSaveBar
+            dirty={emailQuiet.dirty}
+            status={emailQuiet.saveStatus}
+            error={emailQuiet.saveError}
+            onSave={() => void emailQuiet.save()}
+            onDiscard={emailQuiet.discard}
+            testId="settings-email-save"
           />
         </CardContent>
       </Card>
@@ -95,15 +121,18 @@ const NotificationsPage = () => {
                 Send browser push when an in-app event fires.
               </p>
             </div>
-            <Switch
-              id="push-toggle"
-              checked={prefs?.pushNotificationsEnabled ?? false}
-              disabled={disabled}
-              onCheckedChange={(on) =>
-                void persist({ pushNotificationsEnabled: on })
-              }
-              data-testid="settings-push-toggle"
-            />
+            <div className="flex shrink-0 items-center gap-2 pt-0.5">
+              <SaveIndicator status={push.saveStatus} />
+              <Switch
+                id="push-toggle"
+                checked={prefs?.pushNotificationsEnabled ?? false}
+                disabled={disabled}
+                onCheckedChange={(on) =>
+                  void push.persist({ pushNotificationsEnabled: on })
+                }
+                data-testid="settings-push-toggle"
+              />
+            </div>
           </div>
           <p className="text-xs text-muted-foreground">
             Browser permission:{" "}

--- a/pwa/pages/settings/profile.tsx
+++ b/pwa/pages/settings/profile.tsx
@@ -1,35 +1,36 @@
 import { useAuth } from "@/contexts/AuthContext";
-import { usePreferencePersist } from "@/lib/usePreferencePersist";
+import { useSettingsSection } from "@/lib/useSettingsSection";
 import SettingsShell from "@/components/settings/SettingsShell";
-import SaveIndicator from "@/components/settings/SaveIndicator";
+import SectionSaveBar from "@/components/settings/SectionSaveBar";
 import TimezoneSelect from "@/components/settings/TimezoneSelect";
 import StartPageSelect from "@/components/settings/StartPageSelect";
 import { DEFAULT_LANDING } from "@/lib/landingDestination";
 import AvatarSection from "@/components/account/AvatarSection";
 import EmailChangeForm from "@/components/account/EmailChangeForm";
 import ProfileForm from "@/components/account/ProfileForm";
-import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 
 const ProfilePage = () => {
   const { user } = useAuth();
-  const { persist, saveStatus, saveError } = usePreferencePersist();
   const prefs = user?.preferences;
+
+  // Timezone + start page share a card and save together; the identity forms
+  // (email, name) keep their own explicit submit buttons.
+  const workspace = useSettingsSection(
+    {
+      timezone: prefs?.timezone ?? "UTC",
+      landing: prefs?.landing ?? DEFAULT_LANDING,
+    },
+    (next) => ({ timezone: next.timezone, landing: next.landing }),
+  );
 
   return (
     <SettingsShell
       active="profile"
       title="Profile"
       description="How you appear to teammates across Madori."
-      actions={<SaveIndicator status={saveStatus} />}
     >
-      {saveError && (
-        <Alert variant="destructive" data-testid="settings-error">
-          <AlertDescription>{saveError}</AlertDescription>
-        </Alert>
-      )}
-
       <Card>
         <CardHeader>
           <CardTitle>Avatar</CardTitle>
@@ -47,17 +48,36 @@ const ProfilePage = () => {
           <EmailChangeForm />
           <Separator />
           <ProfileForm />
-          <Separator />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Workspace</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
           <TimezoneSelect
-            value={prefs?.timezone ?? "UTC"}
-            onChange={(tz) => void persist({ timezone: tz })}
+            value={workspace.draft.timezone}
+            onChange={(tz) =>
+              workspace.setDraft({ ...workspace.draft, timezone: tz })
+            }
             disabled={!user}
           />
           <Separator />
           <StartPageSelect
-            value={prefs?.landing ?? DEFAULT_LANDING}
-            onChange={(landing) => void persist({ landing })}
+            value={workspace.draft.landing}
+            onChange={(landing) =>
+              workspace.setDraft({ ...workspace.draft, landing })
+            }
             disabled={!user}
+          />
+          <SectionSaveBar
+            dirty={workspace.dirty}
+            status={workspace.saveStatus}
+            error={workspace.saveError}
+            onSave={() => void workspace.save()}
+            onDiscard={workspace.discard}
+            testId="settings-workspace-save"
           />
         </CardContent>
       </Card>


### PR DESCRIPTION
Replaces auto-save on Settings preference controls with buffered per-section saves: each card holds a local draft and a dirty-gated Save / Discard footer, writing to `PATCH /me/preferences` only on Save.

- New `useSettingsSection` hook + `SectionSaveBar` footer.
- Notifications: Delivery matrix and Email & quiet hours each save independently; push toggle stays immediate (browser-permission affordance).
- Profile: timezone + start page → a Workspace card with one Save.
- Security: impersonation toggle + access matrix buffer behind one Save (per-item exceptions keep their own immediate save).
- e2e updated to drive the new Save buttons.

Verified: PWA typecheck + ESLint clean.