### PR TITLE
feat(pwa): set custom field values from the project new-task form

### DIFF
--- a/pwa/components/tasks/CustomFieldValueFields.tsx
+++ b/pwa/components/tasks/CustomFieldValueFields.tsx
@@ -1,0 +1,68 @@
+import { Badge } from "@/components/ui/badge";
+import type { AvatarUser } from "@/components/user/UserAvatar";
+import { violationFor, type ViolationMap } from "@/lib/violations";
+import { subtypeLabelFor } from "@/components/custom-fields/kind-editors";
+import type { CustomFieldDefinition } from "@/components/custom-fields/types";
+import { CustomFieldValueEditor } from "./value-editors";
+
+interface CustomFieldValueFieldsProps {
+  definitions: CustomFieldDefinition[];
+  /** Working values keyed by definition IRI. */
+  values: Record<string, unknown>;
+  onChange: (defIri: string, next: unknown) => void;
+  /** Validation messages keyed by definition IRI. */
+  violations?: ViolationMap;
+  projectIri?: string | null;
+  spaceIri?: string | null;
+  users?: AvatarUser[];
+  disabled?: boolean;
+}
+
+/**
+ * Controlled list of per-definition custom-field value editors — the shared
+ * body of the task drawer's auto-saving CustomFieldValueList and the project
+ * page's new-task form. Purely presentational: it holds no state and never
+ * persists, so the parent owns the working copy and decides when to save.
+ */
+const CustomFieldValueFields = ({
+  definitions,
+  values,
+  onChange,
+  violations = {},
+  projectIri,
+  spaceIri,
+  users,
+  disabled,
+}: CustomFieldValueFieldsProps) => (
+  <div className="space-y-4">
+    {definitions.map((def) => (
+      <div key={def["@id"]} className="space-y-1.5">
+        <div className="flex items-center justify-between gap-2">
+          <label className="text-sm font-medium">
+            {def.name}
+            {!def.nullable && (
+              <span className="ml-0.5 text-destructive" aria-hidden>
+                *
+              </span>
+            )}
+          </label>
+          <Badge variant="outline" className="shrink-0 text-[10px] uppercase">
+            {subtypeLabelFor(def.kind, def.subtype)}
+          </Badge>
+        </div>
+        <CustomFieldValueEditor
+          definition={def}
+          value={values[def["@id"]] ?? null}
+          onChange={(next) => onChange(def["@id"], next)}
+          error={violationFor(violations, def["@id"])}
+          disabled={disabled}
+          projectIri={projectIri}
+          spaceIri={spaceIri}
+          users={users}
+        />
+      </div>
+    ))}
+  </div>
+);
+
+export default CustomFieldValueFields;

--- a/pwa/components/tasks/CustomFieldValueList.tsx
+++ b/pwa/components/tasks/CustomFieldValueList.tsx
@@ -1,11 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Badge } from "@/components/ui/badge";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import type { AvatarUser } from "@/components/user/UserAvatar";
-import { violationFor, type ViolationMap } from "@/lib/violations";
-import { subtypeLabelFor } from "@/components/custom-fields/kind-editors";
+import { type ViolationMap } from "@/lib/violations";
 import type { CustomFieldDefinition } from "@/components/custom-fields/types";
-import { CustomFieldValueEditor } from "./value-editors";
+import CustomFieldValueFields from "./CustomFieldValueFields";
 
 /** One `{definition, value}` pair as carried on `Task.customFieldValues`. */
 export interface CustomFieldValuePair {
@@ -138,35 +136,16 @@ const CustomFieldValueList = ({
         </Alert>
       )}
 
-      <div className="space-y-4">
-        {definitions.map((def) => (
-          <div key={def["@id"]} className="space-y-1.5">
-            <div className="flex items-center justify-between gap-2">
-              <label className="text-sm font-medium">
-                {def.name}
-                {!def.nullable && (
-                  <span className="ml-0.5 text-destructive" aria-hidden>
-                    *
-                  </span>
-                )}
-              </label>
-              <Badge variant="outline" className="shrink-0 text-[10px] uppercase">
-                {subtypeLabelFor(def.kind, def.subtype)}
-              </Badge>
-            </div>
-            <CustomFieldValueEditor
-              definition={def}
-              value={working[def["@id"]] ?? null}
-              onChange={(next) => handleChange(def["@id"], next)}
-              error={violationFor(violations, def["@id"])}
-              disabled={disabled}
-              projectIri={projectIri}
-              spaceIri={spaceIri}
-              users={users}
-            />
-          </div>
-        ))}
-      </div>
+      <CustomFieldValueFields
+        definitions={definitions}
+        values={working}
+        onChange={handleChange}
+        violations={violations}
+        projectIri={projectIri}
+        spaceIri={spaceIri}
+        users={users}
+        disabled={disabled}
+      />
     </section>
   );
 };

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -12,7 +12,9 @@ import MarkdownEditor from "@/components/editor/MarkdownEditor";
 import ActivityPanel from "@/components/activity/ActivityPanel";
 import CustomFieldFooterRow from "@/components/custom-fields/CustomFieldFooterRow";
 import CustomFieldValueCell from "@/components/custom-fields/CustomFieldValueCell";
+import CustomFieldValueFields from "@/components/tasks/CustomFieldValueFields";
 import TaskDetailDrawer from "@/components/tasks/TaskDetailDrawer";
+import { violationsFromBody, type ViolationMap } from "@/lib/violations";
 import UserAvatar from "@/components/user/UserAvatar";
 import type { AssigneeOption } from "@/components/tasks/AssigneesCombobox";
 import type { TagOption } from "@/components/tasks/TagsCombobox";
@@ -90,6 +92,12 @@ const membersOf = <T,>(c: Collection<T>): T[] =>
 const projectSpaceIri = (project: Project): string =>
   typeof project.space === "string" ? project.space : project.space["@id"];
 
+const isEmptyFieldValue = (value: unknown): boolean =>
+  value === null ||
+  value === undefined ||
+  value === "" ||
+  (Array.isArray(value) && value.length === 0);
+
 // Due-date buckets for the grouped list, in render order.
 type Bucket = "overdue" | "week" | "later" | "none" | "done";
 const BUCKET_LABELS: Record<Bucket, string> = {
@@ -134,6 +142,12 @@ const ProjectDetail = () => {
   const [addOpen, setAddOpen] = useState(false);
   const [newTaskTitle, setNewTaskTitle] = useState("");
   const [newTaskDescription, setNewTaskDescription] = useState("");
+  // Custom-field values for the new task, keyed by definition IRI, plus any
+  // per-field validation messages re-mapped from a 422.
+  const [newTaskFieldValues, setNewTaskFieldValues] = useState<
+    Record<string, unknown>
+  >({});
+  const [newTaskFieldErrors, setNewTaskFieldErrors] = useState<ViolationMap>({});
   const [isCreatingTask, setIsCreatingTask] = useState(false);
   const [taskEditorKey, setTaskEditorKey] = useState(0);
 
@@ -263,6 +277,20 @@ const ProjectDetail = () => {
     if (!project || !newTaskTitle.trim()) return;
     setIsCreatingTask(true);
     setError(null);
+    setNewTaskFieldErrors({});
+
+    // Build the value array in definition order, dropping empties, and keep an
+    // index→definition map so `customFieldValues[i]` violations land on the
+    // right field row (mirrors CustomFieldValueList's persist path).
+    const customFieldValues: { definition: string; value: unknown }[] = [];
+    const indexToDef: string[] = [];
+    for (const def of definitions) {
+      const value = newTaskFieldValues[def["@id"]];
+      if (isEmptyFieldValue(value)) continue;
+      indexToDef.push(def["@id"]);
+      customFieldValues.push({ definition: def["@id"], value });
+    }
+
     try {
       const res = await fetch(`${ENTRYPOINT}/tasks`, {
         method: "POST",
@@ -272,18 +300,40 @@ const ProjectDetail = () => {
           title: newTaskTitle.trim(),
           description: newTaskDescription.trim() || null,
           project: project["@id"],
+          ...(customFieldValues.length > 0 ? { customFieldValues } : {}),
         }),
       });
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
-        throw new Error(
-          data.description || data.detail || data["hydra:description"] || "Failed to create task.",
-        );
+        // Re-key customFieldValues[i] violations onto their definition IRI so
+        // each field shows its own error; surface anything else as the banner.
+        const fieldErrors: ViolationMap = {};
+        let otherError: string | null = null;
+        for (const [path, message] of Object.entries(violationsFromBody(data))) {
+          const match = path.match(/^customFieldValues\[(\d+)\]/);
+          const defIri = match ? indexToDef[Number(match[1])] : undefined;
+          if (defIri) fieldErrors[defIri] = message;
+          else otherError = message;
+        }
+        setNewTaskFieldErrors(fieldErrors);
+        const hasFieldErrors = Object.keys(fieldErrors).length > 0;
+        if (otherError || !hasFieldErrors) {
+          setError(
+            otherError ||
+              data.description ||
+              data.detail ||
+              data["hydra:description"] ||
+              "Failed to create task.",
+          );
+        }
+        return;
       }
       const created: ProjectTask = await res.json();
       setTasks((prev) => [...prev, created]);
       setNewTaskTitle("");
       setNewTaskDescription("");
+      setNewTaskFieldValues({});
+      setNewTaskFieldErrors({});
       setTaskEditorKey((k) => k + 1);
       setAddOpen(false);
     } catch (err) {
@@ -630,6 +680,26 @@ const ProjectDetail = () => {
                           onChange={setNewTaskDescription}
                         />
                       </div>
+                      {project && definitions.length > 0 && (
+                        <div className="space-y-3" data-testid="new-task-custom-fields">
+                          <Label>Custom fields</Label>
+                          <CustomFieldValueFields
+                            definitions={definitions}
+                            values={newTaskFieldValues}
+                            onChange={(defIri, next) =>
+                              setNewTaskFieldValues((prev) => ({
+                                ...prev,
+                                [defIri]: next,
+                              }))
+                            }
+                            violations={newTaskFieldErrors}
+                            projectIri={project["@id"]}
+                            spaceIri={projectSpaceIri(project)}
+                            users={assignableUsers}
+                            disabled={isCreatingTask}
+                          />
+                        </div>
+                      )}
                       <div className="flex gap-2">
                         <Button type="submit" disabled={isCreatingTask || !newTaskTitle.trim()}>
                           {isCreatingTask ? "Adding..." : "Add task"}
@@ -637,7 +707,11 @@ const ProjectDetail = () => {
                         <Button
                           type="button"
                           variant="outline"
-                          onClick={() => setAddOpen(false)}
+                          onClick={() => {
+                            setAddOpen(false);
+                            setNewTaskFieldValues({});
+                            setNewTaskFieldErrors({});
+                          }}
                         >
                           Cancel
                         </Button>


### PR DESCRIPTION
The project page's **Add task** form now renders the project's custom field definitions, so values can be set at creation time instead of only after the task exists.

- Non-empty values POST as `customFieldValues`; the backend already accepts this on create (`task:write`).
- Per-field 422s (`customFieldValues[i].value`) map back onto their field rows; other errors stay in the banner.
- Extracts the per-field editor list shared with the task drawer into a controlled, stateless `CustomFieldValueFields` component, reused by both `CustomFieldValueList` and the new-task form.

Known limitation: a *required* field left empty surfaces as the form banner (collection-level violation) rather than inline, matching the drawer's behavior.

Verified: PWA typecheck + ESLint clean; backend contract covered by existing `TaskCustomFieldValueTest`.