### PR TITLE
feat(custom-fields): editor sheet — row actions, live preview, money currency

### DIFF
--- a/api/src/Controller/CustomFieldDefinitionActivityController.php
+++ b/api/src/Controller/CustomFieldDefinitionActivityController.php
@@ -20,13 +20,15 @@ use Symfony\Component\Uid\Uuid;
 /**
  * Project-level change log for the custom-fields schema:
  * `GET /projects/{id}/custom_field_definitions/activity`. Merges the
- * Gedmo audit history of every custom field definition currently in the
- * project, newest-first, reusing {@see ActivityFeedQuery} so the shape
- * matches the task/project feeds (rows + actor map).
+ * Gedmo audit history of every custom field definition in the project,
+ * newest-first, reusing {@see ActivityFeedQuery} so the shape matches the
+ * task/project feeds (rows + actor map).
  *
- * History for fields that have since been deleted falls out of scope —
- * we can only key on the project's current definition ids. Access mirrors
- * the project surface: any space member; 404 otherwise.
+ * Fields that have since been deleted stay in the log: their rows outlive
+ * the entity (the audit table has no FK to it), and we recover their object
+ * ids from the versioned `project` stamped on each create/update entry — so a
+ * deleted field's history, ending in its `remove` event, remains visible.
+ * Access mirrors the project surface: any space member; 404 otherwise.
  */
 class CustomFieldDefinitionActivityController extends AbstractController
 {
@@ -57,13 +59,45 @@ class CustomFieldDefinitionActivityController extends AbstractController
 
         $definitions = $this->em->getRepository(CustomFieldDefinition::class)
             ->findBy(['project' => $project]);
-        $objectIds = array_values(
-            array_map(static fn (CustomFieldDefinition $d): string => (string) $d->getId(), $definitions),
+        $currentIds = array_map(
+            static fn (CustomFieldDefinition $d): string => (string) $d->getId(),
+            $definitions,
         );
+
+        // Union current ids with the ids of fields that were deleted from this
+        // project (recovered from the audit log via the versioned `project`).
+        $objectIds = array_values(array_unique(
+            [...$currentIds, ...$this->deletedDefinitionIds($project)],
+        ));
 
         return new JsonResponse(
             $this->activityFeed->forClass(CustomFieldDefinition::class, $objectIds, $request),
         );
+    }
+
+    /**
+     * Object ids of custom field definitions that once belonged to this project
+     * but no longer exist — read from the audit log's versioned `project`.
+     *
+     * @return list<string>
+     */
+    private function deletedDefinitionIds(Project $project): array
+    {
+        // Gedmo stores the versioned association nested as {"id": "<uuid>"}.
+        $rows = $this->em->getConnection()->executeQuery(
+            "SELECT DISTINCT object_id FROM ext_log_entries
+             WHERE object_class = :class AND data->'project'->>'id' = :project",
+            [
+                'class' => CustomFieldDefinition::class,
+                'project' => (string) $project->getId(),
+            ],
+        )->fetchFirstColumn();
+
+        // object_id is a VARCHAR column, so values are strings; filter defensively.
+        return array_values(array_filter(
+            $rows,
+            static fn (mixed $id): bool => is_string($id),
+        ));
     }
 
     private function canRead(Project $project, User $user): bool

--- a/api/src/Entity/CustomFieldDefinition.php
+++ b/api/src/Entity/CustomFieldDefinition.php
@@ -109,6 +109,10 @@ class CustomFieldDefinition
     #[ORM\ManyToOne(targetEntity: Project::class)]
     #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
     #[Assert\NotNull(message: 'Project is required.')]
+    // Versioned so the audit log records which project the field belonged to —
+    // the change-log endpoint keys on this to recover the history of fields
+    // that have since been deleted (their log rows outlive the row itself).
+    #[Gedmo\Versioned]
     #[Groups(['custom_field_definition:read', 'custom_field_definition:write'])]
     private ?Project $project = null;
 

--- a/api/tests/Api/CustomFieldDefinitionActivityTest.php
+++ b/api/tests/Api/CustomFieldDefinitionActivityTest.php
@@ -81,6 +81,49 @@ class CustomFieldDefinitionActivityTest extends ApiTestCase
         $this->assertSame('CustomFieldDefinition', $first['objectClass'] ?? null);
     }
 
+    public function testActivityRetainsDeletedFieldWithRemoveEvent(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        $created = $client->request('POST', '/custom_field_definitions', [
+            'json' => [
+                'project' => '/projects/' . $project->getId(),
+                'name' => 'Severity',
+                'kind' => 'text',
+                'subtype' => 'text',
+                'config' => ['multi' => false],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $iri = $created['@id'] ?? null;
+        self::assertIsString($iri);
+
+        // Delete the field — its audit rows outlive the entity.
+        $client->request('DELETE', $iri);
+        $this->assertResponseStatusCodeSame(204);
+
+        // The change log still surfaces the field's create history plus a
+        // remove event, rather than dropping it entirely.
+        $client->request('GET', '/projects/' . $project->getId() . '/custom_field_definitions/activity');
+        $this->assertResponseIsSuccessful();
+        $body = $client->getResponse()->toArray();
+
+        $items = $body['items'] ?? null;
+        $this->assertIsArray($items);
+        $actions = [];
+        foreach ($items as $item) {
+            $this->assertIsArray($item);
+            $actions[] = $item['action'] ?? null;
+        }
+        $this->assertContains('create', $actions, 'deleted field create history is retained');
+        $this->assertContains('remove', $actions, 'deletion is recorded as a remove event');
+    }
+
     public function testStrangerGets404(): void
     {
         $alice = $this->createUser('alice@example.com');

--- a/pwa/components/common/ConfirmDialog.tsx
+++ b/pwa/components/common/ConfirmDialog.tsx
@@ -1,0 +1,110 @@
+import { useState } from "react";
+import { Loader2 } from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+export interface ConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description?: React.ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /** Style the confirm button as destructive (red). */
+  destructive?: boolean;
+  /**
+   * Run on confirm. While it's pending the buttons disable and the confirm
+   * button shows a spinner; if it throws, the dialog stays open and surfaces
+   * the error inline. On success the dialog closes.
+   */
+  onConfirm: () => void | Promise<void>;
+}
+
+/**
+ * Shared confirmation modal — the replacement for scattered `window.confirm`
+ * calls. Controlled via `open` / `onOpenChange`, it owns the async confirm
+ * lifecycle (pending spinner, inline error, close-on-success), so callers just
+ * pass an `onConfirm` that throws on failure. While the action is in flight the
+ * dialog can't be dismissed (Escape / outside-click / X are ignored).
+ */
+const ConfirmDialog = ({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  destructive,
+  onConfirm,
+}: ConfirmDialogProps) => {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const close = () => {
+    if (busy) return;
+    setError(null);
+    onOpenChange(false);
+  };
+
+  const handleConfirm = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await onConfirm();
+      onOpenChange(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => (next ? onOpenChange(true) : close())}
+    >
+      <DialogContent className="sm:max-w-md" data-testid="confirm-dialog">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          {description && <DialogDescription>{description}</DialogDescription>}
+        </DialogHeader>
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={close}
+            disabled={busy}
+            data-testid="confirm-dialog-cancel"
+          >
+            {cancelLabel}
+          </Button>
+          <Button
+            type="button"
+            variant={destructive ? "destructive" : "default"}
+            onClick={() => void handleConfirm()}
+            disabled={busy}
+            data-testid="confirm-dialog-confirm"
+          >
+            {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ConfirmDialog;

--- a/pwa/components/custom-fields/CustomFieldSheet.tsx
+++ b/pwa/components/custom-fields/CustomFieldSheet.tsx
@@ -37,6 +37,7 @@ import {
   kindLabelFor,
   subtypeLabelFor,
 } from "./kind-editors";
+import { CustomFieldValueEditor } from "@/components/tasks/value-editors";
 import { fieldHandle } from "./handle";
 import type {
   CustomFieldConfig,
@@ -89,6 +90,42 @@ const errorMessage = async (res: Response): Promise<string> => {
   );
 };
 
+/**
+ * A representative sample value for the live preview, in each subtype's wire
+ * format (matching value-editors.tsx). `reference.*` has no sample IRI, so it
+ * previews empty.
+ */
+const sampleValueFor = (
+  kind: CustomFieldKind,
+  subtype: CustomFieldSubtype,
+  config: CustomFieldConfig,
+): unknown => {
+  const multi = Boolean(config.multi) || subtype === "multi";
+  switch (kind) {
+    case "boolean":
+      return true;
+    case "numeric":
+      if (subtype === "money") {
+        return { amount: 123450, currency: config.currency ?? "USD" };
+      }
+      return subtype === "int" ? 42 : 42.5;
+    case "text":
+      if (subtype === "url") return "https://example.com";
+      return multi ? ["Sample"] : "Sample text";
+    case "date":
+      if (subtype === "time") return "09:00";
+      if (subtype === "datetime") return "2026-06-20T09:00";
+      return "2026-06-20";
+    case "select": {
+      const first = config.options?.[0]?.key;
+      if (first === undefined) return multi ? [] : null;
+      return multi ? [first] : first;
+    }
+    default:
+      return null; // reference — no sample IRI available
+  }
+};
+
 const CustomFieldSheet = ({
   open,
   onOpenChange,
@@ -117,6 +154,30 @@ const CustomFieldSheet = ({
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [optionStats, setOptionStats] = useState<Record<string, number>>({});
+
+  // Live preview: build a definition from the current form state and render
+  // the real task value editor seeded with a representative sample, so the
+  // author sees exactly how the field behaves on a task.
+  const previewDefinition = useMemo<CustomFieldDefinition>(
+    () => ({
+      "@id": "preview",
+      id: "preview",
+      name: name || "Field",
+      kind,
+      subtype,
+      config,
+      footer,
+      nullable,
+      position: 0,
+    }),
+    [name, kind, subtype, config, footer, nullable],
+  );
+  const [previewValue, setPreviewValue] = useState<unknown>(() =>
+    sampleValueFor(kind, subtype, config),
+  );
+  useEffect(() => {
+    setPreviewValue(sampleValueFor(kind, subtype, config));
+  }, [kind, subtype, config]);
 
   // Re-seed the form whenever the sheet opens (new vs edit, or a
   // different field).
@@ -347,7 +408,7 @@ const CustomFieldSheet = ({
           onSubmit={handleSubmit}
           className="flex min-h-0 flex-1 flex-col"
         >
-          <div className="flex-1 space-y-4 overflow-y-auto px-5 py-4">
+          <div className="flex flex-1 flex-col space-y-4 overflow-y-auto px-5 py-4">
             <div className="space-y-1.5">
               <Label htmlFor="cf-name">Name</Label>
               <Input
@@ -397,19 +458,6 @@ const CustomFieldSheet = ({
                   ))}
                 </select>
               </div>
-            </div>
-
-            <div className="flex flex-wrap items-center gap-2 text-xs">
-              <span
-                className={cn("h-1.5 w-1.5 rounded-full", KIND_BADGE[kind].dot)}
-              />
-              <span className="text-muted-foreground">
-                {kindLabelFor(kind).toLowerCase()} ·{" "}
-                {subtypeLabelFor(kind, subtype).toLowerCase()}
-              </span>
-              <span className="rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground">
-                nullable = {String(nullable)}
-              </span>
             </div>
 
             {kind !== "boolean" && (
@@ -553,6 +601,41 @@ const CustomFieldSheet = ({
                 <AlertDescription>{error}</AlertDescription>
               </Alert>
             )}
+
+            {/* Preview pinned to the bottom, set off from the form above. */}
+            <div className="mt-auto space-y-3 border-t pt-8">
+              <div className="space-y-2">
+                <div>
+                  <h3 className="text-base font-semibold text-foreground">
+                    Preview
+                  </h3>
+                  <p className="text-xs text-muted-foreground">
+                    How this field appears when filling in a task.
+                  </p>
+                </div>
+                <div className="rounded-md border bg-muted/20 p-3" data-testid="custom-field-preview">
+                  <CustomFieldValueEditor
+                    definition={previewDefinition}
+                    value={previewValue}
+                    onChange={setPreviewValue}
+                    projectIri={projectIri}
+                  />
+                </div>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-2 text-xs">
+                <span
+                  className={cn("h-1.5 w-1.5 rounded-full", KIND_BADGE[kind].dot)}
+                />
+                <span className="text-muted-foreground">
+                  {kindLabelFor(kind).toLowerCase()} ·{" "}
+                  {subtypeLabelFor(kind, subtype).toLowerCase()}
+                </span>
+                <span className="rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground">
+                  nullable = {String(nullable)}
+                </span>
+              </div>
+            </div>
           </div>
 
           <SheetFooter className="flex-row items-center justify-between border-t px-5 py-3">

--- a/pwa/components/custom-fields/CustomFieldSheet.tsx
+++ b/pwa/components/custom-fields/CustomFieldSheet.tsx
@@ -248,6 +248,14 @@ const CustomFieldSheet = ({
     setSubtype(next);
     if (kind === "select") {
       setConfig((prev) => ({ ...prev, multi: next === "multi" }));
+    } else if (kind === "numeric" && next === "money") {
+      // Money requires a currency; seed the default so the picker's shown
+      // value is actually stored and submit works without touching it.
+      setConfig((prev) => ({
+        ...prev,
+        multi: false,
+        currency: prev.currency ?? "USD",
+      }));
     } else if (descriptor.noMultiSubtypes?.includes(next)) {
       setConfig((prev) => ({ ...prev, multi: false }));
     }

--- a/pwa/components/custom-fields/CustomFieldsManager.tsx
+++ b/pwa/components/custom-fields/CustomFieldsManager.tsx
@@ -13,7 +13,7 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { CircleCheck, Copy, GripVertical, History, Plus, Settings } from "lucide-react";
+import { CircleCheck, Copy, GripVertical, History, Pencil, Plus, Trash2 } from "lucide-react";
 import { ENTRYPOINT } from "@/config/entrypoint";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -29,6 +29,7 @@ import {
 import { cn } from "@/lib/utils";
 import CustomFieldSheet from "./CustomFieldSheet";
 import CustomFieldChangeLog from "./CustomFieldChangeLog";
+import ConfirmDialog from "@/components/common/ConfirmDialog";
 import { fieldHandle } from "./handle";
 import { KIND_BADGE, kindLabelFor, subtypeLabelFor } from "./kind-editors";
 import type {
@@ -100,6 +101,9 @@ const CustomFieldsManager = ({
   const [filled, setFilled] = useState<Record<string, number>>({});
   const [sheetOpen, setSheetOpen] = useState(false);
   const [editing, setEditing] = useState<CustomFieldDefinition | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<CustomFieldDefinition | null>(
+    null,
+  );
   // Bumped on every open so the drawer remounts fresh each time. Reusing one
   // Radix Dialog instance and toggling `open` back on while its close (exit)
   // animation is still pending leaves Radix's Presence state machine stuck and
@@ -183,6 +187,17 @@ const CustomFieldsManager = ({
 
   const handleDeleted = (def: CustomFieldDefinition) => {
     setDefs((prev) => prev.filter((d) => d["@id"] !== def["@id"]));
+  };
+
+  // Deletion is confirmed through the shared ConfirmDialog; the action throws
+  // on failure so the modal surfaces the error and stays open.
+  const confirmDelete = async (def: CustomFieldDefinition) => {
+    const res = await fetch(`${ENTRYPOINT}${def["@id"]}`, {
+      method: "DELETE",
+      credentials: "include",
+    });
+    if (!res.ok) throw new Error(await errorMessage(res));
+    handleDeleted(def);
   };
 
   // Client-side duplicate — there's no copy endpoint, so we POST a fresh
@@ -371,7 +386,7 @@ const CustomFieldsManager = ({
                 <TableHead>Footer</TableHead>
                 <TableHead className="text-right">Filled</TableHead>
                 {isSpaceAdmin && (
-                  <TableHead className="w-20 text-right">Actions</TableHead>
+                  <TableHead className="w-28 text-right">Actions</TableHead>
                 )}
               </TableRow>
             </TableHeader>
@@ -395,6 +410,7 @@ const CustomFieldsManager = ({
                       draggable={isSpaceAdmin && defs.length > 1}
                       onEdit={() => openEdit(def)}
                       onDuplicate={() => void handleDuplicate(def)}
+                      onDelete={() => setDeleteTarget(def)}
                     />
                   ))}
                 </SortableContext>
@@ -439,6 +455,26 @@ const CustomFieldsManager = ({
         onOpenChange={setChangeLogOpen}
         projectId={projectId}
       />
+
+      {deleteTarget && (
+        <ConfirmDialog
+          open
+          onOpenChange={(next) => {
+            if (!next) setDeleteTarget(null);
+          }}
+          title="Delete custom field"
+          description={
+            <>
+              Delete custom field &ldquo;
+              <span className="font-medium">{deleteTarget.name}</span>&rdquo;?
+              Existing values on tasks will also be removed.
+            </>
+          }
+          confirmLabel="Delete"
+          destructive
+          onConfirm={() => confirmDelete(deleteTarget)}
+        />
+      )}
     </div>
   );
 };
@@ -451,6 +487,7 @@ const FieldRow = ({
   draggable,
   onEdit,
   onDuplicate,
+  onDelete,
 }: {
   def: CustomFieldDefinition;
   total: number;
@@ -459,6 +496,7 @@ const FieldRow = ({
   draggable: boolean;
   onEdit: () => void;
   onDuplicate: () => void;
+  onDelete: () => void;
 }) => {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({ id: def["@id"], disabled: !draggable });
@@ -540,22 +578,33 @@ const FieldRow = ({
               size="icon"
               variant="ghost"
               className="h-8 w-8"
-              onClick={onEdit}
-              aria-label={`Edit ${def.name}`}
-              data-testid="custom-field-edit"
+              onClick={onDuplicate}
+              aria-label={`Duplicate ${def.name}`}
+              data-testid="custom-field-duplicate"
             >
-              <Settings className="h-3.5 w-3.5" />
+              <Copy className="h-3.5 w-3.5" />
             </Button>
             <Button
               type="button"
               size="icon"
               variant="ghost"
               className="h-8 w-8"
-              onClick={onDuplicate}
-              aria-label={`Duplicate ${def.name}`}
-              data-testid="custom-field-duplicate"
+              onClick={onEdit}
+              aria-label={`Edit ${def.name}`}
+              data-testid="custom-field-edit"
             >
-              <Copy className="h-3.5 w-3.5" />
+              <Pencil className="h-3.5 w-3.5" />
+            </Button>
+            <Button
+              type="button"
+              size="icon"
+              variant="ghost"
+              className="h-8 w-8 text-muted-foreground hover:text-destructive"
+              onClick={onDelete}
+              aria-label={`Delete ${def.name}`}
+              data-testid="custom-field-delete"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
             </Button>
           </div>
         </TableCell>

--- a/pwa/components/custom-fields/kind-editors.tsx
+++ b/pwa/components/custom-fields/kind-editors.tsx
@@ -37,7 +37,6 @@ import { AVATAR_PALETTE } from "@/lib/avatarPalette";
 import { cn } from "@/lib/utils";
 import {
   CURRENCIES,
-  currencyFractionDigits,
   findCurrency,
   type CurrencyInfo,
 } from "@/lib/currencies";
@@ -90,7 +89,7 @@ export const KIND_DESCRIPTORS: Record<CustomFieldKind, KindDescriptor> = {
     label: "Numeric",
     subtypes: [
       { value: "int", label: "Integer" },
-      { value: "float", label: "Number" },
+      { value: "float", label: "Decimal" },
       { value: "money", label: "Money" },
     ],
     supportsMulti: true,
@@ -489,8 +488,6 @@ const PatternCheck = ({
 const MoneyEditor = ({ config, update }: SubEditorProps) => {
   const code = config.currency ?? "USD";
   const selected = findCurrency(code) ?? null;
-  const digits = currencyFractionDigits(code);
-  const preview = formatMoneyPreview(1234.5, code, digits);
 
   return (
     <div className="space-y-3">
@@ -521,43 +518,12 @@ const MoneyEditor = ({ config, update }: SubEditorProps) => {
         </Combobox>
       </div>
 
-      <div className="flex items-center justify-between rounded-md border border-input bg-muted/40 px-3 py-2">
-        <div>
-          <p className="text-xs uppercase tracking-wide text-muted-foreground">
-            Decimal places
-          </p>
-          <p className="text-sm font-medium">{digits}</p>
-        </div>
-        <div className="text-right">
-          <p className="text-xs uppercase tracking-wide text-muted-foreground">
-            Preview
-          </p>
-          <p className="text-lg font-semibold tabular-nums">{preview}</p>
-        </div>
-      </div>
       <p className="text-xs text-muted-foreground">
         Precision follows the currency (ISO-4217); amounts are stored in
         minor units.
       </p>
     </div>
   );
-};
-
-const formatMoneyPreview = (
-  major: number,
-  code: string,
-  digits: number,
-): string => {
-  try {
-    return new Intl.NumberFormat(undefined, {
-      style: "currency",
-      currency: code,
-      minimumFractionDigits: digits,
-      maximumFractionDigits: digits,
-    }).format(major);
-  } catch {
-    return major.toFixed(digits);
-  }
 };
 
 /* ------------------------------------------------------------------ */

--- a/pwa/components/dev/registry.ts
+++ b/pwa/components/dev/registry.ts
@@ -28,6 +28,7 @@ export const componentRegistry: RegistryEntry[] = [
   { slug: "checkbox", name: "Checkbox", category: "Form", description: "Boolean input with controlled and indeterminate states." },
   { slug: "combobox", name: "Combobox", category: "Form", description: "Searchable select with multi-value chips." },
   { slug: "command", name: "Command", category: "Overlay", description: "Command palette built on cmdk." },
+  { slug: "confirm-dialog", name: "ConfirmDialog", category: "Overlay", description: "Shared confirmation modal (replaces window.confirm) with async confirm, spinner, and inline error." },
   { slug: "dialog", name: "Dialog", category: "Overlay", description: "Modal dialog with title, body, and actions." },
   { slug: "dropdown-menu", name: "Dropdown Menu", category: "Overlay", description: "Anchored menu with items, separators, and submenus." },
   { slug: "formik-field", name: "FormikField", category: "Form", description: "Formik-aware label + input + error wrapper." },

--- a/pwa/components/tasks/CustomFieldValueFields.tsx
+++ b/pwa/components/tasks/CustomFieldValueFields.tsx
@@ -16,6 +16,9 @@ interface CustomFieldValueFieldsProps {
   spaceIri?: string | null;
   users?: AvatarUser[];
   disabled?: boolean;
+  /** Compact mode (e.g. the new-task form): drop the per-field subtype badge
+   *  and editor adornments, for a tighter inline form. */
+  compact?: boolean;
 }
 
 /**
@@ -33,6 +36,7 @@ const CustomFieldValueFields = ({
   spaceIri,
   users,
   disabled,
+  compact,
 }: CustomFieldValueFieldsProps) => (
   <div className="space-y-4">
     {definitions.map((def) => (
@@ -46,9 +50,11 @@ const CustomFieldValueFields = ({
               </span>
             )}
           </label>
-          <Badge variant="outline" className="shrink-0 text-[10px] uppercase">
-            {subtypeLabelFor(def.kind, def.subtype)}
-          </Badge>
+          {!compact && (
+            <Badge variant="outline" className="shrink-0 text-[10px] uppercase">
+              {subtypeLabelFor(def.kind, def.subtype)}
+            </Badge>
+          )}
         </div>
         <CustomFieldValueEditor
           definition={def}
@@ -59,6 +65,7 @@ const CustomFieldValueFields = ({
           projectIri={projectIri}
           spaceIri={spaceIri}
           users={users}
+          compact={compact}
         />
       </div>
     ))}

--- a/pwa/components/tasks/value-editors.tsx
+++ b/pwa/components/tasks/value-editors.tsx
@@ -69,6 +69,9 @@ export interface ValueEditorProps {
   spaceIri?: string | null;
   /** Space members for reference.user (avoids a fetch). */
   users?: AvatarUser[];
+  /** Compact mode (e.g. the new-task form): drop redundant adornments like
+   *  the money currency badge. */
+  compact?: boolean;
 }
 
 const isMulti = (definition: CustomFieldDefinition): boolean =>
@@ -270,6 +273,7 @@ const MoneyValue = ({
   onChange,
   disabled,
   error,
+  compact,
 }: ValueEditorProps) => {
   const currency = definition.config.currency ?? "USD";
   const digits = currencyFractionDigits(currency);
@@ -313,9 +317,11 @@ const MoneyValue = ({
         className="tabular-nums"
         data-testid="custom-field-value-money"
       />
-      <Badge variant="outline" className="shrink-0 font-mono text-xs">
-        {currency}
-      </Badge>
+      {!compact && (
+        <Badge variant="outline" className="shrink-0 font-mono text-xs">
+          {currency}
+        </Badge>
+      )}
     </div>
   );
 };

--- a/pwa/components/tasks/value-editors.tsx
+++ b/pwa/components/tasks/value-editors.tsx
@@ -18,6 +18,12 @@ import {
 } from "@/components/ui/combobox";
 import { Input } from "@/components/ui/input";
 import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+  InputGroupText,
+} from "@/components/ui/input-group";
+import {
   Popover,
   PopoverContent,
   PopoverTrigger,
@@ -303,20 +309,22 @@ const MoneyValue = ({
 
   return (
     <div className="flex items-center gap-2">
-      <span className="text-sm text-muted-foreground">
-        {currencySymbol(currency)}
-      </span>
-      <Input
-        type="number"
-        step={digits === 0 ? 1 : 1 / factor}
-        value={text}
-        onChange={(e) => setText(e.target.value)}
-        onBlur={(e) => commit(e.target.value)}
-        disabled={disabled}
-        aria-invalid={Boolean(error)}
-        className="tabular-nums"
-        data-testid="custom-field-value-money"
-      />
+      <InputGroup className="flex-1">
+        <InputGroupAddon>
+          <InputGroupText>{currencySymbol(currency)}</InputGroupText>
+        </InputGroupAddon>
+        <InputGroupInput
+          type="number"
+          step={digits === 0 ? 1 : 1 / factor}
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onBlur={(e) => commit(e.target.value)}
+          disabled={disabled}
+          aria-invalid={Boolean(error)}
+          className="tabular-nums"
+          data-testid="custom-field-value-money"
+        />
+      </InputGroup>
       {!compact && (
         <Badge variant="outline" className="shrink-0 font-mono text-xs">
           {currency}

--- a/pwa/pages/dev/components/confirm-dialog.tsx
+++ b/pwa/pages/dev/components/confirm-dialog.tsx
@@ -1,0 +1,73 @@
+import { useState } from "react";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+import ConfirmDialog from "@/components/common/ConfirmDialog";
+import { Button } from "@/components/ui/button";
+
+const Basic = () => {
+  const [open, setOpen] = useState(false);
+  const [done, setDone] = useState(false);
+  return (
+    <div className="space-y-2">
+      <Button
+        variant="destructive"
+        size="sm"
+        onClick={() => {
+          setDone(false);
+          setOpen(true);
+        }}
+      >
+        Delete item
+      </Button>
+      {done && <p className="text-sm text-muted-foreground">Item deleted.</p>}
+      <ConfirmDialog
+        open={open}
+        onOpenChange={setOpen}
+        title="Delete item"
+        description="This can’t be undone."
+        confirmLabel="Delete"
+        destructive
+        onConfirm={async () => {
+          // Simulate an async request; throw here to keep the dialog open and
+          // show an inline error instead.
+          await new Promise((resolve) => setTimeout(resolve, 600));
+          setDone(true);
+        }}
+      />
+    </div>
+  );
+};
+
+const ConfirmDialogPage = () => (
+  <ComponentDoc
+    name="ConfirmDialog"
+    description="Shared confirmation modal — the replacement for scattered `window.confirm` calls. Controlled via `open` / `onOpenChange`, it owns the async confirm lifecycle: the confirm button shows a spinner while `onConfirm` runs, an `onConfirm` that throws keeps the dialog open and surfaces the error inline, and a resolved `onConfirm` closes it. While the action is in flight the dialog can't be dismissed (Escape / outside-click / X ignored). Pass `destructive` to style the confirm button red."
+    importPath={`import ConfirmDialog from "@/components/common/ConfirmDialog";`}
+    examples={[
+      {
+        title: "Destructive confirm with an async action",
+        description:
+          "The confirm button spins while onConfirm runs and closes on success. Have onConfirm throw to keep it open with an inline error.",
+        code: `const [open, setOpen] = useState(false);
+
+<Button variant="destructive" onClick={() => setOpen(true)}>
+  Delete item
+</Button>
+
+<ConfirmDialog
+  open={open}
+  onOpenChange={setOpen}
+  title="Delete item"
+  description="This can’t be undone."
+  confirmLabel="Delete"
+  destructive
+  onConfirm={async () => {
+    await api.delete(id); // throw to keep the dialog open + show the error
+  }}
+/>`,
+        preview: <Basic />,
+      },
+    ]}
+  />
+);
+
+export default ConfirmDialogPage;

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -681,8 +681,7 @@ const ProjectDetail = () => {
                         />
                       </div>
                       {project && definitions.length > 0 && (
-                        <div className="space-y-3" data-testid="new-task-custom-fields">
-                          <Label>Custom fields</Label>
+                        <div data-testid="new-task-custom-fields">
                           <CustomFieldValueFields
                             definitions={definitions}
                             values={newTaskFieldValues}
@@ -697,6 +696,7 @@ const ProjectDetail = () => {
                             spaceIri={projectSpaceIri(project)}
                             users={assignableUsers}
                             disabled={isCreatingTask}
+                            compact
                           />
                         </div>
                       )}


### PR DESCRIPTION
Custom-field editor UX improvements (PR 1/5 of the feature/wip batch).

- Shared `ConfirmDialog` confirmation modal
- Pencil-edit + trash-delete row actions on the custom-fields list
- Compact custom-field editors on the new-task form
- Live value preview on the editor sheet
- Money: default currency to USD; render the currency symbol inside the input
- API: keep custom-field change-log history when a field is deleted (recover via the versioned project)

Squash-merges as one changelog entry.