### PR TITLE
feat(pwa): task detail drawer redesign + dormant relative reminders

### DIFF
--- a/api/src/Controller/ProjectActivityController.php
+++ b/api/src/Controller/ProjectActivityController.php
@@ -51,14 +51,36 @@ class ProjectActivityController extends AbstractController
             return new JsonResponse(['error' => 'Not found.'], 404);
         }
 
-        $taskIds = array_values(array_map(
+        $taskIds = array_map(
             static fn (Task $t): string => (string) $t->getId(),
             $project->getTasks()->toArray(),
-        ));
+        );
+
+        // Tasks deleted from this project keep their audit rows (the log table
+        // has no FK to the task). Recover their object ids from the versioned
+        // `project` recorded on each create/update entry so the board's history
+        // still shows a deleted task's lifecycle, ending in its remove event.
+        // Gedmo serialises the versioned association as `{"id": "<uuid>"}`, so
+        // reach into the nested id rather than comparing the whole object.
+        $sql = <<<'SQL'
+            SELECT DISTINCT object_id
+            FROM ext_log_entries
+            WHERE object_class = :class AND data->'project'->>'id' = :pid
+            SQL;
+        $rows = $this->em->getConnection()
+            ->executeQuery($sql, [
+                'class' => Task::class,
+                'pid' => (string) $project->getId(),
+            ])
+            ->fetchFirstColumn();
+        // object_id is a VARCHAR column, so values are strings; filter defensively.
+        $deleted = array_filter($rows, static fn (mixed $oid): bool => is_string($oid));
+
+        $allTaskIds = array_values(array_unique([...$taskIds, ...$deleted]));
 
         return new JsonResponse($this->activityFeed->forObjectGroups([
             Project::class => [(string) $project->getId()],
-            Task::class => $taskIds,
+            Task::class => $allTaskIds,
         ], $request));
     }
 

--- a/api/src/Entity/Task.php
+++ b/api/src/Entity/Task.php
@@ -112,6 +112,10 @@ class Task
      */
     #[ORM\ManyToOne(targetEntity: Project::class, inversedBy: 'tasks')]
     #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    // Versioned so the audit log records which project a task belonged to —
+    // the board's activity feed keys on this to keep a deleted task's history
+    // (ending in its remove event) even after the row is gone.
+    #[Gedmo\Versioned]
     #[Groups(['task:read', 'task:write'])]
     private ?Project $project = null;
 

--- a/api/src/Validator/ValidRemindersValidator.php
+++ b/api/src/Validator/ValidRemindersValidator.php
@@ -40,8 +40,10 @@ final class ValidRemindersValidator extends ConstraintValidator
             return;
         }
 
+        // A relative reminder anchors to the due date, but we allow storing one
+        // before a due date exists: it stays dormant (ReminderScheduler skips it
+        // when there's no anchor) and starts firing once a due date is set.
         $keys = [];
-        $needsDueDate = false;
         foreach ($reminders as $reminder) {
             if (!is_array($reminder) || !$this->scheduler->isValidShape($reminder)) {
                 $this->violate($constraint->messageInvalidShape);
@@ -53,13 +55,6 @@ final class ValidRemindersValidator extends ConstraintValidator
                 return;
             }
             $keys[$key] = true;
-            if ($this->scheduler->requiresDueDate($reminder)) {
-                $needsDueDate = true;
-            }
-        }
-
-        if ($needsDueDate && null === $value->getDueDate()) {
-            $this->violate($constraint->messageRequiresDueDate);
         }
     }
 

--- a/api/tests/Api/ProjectActivityTest.php
+++ b/api/tests/Api/ProjectActivityTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\Project;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Board activity feed: `GET /projects/{id}/activity`. Merges the project's own
+ * history with its tasks', and keeps a deleted task's history (ending in a
+ * remove event) by recovering it from the versioned `project` on the log rows.
+ */
+class ProjectActivityTest extends ApiTestCase
+{
+    use SpaceMembershipFixture;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\ActivityLog')->execute();
+    }
+
+    public function testDeletedTaskStaysInBoardActivity(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        $created = $client->request('POST', '/tasks', [
+            'json' => [
+                'title' => 'Ship it',
+                'project' => '/projects/' . $project->getId(),
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $iri = $created['@id'] ?? null;
+        self::assertIsString($iri);
+
+        // Delete the task — its audit rows outlive the entity.
+        $client->request('DELETE', $iri);
+        $this->assertResponseStatusCodeSame(204);
+
+        // The board's activity still surfaces the task's create history plus a
+        // remove event, rather than dropping it with the row.
+        $client->request('GET', '/projects/' . $project->getId() . '/activity');
+        $this->assertResponseIsSuccessful();
+        $body = $client->getResponse()->toArray();
+
+        $items = $body['items'] ?? null;
+        $this->assertIsArray($items);
+        $taskActions = [];
+        foreach ($items as $item) {
+            $this->assertIsArray($item);
+            if (($item['objectClass'] ?? null) === 'Task') {
+                $taskActions[] = $item['action'] ?? null;
+            }
+        }
+        $this->assertContains('create', $taskActions, 'deleted task create history is retained');
+        $this->assertContains('remove', $taskActions, 'deletion is recorded as a remove event on the board');
+    }
+
+    private function createProject(User $owner, string $title): Project
+    {
+        $project = new Project();
+        $project->setOwner($owner);
+        $project->setTitle($title);
+        $this->addProjectMember($project, $owner);
+        $this->entityManager->persist($project);
+        $this->entityManager->flush();
+
+        return $project;
+    }
+
+    private function createUser(string $email): User
+    {
+        $container = static::getContainer();
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/api/tests/Api/TaskTest.php
+++ b/api/tests/Api/TaskTest.php
@@ -668,8 +668,10 @@ class TaskTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(201);
     }
 
-    public function testRelativeRemindersWithoutDueDateAreRejected(): void
+    public function testRelativeRemindersWithoutDueDateAreStoredDormant(): void
     {
+        // A relative reminder may be configured before a due date exists; it is
+        // stored and stays dormant (never fires) until a due date anchors it.
         $alice = $this->createUser('alice@example.com');
 
         $client = static::createClient();
@@ -684,7 +686,12 @@ class TaskTest extends ApiTestCase
             'headers' => ['Content-Type' => 'application/ld+json'],
         ]);
 
-        $this->assertResponseStatusCodeSame(422);
+        $this->assertResponseStatusCodeSame(201);
+        $task = $this->reloadTaskByTitle('Orphan reminder');
+        $this->assertSame(
+            [['type' => 'relative', 'value' => 1, 'unit' => 'hours', 'repeat' => false]],
+            $task->getReminders(),
+        );
     }
 
     public function testInvalidReminderShapeIsRejected(): void

--- a/e2e/tests/task-detail.spec.js
+++ b/e2e/tests/task-detail.spec.js
@@ -40,10 +40,10 @@ test.describe("Task detail drawer", () => {
       page.locator('[data-testid="task-detail-drawer"]'),
     ).toBeVisible();
 
-    // The three tabs are present.
-    await expect(page.locator('[data-testid="task-tab-details"]')).toBeVisible();
-    await expect(page.locator('[data-testid="task-tab-activity"]')).toBeVisible();
+    // Details show directly (no Details tab); Comments / Activity tabs are at
+    // the bottom of the panel.
     await expect(page.locator('[data-testid="task-tab-comments"]')).toBeVisible();
+    await expect(page.locator('[data-testid="task-tab-activity"]')).toBeVisible();
 
     // Closing the drawer (Escape) removes the deep-link param.
     await page.keyboard.press("Escape");

--- a/pwa/components/tasks/AttachmentsPanel.tsx
+++ b/pwa/components/tasks/AttachmentsPanel.tsx
@@ -10,11 +10,11 @@ import {
   X,
 } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
 import {
   ATTACHMENT_SUPPORTED_MIMES,
   uploadAttachmentFile,
 } from "@/lib/attachments";
-import { cn } from "@/lib/utils";
 
 export interface Attachment {
   "@id": string;
@@ -72,7 +72,6 @@ const AttachmentsPanel = ({
 }: AttachmentsPanelProps) => {
   const [error, setError] = useState<string | null>(null);
   const [busyCount, setBusyCount] = useState(0);
-  const [dragOver, setDragOver] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   // Index into `imageAttachments` (computed below) of the image currently
@@ -308,48 +307,24 @@ const AttachmentsPanel = ({
         </div>
       )}
 
-      <div
-        onDragEnter={(e) => {
-          e.preventDefault();
-          setDragOver(true);
-        }}
-        onDragOver={(e) => e.preventDefault()}
-        onDragLeave={() => setDragOver(false)}
-        onDrop={(e) => {
-          e.preventDefault();
-          setDragOver(false);
-          if (e.dataTransfer.files) void handleFiles(e.dataTransfer.files);
-        }}
-        className={cn(
-          "rounded-md border border-dashed text-sm text-center px-3 py-4 transition-colors",
-          dragOver
-            ? "border-primary bg-primary/5 text-foreground"
-            : "border-input text-muted-foreground",
-        )}
-        data-testid="attachment-dropzone"
-      >
-        <Upload className="h-4 w-4 mx-auto mb-1" aria-hidden="true" />
-        <p>
-          Drop files to attach to{" "}
-          <span className="font-medium text-foreground">"{taskTitle}"</span>, or{" "}
-          <button
-            type="button"
-            onClick={() => fileInputRef.current?.click()}
-            className="text-cyan-700 hover:underline"
-            data-testid="attachment-pick"
-          >
-            choose from your computer
-          </button>
-          .
-        </p>
-        <p className="text-xs mt-1">
+      <div className="space-y-1.5">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={busyCount > 0}
+          aria-label={`Attach files to "${taskTitle}"`}
+          data-testid="attachment-pick"
+        >
+          <Upload className="mr-1.5 h-4 w-4" aria-hidden="true" />
+          {busyCount > 0
+            ? `Uploading ${busyCount} file${busyCount === 1 ? "" : "s"}…`
+            : "Attach files"}
+        </Button>
+        <p className="text-xs text-muted-foreground">
           Up to 10 MB. Images, PDFs, text, CSV, JSON, ZIP.
         </p>
-        {busyCount > 0 && (
-          <p className="text-xs mt-2" data-testid="attachment-uploading">
-            Uploading {busyCount} file{busyCount === 1 ? "" : "s"}…
-          </p>
-        )}
       </div>
 
       <input

--- a/pwa/components/tasks/RemindersEditor.tsx
+++ b/pwa/components/tasks/RemindersEditor.tsx
@@ -42,9 +42,7 @@ const toLocalInput = (iso: string): string => {
 const RemindersEditor = ({ value, dueDate, onChange }: RemindersEditorProps) => {
   const reminders = value ?? [];
   const [adding, setAdding] = useState(false);
-  const [mode, setMode] = useState<"relative" | "absolute">(
-    dueDate ? "relative" : "absolute",
-  );
+  const [mode, setMode] = useState<"relative" | "absolute">("relative");
   const [relValue, setRelValue] = useState(15);
   const [relUnit, setRelUnit] = useState<ReminderUnit>("minutes");
   const [absAt, setAbsAt] = useState("");
@@ -52,7 +50,7 @@ const RemindersEditor = ({ value, dueDate, onChange }: RemindersEditorProps) => 
 
   const resetForm = () => {
     setAdding(false);
-    setMode(dueDate ? "relative" : "absolute");
+    setMode("relative");
     setRelValue(15);
     setRelUnit("minutes");
     setAbsAt("");
@@ -154,10 +152,9 @@ const RemindersEditor = ({ value, dueDate, onChange }: RemindersEditorProps) => 
             <button
               type="button"
               onClick={() => setMode("relative")}
-              disabled={!dueDate}
               aria-pressed={mode === "relative"}
               className={cn(
-                "rounded px-2 py-1 text-xs font-medium transition disabled:opacity-40",
+                "rounded px-2 py-1 text-xs font-medium transition",
                 mode === "relative"
                   ? "bg-primary text-primary-foreground"
                   : "text-muted-foreground hover:text-foreground",
@@ -209,7 +206,13 @@ const RemindersEditor = ({ value, dueDate, onChange }: RemindersEditorProps) => 
               </select>
               <span className="text-sm text-muted-foreground">before due</span>
             </div>
-          ) : (
+          ) : null}
+          {mode === "relative" && !dueDate && (
+            <p className="text-xs text-muted-foreground" data-testid="reminder-rel-dormant">
+              Fires once this task has a due date.
+            </p>
+          )}
+          {mode === "absolute" && (
             <input
               type="datetime-local"
               value={absAt === "" ? "" : toLocalInput(absAt)}

--- a/pwa/components/tasks/TaskDetailDrawer.tsx
+++ b/pwa/components/tasks/TaskDetailDrawer.tsx
@@ -515,12 +515,6 @@ const TaskDetailDrawer = ({
                 </Row>
               </dl>
 
-              <RemindersEditor
-                value={task.reminders}
-                dueDate={task.dueDate}
-                onChange={(next) => void patchTask({ reminders: next })}
-              />
-
               {task.project && definitions.length > 0 && (
                 <CustomFieldValueList
                   definitions={definitions}
@@ -553,6 +547,12 @@ const TaskDetailDrawer = ({
                 canDeleteAll={canModerate}
                 onAttach={handleAttach}
                 onDetach={handleDetach}
+              />
+
+              <RemindersEditor
+                value={task.reminders}
+                dueDate={task.dueDate}
+                onChange={(next) => void patchTask({ reminders: next })}
               />
 
               <Tabs defaultValue="comments" className="mt-auto border-t pt-4">

--- a/pwa/components/tasks/TaskDetailDrawer.tsx
+++ b/pwa/components/tasks/TaskDetailDrawer.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { CheckCircle2, Repeat, Trash2 } from "lucide-react";
 import { ENTRYPOINT } from "@/config/entrypoint";
 import { Sheet, SheetContent } from "@/components/ui/sheet";
 import ConfirmDialog from "@/components/common/ConfirmDialog";
+import MarkdownEditor from "@/components/editor/MarkdownEditor";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -119,6 +120,9 @@ const TaskDetailDrawer = ({
   const [error, setError] = useState<string | null>(null);
   const [recurrenceOpen, setRecurrenceOpen] = useState(false);
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
+  // Local draft for the WYSIWYG description, debounce-saved on edit.
+  const [descDraft, setDescDraft] = useState("");
+  const descDirtyRef = useRef(false);
 
   // Load the task whenever the drawer opens on a new id.
   useEffect(() => {
@@ -263,6 +267,23 @@ const TaskDetailDrawer = ({
     onTaskDeleted?.(iri);
   }, [task, onOpenChange, onTaskDeleted]);
 
+  // Re-seed the description draft when a different task loads.
+  const descTaskIri = task?.["@id"] ?? null;
+  useEffect(() => {
+    descDirtyRef.current = false;
+    setDescDraft(task?.description ?? "");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [descTaskIri]);
+
+  // Debounce-save the description after edits.
+  useEffect(() => {
+    if (!descDirtyRef.current) return;
+    const handle = setTimeout(() => {
+      void patchTask({ description: descDraft.trim() === "" ? null : descDraft });
+    }, 800);
+    return () => clearTimeout(handle);
+  }, [descDraft, patchTask]);
+
   const saveCustomFields = useCallback(
     async (next: CustomFieldValuePair[]): Promise<ViolationMap> => {
       const res = await patchTask({ customFieldValues: next });
@@ -380,7 +401,7 @@ const TaskDetailDrawer = ({
         )}
 
         {task && (
-          <Tabs defaultValue="details" className="flex min-h-0 flex-1 flex-col">
+          <div className="flex min-h-0 flex-1 flex-col">
             <div className="border-b px-5 pt-4 pb-3">
               {/* Top-left mark-done toggle + delete (close button is absolute top-right). */}
               <div className="mb-3 flex items-center gap-2">
@@ -430,142 +451,137 @@ const TaskDetailDrawer = ({
                   data-testid="task-detail-title"
                 />
               </div>
-              {task.tags.length > 0 && (
-                <div className="mt-2 flex flex-wrap gap-1.5 pl-6">
-                  {task.tags.map((tag) => (
-                    <span
-                      key={tag["@id"]}
-                      className="rounded px-1.5 py-0.5 text-xs font-medium"
-                      style={{
-                        backgroundColor: `${tag.color}22`,
-                        color: tag.color,
-                      }}
-                    >
-                      {tag.title}
-                    </span>
-                  ))}
-                </div>
-              )}
-              <TabsList variant="line" className="mt-3">
-                <TabsTrigger value="details" data-testid="task-tab-details">
-                  Details
-                </TabsTrigger>
-                <TabsTrigger value="activity" data-testid="task-tab-activity">
-                  Activity
-                </TabsTrigger>
-                <TabsTrigger value="comments" data-testid="task-tab-comments">
-                  Comments {comments.length > 0 ? `(${comments.length})` : ""}
-                </TabsTrigger>
-              </TabsList>
             </div>
 
-            <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
-              <TabsContent value="details" className="space-y-5">
-                <dl className="space-y-3 text-sm">
-                  <Row label="Assignees">
-                    <AssigneesCombobox
-                      value={task.assignees}
-                      options={assignableUsers}
-                      onChange={(iris) => void patchTask({ assignees: iris })}
-                      subjectLabel={task.title}
-                    />
-                  </Row>
-                  <Row label="Tags">
-                    <TagsCombobox
-                      value={task.tags}
-                      options={allTags}
-                      onChange={(iris) => void patchTask({ tags: iris })}
-                      subjectLabel={task.title}
-                    />
-                  </Row>
-                  <Row label="Due">
-                    <DueDateCell
-                      value={task.dueDate}
-                      onChange={(next) => void patchTask({ dueDate: next })}
-                      ariaLabel={`Due date for ${task.title}`}
-                      testIdPrefix="task-detail-due"
-                      status={dueDateStatus(task.dueDate, Boolean(task.completedOn))}
-                    />
-                  </Row>
-                  <Row label="Repeats">
-                    <Popover open={recurrenceOpen} onOpenChange={setRecurrenceOpen}>
-                      <PopoverTrigger asChild>
-                        <button
-                          type="button"
-                          className="flex items-center gap-1.5 text-left hover:text-foreground"
-                          data-testid="task-detail-repeats"
-                        >
-                          <Repeat className="h-3.5 w-3.5 text-muted-foreground" />
-                          {task.recurrenceRule ? (
-                            <span>{formatRecurrenceSummary(task.recurrenceRule)}</span>
-                          ) : (
-                            <span className="text-muted-foreground">Does not repeat</span>
-                          )}
-                        </button>
-                      </PopoverTrigger>
-                      <PopoverContent align="start" className="w-auto p-0">
-                        <RecurrenceEditor
-                          value={task.recurrenceRule}
-                          dueDate={task.dueDate}
-                          onApply={(rule) => {
-                            void patchTask({ recurrenceRule: rule });
-                            setRecurrenceOpen(false);
-                          }}
-                          onRemove={() => {
-                            void patchTask({ recurrenceRule: null });
-                            setRecurrenceOpen(false);
-                          }}
-                          onCancel={() => setRecurrenceOpen(false)}
-                        />
-                      </PopoverContent>
-                    </Popover>
-                  </Row>
-                </dl>
-
-                <RemindersEditor
-                  value={task.reminders}
-                  dueDate={task.dueDate}
-                  onChange={(next) => void patchTask({ reminders: next })}
-                />
-
-                {task.project && definitions.length > 0 && (
-                  <CustomFieldValueList
-                    definitions={definitions}
-                    values={task.customFieldValues}
-                    onSave={saveCustomFields}
-                    projectIri={task.project}
-                    spaceIri={spaceIri}
-                    users={assignableUsers}
+            <div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-5 py-4">
+              <dl className="space-y-3 text-sm">
+                <Row label="Tags">
+                  <TagsCombobox
+                    value={task.tags}
+                    options={allTags}
+                    onChange={(iris) => void patchTask({ tags: iris })}
+                    subjectLabel={task.title}
                   />
-                )}
+                </Row>
+                <Row label="Due">
+                  <DueDateCell
+                    value={task.dueDate}
+                    onChange={(next) => void patchTask({ dueDate: next })}
+                    ariaLabel={`Due date for ${task.title}`}
+                    testIdPrefix="task-detail-due"
+                    status={dueDateStatus(task.dueDate, Boolean(task.completedOn))}
+                  />
+                </Row>
+                <Row label="Repeats">
+                  <Popover open={recurrenceOpen} onOpenChange={setRecurrenceOpen}>
+                    <PopoverTrigger asChild>
+                      <button
+                        type="button"
+                        className="flex items-center gap-1.5 text-left hover:text-foreground"
+                        data-testid="task-detail-repeats"
+                      >
+                        <Repeat className="h-3.5 w-3.5 text-muted-foreground" />
+                        {task.recurrenceRule ? (
+                          <span>{formatRecurrenceSummary(task.recurrenceRule)}</span>
+                        ) : (
+                          <span className="text-muted-foreground">Does not repeat</span>
+                        )}
+                      </button>
+                    </PopoverTrigger>
+                    <PopoverContent align="start" className="w-auto p-0">
+                      <RecurrenceEditor
+                        value={task.recurrenceRule}
+                        dueDate={task.dueDate}
+                        onApply={(rule) => {
+                          void patchTask({ recurrenceRule: rule });
+                          setRecurrenceOpen(false);
+                        }}
+                        onRemove={() => {
+                          void patchTask({ recurrenceRule: null });
+                          setRecurrenceOpen(false);
+                        }}
+                        onCancel={() => setRecurrenceOpen(false)}
+                      />
+                    </PopoverContent>
+                  </Popover>
+                </Row>
+                <Row label="Assignees">
+                  <AssigneesCombobox
+                    value={task.assignees}
+                    options={assignableUsers}
+                    onChange={(iris) => void patchTask({ assignees: iris })}
+                    subjectLabel={task.title}
+                  />
+                </Row>
+              </dl>
 
-                <AttachmentsPanel
-                  taskTitle={task.title}
-                  attachments={task.attachments}
-                  canDeleteAll={canModerate}
-                  onAttach={handleAttach}
-                  onDetach={handleDetach}
+              <RemindersEditor
+                value={task.reminders}
+                dueDate={task.dueDate}
+                onChange={(next) => void patchTask({ reminders: next })}
+              />
+
+              {task.project && definitions.length > 0 && (
+                <CustomFieldValueList
+                  definitions={definitions}
+                  values={task.customFieldValues}
+                  onSave={saveCustomFields}
+                  projectIri={task.project}
+                  spaceIri={spaceIri}
+                  users={assignableUsers}
                 />
-              </TabsContent>
+              )}
 
-              <TabsContent value="activity">
-                <ActivityPanel endpoint={`/tasks/${task.id}/activity`} />
-              </TabsContent>
-
-              <TabsContent value="comments">
-                <CommentsPanel
-                  parentLabel={task.title}
-                  comments={comments}
-                  isLoading={commentsLoading}
-                  currentUserIri={currentUserIri}
-                  canModerate={canModerate}
-                  onCreate={handleCreateComment}
-                  onEdit={handleEditComment}
-                  onDelete={handleDeleteComment}
+              <div className="space-y-1.5">
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Description
+                </p>
+                <MarkdownEditor
+                  key={`desc-${task["@id"]}`}
+                  value={task.description ?? ""}
+                  onChange={(v) => {
+                    descDirtyRef.current = true;
+                    setDescDraft(v);
+                  }}
+                  ariaLabel="Task description"
                 />
-              </TabsContent>
+              </div>
+
+              <AttachmentsPanel
+                taskTitle={task.title}
+                attachments={task.attachments}
+                canDeleteAll={canModerate}
+                onAttach={handleAttach}
+                onDetach={handleDetach}
+              />
+
+              <Tabs defaultValue="comments" className="border-t pt-4">
+                <TabsList variant="line">
+                  <TabsTrigger value="comments" data-testid="task-tab-comments">
+                    Comments {comments.length > 0 ? `(${comments.length})` : ""}
+                  </TabsTrigger>
+                  <TabsTrigger value="activity" data-testid="task-tab-activity">
+                    Activity
+                  </TabsTrigger>
+                </TabsList>
+                <TabsContent value="comments" className="mt-4">
+                  <CommentsPanel
+                    parentLabel={task.title}
+                    comments={comments}
+                    isLoading={commentsLoading}
+                    currentUserIri={currentUserIri}
+                    canModerate={canModerate}
+                    onCreate={handleCreateComment}
+                    onEdit={handleEditComment}
+                    onDelete={handleDeleteComment}
+                  />
+                </TabsContent>
+                <TabsContent value="activity" className="mt-4">
+                  <ActivityPanel endpoint={`/tasks/${task.id}/activity`} />
+                </TabsContent>
+              </Tabs>
             </div>
-          </Tabs>
+          </div>
         )}
       </SheetContent>
       </Sheet>

--- a/pwa/components/tasks/TaskDetailDrawer.tsx
+++ b/pwa/components/tasks/TaskDetailDrawer.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useState } from "react";
-import { CheckCircle2, Repeat } from "lucide-react";
+import { CheckCircle2, Repeat, Trash2 } from "lucide-react";
 import { ENTRYPOINT } from "@/config/entrypoint";
 import { Sheet, SheetContent } from "@/components/ui/sheet";
+import ConfirmDialog from "@/components/common/ConfirmDialog";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -87,6 +88,8 @@ export interface TaskDetailDrawerProps {
   allTags: TagOption[];
   /** Bubble the updated task up so the list row can re-render in place. */
   onTaskChanged?: (task: DrawerTask) => void;
+  /** Called with the deleted task's IRI so the list can drop the row. */
+  onTaskDeleted?: (taskIri: string) => void;
 }
 
 /**
@@ -104,6 +107,7 @@ const TaskDetailDrawer = ({
   assignableUsers,
   allTags,
   onTaskChanged,
+  onTaskDeleted,
 }: TaskDetailDrawerProps) => {
   const [task, setTask] = useState<DrawerTask | null>(null);
   const [definitions, setDefinitions] = useState<CustomFieldDefinition[]>([]);
@@ -114,6 +118,7 @@ const TaskDetailDrawer = ({
   const [notFound, setNotFound] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [recurrenceOpen, setRecurrenceOpen] = useState(false);
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
 
   // Load the task whenever the drawer opens on a new id.
   useEffect(() => {
@@ -243,6 +248,21 @@ const TaskDetailDrawer = ({
     [task, applyTask],
   );
 
+  // Delete the task. Throws on failure so the ConfirmDialog keeps its modal
+  // open and surfaces the error; on success it closes the drawer and tells the
+  // list to drop the row.
+  const deleteTask = useCallback(async () => {
+    if (!task) return;
+    const iri = task["@id"];
+    const res = await fetch(`${ENTRYPOINT}${iri}`, {
+      method: "DELETE",
+      credentials: "include",
+    });
+    if (!res.ok) throw new Error("Failed to delete task.");
+    onOpenChange(false);
+    onTaskDeleted?.(iri);
+  }, [task, onOpenChange, onTaskDeleted]);
+
   const saveCustomFields = useCallback(
     async (next: CustomFieldValuePair[]): Promise<ViolationMap> => {
       const res = await patchTask({ customFieldValues: next });
@@ -327,7 +347,8 @@ const TaskDetailDrawer = ({
     currentUserIri !== null && task?.owner["@id"] === currentUserIri;
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange} modal={false}>
+    <>
+      <Sheet open={open} onOpenChange={onOpenChange} modal={false}>
       <SheetContent
         side="right"
         dim
@@ -361,8 +382,8 @@ const TaskDetailDrawer = ({
         {task && (
           <Tabs defaultValue="details" className="flex min-h-0 flex-1 flex-col">
             <div className="border-b px-5 pt-4 pb-3">
-              {/* Top-left mark-done toggle (the close button is absolute top-right). */}
-              <div className="mb-3">
+              {/* Top-left mark-done toggle + delete (close button is absolute top-right). */}
+              <div className="mb-3 flex items-center gap-2">
                 <Button
                   type="button"
                   variant="outline"
@@ -384,6 +405,17 @@ const TaskDetailDrawer = ({
                 >
                   <CheckCircle2 className="mr-1.5 h-4 w-4" />
                   {task.completedOn ? "Completed" : "Mark done"}
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                  onClick={() => setConfirmDeleteOpen(true)}
+                  aria-label="Delete task"
+                  data-testid="task-detail-delete"
+                >
+                  <Trash2 className="h-4 w-4" />
                 </Button>
               </div>
               <div className="flex items-start gap-2">
@@ -536,7 +568,18 @@ const TaskDetailDrawer = ({
           </Tabs>
         )}
       </SheetContent>
-    </Sheet>
+      </Sheet>
+      {task && (
+        <ConfirmDialog
+          open={confirmDeleteOpen}
+          onOpenChange={setConfirmDeleteOpen}
+          title="Delete task?"
+          description={`"${task.title}" and its comments will be permanently deleted. This can't be undone.`}
+          confirmLabel="Delete"
+          onConfirm={deleteTask}
+        />
+      )}
+    </>
   );
 };
 

--- a/pwa/components/tasks/TaskDetailDrawer.tsx
+++ b/pwa/components/tasks/TaskDetailDrawer.tsx
@@ -453,7 +453,7 @@ const TaskDetailDrawer = ({
               </div>
             </div>
 
-            <div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-5 py-4">
+            <div className="flex min-h-0 flex-1 flex-col space-y-5 overflow-y-auto px-5 py-4">
               <dl className="space-y-3 text-sm">
                 <Row label="Tags">
                   <TagsCombobox
@@ -555,7 +555,7 @@ const TaskDetailDrawer = ({
                 onDetach={handleDetach}
               />
 
-              <Tabs defaultValue="comments" className="border-t pt-4">
+              <Tabs defaultValue="comments" className="mt-auto border-t pt-4">
                 <TabsList variant="line">
                   <TabsTrigger value="comments" data-testid="task-tab-comments">
                     Comments {comments.length > 0 ? `(${comments.length})` : ""}

--- a/pwa/components/tasks/TaskDetailDrawer.tsx
+++ b/pwa/components/tasks/TaskDetailDrawer.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useState } from "react";
-import { Repeat } from "lucide-react";
+import { CheckCircle2, Repeat } from "lucide-react";
 import { ENTRYPOINT } from "@/config/entrypoint";
 import { Sheet, SheetContent } from "@/components/ui/sheet";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Checkbox } from "@/components/ui/checkbox";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
   Popover,
@@ -360,19 +360,33 @@ const TaskDetailDrawer = ({
 
         {task && (
           <Tabs defaultValue="details" className="flex min-h-0 flex-1 flex-col">
-            <div className="border-b px-5 pt-12 pb-3">
-              <div className="flex items-start gap-2">
-                <Checkbox
-                  checked={Boolean(task.completedOn)}
-                  onCheckedChange={(checked) =>
+            <div className="border-b px-5 pt-4 pb-3">
+              {/* Top-left mark-done toggle (the close button is absolute top-right). */}
+              <div className="mb-3">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() =>
                     void patchTask({
-                      completedOn: checked ? new Date().toISOString() : null,
+                      completedOn: task.completedOn
+                        ? null
+                        : new Date().toISOString(),
                     })
                   }
-                  className="mt-1.5"
-                  aria-label="Mark complete"
+                  aria-pressed={Boolean(task.completedOn)}
+                  className={
+                    task.completedOn
+                      ? "border-emerald-600/40 bg-emerald-600/10 text-emerald-700 hover:bg-emerald-600/15 hover:text-emerald-700 dark:text-emerald-400"
+                      : ""
+                  }
                   data-testid="task-detail-complete"
-                />
+                >
+                  <CheckCircle2 className="mr-1.5 h-4 w-4" />
+                  {task.completedOn ? "Completed" : "Mark done"}
+                </Button>
+              </div>
+              <div className="flex items-start gap-2">
                 <Input
                   defaultValue={task.title}
                   key={task["@id"] + task.title}
@@ -383,11 +397,6 @@ const TaskDetailDrawer = ({
                   className="border-0 px-0 text-lg font-semibold shadow-none focus-visible:ring-0"
                   data-testid="task-detail-title"
                 />
-                {task.completedOn && (
-                  <span className="mt-1.5 shrink-0 rounded-full bg-primary/15 px-2 py-0.5 text-xs font-medium text-primary">
-                    Done
-                  </span>
-                )}
               </div>
               {task.tags.length > 0 && (
                 <div className="mt-2 flex flex-wrap gap-1.5 pl-6">

--- a/pwa/components/tasks/TaskDetailDrawer.tsx
+++ b/pwa/components/tasks/TaskDetailDrawer.tsx
@@ -447,7 +447,7 @@ const TaskDetailDrawer = ({
                     const v = e.target.value.trim();
                     if (v && v !== task.title) void patchTask({ title: v });
                   }}
-                  className="border-0 px-0 text-lg font-semibold shadow-none focus-visible:ring-0"
+                  className="h-auto py-2 text-lg font-semibold"
                   data-testid="task-detail-title"
                 />
               </div>

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -819,6 +819,9 @@ const ProjectDetail = () => {
             ),
           )
         }
+        onTaskDeleted={(iri) =>
+          setTasks((prev) => prev.filter((t) => t["@id"] !== iri))
+        }
       />
     </>
   );

--- a/pwa/pages/tasks.tsx
+++ b/pwa/pages/tasks.tsx
@@ -1269,6 +1269,9 @@ const Tasks = () => {
             ),
           )
         }
+        onTaskDeleted={(iri) =>
+          setTasks((current) => current.filter((t) => t["@id"] !== iri))
+        }
       />
     </>
   );


### PR DESCRIPTION
Task detail drawer redesign (PR 3/5 of the feature/wip batch).

- Replace the drawer checkbox with a top-left "Mark done" button; trash-delete with a confirm modal
- Restructure: inline details, bottom-aligned Comments/Activity tabs, WYSIWYG description
- Attach via an upload button; reminders moved below attachments; title is an input field
- Allow relative reminders without a due date (stored dormant until one is set)
- API: keep deleted tasks in the board activity feed (recover via the versioned project)

Squash-merges as one changelog entry.