### PR TITLE
feat(pwa): web push notifications frontend (#100)

### DIFF
--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -300,7 +300,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TwoFact
         'timezone' => 'UTC',
         // Legacy master switches — kept as hard overrides over the matrix.
         'emailNotificationsEnabled' => true,
-        'pushNotificationsEnabled' => false,
+        'pushNotificationsEnabled' => true,
         'notificationFrequency' => 'realtime',
         // Per-event delivery matrix: row → {inApp, email}.
         'notificationMatrix' => [

--- a/api/tests/Api/NotificationTest.php
+++ b/api/tests/Api/NotificationTest.php
@@ -347,9 +347,11 @@ class NotificationTest extends ApiTestCase
     public function testDispatcherSkipsPushWhenPreferenceDisabled(): void
     {
         $alice = $this->createUser('alice@example.com');
-        // Default for `pushNotificationsEnabled` is false; subscriptions
-        // can exist on the user from a previous opt-in but the dispatcher
-        // must respect the current preference.
+        // Push is on by default, so disable it explicitly: a subscription can
+        // linger from a previous opt-in but the dispatcher must respect the
+        // current preference.
+        $alice->setPreferences(['pushNotificationsEnabled' => false]);
+        $this->entityManager->flush();
         $this->seedPushSubscription($alice, 'https://fcm.example/alice');
         $this->seedDueTask($alice, 'Standup');
 

--- a/pwa/.env.development
+++ b/pwa/.env.development
@@ -3,3 +3,9 @@
 # reject weak passwords the backend would now accept. Staging + production
 # builds inherit the MEDIUM (2) default baked into `pwa/lib/passwordStrength.ts`.
 NEXT_PUBLIC_PASSWORD_MIN_STRENGTH=0
+
+# Web Push (#100) VAPID public key, mirror of the API's VAPID_PUBLIC_KEY.
+# Shipped to the browser so PushManager.subscribe() can apply it. Leave blank
+# to disable the "enable browser notifications" prompts. Generate a pair with
+# `npx web-push generate-vapid-keys` and set the same public key here + in the API.
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=

--- a/pwa/.env.production
+++ b/pwa/.env.production
@@ -6,3 +6,4 @@
 # here — the ID ships in the page source anyway, it is not a secret. While
 # unset, the tracker script is never rendered and analytics is fully off.
 NEXT_PUBLIC_UMAMI_WEBSITE_ID=0217ffc5-83a0-4640-8ea3-79e4b4f75840
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=

--- a/pwa/components/notifications/EnablePushPrompt.tsx
+++ b/pwa/components/notifications/EnablePushPrompt.tsx
@@ -1,35 +1,38 @@
-import { useState } from "react";
-import { Bell } from "lucide-react";
+import { useEffect, useState } from "react";
+import { TriangleAlert } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { usePreferencePersist } from "@/lib/usePreferencePersist";
 import { enablePush, isPushSupported, pushPermission } from "@/lib/push";
-import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 /**
- * Inline nudge to turn on browser (Web Push) notifications — shown where it's
- * worth prompting, e.g. when setting up reminders. Renders nothing if push is
- * unsupported, no VAPID key is configured, or the user already has it on. On
- * "Enable" it subscribes (lib/push) and flips the pushNotificationsEnabled
- * preference so the backend starts delivering.
+ * Small warning shown where reminders are configured but browser (Web Push)
+ * notifications aren't on — so the user knows their reminders won't reach the
+ * browser. Offers an inline "Turn on" when push is actually available (supported
+ * + a VAPID key is configured + not blocked); otherwise it's informational.
+ * Renders nothing once notifications are on, or when push isn't supported.
  */
 const EnablePushPrompt = ({ className }: { className?: string }) => {
   const { user } = useAuth();
   const { persist } = usePreferencePersist();
+  const [mounted, setMounted] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [dismissed, setDismissed] = useState(false);
 
+  // Permission/support are client-only; gate on mount to avoid an SSR mismatch.
+  useEffect(() => setMounted(true), []);
+
   const supported = isPushSupported();
-  const hasVapid = Boolean(process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY);
   const permission = pushPermission();
+  const hasVapid = Boolean(process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY);
   const alreadyOn =
     permission === "granted" &&
     (user?.preferences?.pushNotificationsEnabled ?? false);
 
-  if (!supported || !hasVapid || alreadyOn || dismissed) return null;
+  if (!mounted || !supported || alreadyOn || dismissed) return null;
 
-  const blocked = permission === "denied";
+  const canEnable = hasVapid && permission !== "denied";
 
   const handleEnable = async () => {
     setBusy(true);
@@ -38,61 +41,41 @@ const EnablePushPrompt = ({ className }: { className?: string }) => {
     if (result.ok) {
       await persist({ pushNotificationsEnabled: true });
       setDismissed(true);
-    } else if (result.reason === "denied") {
-      setError(
-        "Notifications are blocked. Allow them in your browser settings, then reload.",
-      );
     } else {
-      setError("Couldn't enable browser notifications. Try again.");
+      setError(
+        result.reason === "denied"
+          ? "Allow notifications in your browser settings, then reload."
+          : "Couldn't enable browser notifications.",
+      );
     }
     setBusy(false);
   };
 
   return (
-    <div
+    <p
       className={cn(
-        "rounded-md border border-input bg-muted/40 p-3 text-sm",
+        "flex flex-wrap items-center gap-1.5 text-xs text-amber-600 dark:text-amber-500",
         className,
       )}
       data-testid="enable-push-prompt"
     >
-      <div className="flex items-start gap-2">
-        <Bell className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
-        <div className="min-w-0 flex-1 space-y-2">
-          <p>
-            Turn on browser notifications to get reminders even when this tab is
-            closed.
-          </p>
-          {blocked ? (
-            <p className="text-xs text-muted-foreground">
-              Notifications are blocked for this site — allow them in your
-              browser settings, then reload.
-            </p>
-          ) : (
-            <div className="flex items-center gap-2">
-              <Button
-                type="button"
-                size="sm"
-                onClick={() => void handleEnable()}
-                disabled={busy}
-                data-testid="enable-push"
-              >
-                {busy ? "Enabling…" : "Enable notifications"}
-              </Button>
-              <Button
-                type="button"
-                size="sm"
-                variant="ghost"
-                onClick={() => setDismissed(true)}
-              >
-                Not now
-              </Button>
-            </div>
-          )}
-          {error && <p className="text-xs text-destructive">{error}</p>}
-        </div>
-      </div>
-    </div>
+      <TriangleAlert className="h-3.5 w-3.5 shrink-0" aria-hidden />
+      <span>
+        Browser notifications are off — you won&apos;t get these reminders.
+      </span>
+      {canEnable && (
+        <button
+          type="button"
+          onClick={() => void handleEnable()}
+          disabled={busy}
+          className="font-medium underline underline-offset-2 hover:no-underline disabled:opacity-60"
+          data-testid="enable-push"
+        >
+          {busy ? "Enabling…" : "Turn on"}
+        </button>
+      )}
+      {error && <span className="text-destructive">{error}</span>}
+    </p>
   );
 };
 

--- a/pwa/components/notifications/EnablePushPrompt.tsx
+++ b/pwa/components/notifications/EnablePushPrompt.tsx
@@ -83,6 +83,17 @@ const EnablePushPrompt = ({ className }: { className?: string }) => {
         </span>
       )}
       {error && <span className="text-destructive">{error}</span>}
+      {/* Dismiss is browser-session only — we deliberately do NOT flip the
+          account preference off here: the user may be on a shared/public
+          computer but still want push on their own devices. */}
+      <button
+        type="button"
+        onClick={() => setDismissed(true)}
+        className="text-muted-foreground underline underline-offset-2 hover:no-underline"
+        data-testid="enable-push-dismiss"
+      >
+        Not now
+      </button>
     </p>
   );
 };

--- a/pwa/components/notifications/EnablePushPrompt.tsx
+++ b/pwa/components/notifications/EnablePushPrompt.tsx
@@ -1,0 +1,99 @@
+import { useState } from "react";
+import { Bell } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { usePreferencePersist } from "@/lib/usePreferencePersist";
+import { enablePush, isPushSupported, pushPermission } from "@/lib/push";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+/**
+ * Inline nudge to turn on browser (Web Push) notifications — shown where it's
+ * worth prompting, e.g. when setting up reminders. Renders nothing if push is
+ * unsupported, no VAPID key is configured, or the user already has it on. On
+ * "Enable" it subscribes (lib/push) and flips the pushNotificationsEnabled
+ * preference so the backend starts delivering.
+ */
+const EnablePushPrompt = ({ className }: { className?: string }) => {
+  const { user } = useAuth();
+  const { persist } = usePreferencePersist();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+
+  const supported = isPushSupported();
+  const hasVapid = Boolean(process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY);
+  const permission = pushPermission();
+  const alreadyOn =
+    permission === "granted" &&
+    (user?.preferences?.pushNotificationsEnabled ?? false);
+
+  if (!supported || !hasVapid || alreadyOn || dismissed) return null;
+
+  const blocked = permission === "denied";
+
+  const handleEnable = async () => {
+    setBusy(true);
+    setError(null);
+    const result = await enablePush();
+    if (result.ok) {
+      await persist({ pushNotificationsEnabled: true });
+      setDismissed(true);
+    } else if (result.reason === "denied") {
+      setError(
+        "Notifications are blocked. Allow them in your browser settings, then reload.",
+      );
+    } else {
+      setError("Couldn't enable browser notifications. Try again.");
+    }
+    setBusy(false);
+  };
+
+  return (
+    <div
+      className={cn(
+        "rounded-md border border-input bg-muted/40 p-3 text-sm",
+        className,
+      )}
+      data-testid="enable-push-prompt"
+    >
+      <div className="flex items-start gap-2">
+        <Bell className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+        <div className="min-w-0 flex-1 space-y-2">
+          <p>
+            Turn on browser notifications to get reminders even when this tab is
+            closed.
+          </p>
+          {blocked ? (
+            <p className="text-xs text-muted-foreground">
+              Notifications are blocked for this site — allow them in your
+              browser settings, then reload.
+            </p>
+          ) : (
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                size="sm"
+                onClick={() => void handleEnable()}
+                disabled={busy}
+                data-testid="enable-push"
+              >
+                {busy ? "Enabling…" : "Enable notifications"}
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                onClick={() => setDismissed(true)}
+              >
+                Not now
+              </Button>
+            </div>
+          )}
+          {error && <p className="text-xs text-destructive">{error}</p>}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EnablePushPrompt;

--- a/pwa/components/notifications/EnablePushPrompt.tsx
+++ b/pwa/components/notifications/EnablePushPrompt.tsx
@@ -26,13 +26,16 @@ const EnablePushPrompt = ({ className }: { className?: string }) => {
   const supported = isPushSupported();
   const permission = pushPermission();
   const hasVapid = Boolean(process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY);
-  const alreadyOn =
-    permission === "granted" &&
-    (user?.preferences?.pushNotificationsEnabled ?? false);
+  // Push is enabled by default, so only warn when the user still wants it (pref
+  // true) but the browser hasn't granted it. If they turned it off in settings,
+  // respect that and stay quiet.
+  const wantsPush = user?.preferences?.pushNotificationsEnabled ?? true;
+  const granted = permission === "granted";
 
-  if (!mounted || !supported || alreadyOn || dismissed) return null;
+  if (!mounted || !supported || !wantsPush || granted || dismissed) return null;
 
-  const canEnable = hasVapid && permission !== "denied";
+  const blocked = permission === "denied";
+  const canEnable = hasVapid && !blocked;
 
   const handleEnable = async () => {
     setBusy(true);
@@ -73,6 +76,11 @@ const EnablePushPrompt = ({ className }: { className?: string }) => {
         >
           {busy ? "Enabling…" : "Turn on"}
         </button>
+      )}
+      {blocked && (
+        <span className="text-muted-foreground">
+          (allow them in your browser settings)
+        </span>
       )}
       {error && <span className="text-destructive">{error}</span>}
     </p>

--- a/pwa/components/tasks/RemindersEditor.tsx
+++ b/pwa/components/tasks/RemindersEditor.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
+import EnablePushPrompt from "@/components/notifications/EnablePushPrompt";
 import {
   describeReminder,
   reminderKey,
@@ -257,6 +258,8 @@ const RemindersEditor = ({ value, dueDate, onChange }: RemindersEditorProps) => 
           <Plus className="h-3.5 w-3.5" /> Add reminder
         </button>
       )}
+
+      {reminders.length > 0 && <EnablePushPrompt />}
     </div>
   );
 };

--- a/pwa/lib/push.ts
+++ b/pwa/lib/push.ts
@@ -1,0 +1,83 @@
+import { ENTRYPOINT } from "@/config/entrypoint";
+
+/**
+ * Web Push (#100) frontend glue: register the service worker, subscribe via the
+ * VAPID public key, and hand the subscription to `POST /me/push-subscriptions`.
+ * The backend (WebPushSender) then delivers reminder/notification payloads even
+ * when the tab is closed; the service worker renders them.
+ */
+export const isPushSupported = (): boolean =>
+  typeof window !== "undefined" &&
+  "serviceWorker" in navigator &&
+  "PushManager" in window &&
+  "Notification" in window;
+
+export const pushPermission = (): NotificationPermission | "unsupported" =>
+  isPushSupported() ? Notification.permission : "unsupported";
+
+const urlBase64ToUint8Array = (base64: string): Uint8Array<ArrayBuffer> => {
+  const padding = "=".repeat((4 - (base64.length % 4)) % 4);
+  const normalized = (base64 + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const raw = window.atob(normalized);
+  const out = new Uint8Array(new ArrayBuffer(raw.length));
+  for (let i = 0; i < raw.length; i += 1) out[i] = raw.charCodeAt(i);
+  return out;
+};
+
+/** Register the push service worker. Idempotent; safe on every load. */
+export const registerPushServiceWorker = async (): Promise<void> => {
+  if (!isPushSupported()) return;
+  try {
+    await navigator.serviceWorker.register("/sw.js");
+  } catch {
+    /* a failed registration shouldn't break the app */
+  }
+};
+
+export type EnablePushResult =
+  | { ok: true }
+  | { ok: false; reason: "unsupported" | "no-vapid" | "denied" | "failed" };
+
+/**
+ * Request notification permission, subscribe with the VAPID key, and register
+ * the subscription with the API. Returns a reason on failure so the caller can
+ * show the right message. Does NOT flip the `pushNotificationsEnabled`
+ * preference — the caller owns that (so the optimistic UI stays in one place).
+ */
+export const enablePush = async (): Promise<EnablePushResult> => {
+  if (!isPushSupported()) return { ok: false, reason: "unsupported" };
+  const vapid = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+  if (!vapid) return { ok: false, reason: "no-vapid" };
+
+  const permission = await Notification.requestPermission();
+  if (permission !== "granted") return { ok: false, reason: "denied" };
+
+  try {
+    const registration = await navigator.serviceWorker.register("/sw.js");
+    await navigator.serviceWorker.ready;
+    let subscription = await registration.pushManager.getSubscription();
+    if (!subscription) {
+      subscription = await registration.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToUint8Array(vapid),
+      });
+    }
+    const keys = subscription.toJSON().keys ?? {};
+    const res = await fetch(`${ENTRYPOINT}/me/push-subscriptions`, {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/ld+json" },
+      body: JSON.stringify({
+        endpoint: subscription.endpoint,
+        p256dh: keys.p256dh,
+        auth: keys.auth,
+      }),
+    });
+    // 422 = this endpoint is already registered (unique constraint) — fine, the
+    // device is subscribed either way.
+    if (!res.ok && res.status !== 422) return { ok: false, reason: "failed" };
+    return { ok: true };
+  } catch {
+    return { ok: false, reason: "failed" };
+  }
+};

--- a/pwa/pages/_app.tsx
+++ b/pwa/pages/_app.tsx
@@ -1,13 +1,21 @@
 import "@blocknote/core/fonts/inter.css"
 import "@blocknote/mantine/style.css"
 import "../styles/globals.css"
+import { useEffect } from "react"
 import Script from "next/script"
 import Layout from "../components/common/Layout"
 import { UMAMI_SCRIPT_SRC, UMAMI_WEBSITE_ID } from "../lib/analytics"
+import { registerPushServiceWorker } from "../lib/push"
 import type { AppProps } from "next/app"
 import type { DehydratedState } from "@tanstack/react-query"
 
 function MyApp({ Component, pageProps }: AppProps<{dehydratedState: DehydratedState}>) {
+  // Register the push service worker so the browser can receive Web Push
+  // payloads (#100). Subscribing still requires explicit user opt-in.
+  useEffect(() => {
+    void registerPushServiceWorker()
+  }, [])
+
   return <>
     {/* Self-hosted Umami analytics — only rendered when a website ID is
         configured (never in dev by default). Cookieless; honors DNT. */}

--- a/pwa/pages/settings/notifications.tsx
+++ b/pwa/pages/settings/notifications.tsx
@@ -1,6 +1,7 @@
 import { useAuth } from "@/contexts/AuthContext";
 import { usePreferencePersist } from "@/lib/usePreferencePersist";
 import { useSettingsSection } from "@/lib/useSettingsSection";
+import { enablePush } from "@/lib/push";
 import { DEFAULT_NOTIFICATION_MATRIX } from "@/lib/notificationPrefs";
 import SettingsShell from "@/components/settings/SettingsShell";
 import SaveIndicator from "@/components/settings/SaveIndicator";
@@ -127,9 +128,18 @@ const NotificationsPage = () => {
                 id="push-toggle"
                 checked={prefs?.pushNotificationsEnabled ?? false}
                 disabled={disabled}
-                onCheckedChange={(on) =>
-                  void push.persist({ pushNotificationsEnabled: on })
-                }
+                onCheckedChange={(on) => {
+                  if (!on) {
+                    void push.persist({ pushNotificationsEnabled: false });
+                    return;
+                  }
+                  // Turning on subscribes the browser first; only flip the
+                  // preference once a subscription is registered.
+                  void enablePush().then((result) => {
+                    if (result.ok)
+                      void push.persist({ pushNotificationsEnabled: true });
+                  });
+                }}
                 data-testid="settings-push-toggle"
               />
             </div>

--- a/pwa/public/sw.js
+++ b/pwa/public/sw.js
@@ -1,0 +1,38 @@
+/*
+ * Madori push service worker (#100). Renders Web Push payloads
+ * ({ title, body, url, tag } from App\Push\PushPayload) as desktop
+ * notifications, and focuses/opens the target URL when one is clicked.
+ */
+self.addEventListener("push", (event) => {
+  let data = {};
+  try {
+    data = event.data ? event.data.json() : {};
+  } catch {
+    data = { title: "Madori", body: event.data ? event.data.text() : "" };
+  }
+  const title = data.title || "Madori";
+  event.waitUntil(
+    self.registration.showNotification(title, {
+      body: data.body || "",
+      icon: "/favicon.svg",
+      badge: "/favicon.svg",
+      tag: data.tag || undefined,
+      data: { url: data.url || "/" },
+    }),
+  );
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const url = (event.notification.data && event.notification.data.url) || "/";
+  event.waitUntil(
+    self.clients
+      .matchAll({ type: "window", includeUncontrolled: true })
+      .then((clients) => {
+        for (const client of clients) {
+          if ("focus" in client && client.url === url) return client.focus();
+        }
+        if (self.clients.openWindow) return self.clients.openWindow(url);
+      }),
+  );
+});


### PR DESCRIPTION
Completes the frontend Web Push piece of #100 (PR 4/5 of the feature/wip batch).

- Service worker (`public/sw.js`) renders PushPayload notifications + handles clicks
- `lib/push.ts` enable flow: permission → PushManager.subscribe(VAPID) → POST /me/push-subscriptions; SW registration in _app
- `EnablePushPrompt` shown in the RemindersEditor: a small warning when a task has reminders but browser notifications are off, with an inline "Turn on"
- Push enabled by default; only warns when wanted-but-not-granted; "Not now" never disables the account setting (public-computer safe)
- Needs VAPID keys set in the API + NEXT_PUBLIC_VAPID_PUBLIC_KEY to deliver

Squash-merges as one changelog entry.