### PR TITLE
feat: activity timeline + project Settings sections + activity hierarchy

### DIFF
--- a/api/src/Controller/ProjectActivityController.php
+++ b/api/src/Controller/ProjectActivityController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller;
 
+use App\Entity\CustomFieldDefinition;
 use App\Entity\Project;
 use App\Entity\Task;
 use App\Entity\User;
@@ -16,13 +17,14 @@ use Symfony\Component\Security\Http\Attribute\CurrentUser;
 use Symfony\Component\Uid\Uuid;
 
 /**
- * Reads the audit history for a project AND every task that belongs to
- * it. Access mirrors the Project GET security expression — any project
- * member can read; non-members get a 404.
+ * Reads the audit history for a project AND every task and custom-field
+ * definition that belongs to it. Access mirrors the Project GET security
+ * expression — any project member can read; non-members get a 404.
  *
- * The history feed combines `Project` rows with `Task` rows (filtered
- * by the project's task IDs) and orders both by `loggedAt` so the PWA
- * sees a single chronological stream.
+ * The history feed combines `Project` rows with `Task` and
+ * `CustomFieldDefinition` rows (filtered by the project's ids, including
+ * deleted ones) and orders them all by `loggedAt` so the PWA sees a single
+ * chronological stream.
  */
 class ProjectActivityController extends AbstractController
 {
@@ -51,37 +53,62 @@ class ProjectActivityController extends AbstractController
             return new JsonResponse(['error' => 'Not found.'], 404);
         }
 
+        $projectId = (string) $project->getId();
+
         $taskIds = array_map(
             static fn (Task $t): string => (string) $t->getId(),
             $project->getTasks()->toArray(),
         );
 
-        // Tasks deleted from this project keep their audit rows (the log table
-        // has no FK to the task). Recover their object ids from the versioned
-        // `project` recorded on each create/update entry so the board's history
-        // still shows a deleted task's lifecycle, ending in its remove event.
-        // Gedmo serialises the versioned association as `{"id": "<uuid>"}`, so
-        // reach into the nested id rather than comparing the whole object.
+        $cfdIds = array_map(
+            static fn (CustomFieldDefinition $d): string => (string) $d->getId(),
+            $this->em->getRepository(CustomFieldDefinition::class)
+                ->findBy(['project' => $project]),
+        );
+
+        // Tasks and custom-field definitions deleted from this project keep their
+        // audit rows (the log table has no FK back to them). Recover their object
+        // ids from the versioned `project` recorded on each entry so the board's
+        // history still shows a deleted item's lifecycle, ending in its remove
+        // event. Gedmo serialises the versioned association as `{"id": "<uuid>"}`,
+        // so reach into the nested id rather than comparing the whole object.
+        $allTaskIds = array_values(array_unique(
+            [...$taskIds, ...$this->deletedObjectIds(Task::class, $projectId)],
+        ));
+        $allCfdIds = array_values(array_unique(
+            [...$cfdIds, ...$this->deletedObjectIds(CustomFieldDefinition::class, $projectId)],
+        ));
+
+        return new JsonResponse($this->activityFeed->forObjectGroups([
+            Project::class => [$projectId],
+            Task::class => $allTaskIds,
+            CustomFieldDefinition::class => $allCfdIds,
+        ], $request));
+    }
+
+    /**
+     * Object ids of `$class` rows whose audit entries record this project via
+     * the versioned `project` association — covers deleted items the entity no
+     * longer references.
+     *
+     * @return list<string>
+     */
+    private function deletedObjectIds(string $class, string $projectId): array
+    {
         $sql = <<<'SQL'
             SELECT DISTINCT object_id
             FROM ext_log_entries
             WHERE object_class = :class AND data->'project'->>'id' = :pid
             SQL;
         $rows = $this->em->getConnection()
-            ->executeQuery($sql, [
-                'class' => Task::class,
-                'pid' => (string) $project->getId(),
-            ])
+            ->executeQuery($sql, ['class' => $class, 'pid' => $projectId])
             ->fetchFirstColumn();
+
         // object_id is a VARCHAR column, so values are strings; filter defensively.
-        $deleted = array_filter($rows, static fn (mixed $oid): bool => is_string($oid));
-
-        $allTaskIds = array_values(array_unique([...$taskIds, ...$deleted]));
-
-        return new JsonResponse($this->activityFeed->forObjectGroups([
-            Project::class => [(string) $project->getId()],
-            Task::class => $allTaskIds,
-        ], $request));
+        return array_values(array_filter(
+            $rows,
+            static fn (mixed $oid): bool => is_string($oid),
+        ));
     }
 
     private function canRead(Project $project, User $user): bool

--- a/api/src/Controller/ProjectActivityController.php
+++ b/api/src/Controller/ProjectActivityController.php
@@ -2,11 +2,10 @@
 
 namespace App\Controller;
 
-use App\Entity\CustomFieldDefinition;
 use App\Entity\Project;
-use App\Entity\Task;
 use App\Entity\User;
 use App\Service\ActivityFeedQuery;
+use App\Service\ProjectActivityScope;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -31,6 +30,7 @@ class ProjectActivityController extends AbstractController
     public function __construct(
         private EntityManagerInterface $em,
         private ActivityFeedQuery $activityFeed,
+        private ProjectActivityScope $scope,
     ) {
     }
 
@@ -53,62 +53,13 @@ class ProjectActivityController extends AbstractController
             return new JsonResponse(['error' => 'Not found.'], 404);
         }
 
-        $projectId = (string) $project->getId();
-
-        $taskIds = array_map(
-            static fn (Task $t): string => (string) $t->getId(),
-            $project->getTasks()->toArray(),
+        // The project's audit history rolls up its tasks and custom-field
+        // definitions — including deleted children, recovered via the versioned
+        // `project` on their log rows. The same grouping feeds the space-level
+        // feed one level up, so the hierarchy stays consistent.
+        return new JsonResponse(
+            $this->activityFeed->forObjectGroups($this->scope->groupsForProject($project), $request),
         );
-
-        $cfdIds = array_map(
-            static fn (CustomFieldDefinition $d): string => (string) $d->getId(),
-            $this->em->getRepository(CustomFieldDefinition::class)
-                ->findBy(['project' => $project]),
-        );
-
-        // Tasks and custom-field definitions deleted from this project keep their
-        // audit rows (the log table has no FK back to them). Recover their object
-        // ids from the versioned `project` recorded on each entry so the board's
-        // history still shows a deleted item's lifecycle, ending in its remove
-        // event. Gedmo serialises the versioned association as `{"id": "<uuid>"}`,
-        // so reach into the nested id rather than comparing the whole object.
-        $allTaskIds = array_values(array_unique(
-            [...$taskIds, ...$this->deletedObjectIds(Task::class, $projectId)],
-        ));
-        $allCfdIds = array_values(array_unique(
-            [...$cfdIds, ...$this->deletedObjectIds(CustomFieldDefinition::class, $projectId)],
-        ));
-
-        return new JsonResponse($this->activityFeed->forObjectGroups([
-            Project::class => [$projectId],
-            Task::class => $allTaskIds,
-            CustomFieldDefinition::class => $allCfdIds,
-        ], $request));
-    }
-
-    /**
-     * Object ids of `$class` rows whose audit entries record this project via
-     * the versioned `project` association — covers deleted items the entity no
-     * longer references.
-     *
-     * @return list<string>
-     */
-    private function deletedObjectIds(string $class, string $projectId): array
-    {
-        $sql = <<<'SQL'
-            SELECT DISTINCT object_id
-            FROM ext_log_entries
-            WHERE object_class = :class AND data->'project'->>'id' = :pid
-            SQL;
-        $rows = $this->em->getConnection()
-            ->executeQuery($sql, ['class' => $class, 'pid' => $projectId])
-            ->fetchFirstColumn();
-
-        // object_id is a VARCHAR column, so values are strings; filter defensively.
-        return array_values(array_filter(
-            $rows,
-            static fn (mixed $oid): bool => is_string($oid),
-        ));
     }
 
     private function canRead(Project $project, User $user): bool

--- a/api/src/Controller/SpaceActivityController.php
+++ b/api/src/Controller/SpaceActivityController.php
@@ -5,9 +5,9 @@ namespace App\Controller;
 use App\Entity\Page;
 use App\Entity\Project;
 use App\Entity\Space;
-use App\Entity\Task;
 use App\Entity\User;
 use App\Service\ActivityFeedQuery;
+use App\Service\ProjectActivityScope;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -34,6 +34,7 @@ class SpaceActivityController extends AbstractController
     public function __construct(
         private EntityManagerInterface $em,
         private ActivityFeedQuery $activityFeed,
+        private ProjectActivityScope $scope,
     ) {
     }
 
@@ -52,25 +53,29 @@ class SpaceActivityController extends AbstractController
             return new JsonResponse(['error' => 'Not found.'], 404);
         }
 
-        // Resolve the id sets that scope the feed to this space. Tasks
-        // are reached through their project (a space has no direct task
-        // collection), mirroring ProjectActivityController.
+        // Roll the per-project activity groups (project + tasks + custom-field
+        // definitions, including deleted children) up across every project in
+        // the space, then add the space's pages. Reusing ProjectActivityScope
+        // keeps the hierarchy consistent: a space sees everything its projects
+        // see, one level down — the same way space membership cascades.
         $projects = $this->em->getRepository(Project::class)->findBy(['space' => $space]);
         $pages = $this->em->getRepository(Page::class)->findBy(['space' => $space]);
-        $projectIds = array_values(array_map(static fn (Project $p): string => (string) $p->getId(), $projects));
-        $pageIds = array_values(array_map(static fn (Page $p): string => (string) $p->getId(), $pages));
-        $taskIds = [];
+
+        /** @var array<class-string, list<string>> $groups */
+        $groups = [Page::class => array_values(array_map(
+            static fn (Page $p): string => (string) $p->getId(),
+            $pages,
+        ))];
         foreach ($projects as $project) {
-            foreach ($project->getTasks() as $task) {
-                $taskIds[] = (string) $task->getId();
+            foreach ($this->scope->groupsForProject($project) as $class => $ids) {
+                $groups[$class] = array_values(array_unique([
+                    ...($groups[$class] ?? []),
+                    ...$ids,
+                ]));
             }
         }
 
-        return new JsonResponse($this->activityFeed->forObjectGroups([
-            Project::class => $projectIds,
-            Page::class => $pageIds,
-            Task::class => $taskIds,
-        ], $request));
+        return new JsonResponse($this->activityFeed->forObjectGroups($groups, $request));
     }
 
     private function canRead(Space $space, User $user): bool

--- a/api/src/Service/ProjectActivityScope.php
+++ b/api/src/Service/ProjectActivityScope.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\CustomFieldDefinition;
+use App\Entity\Project;
+use App\Entity\Task;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Resolves the audit-log object-id groups that make up a project's activity —
+ * the project row itself plus every task and custom-field definition that
+ * belongs to it, INCLUDING ones that have since been deleted (their log rows
+ * outlive the entity). Recovery keys on the versioned `project` association
+ * Gedmo records on each entry as `{"id": "<uuid>"}`.
+ *
+ * Shared so the per-level activity feeds form a consistent hierarchy — the
+ * project feed ({@see \App\Controller\ProjectActivityController}) uses it
+ * directly, and the space feed ({@see \App\Controller\SpaceActivityController})
+ * rolls it up across every project in the space. Both then hand the groups to
+ * {@see ActivityFeedQuery::forObjectGroups()}, so the wire shape stays
+ * identical at every level.
+ */
+final class ProjectActivityScope
+{
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+    ) {
+    }
+
+    /**
+     * Object-id groups for a single project's activity (project + tasks + CFDs,
+     * including deleted children).
+     *
+     * @return array<class-string, list<string>>
+     */
+    public function groupsForProject(Project $project): array
+    {
+        $projectId = (string) $project->getId();
+
+        $taskIds = array_map(
+            static fn (Task $t): string => (string) $t->getId(),
+            $project->getTasks()->toArray(),
+        );
+
+        $cfdIds = array_map(
+            static fn (CustomFieldDefinition $d): string => (string) $d->getId(),
+            $this->em->getRepository(CustomFieldDefinition::class)
+                ->findBy(['project' => $project]),
+        );
+
+        return [
+            Project::class => [$projectId],
+            Task::class => array_values(array_unique(
+                [...$taskIds, ...$this->deletedChildIds(Task::class, $projectId)],
+            )),
+            CustomFieldDefinition::class => array_values(array_unique(
+                [...$cfdIds, ...$this->deletedChildIds(CustomFieldDefinition::class, $projectId)],
+            )),
+        ];
+    }
+
+    /**
+     * Object ids of `$class` rows whose audit entries record `$projectId` via
+     * the versioned `project` association — covers deleted children the entity
+     * no longer references.
+     *
+     * @return list<string>
+     */
+    public function deletedChildIds(string $class, string $projectId): array
+    {
+        $sql = <<<'SQL'
+            SELECT DISTINCT object_id
+            FROM ext_log_entries
+            WHERE object_class = :class AND data->'project'->>'id' = :pid
+            SQL;
+        $rows = $this->em->getConnection()
+            ->executeQuery($sql, ['class' => $class, 'pid' => $projectId])
+            ->fetchFirstColumn();
+
+        // object_id is a VARCHAR column, so values are strings; filter defensively.
+        return array_values(array_filter(
+            $rows,
+            static fn (mixed $oid): bool => is_string($oid),
+        ));
+    }
+}

--- a/api/tests/Api/ProjectActivityTest.php
+++ b/api/tests/Api/ProjectActivityTest.php
@@ -3,6 +3,8 @@
 namespace App\Tests\Api;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\CustomField\CustomFieldKind;
+use App\Entity\CustomFieldDefinition;
 use App\Entity\Project;
 use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
@@ -72,6 +74,42 @@ class ProjectActivityTest extends ApiTestCase
         }
         $this->assertContains('create', $taskActions, 'deleted task create history is retained');
         $this->assertContains('remove', $taskActions, 'deletion is recorded as a remove event on the board');
+    }
+
+    public function testCustomFieldActivityAppearsInBoardActivity(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+
+        // A custom-field definition's lifecycle is Gedmo-logged with the
+        // versioned project, so it should surface on the board's activity feed.
+        $field = new CustomFieldDefinition();
+        $field->setProject($project)
+            ->setName('Priority')
+            ->setKind(CustomFieldKind::TEXT->value)
+            ->setSubtype('text')
+            ->setConfig(['multi' => false])
+            ->setPosition(0);
+        $this->entityManager->persist($field);
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        $client->request('GET', '/projects/' . $project->getId() . '/activity');
+        $this->assertResponseIsSuccessful();
+        $body = $client->getResponse()->toArray();
+
+        $items = $body['items'] ?? null;
+        $this->assertIsArray($items);
+        $cfdActions = [];
+        foreach ($items as $item) {
+            $this->assertIsArray($item);
+            if (($item['objectClass'] ?? null) === 'CustomFieldDefinition') {
+                $cfdActions[] = $item['action'] ?? null;
+            }
+        }
+        $this->assertContains('create', $cfdActions, 'custom-field activity is folded into the board feed');
     }
 
     private function createProject(User $owner, string $title): Project

--- a/api/tests/Api/SpaceActivityTest.php
+++ b/api/tests/Api/SpaceActivityTest.php
@@ -3,6 +3,8 @@
 namespace App\Tests\Api;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\CustomField\CustomFieldKind;
+use App\Entity\CustomFieldDefinition;
 use App\Entity\Project;
 use App\Entity\Space;
 use App\Entity\User;
@@ -93,6 +95,41 @@ class SpaceActivityTest extends ApiTestCase
         $actors = $body['actors'] ?? null;
         $this->assertIsArray($actors);
         $this->assertArrayHasKey('/users/' . $owner->getId(), $actors);
+    }
+
+    public function testCustomFieldActivityRollsUpToSpaceFeed(): void
+    {
+        $owner = $this->createUser('owner@example.com');
+        $project = $this->seedProject($owner, [$owner], 'Launch checklist');
+        $space = $project->getSpace();
+        self::assertNotNull($space);
+
+        // A custom-field definition lives under the project; its activity should
+        // roll up to the space feed the same way tasks do (the hierarchy).
+        $field = new CustomFieldDefinition();
+        $field->setProject($project)
+            ->setName('Priority')
+            ->setKind(CustomFieldKind::TEXT->value)
+            ->setSubtype('text')
+            ->setConfig(['multi' => false])
+            ->setPosition(0);
+        $this->entityManager->persist($field);
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($owner);
+        $client->request('GET', '/spaces/' . $space->getId() . '/activity');
+        $this->assertResponseIsSuccessful();
+        $body = $client->getResponse()->toArray();
+
+        $items = $body['items'] ?? null;
+        $this->assertIsArray($items);
+        $classes = array_column($items, 'objectClass');
+        $this->assertContains(
+            'CustomFieldDefinition',
+            $classes,
+            'Custom-field activity should roll up to the space feed.',
+        );
     }
 
     public function testStrangerCannotReadSpaceActivity(): void

--- a/e2e/tests/custom-fields.spec.js
+++ b/e2e/tests/custom-fields.spec.js
@@ -14,10 +14,11 @@ const openCustomFields = async (page, projectTitle) => {
   await page.getByTestId("new-project-button").click();
   await page.fill("#title", projectTitle);
   await page.click('button[type="submit"]');
-  // Creating navigates straight to the new project's detail page.
+  // Creating navigates straight to the new project's detail page. Custom
+  // fields live under the Settings tab's "Custom fields" section now.
   await expect(page).toHaveURL(/\/projects\/[a-f0-9-]+/);
-  await page.click('[data-testid="project-custom-fields-link"]');
-  await expect(page).toHaveURL(/\/projects\/[a-f0-9-]+\/custom-fields$/);
+  await page.getByTestId("project-settings-tab").click();
+  await page.getByTestId("project-settings-fields").click();
 };
 
 test.describe("Custom field definitions (kind-aware, #227)", () => {

--- a/pwa/components/activity/ActivityPanel.tsx
+++ b/pwa/components/activity/ActivityPanel.tsx
@@ -51,22 +51,60 @@ export interface ActivityPanelProps {
   endpoint: string;
 }
 
-const renderChanges = (data: Record<string, unknown>): string | null => {
-  const keys = Object.keys(data);
-  if (keys.length === 0) return null;
-  // For v1 we just list "field: value" — historic values are not in
-  // the payload because Gedmo only stores the new state. Surfacing
-  // before-state would mean walking adjacent versions, which is a v2
-  // concern.
-  return keys.map((k) => `${k}: ${formatValue(data[k])}`).join(", ");
+// "completedOn" → "completed on", "dueDate" → "due date", "maxLength" → "max length".
+const humanizeKey = (key: string): string =>
+  key
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/_/g, " ")
+    .toLowerCase();
+
+// Gedmo serialises a versioned association as a bare `{ id }` — a UUID with
+// nothing human to show, so we drop those keys from the summary.
+const isReference = (value: unknown): boolean =>
+  typeof value === "object" &&
+  value !== null &&
+  "id" in value &&
+  Object.keys(value).length === 1;
+
+// PHP `DateTime` serialises as `{ date, timezone_type, timezone }`.
+const isPhpDate = (value: unknown): value is { date: string } =>
+  typeof value === "object" &&
+  value !== null &&
+  "date" in value &&
+  typeof (value as { date: unknown }).date === "string";
+
+const DATE_FMT = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+const formatPhpDate = (raw: string): string => {
+  // "2026-06-21 00:32:03.354000" (UTC) → a real Date; trim micro→milliseconds.
+  const normalized = raw.replace(" ", "T").replace(/(\.\d{3})\d*/, "$1");
+  const iso = /([+-]\d{2}:?\d{2}|Z)$/.test(normalized)
+    ? normalized
+    : `${normalized}Z`;
+  const date = new Date(iso);
+  return Number.isNaN(date.getTime()) ? raw : DATE_FMT.format(date);
 };
 
 const formatValue = (value: unknown): string => {
   if (value === null || value === undefined) return "—";
+  if (typeof value === "boolean") return value ? "yes" : "no";
   if (typeof value === "string") return value === "" ? "—" : value;
-  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "number") return String(value);
+  if (isPhpDate(value)) return formatPhpDate(value.date);
   if (typeof value === "object") return JSON.stringify(value);
   return String(value);
+};
+
+const renderChanges = (data: Record<string, unknown>): string | null => {
+  // List "field: value" for the new state (Gedmo only stores the new value,
+  // not the before — surfacing the diff would mean walking adjacent versions).
+  const parts = Object.entries(data)
+    .filter(([, value]) => !isReference(value))
+    .map(([key, value]) => `${humanizeKey(key)}: ${formatValue(value)}`);
+  return parts.length === 0 ? null : parts.join(", ");
 };
 
 const ActivityPanel = ({ endpoint }: ActivityPanelProps) => {

--- a/pwa/components/activity/ActivityPanel.tsx
+++ b/pwa/components/activity/ActivityPanel.tsx
@@ -2,8 +2,10 @@ import { useCallback, useEffect, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import UserAvatar, { type AvatarUser } from "@/components/user/UserAvatar";
-import { displayName } from "@/lib/userDisplay";
+import { type AvatarUser } from "@/components/user/UserAvatar";
+import ActivityTimeline, {
+  type TimelineEvent,
+} from "@/components/activity/ActivityTimeline";
 import { ENTRYPOINT } from "@/config/entrypoint";
 
 /**
@@ -48,35 +50,6 @@ export interface ActivityPanelProps {
    *  Built by the parent so this component stays trigger-agnostic. */
   endpoint: string;
 }
-
-const RELATIVE = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
-
-const formatRelative = (iso: string): string => {
-  const ts = new Date(iso).getTime();
-  if (Number.isNaN(ts)) return "";
-  const diffSec = Math.round((ts - Date.now()) / 1000);
-  const abs = Math.abs(diffSec);
-  if (abs < 60) return RELATIVE.format(diffSec, "second");
-  if (abs < 3600) return RELATIVE.format(Math.round(diffSec / 60), "minute");
-  if (abs < 86400) return RELATIVE.format(Math.round(diffSec / 3600), "hour");
-  if (abs < 2592000) return RELATIVE.format(Math.round(diffSec / 86400), "day");
-  if (abs < 31536000)
-    return RELATIVE.format(Math.round(diffSec / 2592000), "month");
-  return RELATIVE.format(Math.round(diffSec / 31536000), "year");
-};
-
-const verbFor = (action: string): string => {
-  switch (action) {
-    case "create":
-      return "created";
-    case "update":
-      return "updated";
-    case "remove":
-      return "deleted";
-    default:
-      return action;
-  }
-};
 
 const renderChanges = (data: Record<string, unknown>): string | null => {
   const keys = Object.keys(data);
@@ -151,42 +124,18 @@ const ActivityPanel = ({ endpoint }: ActivityPanelProps) => {
             No activity yet.
           </p>
         ) : (
-          <ul className="space-y-3" data-testid="activity-list">
-            {items.map((row) => {
-              const actor = row.actor ? actors[row.actor] : null;
-              const changes = renderChanges(row.data);
-              return (
-                <li
-                  key={row.id}
-                  className="flex gap-3 items-start text-sm"
-                  data-testid="activity-item"
-                >
-                  {actor ? (
-                    <UserAvatar user={actor} size="sm" />
-                  ) : (
-                    <span
-                      aria-hidden="true"
-                      className="h-8 w-8 shrink-0 rounded-full bg-muted"
-                    />
-                  )}
-                  <div className="min-w-0 flex-1">
-                    <p>
-                      <span className="font-medium">
-                        {actor ? displayName(actor) : "Someone"}
-                      </span>{" "}
-                      <span className="text-muted-foreground">
-                        {verbFor(row.action)} this {row.objectClass.toLowerCase()}
-                        {changes && row.action !== "remove" ? ` — ${changes}` : ""}
-                      </span>
-                    </p>
-                    <p className="text-xs text-muted-foreground">
-                      {formatRelative(row.loggedAt)}
-                    </p>
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
+          <ActivityTimeline
+            events={items.map(
+              (row): TimelineEvent => ({
+                id: row.id,
+                action: row.action,
+                loggedAt: row.loggedAt,
+                objectClass: row.objectClass,
+                actor: row.actor ? (actors[row.actor] ?? null) : null,
+                changes: renderChanges(row.data),
+              }),
+            )}
+          />
         )}
         {hasMore && (
           <div className="mt-3">

--- a/pwa/components/activity/ActivityTimeline.tsx
+++ b/pwa/components/activity/ActivityTimeline.tsx
@@ -4,16 +4,16 @@ import { displayName } from "@/lib/userDisplay";
 
 /**
  * Responsive "history point graph" for activity streams. Renders a vertical
- * rail of point markers with one event card per entry.
+ * rail of point markers with one event card each.
  *
  *  - When the container is wide enough (`@2xl`, ~42rem) the rail sits in the
  *    middle and cards alternate to either side.
  *  - When it's narrow the rail moves to the left and every card stacks on the
  *    right — so it works inside the task drawer as well as a full-width tab.
  *
- * It's a presentational component: the caller resolves each event's actor and
- * change summary and passes them in. Layout responds to its own width via CSS
- * container queries, so the same component adapts wherever it's mounted.
+ * The rail line and dots are positioned at exactly 50% of the (full-width) row,
+ * so the centre never drifts regardless of card widths. It's presentational:
+ * the caller resolves each event's actor and change summary.
  */
 export type TimelineActor = AvatarUser & { "@id"?: string };
 
@@ -88,7 +88,7 @@ const dotClass = (action: string): string => {
 const ActivityTimeline = ({ events, className }: ActivityTimelineProps) => {
   return (
     <ol
-      className={cn("@container relative space-y-0", className)}
+      className={cn("@container relative w-full", className)}
       data-testid="activity-timeline"
     >
       {events.map((event, index) => {
@@ -97,41 +97,36 @@ const ActivityTimeline = ({ events, className }: ActivityTimelineProps) => {
         return (
           <li
             key={event.id}
-            className={cn(
-              "grid items-start gap-x-3 pb-6",
-              // Narrow: [rail | card]. Wide: [card | rail | card].
-              "grid-cols-[1.5rem_minmax(0,1fr)]",
-              "@2xl:grid-cols-[minmax(0,1fr)_1.5rem_minmax(0,1fr)]",
-            )}
+            className="relative pb-6"
             data-testid="activity-timeline-item"
           >
-            {/* Rail: continuous connecting line + the point marker. */}
-            <div
+            {/* Connecting line: at the left when narrow, dead-centre when wide. */}
+            <span
               aria-hidden
-              className="relative col-start-1 flex h-full justify-center @2xl:col-start-2"
-            >
-              <span className="absolute top-1 bottom-[-1.5rem] w-px bg-border" />
-              <span
-                className={cn(
-                  "relative z-10 mt-1 h-3 w-3 shrink-0 rounded-full ring-4 ring-background",
-                  dotClass(event.action),
-                )}
-              />
-            </div>
+              className="absolute inset-y-0 left-[0.5625rem] w-px -translate-x-1/2 bg-border @2xl:left-1/2"
+            />
+            {/* Point marker, sharing the line's x so they always align. */}
+            <span
+              aria-hidden
+              className={cn(
+                "absolute top-1.5 left-[0.5625rem] z-10 h-3 w-3 -translate-x-1/2 rounded-full ring-4 ring-background @2xl:left-1/2",
+                dotClass(event.action),
+              )}
+            />
 
-            {/* Card: always the right column when narrow; alternates when wide. */}
+            {/* Card: right of the line when narrow; alternating halves when wide. */}
             <div
               className={cn(
-                "col-start-2 min-w-0",
+                "pl-6 @2xl:pl-0",
                 onLeft
-                  ? "@2xl:col-start-1 @2xl:row-start-1 @2xl:text-right"
-                  : "@2xl:col-start-3 @2xl:row-start-1",
+                  ? "@2xl:pr-[calc(50%+1rem)] @2xl:text-right"
+                  : "@2xl:pl-[calc(50%+1rem)]",
               )}
             >
               <div
                 className={cn(
-                  "inline-flex max-w-full items-start gap-2 rounded-lg border bg-card px-3 py-2 text-sm",
-                  onLeft && "@2xl:flex-row-reverse @2xl:text-left",
+                  "inline-flex max-w-full items-start gap-2 rounded-lg border bg-card px-3 py-2 text-left text-sm",
+                  onLeft && "@2xl:flex-row-reverse",
                 )}
               >
                 {event.actor ? (
@@ -143,7 +138,7 @@ const ActivityTimeline = ({ events, className }: ActivityTimelineProps) => {
                   />
                 )}
                 <div className="min-w-0">
-                  <p className="leading-snug">
+                  <p className="leading-snug break-words">
                     <span className="font-medium">{name}</span>{" "}
                     <span className="text-muted-foreground">
                       {verbFor(event.action)} this {objectLabel(event.objectClass)}

--- a/pwa/components/activity/ActivityTimeline.tsx
+++ b/pwa/components/activity/ActivityTimeline.tsx
@@ -1,0 +1,168 @@
+import { cn } from "@/lib/utils";
+import UserAvatar, { type AvatarUser } from "@/components/user/UserAvatar";
+import { displayName } from "@/lib/userDisplay";
+
+/**
+ * Responsive "history point graph" for activity streams. Renders a vertical
+ * rail of point markers with one event card per entry.
+ *
+ *  - When the container is wide enough (`@2xl`, ~42rem) the rail sits in the
+ *    middle and cards alternate to either side.
+ *  - When it's narrow the rail moves to the left and every card stacks on the
+ *    right — so it works inside the task drawer as well as a full-width tab.
+ *
+ * It's a presentational component: the caller resolves each event's actor and
+ * change summary and passes them in. Layout responds to its own width via CSS
+ * container queries, so the same component adapts wherever it's mounted.
+ */
+export type TimelineActor = AvatarUser & { "@id"?: string };
+
+export interface TimelineEvent {
+  id: number;
+  action: string;
+  loggedAt: string;
+  objectClass: string;
+  actor: TimelineActor | null;
+  /** Pre-rendered "field: value, …" summary, or null. */
+  changes?: string | null;
+}
+
+export interface ActivityTimelineProps {
+  events: TimelineEvent[];
+  className?: string;
+}
+
+const RELATIVE = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+
+const formatRelative = (iso: string): string => {
+  const ts = new Date(iso).getTime();
+  if (Number.isNaN(ts)) return "";
+  const diffSec = Math.round((ts - Date.now()) / 1000);
+  const abs = Math.abs(diffSec);
+  if (abs < 60) return RELATIVE.format(diffSec, "second");
+  if (abs < 3600) return RELATIVE.format(Math.round(diffSec / 60), "minute");
+  if (abs < 86400) return RELATIVE.format(Math.round(diffSec / 3600), "hour");
+  if (abs < 2592000) return RELATIVE.format(Math.round(diffSec / 86400), "day");
+  if (abs < 31536000)
+    return RELATIVE.format(Math.round(diffSec / 2592000), "month");
+  return RELATIVE.format(Math.round(diffSec / 31536000), "year");
+};
+
+const verbFor = (action: string): string => {
+  switch (action) {
+    case "create":
+      return "created";
+    case "update":
+      return "updated";
+    case "remove":
+      return "deleted";
+    default:
+      return action;
+  }
+};
+
+/** Human label for a Loggable entity short-name. */
+const objectLabel = (objectClass: string): string => {
+  switch (objectClass) {
+    case "CustomFieldDefinition":
+      return "custom field";
+    default:
+      return objectClass.toLowerCase();
+  }
+};
+
+/** Marker colour by action, so the rail reads as a status graph at a glance. */
+const dotClass = (action: string): string => {
+  switch (action) {
+    case "create":
+      return "bg-emerald-500";
+    case "remove":
+      return "bg-destructive";
+    case "update":
+      return "bg-sky-500";
+    default:
+      return "bg-muted-foreground";
+  }
+};
+
+const ActivityTimeline = ({ events, className }: ActivityTimelineProps) => {
+  return (
+    <ol
+      className={cn("@container relative space-y-0", className)}
+      data-testid="activity-timeline"
+    >
+      {events.map((event, index) => {
+        const onLeft = index % 2 === 0;
+        const name = event.actor ? displayName(event.actor) : "Someone";
+        return (
+          <li
+            key={event.id}
+            className={cn(
+              "grid items-start gap-x-3 pb-6",
+              // Narrow: [rail | card]. Wide: [card | rail | card].
+              "grid-cols-[1.5rem_minmax(0,1fr)]",
+              "@2xl:grid-cols-[minmax(0,1fr)_1.5rem_minmax(0,1fr)]",
+            )}
+            data-testid="activity-timeline-item"
+          >
+            {/* Rail: continuous connecting line + the point marker. */}
+            <div
+              aria-hidden
+              className="relative col-start-1 flex h-full justify-center @2xl:col-start-2"
+            >
+              <span className="absolute top-1 bottom-[-1.5rem] w-px bg-border" />
+              <span
+                className={cn(
+                  "relative z-10 mt-1 h-3 w-3 shrink-0 rounded-full ring-4 ring-background",
+                  dotClass(event.action),
+                )}
+              />
+            </div>
+
+            {/* Card: always the right column when narrow; alternates when wide. */}
+            <div
+              className={cn(
+                "col-start-2 min-w-0",
+                onLeft
+                  ? "@2xl:col-start-1 @2xl:row-start-1 @2xl:text-right"
+                  : "@2xl:col-start-3 @2xl:row-start-1",
+              )}
+            >
+              <div
+                className={cn(
+                  "inline-flex max-w-full items-start gap-2 rounded-lg border bg-card px-3 py-2 text-sm",
+                  onLeft && "@2xl:flex-row-reverse @2xl:text-left",
+                )}
+              >
+                {event.actor ? (
+                  <UserAvatar user={event.actor} size="sm" />
+                ) : (
+                  <span
+                    aria-hidden
+                    className="h-8 w-8 shrink-0 rounded-full bg-muted"
+                  />
+                )}
+                <div className="min-w-0">
+                  <p className="leading-snug">
+                    <span className="font-medium">{name}</span>{" "}
+                    <span className="text-muted-foreground">
+                      {verbFor(event.action)} this {objectLabel(event.objectClass)}
+                      {event.changes && event.action !== "remove"
+                        ? ` — ${event.changes}`
+                        : ""}
+                    </span>
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {formatRelative(event.loggedAt)}
+                  </p>
+                </div>
+              </div>
+            </div>
+          </li>
+        );
+      })}
+    </ol>
+  );
+};
+
+export default ActivityTimeline;

--- a/pwa/components/custom-fields/CustomFieldsManager.tsx
+++ b/pwa/components/custom-fields/CustomFieldsManager.tsx
@@ -304,15 +304,6 @@ const CustomFieldsManager = ({
           </p>
         </div>
         <div className="flex items-center gap-2">
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={() => setChangeLogOpen(true)}
-            data-testid="custom-fields-changelog"
-          >
-            <History className="mr-1 h-3.5 w-3.5" /> Change log
-          </Button>
           {isSpaceAdmin && (
             <Button
               type="button"
@@ -383,6 +374,20 @@ const CustomFieldsManager = ({
         </div>
       ) : (
         <div className="rounded-lg border">
+          <div className="flex items-center justify-end border-b px-2 py-1">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 text-muted-foreground hover:text-foreground"
+              onClick={() => setChangeLogOpen(true)}
+              aria-label="Custom fields change log"
+              title="Change log"
+              data-testid="custom-fields-changelog"
+            >
+              <History className="h-4 w-4" />
+            </Button>
+          </div>
           <Table>
             <TableHeader>
               <TableRow>

--- a/pwa/components/custom-fields/CustomFieldsManager.tsx
+++ b/pwa/components/custom-fields/CustomFieldsManager.tsx
@@ -334,8 +334,8 @@ const CustomFieldsManager = ({
               <>
                 You&apos;re editing as a{" "}
                 <span className="font-medium text-foreground">space admin</span>.
-                Members in {spaceName ?? "this space"} can use these fields on
-                tasks but can&apos;t change definitions.
+                Members in {spaceName ?? "this space"}{" "}
+                can use these fields on tasks but can&apos;t change definitions.
               </>
             ) : (
               <>

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -137,6 +137,10 @@ const ProjectDetail = () => {
   const [notFound, setNotFound] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Which detail tab is active — controlled so the header's "New task" button
+  // can show on the Tasks tab only.
+  const [activeTab, setActiveTab] = useState("tasks");
+
   // Quick add-task (collapsed behind "+ New task").
   const [addOpen, setAddOpen] = useState(false);
   const [newTaskTitle, setNewTaskTitle] = useState("");
@@ -535,15 +539,17 @@ const ProjectDetail = () => {
                     <Lock className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
                   )}
                 </div>
-                <div className="flex flex-wrap items-center gap-2">
-                  <Button
-                    size="sm"
-                    onClick={openAddRow}
-                    data-testid="project-new-task"
-                  >
-                    <Plus className="mr-1 h-3.5 w-3.5" /> New task
-                  </Button>
-                </div>
+                {activeTab === "tasks" && (
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Button
+                      size="sm"
+                      onClick={openAddRow}
+                      data-testid="project-new-task"
+                    >
+                      <Plus className="mr-1 h-3.5 w-3.5" /> New task
+                    </Button>
+                  </div>
+                )}
               </div>
 
               {error && (
@@ -552,7 +558,7 @@ const ProjectDetail = () => {
                 </Alert>
               )}
 
-              <Tabs defaultValue="tasks">
+              <Tabs value={activeTab} onValueChange={setActiveTab}>
                 <TabsList variant="line">
                   <TabsTrigger value="tasks">
                     Tasks{" "}

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -2,7 +2,7 @@ import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Lock, PanelRight, Plus } from "lucide-react";
+import { Lock, PanelRight, Plus, Shield, Table2, Trash2, TriangleAlert } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
 import { ENTRYPOINT } from "@/config/entrypoint";
@@ -29,6 +29,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import ConfirmDialog from "@/components/common/ConfirmDialog";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -140,6 +141,12 @@ const ProjectDetail = () => {
   // Which detail tab is active — controlled so the header's "New task" button
   // can show on the Tasks tab only.
   const [activeTab, setActiveTab] = useState("tasks");
+  // Settings sub-section (left menu like the user settings page).
+  const [settingsSection, setSettingsSection] = useState<
+    "privacy" | "fields" | "danger"
+  >("privacy");
+  const [confirmDeleteProjectOpen, setConfirmDeleteProjectOpen] =
+    useState(false);
 
   // Quick add-task (collapsed behind "+ New task").
   const [addOpen, setAddOpen] = useState(false);
@@ -447,6 +454,18 @@ const ProjectDetail = () => {
     }
   };
 
+  const handleDeleteProject = async () => {
+    if (!project) return;
+    const res = await fetch(
+      `${ENTRYPOINT}/projects/${encodeURIComponent(project.id)}`,
+      { method: "DELETE", credentials: "include" },
+    );
+    if (!res.ok && res.status !== 204) {
+      throw new Error("Failed to delete project.");
+    }
+    await router.push("/projects");
+  };
+
   const grouped = useMemo(() => {
     const ordered = [...tasks].sort((a, b) => a.position - b.position);
     const map = new Map<Bucket, ProjectTask[]>();
@@ -570,119 +589,223 @@ const ProjectDetail = () => {
                   </TabsTrigger>
                 </TabsList>
 
-                <TabsContent value="settings" className="mt-4 space-y-6">
-                  <Card>
-                  <CardContent className="space-y-3 pt-6" data-testid="project-space-info">
-                    {project.description && (
-                      <p className="text-sm text-muted-foreground">{project.description}</p>
-                    )}
-                    <div className="flex flex-wrap items-center gap-2">
-                      <span className="text-xs text-muted-foreground">Space</span>
-                      <Badge variant="secondary" className="gap-1">
-                        {space?.isPersonal && <Lock className="h-3 w-3" aria-hidden />}
-                        {space?.name ??
-                          (typeof project.space === "string" ? "Unknown space" : project.space.name)}
-                      </Badge>
-                      {spaceId && (
-                        <Button asChild variant="link" size="sm" className="h-auto p-0">
-                          <Link href={`/spaces/${spaceId}`}>Manage members in space</Link>
-                        </Button>
-                      )}
-                    </div>
-
-                    <div
-                      className="flex flex-wrap items-center gap-2"
-                      data-testid="project-move-form"
+                <TabsContent value="settings" className="mt-4">
+                  <div className="flex flex-col gap-6 sm:flex-row">
+                    {/* Left menu, mirroring the user settings nav. */}
+                    <nav
+                      className="flex shrink-0 gap-1 overflow-x-auto sm:w-44 sm:flex-col"
+                      aria-label="Project settings sections"
+                      data-testid="project-settings-nav"
                     >
-                      <Label
-                        htmlFor="project-move-target"
-                        className="text-xs text-muted-foreground"
-                      >
-                        Move to
-                      </Label>
-                      <select
-                        id="project-move-target"
-                        value={moveTargetIri}
-                        onChange={(e) => setMoveTargetIri(e.target.value)}
-                        className="h-8 rounded-md border border-input bg-background px-2 text-sm"
-                        data-testid="project-move-select"
-                      >
-                        <option value="">Pick a space…</option>
-                        {spaces
-                          .filter((s) => s["@id"] !== projectSpaceIri(project))
-                          .map((s) => (
-                            <option key={s["@id"]} value={s["@id"]}>
-                              {s.name}
-                              {s.isPersonal ? " (Private)" : ""}
-                            </option>
-                          ))}
-                      </select>
-                      <Button
-                        type="button"
-                        size="sm"
-                        variant="outline"
-                        onClick={handleMove}
-                        disabled={!moveTargetIri || isMoving || isCopying}
-                        data-testid="project-move-submit"
-                      >
-                        {isMoving ? "Moving…" : "Move"}
-                      </Button>
-                      <Button
-                        type="button"
-                        size="sm"
-                        variant="outline"
-                        onClick={handleCopy}
-                        disabled={isMoving || isCopying}
-                        data-testid="project-copy-submit"
-                      >
-                        {isCopying ? "Copying…" : "Copy"}
-                      </Button>
-                      <label className="flex items-center gap-1.5 text-xs text-muted-foreground select-none">
-                        <input
-                          type="checkbox"
-                          checked={copyIncludeTasks}
-                          onChange={(e) => setCopyIncludeTasks(e.target.checked)}
-                          className="h-3.5 w-3.5"
-                          data-testid="project-copy-include-tasks"
-                        />
-                        include tasks
-                      </label>
-                      {moveMessage && (
-                        <span
-                          role="alert"
+                      {(
+                        [
+                          { key: "privacy", label: "Privacy", Icon: Shield },
+                          { key: "fields", label: "Custom fields", Icon: Table2 },
+                          { key: "danger", label: "Danger zone", Icon: TriangleAlert },
+                        ] as const
+                      ).map(({ key, label, Icon }) => (
+                        <button
+                          key={key}
+                          type="button"
+                          onClick={() => setSettingsSection(key)}
+                          aria-current={settingsSection === key ? "page" : undefined}
                           className={cn(
-                            "text-xs",
-                            moveMessage.kind === "success"
-                              ? "text-muted-foreground"
-                              : "text-destructive",
+                            "flex items-center gap-2 rounded-md px-3 py-2 text-left text-sm whitespace-nowrap transition-colors",
+                            settingsSection === key
+                              ? "bg-muted font-medium text-foreground"
+                              : "text-muted-foreground hover:bg-muted/50 hover:text-foreground",
+                            key === "danger" &&
+                              settingsSection !== key &&
+                              "text-destructive/80 hover:text-destructive",
                           )}
+                          data-testid={`project-settings-${key}`}
                         >
-                          {moveMessage.text}
-                        </span>
+                          <Icon className="h-4 w-4 shrink-0" /> {label}
+                        </button>
+                      ))}
+                    </nav>
+
+                    <div className="min-w-0 flex-1 space-y-6">
+                      {settingsSection === "privacy" && (
+                        <Card>
+                          <CardContent
+                            className="space-y-3 pt-6"
+                            data-testid="project-space-info"
+                          >
+                            {project.description && (
+                              <p className="text-sm text-muted-foreground">
+                                {project.description}
+                              </p>
+                            )}
+                            <div className="flex flex-wrap items-center gap-2">
+                              <span className="text-xs text-muted-foreground">Space</span>
+                              <Badge variant="secondary" className="gap-1">
+                                {space?.isPersonal && (
+                                  <Lock className="h-3 w-3" aria-hidden />
+                                )}
+                                {space?.name ??
+                                  (typeof project.space === "string"
+                                    ? "Unknown space"
+                                    : project.space.name)}
+                              </Badge>
+                              {spaceId && (
+                                <Button
+                                  asChild
+                                  variant="link"
+                                  size="sm"
+                                  className="h-auto p-0"
+                                >
+                                  <Link href={`/spaces/${spaceId}`}>
+                                    Manage members in space
+                                  </Link>
+                                </Button>
+                              )}
+                            </div>
+
+                            {project.members.length > 0 && (
+                              <ul
+                                className="flex flex-wrap items-center gap-1"
+                                data-testid="member-list"
+                              >
+                                {project.members.map((member) => (
+                                  <li key={member["@id"]} data-testid="member-pill">
+                                    <Badge variant="outline">{member.email}</Badge>
+                                  </li>
+                                ))}
+                              </ul>
+                            )}
+                          </CardContent>
+                        </Card>
+                      )}
+
+                      {settingsSection === "fields" && (
+                        <CustomFieldsManager
+                          projectIri={project["@id"]}
+                          projectTitle={project.title}
+                          spaceName={space?.name}
+                          isSpaceAdmin={isSpaceAdmin}
+                          onDefinitionsChanged={() => void reloadDefinitions()}
+                        />
+                      )}
+
+                      {settingsSection === "danger" && (
+                        <div className="space-y-6">
+                          <Card>
+                            <CardContent className="space-y-3 pt-6">
+                              <div>
+                                <h3 className="text-sm font-medium">Move or copy</h3>
+                                <p className="text-xs text-muted-foreground">
+                                  Relocate this project to another space, or duplicate it.
+                                </p>
+                              </div>
+                              <div
+                                className="flex flex-wrap items-center gap-2"
+                                data-testid="project-move-form"
+                              >
+                                <Label
+                                  htmlFor="project-move-target"
+                                  className="text-xs text-muted-foreground"
+                                >
+                                  Move to
+                                </Label>
+                                <select
+                                  id="project-move-target"
+                                  value={moveTargetIri}
+                                  onChange={(e) => setMoveTargetIri(e.target.value)}
+                                  className="h-8 rounded-md border border-input bg-background px-2 text-sm"
+                                  data-testid="project-move-select"
+                                >
+                                  <option value="">Pick a space…</option>
+                                  {spaces
+                                    .filter((s) => s["@id"] !== projectSpaceIri(project))
+                                    .map((s) => (
+                                      <option key={s["@id"]} value={s["@id"]}>
+                                        {s.name}
+                                        {s.isPersonal ? " (Private)" : ""}
+                                      </option>
+                                    ))}
+                                </select>
+                                <Button
+                                  type="button"
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={handleMove}
+                                  disabled={!moveTargetIri || isMoving || isCopying}
+                                  data-testid="project-move-submit"
+                                >
+                                  {isMoving ? "Moving…" : "Move"}
+                                </Button>
+                                <Button
+                                  type="button"
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={handleCopy}
+                                  disabled={isMoving || isCopying}
+                                  data-testid="project-copy-submit"
+                                >
+                                  {isCopying ? "Copying…" : "Copy"}
+                                </Button>
+                                <label className="flex items-center gap-1.5 text-xs text-muted-foreground select-none">
+                                  <input
+                                    type="checkbox"
+                                    checked={copyIncludeTasks}
+                                    onChange={(e) => setCopyIncludeTasks(e.target.checked)}
+                                    className="h-3.5 w-3.5"
+                                    data-testid="project-copy-include-tasks"
+                                  />
+                                  include tasks
+                                </label>
+                                {moveMessage && (
+                                  <span
+                                    role="alert"
+                                    className={cn(
+                                      "text-xs",
+                                      moveMessage.kind === "success"
+                                        ? "text-muted-foreground"
+                                        : "text-destructive",
+                                    )}
+                                  >
+                                    {moveMessage.text}
+                                  </span>
+                                )}
+                              </div>
+                            </CardContent>
+                          </Card>
+
+                          <Card className="border-destructive/40">
+                            <CardContent className="space-y-3 pt-6">
+                              <div>
+                                <h3 className="text-sm font-medium text-destructive">
+                                  Delete this project
+                                </h3>
+                                <p className="text-xs text-muted-foreground">
+                                  Permanently delete this project and all of its tasks.
+                                  This can&apos;t be undone.
+                                </p>
+                              </div>
+                              <Button
+                                type="button"
+                                variant="destructive"
+                                size="sm"
+                                onClick={() => setConfirmDeleteProjectOpen(true)}
+                                data-testid="project-delete"
+                              >
+                                <Trash2 className="mr-1 h-3.5 w-3.5" /> Delete project
+                              </Button>
+                            </CardContent>
+                          </Card>
+                        </div>
                       )}
                     </div>
+                  </div>
 
-                    {project.members.length > 0 && (
-                      <ul
-                        className="flex flex-wrap items-center gap-1"
-                        data-testid="member-list"
-                      >
-                        {project.members.map((member) => (
-                          <li key={member["@id"]} data-testid="member-pill">
-                            <Badge variant="outline">{member.email}</Badge>
-                          </li>
-                        ))}
-                      </ul>
-                    )}
-                  </CardContent>
-                </Card>
-
-                  <CustomFieldsManager
-                    projectIri={project["@id"]}
-                    projectTitle={project.title}
-                    spaceName={space?.name}
-                    isSpaceAdmin={isSpaceAdmin}
-                    onDefinitionsChanged={() => void reloadDefinitions()}
+                  <ConfirmDialog
+                    open={confirmDeleteProjectOpen}
+                    onOpenChange={setConfirmDeleteProjectOpen}
+                    title="Delete this project?"
+                    description={`"${project.title}" and all of its tasks will be permanently deleted. This can't be undone.`}
+                    confirmLabel="Delete project"
+                    onConfirm={handleDeleteProject}
                   />
                 </TabsContent>
 


### PR DESCRIPTION
Activity stream redesign + project Settings sections (PR 5/5 of the feature/wip batch).

- Render activity streams as a responsive history-point timeline (alternating cards when wide, stacked when narrow); readable change values (dates, refs, booleans)
- Fold custom-field activity into the board feed; reach the change log via a history icon on the list
- Share ProjectActivityScope so the space feed rolls up tasks + custom fields (space ⊃ project ⊃ task, like permissions)
- Section the project Settings tab (Privacy / Custom fields / Danger zone) with a left menu
- Show the New task button on the Tasks tab only; fix the "Private can…" spacing
- E2E: reach custom fields via the Settings tab section

Squash-merges as one changelog entry.