### PR TITLE
feat: task sections + Kanban board view

### DIFF
--- a/api/migrations/Version20260621045856.php
+++ b/api/migrations/Version20260621045856.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260621045856 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add task_section (board sections) and task.section_id; null section = default "In progress" group.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE task_section (id UUID NOT NULL, title VARCHAR(120) NOT NULL, position INT NOT NULL, project_id UUID NOT NULL, space_id UUID NOT NULL, PRIMARY KEY (id))');
+        $this->addSql('CREATE INDEX IDX_32925005166D1F9C ON task_section (project_id)');
+        $this->addSql('CREATE INDEX idx_task_section_project_position ON task_section (project_id, position)');
+        $this->addSql('CREATE INDEX idx_task_section_space ON task_section (space_id)');
+        $this->addSql('ALTER TABLE task_section ADD CONSTRAINT FK_32925005166D1F9C FOREIGN KEY (project_id) REFERENCES project (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE task_section ADD CONSTRAINT FK_3292500523575340 FOREIGN KEY (space_id) REFERENCES space (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE task ADD section_id UUID DEFAULT NULL');
+        $this->addSql('ALTER TABLE task ADD CONSTRAINT FK_527EDB25D823E37A FOREIGN KEY (section_id) REFERENCES task_section (id) ON DELETE SET NULL NOT DEFERRABLE');
+        $this->addSql('CREATE INDEX IDX_527EDB25D823E37A ON task (section_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE task_section DROP CONSTRAINT FK_32925005166D1F9C');
+        $this->addSql('ALTER TABLE task_section DROP CONSTRAINT FK_3292500523575340');
+        $this->addSql('DROP TABLE task_section');
+        $this->addSql('ALTER TABLE task DROP CONSTRAINT FK_527EDB25D823E37A');
+        $this->addSql('DROP INDEX IDX_527EDB25D823E37A');
+        $this->addSql('ALTER TABLE task DROP section_id');
+    }
+}

--- a/api/src/Controller/CustomFieldFooterController.php
+++ b/api/src/Controller/CustomFieldFooterController.php
@@ -156,7 +156,7 @@ class CustomFieldFooterController extends AbstractController
             $qb->andWhere('t.section IS NULL');
         } elseif (is_string($section) && '' !== $section) {
             $sectionId = str_contains($section, '/')
-                ? (string) substr((string) strrchr($section, '/'), 1)
+                ? substr((string) strrchr($section, '/'), 1)
                 : $section;
             if (Uuid::isValid($sectionId)) {
                 $qb->andWhere('t.section = :section')

--- a/api/src/Controller/CustomFieldFooterController.php
+++ b/api/src/Controller/CustomFieldFooterController.php
@@ -148,6 +148,22 @@ class CustomFieldFooterController extends AbstractController
                 ->setParameter('ftsQuery', trim($search));
         }
 
+        // Scope to a board section so the list view can footer each section
+        // independently. `none` = the default (unsectioned) group; an IRI or
+        // bare UUID = that section; omitting it aggregates the whole board.
+        $section = $request->query->get('section');
+        if ('none' === $section) {
+            $qb->andWhere('t.section IS NULL');
+        } elseif (is_string($section) && '' !== $section) {
+            $sectionId = str_contains($section, '/')
+                ? (string) substr((string) strrchr($section, '/'), 1)
+                : $section;
+            if (Uuid::isValid($sectionId)) {
+                $qb->andWhere('t.section = :section')
+                    ->setParameter('section', $sectionId);
+            }
+        }
+
         /** @var list<array{id: Uuid|string}> $rows */
         $rows = $qb->getQuery()->getArrayResult();
         $ids = [];

--- a/api/src/Doctrine/TaskSectionAccessExtension.php
+++ b/api/src/Doctrine/TaskSectionAccessExtension.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Doctrine;
+
+use App\Entity\TaskSection;
+
+/**
+ * Scopes TaskSection queries to spaces the current user belongs to. Uses the
+ * denormalised `space` FK so the shared direct-or-via-group membership
+ * predicate works without joining through `project`. See
+ * {@see AbstractSpaceAccessExtension}.
+ */
+final class TaskSectionAccessExtension extends AbstractSpaceAccessExtension
+{
+    protected function getResourceClass(): string
+    {
+        return TaskSection::class;
+    }
+
+    protected function getAliasPrefix(): string
+    {
+        return 'task_section_access';
+    }
+
+    protected function getImpersonationItemType(): ?string
+    {
+        // Sections follow their project's space + the 'projects' category
+        // default; they aren't individually addressable for per-item overrides.
+        return null;
+    }
+}

--- a/api/src/Entity/Task.php
+++ b/api/src/Entity/Task.php
@@ -6,6 +6,7 @@ use ApiPlatform\Doctrine\Orm\Filter\DateFilter;
 use ApiPlatform\Doctrine\Orm\Filter\OrderFilter;
 use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use App\Filter\OverdueFilter;
 use App\Filter\TaskSearchFilter;
@@ -118,6 +119,18 @@ class Task
     #[Gedmo\Versioned]
     #[Groups(['task:read', 'task:write'])]
     private ?Project $project = null;
+
+    /**
+     * Board section the task is grouped under. Null = the implicit default
+     * "In progress" group, so existing tasks need no backfill. When the parent
+     * section is deleted the FK is set to null, dropping the task back into the
+     * default group.
+     */
+    #[ApiProperty(readableLink: false)]
+    #[ORM\ManyToOne(targetEntity: TaskSection::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    #[Groups(['task:read', 'task:write'])]
+    private ?TaskSection $section = null;
 
     #[ORM\Column(length: 255)]
     #[Assert\NotBlank(message: 'Title is required.')]
@@ -294,6 +307,17 @@ class Task
     public function setProject(?Project $project): static
     {
         $this->project = $project;
+        return $this;
+    }
+
+    public function getSection(): ?TaskSection
+    {
+        return $this->section;
+    }
+
+    public function setSection(?TaskSection $section): static
+    {
+        $this->section = $section;
         return $this;
     }
 

--- a/api/src/Entity/TaskSection.php
+++ b/api/src/Entity/TaskSection.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Doctrine\Orm\Filter\OrderFilter;
+use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
+use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use App\Repository\TaskSectionRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * A named group of tasks on a project board ("section"). Tasks reference a
+ * section via {@see Task::$section}; a task with no section renders under the
+ * implicit default "In progress" group, so existing tasks need no backfill.
+ *
+ * Access mirrors the parent project's space (any space member can read and
+ * manage sections — they're lightweight board organisation, not structural
+ * schema like custom fields). The denormalised `space` FK lets the shared
+ * {@see App\Doctrine\AbstractSpaceAccessExtension} scope collections without
+ * joining through `project`.
+ */
+#[ApiResource(
+    shortName: 'TaskSection',
+    operations: [
+        new GetCollection(
+            security: "is_granted('ROLE_USER')",
+        ),
+        new Post(
+            security: "is_granted('ROLE_USER')",
+            securityPostDenormalize: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or (object.getProject() !== null and object.getProject().isAccessibleBy(user)))",
+        ),
+        new Get(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getProject().isAccessibleBy(user))",
+        ),
+        new Patch(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getProject().isAccessibleBy(user))",
+        ),
+        new Delete(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getProject().isAccessibleBy(user))",
+        ),
+    ],
+    normalizationContext: ['groups' => ['task_section:read']],
+    denormalizationContext: ['groups' => ['task_section:write']],
+    order: ['position' => 'ASC'],
+)]
+#[ApiFilter(SearchFilter::class, properties: ['project' => 'exact'])]
+#[ApiFilter(OrderFilter::class, properties: ['position'], arguments: ['orderParameterName' => 'order'])]
+#[ORM\Entity(repositoryClass: TaskSectionRepository::class)]
+#[ORM\Table(name: 'task_section')]
+#[ORM\Index(columns: ['project_id', 'position'], name: 'idx_task_section_project_position')]
+#[ORM\Index(columns: ['space_id'], name: 'idx_task_section_space')]
+#[ORM\HasLifecycleCallbacks]
+class TaskSection
+{
+    public const MAX_TITLE_LENGTH = 120;
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
+    #[Groups(['task_section:read'])]
+    private ?Uuid $id = null;
+
+    #[ApiProperty(readableLink: false)]
+    #[ORM\ManyToOne(targetEntity: Project::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    #[Assert\NotNull(message: 'Project is required.')]
+    #[Groups(['task_section:read', 'task_section:write'])]
+    private ?Project $project = null;
+
+    #[ORM\ManyToOne(targetEntity: Space::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    #[Groups(['task_section:read'])]
+    private ?Space $space = null;
+
+    #[ORM\Column(length: self::MAX_TITLE_LENGTH)]
+    #[Assert\NotBlank(message: 'Section title is required.')]
+    #[Assert\Length(
+        max: self::MAX_TITLE_LENGTH,
+        maxMessage: 'Section title cannot be longer than {{ limit }} characters.',
+    )]
+    #[Groups(['task_section:read', 'task_section:write'])]
+    private string $title = '';
+
+    #[ORM\Column(type: 'integer')]
+    #[Groups(['task_section:read', 'task_section:write'])]
+    private int $position = 0;
+
+    /**
+     * Denormalise the parent project's space on insert so the access extension
+     * can scope by `space` without joining through `project` (mirrors
+     * CustomFieldDefinition::syncSpaceFromProject).
+     */
+    #[ORM\PrePersist]
+    #[ORM\PreUpdate]
+    public function syncSpaceFromProject(): void
+    {
+        if (null !== $this->project) {
+            $this->space = $this->project->getSpace();
+        }
+    }
+
+    public function getId(): ?Uuid
+    {
+        return $this->id;
+    }
+
+    public function getProject(): ?Project
+    {
+        return $this->project;
+    }
+
+    public function setProject(?Project $project): self
+    {
+        $this->project = $project;
+
+        return $this;
+    }
+
+    public function getSpace(): ?Space
+    {
+        return $this->space;
+    }
+
+    public function setSpace(?Space $space): self
+    {
+        $this->space = $space;
+
+        return $this;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): self
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function setPosition(int $position): self
+    {
+        $this->position = $position;
+
+        return $this;
+    }
+}

--- a/api/src/Repository/TaskSectionRepository.php
+++ b/api/src/Repository/TaskSectionRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\TaskSection;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<TaskSection>
+ */
+class TaskSectionRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, TaskSection::class);
+    }
+}

--- a/api/tests/Api/CustomFieldDefinitionActivityTest.php
+++ b/api/tests/Api/CustomFieldDefinitionActivityTest.php
@@ -111,7 +111,9 @@ class CustomFieldDefinitionActivityTest extends ApiTestCase
         // remove event, rather than dropping it entirely.
         $client->request('GET', '/projects/' . $project->getId() . '/custom_field_definitions/activity');
         $this->assertResponseIsSuccessful();
-        $body = $client->getResponse()->toArray();
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
 
         $items = $body['items'] ?? null;
         $this->assertIsArray($items);

--- a/api/tests/Api/ProjectActivityTest.php
+++ b/api/tests/Api/ProjectActivityTest.php
@@ -61,7 +61,9 @@ class ProjectActivityTest extends ApiTestCase
         // remove event, rather than dropping it with the row.
         $client->request('GET', '/projects/' . $project->getId() . '/activity');
         $this->assertResponseIsSuccessful();
-        $body = $client->getResponse()->toArray();
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
 
         $items = $body['items'] ?? null;
         $this->assertIsArray($items);
@@ -98,7 +100,9 @@ class ProjectActivityTest extends ApiTestCase
 
         $client->request('GET', '/projects/' . $project->getId() . '/activity');
         $this->assertResponseIsSuccessful();
-        $body = $client->getResponse()->toArray();
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
 
         $items = $body['items'] ?? null;
         $this->assertIsArray($items);

--- a/api/tests/Api/SpaceActivityTest.php
+++ b/api/tests/Api/SpaceActivityTest.php
@@ -120,7 +120,9 @@ class SpaceActivityTest extends ApiTestCase
         $client->loginUser($owner);
         $client->request('GET', '/spaces/' . $space->getId() . '/activity');
         $this->assertResponseIsSuccessful();
-        $body = $client->getResponse()->toArray();
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
 
         $items = $body['items'] ?? null;
         $this->assertIsArray($items);

--- a/api/tests/Api/TaskSectionTest.php
+++ b/api/tests/Api/TaskSectionTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\Project;
+use App\Entity\Task;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Task sections (board grouping): CRUD + space scoping, and assigning a task to
+ * a section via the Task `section` write group.
+ */
+class TaskSectionTest extends ApiTestCase
+{
+    use SpaceMembershipFixture;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = static::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\TaskSection')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testMemberCreatesSectionAndAssignsTask(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        // Create a section.
+        $section = $client->request('POST', '/task_sections', [
+            'json' => [
+                'project' => '/projects/' . $project->getId(),
+                'title' => 'Up next',
+                'position' => 0,
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $sectionIri = $section['@id'];
+        $this->assertIsString($sectionIri);
+
+        // It shows up in the project-scoped collection.
+        $list = $client->request('GET', '/task_sections?project=/projects/' . $project->getId())
+            ->toArray();
+        $this->assertSame(1, $list['totalItems'] ?? null);
+
+        // Assign a task to the section.
+        $task = $client->request('POST', '/tasks', [
+            'json' => [
+                'title' => 'Wire it up',
+                'project' => '/projects/' . $project->getId(),
+                'section' => $sectionIri,
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertSame($sectionIri, $task['section'] ?? null);
+    }
+
+    public function testNonMemberCannotSeeSections(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $stranger = $this->createUser('stranger@example.com');
+        $project = $this->createProject($alice, 'Private');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $created = $client->request('POST', '/task_sections', [
+            'json' => ['project' => '/projects/' . $project->getId(), 'title' => 'Secret'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $iri = $created['@id'];
+        $this->assertIsString($iri);
+
+        // The stranger's scoped list is empty and the item lookup 404s.
+        $client->loginUser($stranger);
+        $list = $client->request('GET', '/task_sections?project=/projects/' . $project->getId())
+            ->toArray();
+        $this->assertSame(0, $list['totalItems'] ?? null);
+
+        $client->request('GET', $iri);
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    private function createProject(User $owner, string $title): Project
+    {
+        $project = new Project();
+        $project->setOwner($owner);
+        $project->setTitle($title);
+        $this->addProjectMember($project, $owner);
+        $this->entityManager->persist($project);
+        $this->entityManager->flush();
+
+        return $project;
+    }
+
+    private function createUser(string $email): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/e2e/tests/tags.spec.js
+++ b/e2e/tests/tags.spec.js
@@ -77,7 +77,7 @@ test.describe("Tags", () => {
 
     // The tags combobox input is always present; click into it so Base UI
     // opens the options popover.
-    const tagInput = item.locator('[data-slot="combobox-chip-input"]');
+    const tagInput = item.locator('[data-testid="task-tags"] [data-slot="combobox-chip-input"]');
     await tagInput.click();
     await page.getByRole("option", { name: `Blue-${suffix}` }).click();
     await expect(item.locator('[data-testid="task-tag"]')).toContainText(`Blue-${suffix}`);
@@ -122,7 +122,7 @@ test.describe("Tags", () => {
     await createTaskInline(page, taskTitle);
     const item = page.locator('[data-testid="task-item"]', { hasText: taskTitle });
     // Click into the always-present chip-input to open the Base UI Combobox popover.
-    await item.locator('[data-slot="combobox-chip-input"]').click();
+    await item.locator('[data-testid="task-tags"] [data-slot="combobox-chip-input"]').click();
     await page.getByRole("option", { name: tagTitle }).click();
     await expect(item.locator('[data-testid="task-tag"]')).toContainText(tagTitle);
     // Dismiss the popover.

--- a/pwa/components/custom-fields/CustomFieldFooterRow.tsx
+++ b/pwa/components/custom-fields/CustomFieldFooterRow.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { ENTRYPOINT } from "@/config/entrypoint";
 import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
 import type { FooterResponse, FooterRow } from "./types";
 
 /**
@@ -18,6 +19,10 @@ interface Props {
   filters?: string;
   /** Bump to force a re-fetch (e.g. after a task value is edited inline). */
   refreshKey?: number;
+  /** Optional leading label (e.g. "Grand total") — also switches to a
+   *  standalone rounded card instead of the table-attached style. */
+  heading?: string;
+  className?: string;
 }
 
 const formatValue = (row: FooterRow): string => {
@@ -62,7 +67,13 @@ const formatNumber = (v: number): string => {
     : v.toLocaleString(undefined, { maximumFractionDigits: 2 });
 };
 
-const CustomFieldFooterRow = ({ projectId, filters, refreshKey }: Props) => {
+const CustomFieldFooterRow = ({
+  projectId,
+  filters,
+  refreshKey,
+  heading,
+  className,
+}: Props) => {
   const [rows, setRows] = useState<FooterRow[]>([]);
   const [error, setError] = useState<string | null>(null);
 
@@ -94,10 +105,18 @@ const CustomFieldFooterRow = ({ projectId, filters, refreshKey }: Props) => {
 
   return (
     <Card
-      className="rounded-t-none border-t-0"
+      className={cn(
+        heading ? "rounded-lg" : "rounded-t-none border-t-0",
+        className,
+      )}
       data-testid="custom-field-footer-row"
     >
-      <CardContent className="py-2 flex flex-wrap gap-x-6 gap-y-1 text-sm">
+      <CardContent className="py-2 flex flex-wrap items-baseline gap-x-6 gap-y-1 text-sm">
+        {heading && (
+          <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {heading}
+          </span>
+        )}
         {rows.map((row) => (
           <div
             key={row.definition}

--- a/pwa/components/projects/TaskBoard.tsx
+++ b/pwa/components/projects/TaskBoard.tsx
@@ -1,0 +1,263 @@
+import { useState } from "react";
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core";
+import { MoreHorizontal, Plus, Trash2 } from "lucide-react";
+import UserAvatar, { type AvatarUser } from "@/components/user/UserAvatar";
+import { Badge } from "@/components/ui/badge";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+
+/**
+ * Kanban board view for a project: one column per board section, with task
+ * cards that open the detail drawer on click and drag between sections. The
+ * default "In progress" group (sectionIri === null) is the first column.
+ *
+ * Drag uses @dnd-kit with a pointer activation distance so a plain click still
+ * opens the drawer; dropping a card on a column moves the task to that section.
+ */
+export interface BoardTask {
+  "@id": string;
+  id: string;
+  title: string;
+  completedOn: string | null;
+  dueDate: string | null;
+  section: string | null;
+  tags: { "@id": string; title: string }[];
+  assignees: AvatarUser[];
+}
+
+export interface BoardColumn {
+  key: string;
+  sectionIri: string | null;
+  title: string;
+  tasks: BoardTask[];
+}
+
+interface TaskBoardProps {
+  columns: BoardColumn[];
+  onOpen: (taskIri: string) => void;
+  onMove: (taskIri: string, sectionIri: string | null) => void;
+  onAddTask: (sectionIri: string | null) => void;
+  onAddSection: () => void;
+  onDeleteSection: (sectionIri: string) => void;
+}
+
+const COL_PREFIX = "col:";
+
+const dueLabel = (iso: string): string => {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+};
+
+const CardBody = ({ task }: { task: BoardTask }) => (
+  <div className="space-y-1.5">
+    <p
+      className={cn(
+        "text-sm leading-snug",
+        task.completedOn && "text-muted-foreground line-through",
+      )}
+    >
+      {task.title}
+    </p>
+    {(task.tags.length > 0 || task.dueDate || task.assignees.length > 0) && (
+      <div className="flex flex-wrap items-center gap-1">
+        {task.dueDate && (
+          <Badge variant="secondary" className="px-1.5 py-0 text-[10px] font-normal">
+            {dueLabel(task.dueDate)}
+          </Badge>
+        )}
+        {task.tags.map((tag) => (
+          <Badge
+            key={tag["@id"]}
+            variant="outline"
+            className="px-1.5 py-0 text-[10px] font-normal"
+          >
+            {tag.title}
+          </Badge>
+        ))}
+        {task.assignees.length > 0 && (
+          <span className="ml-auto flex -space-x-1.5">
+            {task.assignees.slice(0, 3).map((a, i) => (
+              <UserAvatar key={i} user={a} size="sm" className="ring-2 ring-card" />
+            ))}
+          </span>
+        )}
+      </div>
+    )}
+  </div>
+);
+
+const TaskCard = ({
+  task,
+  onOpen,
+}: {
+  task: BoardTask;
+  onOpen: (taskIri: string) => void;
+}) => {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: task["@id"],
+  });
+  return (
+    <button
+      ref={setNodeRef}
+      type="button"
+      {...attributes}
+      {...listeners}
+      onClick={() => onOpen(task["@id"])}
+      className={cn(
+        "w-full cursor-grab rounded-lg border bg-card p-2.5 text-left shadow-sm transition hover:border-foreground/20 active:cursor-grabbing",
+        isDragging && "opacity-40",
+      )}
+      data-testid="board-card"
+    >
+      <CardBody task={task} />
+    </button>
+  );
+};
+
+const BoardColumnView = ({
+  column,
+  onOpen,
+  onAddTask,
+  onDeleteSection,
+}: {
+  column: BoardColumn;
+  onOpen: (taskIri: string) => void;
+  onAddTask: (sectionIri: string | null) => void;
+  onDeleteSection: (sectionIri: string) => void;
+}) => {
+  const { setNodeRef, isOver } = useDroppable({ id: `${COL_PREFIX}${column.key}` });
+  return (
+    <div className="flex w-72 shrink-0 flex-col" data-testid="board-column">
+      <div className="mb-2 flex items-center gap-2 px-1">
+        <span className="text-sm font-semibold">{column.title}</span>
+        <span className="text-xs text-muted-foreground">{column.tasks.length}</span>
+        {column.sectionIri && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                className="ml-auto rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                aria-label="Section actions"
+              >
+                <MoreHorizontal className="h-4 w-4" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                onClick={() => onDeleteSection(column.sectionIri as string)}
+                className="text-destructive"
+              >
+                <Trash2 className="mr-2 h-4 w-4" /> Delete section
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+      </div>
+      <div
+        ref={setNodeRef}
+        className={cn(
+          "flex min-h-24 flex-1 flex-col gap-2 rounded-lg border border-dashed border-transparent bg-muted/30 p-2 transition",
+          isOver && "border-foreground/30 bg-muted/60",
+        )}
+      >
+        {column.tasks.map((task) => (
+          <TaskCard key={task["@id"]} task={task} onOpen={onOpen} />
+        ))}
+        <button
+          type="button"
+          onClick={() => onAddTask(column.sectionIri)}
+          className="flex items-center gap-1 rounded-md px-1.5 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+          data-testid="board-add-task"
+        >
+          <Plus className="h-3.5 w-3.5" /> Add task
+        </button>
+      </div>
+    </div>
+  );
+};
+
+const TaskBoard = ({
+  columns,
+  onOpen,
+  onMove,
+  onAddTask,
+  onAddSection,
+  onDeleteSection,
+}: TaskBoardProps) => {
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  );
+
+  const draggingTask = draggingId
+    ? columns.flatMap((c) => c.tasks).find((t) => t["@id"] === draggingId)
+    : null;
+
+  const handleStart = (event: DragStartEvent) =>
+    setDraggingId(String(event.active.id));
+
+  const handleEnd = (event: DragEndEvent) => {
+    setDraggingId(null);
+    const { active, over } = event;
+    if (!over) return;
+    const overId = String(over.id);
+    if (!overId.startsWith(COL_PREFIX)) return;
+    const colKey = overId.slice(COL_PREFIX.length);
+    const target = columns.find((c) => c.key === colKey);
+    if (!target) return;
+    const taskIri = String(active.id);
+    const task = columns.flatMap((c) => c.tasks).find((t) => t["@id"] === taskIri);
+    if (task && task.section !== target.sectionIri) {
+      onMove(taskIri, target.sectionIri);
+    }
+  };
+
+  return (
+    <DndContext sensors={sensors} onDragStart={handleStart} onDragEnd={handleEnd}>
+      <div className="flex gap-4 overflow-x-auto pb-2" data-testid="task-board">
+        {columns.map((column) => (
+          <BoardColumnView
+            key={column.key}
+            column={column}
+            onOpen={onOpen}
+            onAddTask={onAddTask}
+            onDeleteSection={onDeleteSection}
+          />
+        ))}
+        <button
+          type="button"
+          onClick={onAddSection}
+          className="flex h-9 w-72 shrink-0 items-center gap-1 rounded-lg border border-dashed px-3 text-sm text-muted-foreground hover:bg-muted hover:text-foreground"
+          data-testid="board-add-section"
+        >
+          <Plus className="h-4 w-4" /> Add section
+        </button>
+      </div>
+      <DragOverlay>
+        {draggingTask ? (
+          <div className="w-72 rounded-lg border bg-card p-2.5 shadow-lg">
+            <CardBody task={draggingTask} />
+          </div>
+        ) : null}
+      </DragOverlay>
+    </DndContext>
+  );
+};
+
+export default TaskBoard;

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -1,8 +1,8 @@
 import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Lock, PanelRight, Plus, Shield, Table2, Trash2, TriangleAlert } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from "react";
+import { ChevronDown, Lock, MoreHorizontal, PanelRight, Plus, Rows3, Shield, Table2, Trash2, TriangleAlert } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
 import { ENTRYPOINT } from "@/config/entrypoint";
@@ -20,8 +20,6 @@ import TaskDetailDrawer from "@/components/tasks/TaskDetailDrawer";
 import type { CustomFieldDefinition } from "@/components/custom-fields/types";
 import {
   dueDateStatus,
-  isoToLocalDate,
-  todayLocalMidnight,
   type Reminder,
   type RecurrenceRule,
 } from "@/components/tasks/taskHelpers";
@@ -30,6 +28,12 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import ConfirmDialog from "@/components/common/ConfirmDialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -79,6 +83,15 @@ interface ProjectTask {
   recurrenceRule: RecurrenceRule | null;
   reminders: Reminder[] | null;
   customFieldValues: CustomFieldValuePair[];
+  /** Board section IRI, or null = the default "In progress" group. */
+  section: string | null;
+}
+
+interface TaskSection {
+  "@id": string;
+  id: string;
+  title: string;
+  position: number;
 }
 
 interface Collection<T> {
@@ -98,28 +111,9 @@ const isEmptyFieldValue = (value: unknown): boolean =>
   value === "" ||
   (Array.isArray(value) && value.length === 0);
 
-// Due-date buckets for the grouped list, in render order.
-type Bucket = "overdue" | "week" | "later" | "none" | "done";
-const BUCKET_LABELS: Record<Bucket, string> = {
-  overdue: "Overdue",
-  week: "This week",
-  later: "Later",
-  none: "No due date",
-  done: "Completed",
-};
-const BUCKET_ORDER: Bucket[] = ["overdue", "week", "later", "none", "done"];
-
-const bucketFor = (task: ProjectTask): Bucket => {
-  if (task.completedOn) return "done";
-  const status = dueDateStatus(task.dueDate, false);
-  if (status === "overdue") return "overdue";
-  if (!task.dueDate) return "none";
-  const due = isoToLocalDate(task.dueDate);
-  if (!due) return "none";
-  const weekEnd = todayLocalMidnight();
-  weekEnd.setDate(weekEnd.getDate() + 7);
-  return due.getTime() <= weekEnd.getTime() ? "week" : "later";
-};
+// The implicit group for tasks with no section (Task.section === null).
+const DEFAULT_SECTION_KEY = "__default__";
+const DEFAULT_SECTION_LABEL = "In progress";
 
 const ProjectDetail = () => {
   const { user, isAuthenticated, isLoading: authLoading } = useAuth();
@@ -132,6 +126,7 @@ const ProjectDetail = () => {
   const [project, setProject] = useState<Project | null>(null);
   const [tasks, setTasks] = useState<ProjectTask[]>([]);
   const [definitions, setDefinitions] = useState<CustomFieldDefinition[]>([]);
+  const [sections, setSections] = useState<TaskSection[]>([]);
   const [assignableUsers, setAssignableUsers] = useState<AssigneeOption[]>([]);
   const [allTags, setAllTags] = useState<TagOption[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -148,8 +143,12 @@ const ProjectDetail = () => {
   const [confirmDeleteProjectOpen, setConfirmDeleteProjectOpen] =
     useState(false);
 
-  // Quick add-task (collapsed behind "+ New task").
-  const [addOpen, setAddOpen] = useState(false);
+  // Quick add-task. `addSection` is which group the inline add row is open in:
+  // undefined = closed, null = the default "In progress" group, a string = that
+  // section's IRI. So new tasks land in the section the user added them under.
+  const [addSection, setAddSection] = useState<string | null | undefined>(
+    undefined,
+  );
   const [newTaskTitle, setNewTaskTitle] = useState("");
   const [isCreatingTask, setIsCreatingTask] = useState(false);
   const newTaskInputRef = useRef<HTMLInputElement | null>(null);
@@ -219,10 +218,14 @@ const ProjectDetail = () => {
       setProject(projectData);
 
       const projectIri = projectData["@id"];
-      const [tasksRes, defsRes, usersRes, tagsRes] = await Promise.all([
+      const [tasksRes, defsRes, sectionsRes, usersRes, tagsRes] = await Promise.all([
         fetch(`${ENTRYPOINT}/tasks?project=${encodeURIComponent(projectIri)}`, init),
         fetch(
           `${ENTRYPOINT}/custom_field_definitions?project=${encodeURIComponent(projectIri)}`,
+          init,
+        ),
+        fetch(
+          `${ENTRYPOINT}/task_sections?project=${encodeURIComponent(projectIri)}`,
           init,
         ),
         fetch(`${ENTRYPOINT}/me/assignable-users`, init),
@@ -233,6 +236,13 @@ const ProjectDetail = () => {
       if (defsRes.ok) {
         setDefinitions(
           membersOf<CustomFieldDefinition>(await defsRes.json()).sort(
+            (a, b) => a.position - b.position,
+          ),
+        );
+      }
+      if (sectionsRes.ok) {
+        setSections(
+          membersOf<TaskSection>(await sectionsRes.json()).sort(
             (a, b) => a.position - b.position,
           ),
         );
@@ -350,7 +360,12 @@ const ProjectDetail = () => {
         method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/ld+json" },
-        body: JSON.stringify({ title, project: project["@id"] }),
+        body: JSON.stringify({
+          title,
+          project: project["@id"],
+          // `addSection` is the IRI of the group being added to; null = default.
+          ...(typeof addSection === "string" ? { section: addSection } : {}),
+        }),
       });
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
@@ -372,13 +387,76 @@ const ProjectDetail = () => {
     }
   };
 
-  const openAddRow = () => {
-    setAddOpen(true);
+  const openAddRow = (section: string | null = null) => {
+    setAddSection(section);
     requestAnimationFrame(() => newTaskInputRef.current?.focus());
   };
   const closeAddRow = () => {
-    setAddOpen(false);
+    setAddSection(undefined);
     setNewTaskTitle("");
+  };
+
+  const createSection = async () => {
+    if (!project) return;
+    try {
+      const res = await fetch(`${ENTRYPOINT}/task_sections`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/ld+json" },
+        body: JSON.stringify({
+          project: project["@id"],
+          title: "New section",
+          position: sections.length,
+        }),
+      });
+      if (!res.ok) throw new Error("Failed to add section.");
+      const created: TaskSection = await res.json();
+      setSections((prev) => [...prev, created]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to add section.");
+    }
+  };
+
+  const renameSection = async (section: TaskSection, title: string) => {
+    const trimmed = title.trim();
+    if (trimmed === "" || trimmed === section.title) return;
+    setSections((prev) =>
+      prev.map((s) =>
+        s["@id"] === section["@id"] ? { ...s, title: trimmed } : s,
+      ),
+    );
+    try {
+      const res = await fetch(`${ENTRYPOINT}${section["@id"]}`, {
+        method: "PATCH",
+        credentials: "include",
+        headers: { "Content-Type": "application/merge-patch+json" },
+        body: JSON.stringify({ title: trimmed }),
+      });
+      if (!res.ok) throw new Error("Failed to rename section.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to rename section.");
+    }
+  };
+
+  const deleteSection = async (section: TaskSection) => {
+    try {
+      const res = await fetch(`${ENTRYPOINT}${section["@id"]}`, {
+        method: "DELETE",
+        credentials: "include",
+      });
+      if (!res.ok && res.status !== 204) {
+        throw new Error("Failed to delete section.");
+      }
+      setSections((prev) => prev.filter((s) => s["@id"] !== section["@id"]));
+      // Its tasks fall back to the default group (server SET NULL).
+      setTasks((prev) =>
+        prev.map((t) =>
+          t.section === section["@id"] ? { ...t, section: null } : t,
+        ),
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete section.");
+    }
   };
 
   const handleMove = async () => {
@@ -466,23 +544,40 @@ const ProjectDetail = () => {
     await router.push("/projects");
   };
 
-  const grouped = useMemo(() => {
+  // Group tasks by board section. The default "In progress" group (null
+  // section) always leads; user sections follow in position order. Empty
+  // sections still render so tasks can be added/moved into them.
+  const sectionGroups = useMemo(() => {
     const ordered = [...tasks].sort((a, b) => a.position - b.position);
-    const map = new Map<Bucket, ProjectTask[]>();
+    const bySection = new Map<string, ProjectTask[]>();
     for (const task of ordered) {
-      const bucket = bucketFor(task);
-      const list = map.get(bucket) ?? [];
+      const key = task.section ?? DEFAULT_SECTION_KEY;
+      const list = bySection.get(key) ?? [];
       list.push(task);
-      map.set(bucket, list);
+      bySection.set(key, list);
     }
-    return BUCKET_ORDER.map((bucket) => ({
-      bucket,
-      tasks: map.get(bucket) ?? [],
-    })).filter((g) => g.tasks.length > 0);
-  }, [tasks]);
+    const groups: {
+      key: string;
+      section: TaskSection | null;
+      tasks: ProjectTask[];
+    }[] = [
+      {
+        key: DEFAULT_SECTION_KEY,
+        section: null,
+        tasks: bySection.get(DEFAULT_SECTION_KEY) ?? [],
+      },
+    ];
+    for (const section of [...sections].sort((a, b) => a.position - b.position)) {
+      groups.push({
+        key: section["@id"],
+        section,
+        tasks: bySection.get(section["@id"]) ?? [],
+      });
+    }
+    return groups;
+  }, [tasks, sections]);
 
   const openCount = tasks.filter((t) => !t.completedOn).length;
-  const totalCols = 7 + definitions.length;
 
   if (authLoading || !isAuthenticated) {
     return (
@@ -559,14 +654,38 @@ const ProjectDetail = () => {
                   )}
                 </div>
                 {activeTab === "tasks" && (
-                  <div className="flex flex-wrap items-center gap-2">
+                  <div className="flex items-center">
                     <Button
                       size="sm"
-                      onClick={openAddRow}
+                      className="rounded-r-none"
+                      onClick={() => openAddRow(null)}
                       data-testid="project-new-task"
                     >
                       <Plus className="mr-1 h-3.5 w-3.5" /> New task
                     </Button>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          size="sm"
+                          className="rounded-l-none border-l border-primary-foreground/25 px-1.5"
+                          aria-label="More add options"
+                          data-testid="project-add-menu"
+                        >
+                          <ChevronDown className="h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem onClick={() => openAddRow(null)}>
+                          <Plus className="mr-2 h-4 w-4" /> New task
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onClick={() => void createSection()}
+                          data-testid="project-add-section"
+                        >
+                          <Rows3 className="mr-2 h-4 w-4" /> Add section
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
                   </div>
                 )}
               </div>
@@ -810,107 +929,67 @@ const ProjectDetail = () => {
                 </TabsContent>
 
                 <TabsContent value="tasks" className="mt-4">
-                  {tasks.length === 0 && !addOpen ? (
-                    <Card>
-                      <CardContent className="pt-6">
-                        <p className="text-muted-foreground">
-                          No tasks in this project yet.
-                        </p>
-                      </CardContent>
-                    </Card>
-                  ) : (
-                    <div className="overflow-x-auto rounded-t-lg border">
-                      <table className="w-full text-sm" data-testid="project-task-list">
-                        <thead>
-                          <tr className="border-b text-xs uppercase tracking-wide text-muted-foreground">
-                            <th className="w-8 px-3 py-2" />
-                            <th className="w-10 px-1 py-2 text-left font-medium">#</th>
-                            <th className="px-2 py-2 text-left font-medium">Task</th>
-                            <th className="px-2 py-2 text-left font-medium">Tags</th>
-                            {definitions.map((def) => (
-                              <th
-                                key={def["@id"]}
-                                className="px-2 py-2 text-left font-medium whitespace-nowrap"
-                              >
-                                {def.name}
-                              </th>
-                            ))}
-                            <th className="px-2 py-2 text-left font-medium">Due</th>
-                            <th className="px-2 py-2 text-left font-medium">Assignees</th>
-                            <th className="w-10 px-2 py-2" />
-                          </tr>
-                        </thead>
-                        <tbody>
-                          {addOpen && (
-                            <tr
-                              className="border-b bg-muted/20"
-                              data-testid="project-new-task-row"
-                            >
-                              <td className="px-3 py-2 align-middle">
-                                <Plus
-                                  className="h-4 w-4 text-muted-foreground"
-                                  aria-hidden
-                                />
-                              </td>
-                              <td className="px-1 py-2" />
-                              <td className="px-2 py-2">
-                                <Input
-                                  ref={newTaskInputRef}
-                                  value={newTaskTitle}
-                                  onChange={(e) => setNewTaskTitle(e.target.value)}
-                                  onKeyDown={(e) => {
-                                    if (e.key === "Enter") {
-                                      e.preventDefault();
-                                      void createTask();
-                                    } else if (e.key === "Escape") {
-                                      e.preventDefault();
-                                      closeAddRow();
-                                    }
-                                  }}
-                                  onBlur={() => {
-                                    if (!newTaskTitle.trim()) closeAddRow();
-                                  }}
-                                  placeholder="Task title, then Enter…"
-                                  maxLength={255}
-                                  disabled={isCreatingTask}
-                                  className="h-8"
-                                  data-testid="project-new-task-title"
-                                />
-                              </td>
-                              <td
-                                colSpan={definitions.length + 4}
-                                className="px-2 py-2 text-xs text-muted-foreground"
-                              >
-                                Enter to add · Esc to cancel
-                              </td>
-                            </tr>
-                          )}
-                          {grouped.map((group) => (
-                            <GroupRows
-                              key={group.bucket}
-                              label={BUCKET_LABELS[group.bucket]}
-                              count={group.tasks.length}
-                              colSpan={totalCols}
-                              tasks={group.tasks}
-                              definitions={definitions}
-                              allTags={allTags}
-                              assignableUsers={assignableUsers}
-                              projectIri={project["@id"]}
-                              spaceIri={projectSpaceIri(project)}
-                              onToggle={toggleComplete}
-                              onOpen={openTaskDetail}
-                              patchTask={patchTask}
-                              onCustomFieldChange={handleCustomFieldChange}
-                            />
-                          ))}
-                        </tbody>
-                      </table>
-                      <CustomFieldFooterRow
-                        projectId={project.id}
-                        refreshKey={footerKey}
-                      />
-                    </div>
-                  )}
+                  {/* Grand totals across the whole board — top. */}
+                  <CustomFieldFooterRow
+                    projectId={project.id}
+                    refreshKey={footerKey}
+                    heading="Grand total"
+                    className="mb-6 rounded-lg"
+                  />
+
+                  <div className="space-y-6" data-testid="project-task-list">
+                    {sectionGroups.map((group) => {
+                      const sectionIri = group.section
+                        ? group.section["@id"]
+                        : null;
+                      return (
+                        <SectionBlock
+                          key={group.key}
+                          section={group.section}
+                          title={
+                            group.section
+                              ? group.section.title
+                              : DEFAULT_SECTION_LABEL
+                          }
+                          tasks={group.tasks}
+                          definitions={definitions}
+                          projectId={project.id}
+                          projectIri={project["@id"]}
+                          spaceIri={projectSpaceIri(project)}
+                          allTags={allTags}
+                          assignableUsers={assignableUsers}
+                          footerFilter={
+                            sectionIri
+                              ? `section=${encodeURIComponent(sectionIri)}`
+                              : "section=none"
+                          }
+                          footerKey={footerKey}
+                          addOpen={addSection === sectionIri}
+                          newTaskTitle={newTaskTitle}
+                          newTaskInputRef={newTaskInputRef}
+                          isCreatingTask={isCreatingTask}
+                          onNewTaskTitle={setNewTaskTitle}
+                          onCreateTask={createTask}
+                          onAddRow={() => openAddRow(sectionIri)}
+                          onCloseAddRow={closeAddRow}
+                          onToggle={toggleComplete}
+                          onOpen={openTaskDetail}
+                          patchTask={patchTask}
+                          onCustomFieldChange={handleCustomFieldChange}
+                          onRename={renameSection}
+                          onDelete={deleteSection}
+                        />
+                      );
+                    })}
+                  </div>
+
+                  {/* Grand totals across the whole board — bottom. */}
+                  <CustomFieldFooterRow
+                    projectId={project.id}
+                    refreshKey={footerKey}
+                    heading="Grand total"
+                    className="mt-6 rounded-lg"
+                  />
                 </TabsContent>
 
                 <TabsContent value="activity" className="mt-4">
@@ -956,11 +1035,223 @@ const ProjectDetail = () => {
   );
 };
 
-interface GroupRowsProps {
-  label: string;
-  count: number;
-  colSpan: number;
+interface SectionBlockProps {
+  section: TaskSection | null;
+  title: string;
   tasks: ProjectTask[];
+  definitions: CustomFieldDefinition[];
+  projectId: string;
+  projectIri: string;
+  spaceIri: string;
+  allTags: TagOption[];
+  assignableUsers: AssigneeOption[];
+  footerFilter: string;
+  footerKey: number;
+  addOpen: boolean;
+  newTaskTitle: string;
+  newTaskInputRef: RefObject<HTMLInputElement | null>;
+  isCreatingTask: boolean;
+  onNewTaskTitle: (value: string) => void;
+  onCreateTask: () => void | Promise<void>;
+  onAddRow: () => void;
+  onCloseAddRow: () => void;
+  onToggle: (task: ProjectTask) => void;
+  onOpen: (task: ProjectTask) => void;
+  patchTask: (task: ProjectTask, body: Record<string, unknown>) => Promise<void>;
+  onCustomFieldChange: (task: ProjectTask, defIri: string, value: unknown) => void;
+  onRename: (section: TaskSection, title: string) => void | Promise<void>;
+  onDelete: (section: TaskSection) => void | Promise<void>;
+}
+
+/** One board section: editable title + its own task table + a footer. */
+const SectionBlock = ({
+  section,
+  title,
+  tasks,
+  definitions,
+  projectId,
+  projectIri,
+  spaceIri,
+  allTags,
+  assignableUsers,
+  footerFilter,
+  footerKey,
+  addOpen,
+  newTaskTitle,
+  newTaskInputRef,
+  isCreatingTask,
+  onNewTaskTitle,
+  onCreateTask,
+  onAddRow,
+  onCloseAddRow,
+  onToggle,
+  onOpen,
+  patchTask,
+  onCustomFieldChange,
+  onRename,
+  onDelete,
+}: SectionBlockProps) => {
+  const addColSpan = definitions.length + 4;
+  const fullColSpan = definitions.length + 7;
+  return (
+    <div data-testid="project-section">
+      <div className="mb-1.5 flex items-center gap-2">
+        {section ? (
+          <input
+            defaultValue={title}
+            onBlur={(e) => void onRename(section, e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") (e.target as HTMLInputElement).blur();
+            }}
+            className="rounded border border-transparent bg-transparent px-1 py-0.5 text-sm font-semibold hover:border-input focus:border-input focus:outline-none"
+            aria-label="Section title"
+            data-testid="section-title-input"
+          />
+        ) : (
+          <span className="px-1 text-sm font-semibold">{title}</span>
+        )}
+        <span className="text-xs text-muted-foreground">{tasks.length}</span>
+        <button
+          type="button"
+          onClick={onAddRow}
+          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+          data-testid="section-add-task"
+        >
+          <Plus className="h-3.5 w-3.5" /> Add task
+        </button>
+        {section && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                className="ml-auto rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                aria-label="Section actions"
+                data-testid="section-menu"
+              >
+                <MoreHorizontal className="h-4 w-4" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                onClick={() => void onDelete(section)}
+                className="text-destructive"
+                data-testid="section-delete"
+              >
+                <Trash2 className="mr-2 h-4 w-4" /> Delete section
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+      </div>
+
+      <div className="overflow-x-auto rounded-t-lg border">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b text-xs uppercase tracking-wide text-muted-foreground">
+              <th className="w-8 px-3 py-2" />
+              <th className="w-10 px-1 py-2 text-left font-medium">#</th>
+              <th className="px-2 py-2 text-left font-medium">Task</th>
+              <th className="px-2 py-2 text-left font-medium">Tags</th>
+              {definitions.map((def) => (
+                <th
+                  key={def["@id"]}
+                  className="px-2 py-2 text-left font-medium whitespace-nowrap"
+                >
+                  {def.name}
+                </th>
+              ))}
+              <th className="px-2 py-2 text-left font-medium">Due</th>
+              <th className="px-2 py-2 text-left font-medium">Assignees</th>
+              <th className="w-10 px-2 py-2" />
+            </tr>
+          </thead>
+          <tbody>
+            {tasks.map((task, i) => (
+              <ProjectTaskRow
+                key={task["@id"]}
+                task={task}
+                index={i}
+                definitions={definitions}
+                allTags={allTags}
+                assignableUsers={assignableUsers}
+                projectIri={projectIri}
+                spaceIri={spaceIri}
+                onToggle={onToggle}
+                onOpen={onOpen}
+                patchTask={patchTask}
+                onCustomFieldChange={onCustomFieldChange}
+              />
+            ))}
+            {addOpen && (
+              <tr className="border-b bg-muted/20" data-testid="project-new-task-row">
+                <td className="px-3 py-2 align-middle">
+                  <Plus className="h-4 w-4 text-muted-foreground" aria-hidden />
+                </td>
+                <td className="px-1 py-2" />
+                <td className="px-2 py-2">
+                  <Input
+                    ref={newTaskInputRef}
+                    value={newTaskTitle}
+                    onChange={(e) => onNewTaskTitle(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        e.preventDefault();
+                        void onCreateTask();
+                      } else if (e.key === "Escape") {
+                        e.preventDefault();
+                        onCloseAddRow();
+                      }
+                    }}
+                    onBlur={() => {
+                      if (!newTaskTitle.trim()) onCloseAddRow();
+                    }}
+                    placeholder="Task title, then Enter…"
+                    maxLength={255}
+                    disabled={isCreatingTask}
+                    className="h-8"
+                    data-testid="project-new-task-title"
+                  />
+                </td>
+                <td
+                  colSpan={addColSpan}
+                  className="px-2 py-2 text-xs text-muted-foreground"
+                >
+                  Enter to add · Esc to cancel
+                </td>
+              </tr>
+            )}
+            {tasks.length === 0 && !addOpen && (
+              <tr>
+                <td
+                  colSpan={fullColSpan}
+                  className="px-3 py-3 text-sm text-muted-foreground"
+                >
+                  No tasks here yet.{" "}
+                  <button
+                    type="button"
+                    onClick={onAddRow}
+                    className="text-foreground underline underline-offset-2 hover:no-underline"
+                  >
+                    Add one
+                  </button>
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+        <CustomFieldFooterRow
+          projectId={projectId}
+          filters={footerFilter}
+          refreshKey={footerKey}
+        />
+      </div>
+    </div>
+  );
+};
+
+interface ProjectTaskRowProps {
+  task: ProjectTask;
+  index: number;
   definitions: CustomFieldDefinition[];
   allTags: TagOption[];
   assignableUsers: AssigneeOption[];
@@ -971,46 +1262,6 @@ interface GroupRowsProps {
   patchTask: (task: ProjectTask, body: Record<string, unknown>) => Promise<void>;
   onCustomFieldChange: (task: ProjectTask, defIri: string, value: unknown) => void;
 }
-
-const GroupRows = ({
-  label,
-  count,
-  colSpan,
-  tasks,
-  definitions,
-  allTags,
-  assignableUsers,
-  projectIri,
-  spaceIri,
-  onToggle,
-  onOpen,
-  patchTask,
-  onCustomFieldChange,
-}: GroupRowsProps) => (
-  <>
-    <tr className="border-b bg-muted/40">
-      <td colSpan={colSpan} className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-        {label} <span className="text-muted-foreground/60">{count}</span>
-      </td>
-    </tr>
-    {tasks.map((task, i) => (
-      <ProjectTaskRow
-        key={task["@id"]}
-        task={task}
-        index={i}
-        definitions={definitions}
-        allTags={allTags}
-        assignableUsers={assignableUsers}
-        projectIri={projectIri}
-        spaceIri={spaceIri}
-        onToggle={onToggle}
-        onOpen={onOpen}
-        patchTask={patchTask}
-        onCustomFieldChange={onCustomFieldChange}
-      />
-    ))}
-  </>
-);
 
 const ProjectTaskRow = ({
   task,
@@ -1024,10 +1275,7 @@ const ProjectTaskRow = ({
   onOpen,
   patchTask,
   onCustomFieldChange,
-}: Omit<GroupRowsProps, "label" | "count" | "colSpan" | "tasks"> & {
-  task: ProjectTask;
-  index: number;
-}) => {
+}: ProjectTaskRowProps) => {
   return (
     <tr
       className="border-b last:border-0 hover:bg-accent/40"

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -8,6 +8,7 @@ import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
 import { ENTRYPOINT } from "@/config/entrypoint";
 import { signinHrefForCurrent } from "@/lib/authRedirect";
 import ActivityPanel from "@/components/activity/ActivityPanel";
+import TaskBoard from "@/components/projects/TaskBoard";
 import CustomFieldFooterRow from "@/components/custom-fields/CustomFieldFooterRow";
 import CustomFieldsManager from "@/components/custom-fields/CustomFieldsManager";
 import { CustomFieldValueEditor } from "@/components/tasks/value-editors";
@@ -136,6 +137,8 @@ const ProjectDetail = () => {
   // Which detail tab is active — controlled so the header's "New task" button
   // can show on the Tasks tab only.
   const [activeTab, setActiveTab] = useState("tasks");
+  // Tasks tab view mode: the list (grouped tables) or the Kanban board.
+  const [view, setView] = useState<"list" | "board">("list");
   // Settings sub-section (left menu like the user settings page).
   const [settingsSection, setSettingsSection] = useState<
     "privacy" | "fields" | "danger"
@@ -457,6 +460,17 @@ const ProjectDetail = () => {
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to delete section.");
     }
+  };
+
+  // Move a task to another section (or the default group when null) — used by
+  // the board's drag-between-columns.
+  const moveTaskToSection = (taskIri: string, sectionIri: string | null) => {
+    const task = tasks.find((t) => t["@id"] === taskIri);
+    if (!task || task.section === sectionIri) return;
+    setTasks((prev) =>
+      prev.map((t) => (t["@id"] === taskIri ? { ...t, section: sectionIri } : t)),
+    );
+    void patchTask(task, { section: sectionIri });
   };
 
   const handleMove = async () => {
@@ -929,6 +943,55 @@ const ProjectDetail = () => {
                 </TabsContent>
 
                 <TabsContent value="tasks" className="mt-4">
+                  {/* List / Board view toggle. */}
+                  <div className="mb-4 inline-flex rounded-md border p-0.5">
+                    {(["list", "board"] as const).map((mode) => (
+                      <button
+                        key={mode}
+                        type="button"
+                        onClick={() => setView(mode)}
+                        className={cn(
+                          "rounded px-3 py-1 text-sm capitalize transition-colors",
+                          view === mode
+                            ? "bg-muted font-medium text-foreground"
+                            : "text-muted-foreground hover:text-foreground",
+                        )}
+                        data-testid={`view-${mode}`}
+                      >
+                        {mode}
+                      </button>
+                    ))}
+                  </div>
+
+                  {view === "board" ? (
+                    <TaskBoard
+                      columns={sectionGroups.map((group) => ({
+                        key: group.key,
+                        sectionIri: group.section ? group.section["@id"] : null,
+                        title: group.section
+                          ? group.section.title
+                          : DEFAULT_SECTION_LABEL,
+                        tasks: group.tasks,
+                      }))}
+                      onOpen={(taskIri) => {
+                        const task = tasks.find((t) => t["@id"] === taskIri);
+                        if (task) openTaskDetail(task);
+                      }}
+                      onMove={moveTaskToSection}
+                      onAddTask={(sectionIri) => {
+                        setView("list");
+                        openAddRow(sectionIri);
+                      }}
+                      onAddSection={() => void createSection()}
+                      onDeleteSection={(sectionIri) => {
+                        const section = sections.find(
+                          (s) => s["@id"] === sectionIri,
+                        );
+                        if (section) void deleteSection(section);
+                      }}
+                    />
+                  ) : (
+                  <>
                   {/* Grand totals across the whole board — top. */}
                   <CustomFieldFooterRow
                     projectId={project.id}
@@ -990,6 +1053,8 @@ const ProjectDetail = () => {
                     heading="Grand total"
                     className="mt-6 rounded-lg"
                   />
+                  </>
+                  )}
                 </TabsContent>
 
                 <TabsContent value="activity" className="mt-4">


### PR DESCRIPTION
Group tasks into board sections, with a list view and a Kanban board view.

**Backend**
- `TaskSection` entity at `/task_sections` (per-project, title, position), space-scoped access (any space member manages sections)
- Nullable `Task.section` FK — null = the implicit default "In progress" group, so existing tasks need no backfill; deleting a section SET NULLs its tasks back to the default
- `custom_field_footers` endpoint accepts `?section=<iri|none>` so each section aggregates independently
- Migration + API tests (`TaskSectionTest`)

**List view**
- Each section is its own table with an editable title, a per-section custom-field footer, and an inline add-row (new tasks land in that section)
- Grand-total footers bracket the board top and bottom
- The "New task" button is a split dropdown with an "Add section" item; each section has a … menu to delete it

**Board view**
- List / Board toggle on the Tasks tab
- Sections as columns of task cards (title, due, tags, assignee avatars) that open the drawer on click and drag between sections via @dnd-kit