### PR TITLE
feat: task relationships (parent/required/related/duplicate)

### DIFF
--- a/api/migrations/Version20260621063449.php
+++ b/api/migrations/Version20260621063449.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260621063449 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add task_relationship (directed links between tasks: parent/required/related/duplicate).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE task_relationship (id UUID NOT NULL, type VARCHAR(16) NOT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, source_id UUID NOT NULL, target_id UUID NOT NULL, PRIMARY KEY (id))');
+        $this->addSql('CREATE INDEX idx_task_relationship_source ON task_relationship (source_id)');
+        $this->addSql('CREATE INDEX idx_task_relationship_target ON task_relationship (target_id)');
+        $this->addSql('CREATE UNIQUE INDEX uniq_task_relationship ON task_relationship (source_id, target_id, type)');
+        $this->addSql('ALTER TABLE task_relationship ADD CONSTRAINT FK_E895608D953C1C61 FOREIGN KEY (source_id) REFERENCES task (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE task_relationship ADD CONSTRAINT FK_E895608D158E0B66 FOREIGN KEY (target_id) REFERENCES task (id) ON DELETE CASCADE NOT DEFERRABLE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE task_relationship DROP CONSTRAINT FK_E895608D953C1C61');
+        $this->addSql('ALTER TABLE task_relationship DROP CONSTRAINT FK_E895608D158E0B66');
+        $this->addSql('DROP TABLE task_relationship');
+    }
+}

--- a/api/src/Controller/TaskRelationshipController.php
+++ b/api/src/Controller/TaskRelationshipController.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\Task;
+use App\Entity\TaskRelationship;
+use App\Entity\User;
+use App\Repository\TaskRelationshipRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * `GET /tasks/{id}/relationships` — every relationship touching the task, on
+ * either side, flattened into the task's own point of view: each row carries
+ * the direction-aware label and a summary of the *other* task. Access mirrors
+ * the Task GET expression (admin / owner / project-space member); 404 for
+ * unreachable ids, matching the rest of the API.
+ */
+class TaskRelationshipController extends AbstractController
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private TaskRelationshipRepository $relationships,
+    ) {
+    }
+
+    #[Route('/tasks/{id}/relationships', name: 'task_relationships', methods: ['GET'])]
+    public function __invoke(string $id, #[CurrentUser] ?User $user): Response
+    {
+        if (null === $user) {
+            return new JsonResponse(['error' => 'Not authenticated.'], 401);
+        }
+        if (!Uuid::isValid($id)) {
+            return new JsonResponse(['error' => 'Not found.'], 404);
+        }
+
+        $task = $this->em->getRepository(Task::class)->find($id);
+        if (null === $task || !$this->canRead($task, $user)) {
+            return new JsonResponse(['error' => 'Not found.'], 404);
+        }
+
+        $taskId = (string) $task->getId();
+        $items = [];
+        foreach ($this->relationships->findForTask($task) as $relationship) {
+            $source = $relationship->getSource();
+            $target = $relationship->getTarget();
+            if (null === $source || null === $target) {
+                continue;
+            }
+            $outgoing = (string) $source->getId() === $taskId;
+            $other = $outgoing ? $target : $source;
+
+            $items[] = [
+                '@id' => '/task_relationships/' . $relationship->getId(),
+                'id' => (string) $relationship->getId(),
+                'type' => $relationship->getType(),
+                'direction' => $outgoing ? 'outgoing' : 'incoming',
+                'label' => TaskRelationship::labelFor($relationship->getType(), $outgoing),
+                'task' => [
+                    '@id' => $other->getId() !== null ? '/tasks/' . $other->getId() : null,
+                    'id' => (string) $other->getId(),
+                    'title' => $other->getTitle(),
+                    'completedOn' => $other->getCompletedOn()?->format(\DATE_ATOM),
+                    'dueDate' => $other->getDueDate()?->format(\DATE_ATOM),
+                ],
+            ];
+        }
+
+        return new JsonResponse(['relationships' => $items]);
+    }
+
+    private function canRead(Task $task, User $user): bool
+    {
+        if ($this->isGranted('ROLE_ADMIN')) {
+            return true;
+        }
+
+        return $task->isAccessibleBy($user);
+    }
+}

--- a/api/src/Entity/TaskRelationship.php
+++ b/api/src/Entity/TaskRelationship.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Post;
+use App\Repository\TaskRelationshipRepository;
+use App\Validator\ValidTaskRelationship;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * A directed link between two tasks. One row stores the relationship from
+ * `source` to `target`; the inverse label is derived per viewing side (see
+ * {@see directionLabel()}). `related` is symmetric — the label is the same
+ * both ways. Reads come through `GET /tasks/{id}/relationships`
+ * ({@see App\Controller\TaskRelationshipController}); this resource only
+ * exposes create/delete (+ item Get) since a relationship is reachable through
+ * either of its tasks, both of which are already access-controlled.
+ */
+#[ApiResource(
+    shortName: 'TaskRelationship',
+    operations: [
+        new Post(
+            security: "is_granted('ROLE_USER')",
+            securityPostDenormalize: "is_granted('ROLE_USER') and object.getSource() !== null and object.getTarget() !== null and (is_granted('ROLE_ADMIN') or (object.getSource().isAccessibleBy(user) and object.getTarget().isAccessibleBy(user)))",
+        ),
+        new Get(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getSource().isAccessibleBy(user) or object.getTarget().isAccessibleBy(user))",
+        ),
+        new Delete(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getSource().isAccessibleBy(user) or object.getTarget().isAccessibleBy(user))",
+        ),
+    ],
+    normalizationContext: ['groups' => ['task_relationship:read']],
+    denormalizationContext: ['groups' => ['task_relationship:write']],
+)]
+#[ORM\Entity(repositoryClass: TaskRelationshipRepository::class)]
+#[ORM\Table(name: 'task_relationship')]
+#[ORM\Index(columns: ['source_id'], name: 'idx_task_relationship_source')]
+#[ORM\Index(columns: ['target_id'], name: 'idx_task_relationship_target')]
+#[ORM\UniqueConstraint(name: 'uniq_task_relationship', columns: ['source_id', 'target_id', 'type'])]
+#[ValidTaskRelationship]
+class TaskRelationship
+{
+    public const TYPE_PARENT = 'parent';
+    public const TYPE_REQUIRED = 'required';
+    public const TYPE_RELATED = 'related';
+    public const TYPE_DUPLICATE = 'duplicate';
+
+    public const TYPES = [
+        self::TYPE_PARENT,
+        self::TYPE_REQUIRED,
+        self::TYPE_RELATED,
+        self::TYPE_DUPLICATE,
+    ];
+
+    /** `related` reads the same in both directions. */
+    public const SYMMETRIC_TYPES = [self::TYPE_RELATED];
+
+    /** @var array<string, array{0: string, 1: string}> type => [outgoing, incoming] label */
+    private const LABELS = [
+        self::TYPE_PARENT => ['parent of', 'child of'],
+        self::TYPE_REQUIRED => ['required for', 'required by'],
+        self::TYPE_RELATED => ['related to', 'related to'],
+        self::TYPE_DUPLICATE => ['duplicate of', 'duplicated by'],
+    ];
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
+    #[Groups(['task_relationship:read'])]
+    private ?Uuid $id = null;
+
+    #[ApiProperty(readableLink: false)]
+    #[ORM\ManyToOne(targetEntity: Task::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    #[Assert\NotNull(message: 'Source task is required.')]
+    #[Groups(['task_relationship:read', 'task_relationship:write'])]
+    private ?Task $source = null;
+
+    #[ApiProperty(readableLink: false)]
+    #[ORM\ManyToOne(targetEntity: Task::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    #[Assert\NotNull(message: 'Target task is required.')]
+    #[Groups(['task_relationship:read', 'task_relationship:write'])]
+    private ?Task $target = null;
+
+    #[ORM\Column(length: 16)]
+    #[Assert\NotBlank(message: 'Relationship type is required.')]
+    #[Assert\Choice(choices: self::TYPES, message: 'Invalid relationship type.')]
+    #[Groups(['task_relationship:read', 'task_relationship:write'])]
+    private string $type = self::TYPE_RELATED;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    #[Groups(['task_relationship:read'])]
+    private \DateTimeImmutable $createdAt;
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    /** Human label for this relationship as seen from `$outgoing` side. */
+    public static function labelFor(string $type, bool $outgoing): string
+    {
+        $labels = self::LABELS[$type] ?? ['related to', 'related to'];
+
+        return $outgoing ? $labels[0] : $labels[1];
+    }
+
+    public function getId(): ?Uuid
+    {
+        return $this->id;
+    }
+
+    public function getSource(): ?Task
+    {
+        return $this->source;
+    }
+
+    public function setSource(?Task $source): self
+    {
+        $this->source = $source;
+
+        return $this;
+    }
+
+    public function getTarget(): ?Task
+    {
+        return $this->target;
+    }
+
+    public function setTarget(?Task $target): self
+    {
+        $this->target = $target;
+
+        return $this;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function setType(string $type): self
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+}

--- a/api/src/Repository/TaskRelationshipRepository.php
+++ b/api/src/Repository/TaskRelationshipRepository.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Task;
+use App\Entity\TaskRelationship;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<TaskRelationship>
+ */
+class TaskRelationshipRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, TaskRelationship::class);
+    }
+
+    /**
+     * Every relationship touching the given task, on either side.
+     *
+     * @return TaskRelationship[]
+     */
+    public function findForTask(Task $task): array
+    {
+        return $this->createQueryBuilder('r')
+            ->where('r.source = :task OR r.target = :task')
+            ->setParameter('task', $task)
+            ->orderBy('r.createdAt', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * The relationship between two tasks of a given type, in either direction
+     * (used to reject duplicates/reverses before insert).
+     */
+    public function findBetween(Task $a, Task $b, string $type): ?TaskRelationship
+    {
+        return $this->createQueryBuilder('r')
+            ->where('r.type = :type')
+            ->andWhere(
+                '(r.source = :a AND r.target = :b) OR (r.source = :b AND r.target = :a)',
+            )
+            ->setParameter('type', $type)
+            ->setParameter('a', $a)
+            ->setParameter('b', $b)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+}

--- a/api/src/Validator/ValidTaskRelationship.php
+++ b/api/src/Validator/ValidTaskRelationship.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Class-level constraint on TaskRelationship. Rejects a task relating to
+ * itself, and a duplicate of an existing relationship of the same type between
+ * the two tasks in either direction (so `A parent-of B` blocks both a repeat
+ * and the reverse `B parent-of A`, while still allowing a different type
+ * between the same pair).
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class ValidTaskRelationship extends Constraint
+{
+    public string $messageSelf = 'A task cannot relate to itself.';
+    public string $messageDuplicate = 'These tasks already have this relationship.';
+
+    public function getTargets(): string
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/api/src/Validator/ValidTaskRelationshipValidator.php
+++ b/api/src/Validator/ValidTaskRelationshipValidator.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Validator;
+
+use App\Entity\TaskRelationship;
+use App\Repository\TaskRelationshipRepository;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+final class ValidTaskRelationshipValidator extends ConstraintValidator
+{
+    public function __construct(
+        private readonly TaskRelationshipRepository $repository,
+    ) {
+    }
+
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof ValidTaskRelationship) {
+            throw new UnexpectedTypeException($constraint, ValidTaskRelationship::class);
+        }
+        if (null === $value) {
+            return;
+        }
+        if (!$value instanceof TaskRelationship) {
+            throw new UnexpectedValueException($value, TaskRelationship::class);
+        }
+
+        $source = $value->getSource();
+        $target = $value->getTarget();
+        // NotNull on the columns reports the missing side; nothing to cross-check.
+        if (null === $source || null === $target) {
+            return;
+        }
+
+        if ($source === $target || true === $source->getId()?->equals($target->getId())) {
+            $this->context->buildViolation($constraint->messageSelf)
+                ->atPath('target')
+                ->addViolation();
+
+            return;
+        }
+
+        $existing = $this->repository->findBetween($source, $target, $value->getType());
+        if (null !== $existing && $existing !== $value) {
+            $this->context->buildViolation($constraint->messageDuplicate)
+                ->atPath('target')
+                ->addViolation();
+        }
+    }
+}

--- a/api/tests/Api/TaskRelationshipTest.php
+++ b/api/tests/Api/TaskRelationshipTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\Project;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Task relationships: create a directed link, read it back from each side with
+ * the right label, and the self / duplicate guards.
+ */
+class TaskRelationshipTest extends ApiTestCase
+{
+    use SpaceMembershipFixture;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = static::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\TaskRelationship')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testCreateReadFromBothSidesAndDelete(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        $a = $this->createTask($client, $project, 'Design API');
+        $b = $this->createTask($client, $project, 'Build endpoint');
+
+        // A is parent of B.
+        $relationship = $client->request('POST', '/task_relationships', [
+            'json' => ['source' => $a, 'target' => $b, 'type' => 'parent'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $relIri = $relationship['@id'];
+        $this->assertIsString($relIri);
+
+        // From A's side: outgoing "parent of" B.
+        $fromA = $client->request('GET', $a . '/relationships')->toArray();
+        $rowsA = $fromA['relationships'];
+        $this->assertIsArray($rowsA);
+        $this->assertCount(1, $rowsA);
+        $rowA = $rowsA[0];
+        $this->assertIsArray($rowA);
+        $this->assertSame('outgoing', $rowA['direction']);
+        $this->assertSame('parent of', $rowA['label']);
+        $taskA = $rowA['task'];
+        $this->assertIsArray($taskA);
+        $this->assertSame('Build endpoint', $taskA['title']);
+
+        // From B's side: incoming "child of" A.
+        $fromB = $client->request('GET', $b . '/relationships')->toArray();
+        $rowsB = $fromB['relationships'];
+        $this->assertIsArray($rowsB);
+        $rowB = $rowsB[0];
+        $this->assertIsArray($rowB);
+        $this->assertSame('incoming', $rowB['direction']);
+        $this->assertSame('child of', $rowB['label']);
+
+        // Delete it.
+        $client->request('DELETE', $relIri);
+        $this->assertResponseStatusCodeSame(204);
+        $after = $client->request('GET', $a . '/relationships')->toArray();
+        $this->assertSame([], $after['relationships']);
+    }
+
+    public function testRejectsSelfAndDuplicate(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        $a = $this->createTask($client, $project, 'A');
+        $b = $this->createTask($client, $project, 'B');
+
+        // Self-relationship → 422.
+        $client->request('POST', '/task_relationships', [
+            'json' => ['source' => $a, 'target' => $a, 'type' => 'related'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+
+        // First related link is fine.
+        $client->request('POST', '/task_relationships', [
+            'json' => ['source' => $a, 'target' => $b, 'type' => 'related'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+
+        // The reverse of a same-type link → 422 (duplicate, either direction).
+        $client->request('POST', '/task_relationships', [
+            'json' => ['source' => $b, 'target' => $a, 'type' => 'related'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    private function createTask(object $client, Project $project, string $title): string
+    {
+        $task = $client->request('POST', '/tasks', [
+            'json' => ['title' => $title, 'project' => '/projects/' . $project->getId()],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $iri = $task['@id'];
+        $this->assertIsString($iri);
+
+        return $iri;
+    }
+
+    private function createProject(User $owner, string $title): Project
+    {
+        $project = new Project();
+        $project->setOwner($owner);
+        $project->setTitle($title);
+        $this->addProjectMember($project, $owner);
+        $this->entityManager->persist($project);
+        $this->entityManager->flush();
+
+        return $project;
+    }
+
+    private function createUser(string $email): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/pwa/components/tasks/TaskDetailDrawer.tsx
+++ b/pwa/components/tasks/TaskDetailDrawer.tsx
@@ -21,6 +21,7 @@ import AttachmentsPanel from "@/components/tasks/AttachmentsPanel";
 import DueDateCell from "@/components/tasks/DueDateCell";
 import RecurrenceEditor from "@/components/tasks/RecurrenceEditor";
 import RemindersEditor from "@/components/tasks/RemindersEditor";
+import TaskRelationshipsPanel from "@/components/tasks/TaskRelationshipsPanel";
 import CommentsPanel from "@/components/common/CommentsPanel";
 import ActivityPanel from "@/components/activity/ActivityPanel";
 import CustomFieldValueList, {
@@ -525,6 +526,8 @@ const TaskDetailDrawer = ({
                   users={assignableUsers}
                 />
               )}
+
+              <TaskRelationshipsPanel taskIri={task["@id"]} />
 
               <div className="space-y-1.5">
                 <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">

--- a/pwa/components/tasks/TaskRelationshipsPanel.tsx
+++ b/pwa/components/tasks/TaskRelationshipsPanel.tsx
@@ -1,0 +1,252 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Link2, Plus, X } from "lucide-react";
+import { ENTRYPOINT } from "@/config/entrypoint";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+/**
+ * Relationships section for the task drawer. Lists every relationship touching
+ * the task (via `GET /tasks/{id}/relationships`) with a direction-aware label,
+ * and an add form: pick a directional type + search for the other task, then
+ * POST /task_relationships. The directional option resolves to (type, which
+ * side is source) so one stored row covers both viewing directions.
+ */
+interface RelationshipRow {
+  "@id": string;
+  id: string;
+  type: string;
+  direction: "outgoing" | "incoming";
+  label: string;
+  task: {
+    "@id": string | null;
+    id: string;
+    title: string;
+    completedOn: string | null;
+  };
+}
+
+interface TaskHit {
+  "@id": string;
+  id: string;
+  title: string;
+}
+
+/** Directional options the user picks from, mapped to the stored shape. */
+const REL_OPTIONS = [
+  { value: "parent-out", label: "Parent of", type: "parent", currentIsSource: true },
+  { value: "parent-in", label: "Child of", type: "parent", currentIsSource: false },
+  { value: "required-out", label: "Required for", type: "required", currentIsSource: true },
+  { value: "required-in", label: "Required by", type: "required", currentIsSource: false },
+  { value: "related", label: "Related to", type: "related", currentIsSource: true },
+  { value: "duplicate-out", label: "Duplicate of", type: "duplicate", currentIsSource: true },
+  { value: "duplicate-in", label: "Duplicated by", type: "duplicate", currentIsSource: false },
+] as const;
+
+interface TaskRelationshipsPanelProps {
+  taskIri: string;
+}
+
+const TaskRelationshipsPanel = ({ taskIri }: TaskRelationshipsPanelProps) => {
+  const [rows, setRows] = useState<RelationshipRow[]>([]);
+  const [adding, setAdding] = useState(false);
+  const [optionValue, setOptionValue] = useState<string>(REL_OPTIONS[0].value);
+  const [query, setQuery] = useState("");
+  const [hits, setHits] = useState<TaskHit[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const searchSeq = useRef(0);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch(`${ENTRYPOINT}${taskIri}/relationships`, {
+        credentials: "include",
+        headers: { Accept: "application/json" },
+      });
+      if (!res.ok) return;
+      const data = await res.json();
+      setRows(Array.isArray(data.relationships) ? data.relationships : []);
+    } catch {
+      /* leave the list as-is on a transient error */
+    }
+  }, [taskIri]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  // Debounced task search for the picker (excludes the current task).
+  useEffect(() => {
+    if (!adding || query.trim().length === 0) {
+      setHits([]);
+      return;
+    }
+    const seq = ++searchSeq.current;
+    const handle = setTimeout(() => {
+      void fetch(
+        `${ENTRYPOINT}/tasks?search=${encodeURIComponent(query.trim())}&itemsPerPage=8`,
+        { credentials: "include", headers: { Accept: "application/ld+json" } },
+      )
+        .then((res) => (res.ok ? res.json() : { member: [] }))
+        .then((data) => {
+          if (seq !== searchSeq.current) return;
+          const members: TaskHit[] = data.member ?? data["hydra:member"] ?? [];
+          setHits(members.filter((t) => t["@id"] !== taskIri));
+        })
+        .catch(() => {});
+    }, 250);
+    return () => clearTimeout(handle);
+  }, [adding, query, taskIri]);
+
+  const resetAdd = () => {
+    setAdding(false);
+    setQuery("");
+    setHits([]);
+    setError(null);
+  };
+
+  const addRelationship = async (other: TaskHit) => {
+    const option = REL_OPTIONS.find((o) => o.value === optionValue);
+    if (!option) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(`${ENTRYPOINT}/task_relationships`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/ld+json" },
+        body: JSON.stringify({
+          source: option.currentIsSource ? taskIri : other["@id"],
+          target: option.currentIsSource ? other["@id"] : taskIri,
+          type: option.type,
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(
+          data.description ||
+            data.detail ||
+            data["hydra:description"] ||
+            "Couldn't add the relationship.",
+        );
+      }
+      resetAdd();
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Couldn't add the relationship.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const removeRelationship = async (row: RelationshipRow) => {
+    setRows((prev) => prev.filter((r) => r["@id"] !== row["@id"]));
+    try {
+      await fetch(`${ENTRYPOINT}${row["@id"]}`, {
+        method: "DELETE",
+        credentials: "include",
+      });
+    } catch {
+      void load();
+    }
+  };
+
+  return (
+    <div className="space-y-2" data-testid="task-relationships">
+      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        Relationships
+      </p>
+
+      {rows.length > 0 && (
+        <ul className="space-y-1.5">
+          {rows.map((row) => (
+            <li
+              key={row["@id"]}
+              className="flex items-center gap-2 rounded-md border border-input px-2.5 py-1.5 text-sm"
+              data-testid="relationship-item"
+            >
+              <Link2 className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
+              <span className="shrink-0 text-xs text-muted-foreground">{row.label}</span>
+              <span
+                className={cn(
+                  "min-w-0 flex-1 truncate",
+                  row.task.completedOn && "text-muted-foreground line-through",
+                )}
+              >
+                {row.task.title}
+              </span>
+              <button
+                type="button"
+                onClick={() => void removeRelationship(row)}
+                className="text-muted-foreground hover:text-destructive"
+                aria-label="Remove relationship"
+                data-testid="relationship-remove"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {adding ? (
+        <div className="space-y-2 rounded-md border border-input p-2.5" data-testid="relationship-form">
+          <select
+            value={optionValue}
+            onChange={(e) => setOptionValue(e.target.value)}
+            className="h-8 w-full rounded-md border border-input bg-background px-2 text-sm"
+            data-testid="relationship-type"
+          >
+            {REL_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+          <Input
+            autoFocus
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search a task…"
+            className="h-8"
+            data-testid="relationship-search"
+          />
+          {hits.length > 0 && (
+            <ul className="max-h-44 overflow-y-auto rounded-md border">
+              {hits.map((hit) => (
+                <li key={hit["@id"]}>
+                  <button
+                    type="button"
+                    disabled={busy}
+                    onClick={() => void addRelationship(hit)}
+                    className="block w-full truncate px-2.5 py-1.5 text-left text-sm hover:bg-accent disabled:opacity-60"
+                    data-testid="relationship-hit"
+                  >
+                    {hit.title}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+          {error && <p className="text-xs text-destructive">{error}</p>}
+          <div className="flex justify-end">
+            <Button type="button" variant="ghost" size="sm" onClick={resetAdd}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setAdding(true)}
+          className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+          data-testid="relationship-add"
+        >
+          <Plus className="h-3.5 w-3.5" /> Add relationship
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default TaskRelationshipsPanel;


### PR DESCRIPTION
Add directed relationships between tasks, surfaced in the task detail drawer.

**Backend**
- `TaskRelationship` entity at `/task_relationships` — a directed `source → target` link with `type ∈ {parent, required, related, duplicate}`, one row per relationship (unique on source+target+type)
- `GET /tasks/{id}/relationships` flattens both sides into the task's point of view with a direction-aware label and the other task's summary
- Create requires access to both tasks; read/delete needs access to either
- `ValidTaskRelationship` rejects self-links and a same-type duplicate in either direction (so `A parent-of B` blocks the reverse too)
- Migration + tests (`TaskRelationshipTest`)

**Frontend**
- A Relationships section in the task drawer: lists relationships with their label + the other task title (strikethrough when done), an add form (directional type picker — parent of / child of / required for / required by / related to / duplicate of / duplicated by — + task search), and per-row remove

Label map (stored `type` → outgoing / incoming): parent → parent of / child of · required → required for / required by · related → related to (both) · duplicate → duplicate of / duplicated by.