### PR TITLE
fix(api): PHPStan level 10 in task-relationship code

### DIFF
--- a/api/src/Repository/TaskRelationshipRepository.php
+++ b/api/src/Repository/TaskRelationshipRepository.php
@@ -38,7 +38,7 @@ class TaskRelationshipRepository extends ServiceEntityRepository
      */
     public function findBetween(Task $a, Task $b, string $type): ?TaskRelationship
     {
-        return $this->createQueryBuilder('r')
+        $result = $this->createQueryBuilder('r')
             ->where('r.type = :type')
             ->andWhere(
                 '(r.source = :a AND r.target = :b) OR (r.source = :b AND r.target = :a)',
@@ -49,5 +49,7 @@ class TaskRelationshipRepository extends ServiceEntityRepository
             ->setMaxResults(1)
             ->getQuery()
             ->getOneOrNullResult();
+
+        return $result instanceof TaskRelationship ? $result : null;
     }
 }

--- a/api/tests/Api/TaskRelationshipTest.php
+++ b/api/tests/Api/TaskRelationshipTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Api;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
 use App\Entity\Project;
 use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
@@ -111,7 +112,7 @@ class TaskRelationshipTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(422);
     }
 
-    private function createTask(object $client, Project $project, string $title): string
+    private function createTask(Client $client, Project $project, string $title): string
     {
         $task = $client->request('POST', '/tasks', [
             'json' => ['title' => $title, 'project' => '/projects/' . $project->getId()],


### PR DESCRIPTION
Follow-up to #497: narrow findBetween's getOneOrNullResult() and type the test client param, clearing 4 PHPStan level-10 errors that landed on main via the admin merge.