### PR TITLE
chore: wire web push VAPID keys for production (#100)

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -20,6 +20,11 @@ services:
       MERCURE_JWT_SECRET: ${CADDY_MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
       MAILER_DSN: ${MAILER_DSN:-smtp://mailpit:1025}
       MAILER_FROM: ${MAILER_FROM:-no-reply@madori.test}
+      # Web Push (#100) VAPID keys — values live in the server .env (private key
+      # never enters the repo); blank locally = push no-ops.
+      VAPID_PUBLIC_KEY: ${VAPID_PUBLIC_KEY:-}
+      VAPID_PRIVATE_KEY: ${VAPID_PRIVATE_KEY:-}
+      VAPID_SUBJECT: ${VAPID_SUBJECT:-}
       APP_FRONTEND_URL: ${APP_FRONTEND_URL:-https://localhost}
       MESSENGER_TRANSPORT_DSN: ${MESSENGER_TRANSPORT_DSN:-doctrine://default?auto_setup=false}
       # Hostname for the Umami dashboard site block in the Caddyfile.
@@ -93,6 +98,11 @@ services:
       DATABASE_URL: postgresql://${POSTGRES_USER:-app}:${POSTGRES_PASSWORD:-!ChangeMe!}@database:5432/${POSTGRES_DB:-app}?serverVersion=${POSTGRES_VERSION:-16}&charset=${POSTGRES_CHARSET:-utf8}
       MAILER_DSN: ${MAILER_DSN:-smtp://mailpit:1025}
       MAILER_FROM: ${MAILER_FROM:-no-reply@madori.test}
+      # Web Push (#100): the worker sends reminder/digest push, so it needs the
+      # VAPID keys too (values from the server .env).
+      VAPID_PUBLIC_KEY: ${VAPID_PUBLIC_KEY:-}
+      VAPID_PRIVATE_KEY: ${VAPID_PRIVATE_KEY:-}
+      VAPID_SUBJECT: ${VAPID_SUBJECT:-}
       APP_FRONTEND_URL: ${APP_FRONTEND_URL:-https://localhost}
       MESSENGER_TRANSPORT_DSN: ${MESSENGER_TRANSPORT_DSN:-doctrine://default?auto_setup=false}
       MERCURE_URL: ${CADDY_MERCURE_URL:-http://php/.well-known/mercure}

--- a/pwa/.env.production
+++ b/pwa/.env.production
@@ -6,4 +6,4 @@
 # here — the ID ships in the page source anyway, it is not a secret. While
 # unset, the tracker script is never rendered and analytics is fully off.
 NEXT_PUBLIC_UMAMI_WEBSITE_ID=0217ffc5-83a0-4640-8ea3-79e4b4f75840
-NEXT_PUBLIC_VAPID_PUBLIC_KEY=
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=BI0zaJu3pluxfEaKoSa2r1lnpwv_mlU1y7GTKPwNKGlsl8LgjlXS35HtB8RNJJQT3MkOijxca2z_mDOwdOlDD5A


### PR DESCRIPTION
Activates Web Push (#100) in production.

- `compose.yaml`: expose `VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY` / `VAPID_SUBJECT` to the `php` + `worker` services (values resolve from the server's untracked `/opt/aura/.env`, so the **private key never enters the repo**).
- `pwa/.env.production`: set the public VAPID key (baked into the PWA build at CI; not secret).

The keypair was generated on the server (`minishlink/web-push`) and the three values are already written to `/opt/aura/.env`. Once this lands on `production` via a promote, the worker/php pick up the keys and the PWA ships the public key — push starts delivering.