### PR TITLE
fix(ci): stage docs into the PWA build so /guides pages render in prod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       -
+        # Stage repo-root docs into pwa/.content/docs so the prod PWA build
+        # (context ./pwa) can render the /guides routes. See sync-docs.mjs.
+        name: Stage docs for the PWA build
+        run: node pwa/scripts/sync-docs.mjs
+      -
         name: Build dev stack (app-php, app-pwa)
         uses: docker/bake-action@v6
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,6 +79,12 @@ jobs:
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/app-php:buildcache
           cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/app-php:buildcache,mode=max
 
+      # Stage the repo-root docs into pwa/.content/docs so the /guides routes
+      # build with content. The pwa build context is `pwa/`, which can't reach
+      # `docs/`; sync-docs (re-included via pwa/.dockerignore) pre-stages it.
+      - name: Stage docs for the PWA build
+        run: node pwa/scripts/sync-docs.mjs
+
       - name: Build & push pwa image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:

--- a/e2e/tests/guides.spec.js
+++ b/e2e/tests/guides.spec.js
@@ -1,0 +1,22 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+const { BASE_URL } = require("./helpers");
+
+// Public docs surface (/guides) rendered from the repo-root `docs/` tree,
+// staged into the PWA build by scripts/sync-docs.mjs. Guards the build wiring:
+// if the docs aren't staged before the prod image build, getAllDocs() is empty,
+// the index has no links and the slug pages 404 — so this fails.
+test.describe("Guides (public docs)", () => {
+  test("index lists guides and a guide page renders", async ({ page }) => {
+    await page.goto(`${BASE_URL}/guides`);
+
+    const link = page.locator('a[href^="/guides/"]').first();
+    await expect(link).toBeVisible();
+    const href = await link.getAttribute("href");
+    expect(href).toBeTruthy();
+
+    await page.goto(`${BASE_URL}${href}`);
+    // The markdown rendered into a real page (not a 404).
+    await expect(page.locator("main h1, article h1, h1").first()).toBeVisible();
+  });
+});


### PR DESCRIPTION
**Bug:** `/guides/<slug>` pages 404 in production (e.g. `/guides/developer/api-guide`, linked from the footer + guides index).

**Cause:** the prod PWA image builds with `context: pwa`, but `scripts/sync-docs.mjs` mirrors repo-root `docs/` → `pwa/.content/docs/` and can't reach `docs/` from inside the `pwa/` context. So `getAllDocs()` was empty at build, `getStaticPaths` (`fallback:false`) generated **zero** guide pages, and every slug 404'd. (`sync-docs` is built to leave `.content/docs` as-is when no source is found and expects it pre-staged, re-included via `pwa/.dockerignore`'s `!.content/docs/**/*.md`.)

**Fix:** run `node pwa/scripts/sync-docs.mjs` in CI **before** the PWA build — both the prod deploy build (`deploy.yml`) and the E2E prod build (`ci.yml`). Adds an E2E test that loads `/guides` and a guide page so the wiring can't silently regress.

Needs a promote/deploy to take effect in prod; I'll verify `/guides/developer/api-guide` returns 200 after.