### PR TITLE
docs: add web-push + task-organization developer guides

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,6 +239,8 @@ Developer docs:
 - `docs/developer/two-factor-auth.md` - 2FA implementation reference (entity model, endpoints, recovery flow, threat model)
 - `docs/developer/password-reset.md` - Forgot/reset implementation, token model, email-enumeration mitigations, rate limiting
 - `docs/developer/data-export.md` - Space + account (GDPR) data exports: shared async-build/token/prune machinery, access bars, retention
+- `docs/developer/web-push.md` - Web Push (#100): PushSubscription, WebPushSender, the service worker + enable flow, VAPID key setup
+- `docs/developer/task-organization.md` - Task sections, the Kanban board view, and task relationships (entities, endpoints, validation, UI)
 
 User docs:
 - `docs/user/two-factor-auth.md` - End-user guide for enabling, using, and recovering 2FA

--- a/docs/developer/task-organization.md
+++ b/docs/developer/task-organization.md
@@ -1,0 +1,36 @@
+# Task organisation: sections, board view, and relationships
+
+Three features structure tasks beyond a flat list: **sections** group a project's tasks, a **Kanban board view** shows those sections as columns, and **relationships** link tasks to one another.
+
+## Sections (#496)
+
+- **`TaskSection`** (entity, table `task_section`) — per-project `title` + `position`, exposed at `/task_sections`. Any space member can CRUD (security via `object.getProject().isAccessibleBy(user)`); the collection is scoped by `TaskSectionAccessExtension`.
+- **`Task.section`** — a **nullable** FK (`onDelete: SET NULL`). `null` = the implicit default **"In progress"** group, so existing tasks need no backfill and deleting a section drops its tasks back to the default rather than orphaning them.
+- **List view** (`pwa/pages/projects/[id].tsx`): tasks render grouped into per-section tables — each its own table with an editable title, an inline add-row (new tasks land in that section), and a per-section custom-field footer. Grand-total footers bracket the whole board, top and bottom. The "New task" button is a split dropdown with an "Add section" item; each user section has a `…` menu to delete it.
+- **Footers per section**: `GET /projects/{id}/custom_field_footers` accepts `?section=<iri|none>` so each section aggregates independently (`none` = the default group; omit the param for the whole board). See the custom-field footer entry in `CLAUDE.md`.
+
+## Board (Kanban) view (#496)
+
+`pwa/components/projects/TaskBoard.tsx` (built on `@dnd-kit`) toggles alongside the list view on the project's Tasks tab. Sections become columns of task cards (title, due date, tags, assignee avatars). A card opens the task drawer on click and **drags between sections** — a drop issues `PATCH /tasks/{id}` with the new `section` IRI. A pointer activation distance keeps a plain click (open drawer) distinct from a drag. The default "In progress" group is the first column.
+
+## Relationships (#497)
+
+- **`TaskRelationship`** (entity, table `task_relationship`) — `source` / `target` Task FKs + `type`, exposed at `/task_relationships`, unique on `(source, target, type)`.
+- **Types**: `parent` / `required` / `related` / `duplicate`. One row stores the link from `source` → `target`; the human label is derived per viewing side (`TaskRelationship::labelFor()`):
+
+  | type | from the source | from the target |
+  | --- | --- | --- |
+  | `parent` | parent of | child of |
+  | `required` | required for | required by |
+  | `related` | related to | related to |
+  | `duplicate` | duplicate of | duplicated by |
+
+  `related` is symmetric — the same label both ways.
+- **Validation** (`ValidTaskRelationship`, class-level): rejects self-links, and a same-type duplicate in **either** direction (so `A parent-of B` blocks both a repeat and the reverse `B parent-of A`), while still allowing a *different* type between the same pair.
+- **API**: the resource exposes only `Post` / `Get` / `Delete` (security gates on `source` / `target` `isAccessibleBy` — you must be able to reach both tasks to create a link, either to delete one). Reads come through a dedicated endpoint, **`GET /tasks/{id}/relationships`** (`TaskRelationshipController`), which returns every link touching the task from that task's viewpoint — each with the resolved directional label and the other task's summary.
+- **PWA**: a **Relationships** section in the task detail drawer (`pwa/components/tasks/TaskRelationshipsPanel.tsx`) — a list grouped by label, an add form (directional type picker + task search), and a per-row remove.
+
+## Tests
+
+- `App\Tests\Api\TaskSectionTest`, `App\Tests\Api\TaskRelationshipTest` (entity access + validation).
+- `e2e/tests/*` exercise the project board UI.

--- a/docs/developer/web-push.md
+++ b/docs/developer/web-push.md
@@ -1,0 +1,48 @@
+# Web Push notifications (#100)
+
+Web Push delivers notifications (task reminders, mentions, comments, status changes) to a user's browser even when the tab is closed. The backend signs payloads with a VAPID key pair and POSTs them to each subscribed device's push service; a service worker in the PWA renders them.
+
+## Moving parts
+
+- **`PushSubscription`** (entity) — one row per subscribed device, holding the push service `endpoint` and the `p256dh` / `auth` keys, owned by a user. Managed via `GET` / `POST` / `DELETE /me/push-subscriptions` (POST is idempotent on the endpoint — a re-subscribe 422s on the unique constraint, which the client treats as "already subscribed").
+- **`App\Push\WebPushSender`** — signs and sends a `PushPayload` to a subscription via `minishlink/web-push`, using the VAPID env keys. **No-ops with a logged warning when the keys are blank**, so a fresh install doesn't error. Endpoints the push service rejects with `404`/`410` are pruned inline so dead subscriptions don't accumulate.
+- **`pwa/public/sw.js`** — the service worker. On `push` it renders the `{title, body, url, tag}` payload as a desktop notification; on `notificationclick` it focuses an existing tab on the URL or opens a new one. Registered once from `_app.tsx`.
+- **`pwa/lib/push.ts`** — `enablePush()` runs the browser opt-in: `Notification.requestPermission()` → `PushManager.subscribe({ applicationServerKey })` → `POST /me/push-subscriptions`. Plus `isPushSupported()` / `pushPermission()` helpers.
+- **`EnablePushPrompt`** (`pwa/components/notifications/EnablePushPrompt.tsx`) — a small amber nudge shown in the `RemindersEditor` when a task has reminders but the browser isn't subscribed, with an inline "Turn on". Its "Not now" dismiss is browser-session only and **never** disables the account-level `pushNotificationsEnabled` preference (so dismissing on a shared/public computer doesn't kill push on the user's own devices).
+
+## Delivery
+
+`App\Service\NotificationDispatcher` (and the reminder cron `app:tasks:reminders:dispatch`) fan each event out to every registered device of a recipient who has `pushNotificationsEnabled = true` (the **default**) and isn't in quiet hours, reusing `WebPushSender`. Push runs alongside the in-app bell (Mercure) and email — see the **Notifications** entry in `CLAUDE.md`.
+
+## VAPID keys
+
+The application-server key pair is split by sensitivity:
+
+| Var | Side | Notes |
+| --- | --- | --- |
+| `VAPID_PUBLIC_KEY` | API | Base64url P-256 public key. **Must equal `NEXT_PUBLIC_VAPID_PUBLIC_KEY`.** |
+| `VAPID_PRIVATE_KEY` | API | Base64url P-256 private key. **Secret** — server `.env` only, never the repo. |
+| `VAPID_SUBJECT` | API | `mailto:` or `https://` contact for the push service to reach you. |
+| `NEXT_PUBLIC_VAPID_PUBLIC_KEY` | PWA | The same public key, read by `PushManager.subscribe()`. Baked into the PWA at build time; committed in `pwa/.env.production` (not secret — it ships to every browser). |
+
+The API reads the three `VAPID_*` vars via `%env(default::VAPID_*)%` in `WebPushSender`.
+
+### Generating and setting the keys
+
+Generate a P-256 key pair (anywhere with the `web-push` CLI, or on the server via the bundled `minishlink/web-push`):
+
+```bash
+npx web-push generate-vapid-keys
+# Public Key:  B....
+# Private Key: ....
+```
+
+Then:
+
+- Put the **public** key in `pwa/.env.production` as `NEXT_PUBLIC_VAPID_PUBLIC_KEY` (committed; baked into the build at CI).
+- Put **all three** in the server's untracked `/opt/aura/.env` (`VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY` / `VAPID_SUBJECT`). `compose.yaml` wires them to the `php` **and** `worker` services via `${VAPID_*}` references (the worker sends reminder/digest push, so it needs them too).
+- The public key must match on both sides, or browsers can't validate the subscription.
+
+Until the keys are set, `WebPushSender` no-ops (logging a warning) and the PWA's enable prompts stay hidden — everything else works normally.
+
+Web Push requires HTTPS (the Service Worker and Push APIs do). See `docs/developer/deployment.md` § Web Push for the production env-var table.


### PR DESCRIPTION
Fills the documentation gaps the audit surfaced — recent features that had no dedicated `docs/developer/` file:

- **`docs/developer/web-push.md`** (#100): `PushSubscription`, `WebPushSender`, the service worker (`sw.js`) + `enablePush()` flow, `EnablePushPrompt`, and full VAPID key setup (which key is secret, where each lives, how to generate + set them).
- **`docs/developer/task-organization.md`**: task **sections** (`TaskSection`, nullable `Task.section`, per-section footers), the **Kanban board view** (`TaskBoard`, drag-between-sections), and task **relationships** (`TaskRelationship`, the four types + directional labels, `ValidTaskRelationship`, `GET /tasks/{id}/relationships`).

Both registered in the CLAUDE.md developer-docs index. Every cited class / endpoint / file was verified against the source. (These render as `/guides` pages once #503's docs-staging fix deploys.)

Scope: limited to the recently-shipped features that lacked docs; mature features (custom fields, search, spaces, …) are already covered in CLAUDE.md.