### PR TITLE
feat: custom-field visibility (list / board / both)

### DIFF
--- a/api/migrations/Version20260621070000.php
+++ b/api/migrations/Version20260621070000.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add custom_field_definition.visibility — controls whether a field is
+ * shown in the project task list, the Kanban board cards, or both
+ * (default). Existing fields keep showing everywhere.
+ */
+final class Version20260621070000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add custom_field_definition.visibility (list|board|both, default both).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE custom_field_definition ADD COLUMN visibility VARCHAR(16) NOT NULL DEFAULT 'both'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE custom_field_definition DROP COLUMN visibility');
+    }
+}

--- a/api/src/Controller/ProjectCopyController.php
+++ b/api/src/Controller/ProjectCopyController.php
@@ -126,7 +126,8 @@ class ProjectCopyController extends AbstractController
                 ->setConfig($sourceDefinition->getConfig())
                 ->setFooter($sourceDefinition->getFooter())
                 ->setPosition($sourceDefinition->getPosition())
-                ->setNullable($sourceDefinition->isNullable());
+                ->setNullable($sourceDefinition->isNullable())
+                ->setVisibility($sourceDefinition->getVisibility());
             $this->em->persist($clone);
         }
 

--- a/api/src/Entity/CustomFieldDefinition.php
+++ b/api/src/Entity/CustomFieldDefinition.php
@@ -98,6 +98,17 @@ class CustomFieldDefinition
 
     public const MAX_NAME_LENGTH = 80;
 
+    public const VISIBILITY_LIST = 'list';
+    public const VISIBILITY_BOARD = 'board';
+    public const VISIBILITY_BOTH = 'both';
+
+    /** @var list<string> */
+    public const VISIBILITIES = [
+        self::VISIBILITY_LIST,
+        self::VISIBILITY_BOARD,
+        self::VISIBILITY_BOTH,
+    ];
+
     #[ORM\Id]
     #[ORM\Column(type: 'uuid', unique: true)]
     #[ORM\GeneratedValue(strategy: 'CUSTOM')]
@@ -193,6 +204,20 @@ class CustomFieldDefinition
     #[Gedmo\Versioned]
     #[Groups(['custom_field_definition:read', 'custom_field_definition:write'])]
     private int $position = 0;
+
+    /**
+     * Where the field is shown to readers: in the project task list
+     * (`list`), the Kanban board cards (`board`), or both (default).
+     * The task detail drawer always shows every field regardless.
+     */
+    #[ORM\Column(length: 16, options: ['default' => self::VISIBILITY_BOTH])]
+    #[Assert\Choice(
+        choices: self::VISIBILITIES,
+        message: 'Visibility must be one of: {{ choices }}.',
+    )]
+    #[Gedmo\Versioned]
+    #[Groups(['custom_field_definition:read', 'custom_field_definition:write'])]
+    private string $visibility = self::VISIBILITY_BOTH;
 
     /**
      * Legacy `required` column — kept as a denormalised mirror of
@@ -357,6 +382,17 @@ class CustomFieldDefinition
     public function setPosition(int $position): static
     {
         $this->position = $position;
+        return $this;
+    }
+
+    public function getVisibility(): string
+    {
+        return $this->visibility;
+    }
+
+    public function setVisibility(string $visibility): static
+    {
+        $this->visibility = $visibility;
         return $this;
     }
 

--- a/api/src/Mcp/McpEntitySerializer.php
+++ b/api/src/Mcp/McpEntitySerializer.php
@@ -209,6 +209,7 @@ final class McpEntitySerializer
             'footer' => $field->getFooter(),
             'nullable' => $field->isNullable(),
             'position' => $field->getPosition(),
+            'visibility' => $field->getVisibility(),
             'projectId' => null === $field->getProject() ? null : (string) $field->getProject()->getId(),
         ];
     }

--- a/api/src/Mcp/Tool/GetCustomFieldsTool.php
+++ b/api/src/Mcp/Tool/GetCustomFieldsTool.php
@@ -28,7 +28,7 @@ final class GetCustomFieldsTool implements McpToolInterface
 
     public function getDescription(): string
     {
-        return 'List custom field definitions for a project, ordered by position. Returns each field\'s name, kind/subtype (boolean.boolean, text.{text,rich_text,url}, numeric.{int,float,money}, date.{date,time,datetime}, select.{single,multi}, reference.{user,task,page,discussion}), config, optional footer aggregation descriptor, and nullable flag.';
+        return 'List custom field definitions for a project, ordered by position. Returns each field\'s name, kind/subtype (boolean.boolean, text.{text,rich_text,url}, numeric.{int,float,money}, date.{date,time,datetime}, select.{single,multi}, reference.{user,task,page,discussion}), config, optional footer aggregation descriptor, nullable flag, and visibility (list|board|both).';
     }
 
     public function getInputSchema(): array

--- a/api/tests/Api/CustomFieldDefinitionTest.php
+++ b/api/tests/Api/CustomFieldDefinitionTest.php
@@ -53,6 +53,70 @@ class CustomFieldDefinitionTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(201);
     }
 
+    public function testVisibilityDefaultsToBoth(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/custom_field_definitions', [
+            'json' => [
+                'project' => '/projects/' . $project->getId(),
+                'name' => 'Severity',
+                'kind' => 'text',
+                'subtype' => 'text',
+                'config' => ['multi' => false],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertJsonContains(['visibility' => 'both']);
+    }
+
+    public function testVisibilityCanBeSetToBoard(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/custom_field_definitions', [
+            'json' => [
+                'project' => '/projects/' . $project->getId(),
+                'name' => 'Severity',
+                'kind' => 'text',
+                'subtype' => 'text',
+                'config' => ['multi' => false],
+                'visibility' => 'board',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertJsonContains(['visibility' => 'board']);
+    }
+
+    public function testInvalidVisibilityIsRejected(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/custom_field_definitions', [
+            'json' => [
+                'project' => '/projects/' . $project->getId(),
+                'name' => 'Severity',
+                'kind' => 'text',
+                'subtype' => 'text',
+                'config' => ['multi' => false],
+                'visibility' => 'sidebar',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+    }
+
     public function testNonOwnerMemberCannotCreate(): void
     {
         $alice = $this->createUser('alice@example.com');

--- a/pwa/components/custom-fields/CustomFieldFooterRow.tsx
+++ b/pwa/components/custom-fields/CustomFieldFooterRow.tsx
@@ -23,6 +23,9 @@ interface Props {
    *  standalone rounded card instead of the table-attached style. */
   heading?: string;
   className?: string;
+  /** When set, only footers for these definition IRIs are shown — keeps the
+   *  list footer in step with the list's `visibility`-filtered columns. */
+  visibleDefinitions?: string[];
 }
 
 const formatValue = (row: FooterRow): string => {
@@ -73,6 +76,7 @@ const CustomFieldFooterRow = ({
   refreshKey,
   heading,
   className,
+  visibleDefinitions,
 }: Props) => {
   const [rows, setRows] = useState<FooterRow[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -101,7 +105,11 @@ const CustomFieldFooterRow = ({
     };
   }, [projectId, filters, refreshKey]);
 
-  if (error || rows.length === 0) return null;
+  const visibleRows = visibleDefinitions
+    ? rows.filter((row) => visibleDefinitions.includes(row.definition))
+    : rows;
+
+  if (error || visibleRows.length === 0) return null;
 
   return (
     <Card
@@ -117,7 +125,7 @@ const CustomFieldFooterRow = ({
             {heading}
           </span>
         )}
-        {rows.map((row) => (
+        {visibleRows.map((row) => (
           <div
             key={row.definition}
             className="flex items-baseline gap-2"

--- a/pwa/components/custom-fields/CustomFieldSheet.tsx
+++ b/pwa/components/custom-fields/CustomFieldSheet.tsx
@@ -44,6 +44,7 @@ import type {
   CustomFieldDefinition,
   CustomFieldKind,
   CustomFieldSubtype,
+  CustomFieldVisibility,
   FooterDescriptor,
   FooterKind,
   OptionStatsResponse,
@@ -79,6 +80,12 @@ const FOOTER_LABELS: Record<FooterKind, string> = {
   min: "Min",
   max: "Max",
 };
+
+const VISIBILITY_OPTIONS: { value: CustomFieldVisibility; label: string }[] = [
+  { value: "list", label: "List view" },
+  { value: "board", label: "Board view" },
+  { value: "both", label: "Both" },
+];
 
 const errorMessage = async (res: Response): Promise<string> => {
   const data = await res.json().catch(() => ({}));
@@ -150,6 +157,7 @@ const CustomFieldSheet = ({
   );
   const [nullable, setNullable] = useState(true);
   const [footer, setFooter] = useState<FooterDescriptor | null>(null);
+  const [visibility, setVisibility] = useState<CustomFieldVisibility>("both");
   const [submitting, setSubmitting] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -169,8 +177,9 @@ const CustomFieldSheet = ({
       footer,
       nullable,
       position: 0,
+      visibility,
     }),
-    [name, kind, subtype, config, footer, nullable],
+    [name, kind, subtype, config, footer, nullable, visibility],
   );
   const [previewValue, setPreviewValue] = useState<unknown>(() =>
     sampleValueFor(kind, subtype, config),
@@ -192,6 +201,7 @@ const CustomFieldSheet = ({
       setConfig(initial.config);
       setNullable(initial.nullable);
       setFooter(initial.footer);
+      setVisibility(initial.visibility ?? "both");
     } else {
       setName("");
       setKind("text");
@@ -199,6 +209,7 @@ const CustomFieldSheet = ({
       setConfig(defaultConfigFor("text", "text"));
       setNullable(true);
       setFooter(null);
+      setVisibility("both");
     }
   }, [open, initial]);
 
@@ -284,6 +295,7 @@ const CustomFieldSheet = ({
         config,
         nullable,
         footer,
+        visibility,
       };
       let res: Response;
       if (isEdit && initial) {
@@ -523,6 +535,39 @@ const CustomFieldSheet = ({
               onCheckedChange={(checked) => setNullable(!checked)}
               testId="custom-field-required-input"
             />
+
+            <div className="space-y-2">
+              <Label>
+                Visibility{" "}
+                <span className="text-muted-foreground text-xs">
+                  (where the field's value is shown)
+                </span>
+              </Label>
+              <div
+                className="inline-flex rounded-md border p-0.5"
+                data-testid="custom-field-visibility-input"
+              >
+                {VISIBILITY_OPTIONS.map((opt) => (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    onClick={() => setVisibility(opt.value)}
+                    className={cn(
+                      "rounded px-3 py-1 text-sm transition-colors",
+                      visibility === opt.value
+                        ? "bg-muted font-medium text-foreground"
+                        : "text-muted-foreground hover:text-foreground",
+                    )}
+                    data-testid={`custom-field-visibility-${opt.value}`}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+              <p className="text-muted-foreground text-xs">
+                The task detail drawer always shows every field.
+              </p>
+            </div>
 
             <div className="space-y-2">
               <Label>

--- a/pwa/components/custom-fields/CustomFieldsManager.tsx
+++ b/pwa/components/custom-fields/CustomFieldsManager.tsx
@@ -34,6 +34,7 @@ import { fieldHandle } from "./handle";
 import { KIND_BADGE, kindLabelFor, subtypeLabelFor } from "./kind-editors";
 import type {
   CustomFieldDefinition,
+  CustomFieldVisibility,
   FieldStatsResponse,
 } from "./types";
 
@@ -63,6 +64,12 @@ interface Props {
 }
 
 const projectIdFromIri = (iri: string): string => iri.split("/").pop() ?? "";
+
+const VISIBILITY_LABELS: Record<CustomFieldVisibility, string> = {
+  list: "List",
+  board: "Board",
+  both: "Both",
+};
 
 /** `Spring Collection Launch` → `spring-collection-launch` (header badge). */
 const slugify = (value: string): string =>
@@ -224,6 +231,7 @@ const CustomFieldsManager = ({
             config: def.config,
             nullable: def.nullable,
             footer: def.footer,
+            visibility: def.visibility,
             project: projectIri,
             position: nextPosition,
           }),
@@ -395,6 +403,7 @@ const CustomFieldsManager = ({
                 <TableHead>Name</TableHead>
                 <TableHead>Kind</TableHead>
                 <TableHead>Required</TableHead>
+                <TableHead>Visibility</TableHead>
                 <TableHead>Footer</TableHead>
                 <TableHead className="text-right">Filled</TableHead>
                 {isSpaceAdmin && (
@@ -568,6 +577,11 @@ const FieldRow = ({
             Required
           </span>
         )}
+      </TableCell>
+      <TableCell>
+        <span className="inline-flex items-center gap-1.5 rounded-full border border-input bg-muted/40 px-2.5 py-0.5 text-xs text-muted-foreground">
+          {VISIBILITY_LABELS[def.visibility ?? "both"]}
+        </span>
       </TableCell>
       <TableCell>
         {def.footer ? (

--- a/pwa/components/custom-fields/types.ts
+++ b/pwa/components/custom-fields/types.ts
@@ -70,6 +70,9 @@ export interface FooterDescriptor {
   label?: string;
 }
 
+/** Where a field's value is surfaced to readers (the task drawer always shows all). */
+export type CustomFieldVisibility = "list" | "board" | "both";
+
 export interface CustomFieldDefinition {
   "@id": string;
   id: string;
@@ -80,6 +83,7 @@ export interface CustomFieldDefinition {
   footer: FooterDescriptor | null;
   nullable: boolean;
   position: number;
+  visibility: CustomFieldVisibility;
 }
 
 export interface FooterRow {

--- a/pwa/components/projects/TaskBoard.tsx
+++ b/pwa/components/projects/TaskBoard.tsx
@@ -13,6 +13,9 @@ import {
 import { MoreHorizontal, Plus, Trash2 } from "lucide-react";
 import UserAvatar, { type AvatarUser } from "@/components/user/UserAvatar";
 import { Badge } from "@/components/ui/badge";
+import CustomFieldValueCell from "@/components/custom-fields/CustomFieldValueCell";
+import type { CustomFieldDefinition } from "@/components/custom-fields/types";
+import type { CustomFieldValuePair } from "@/components/tasks/CustomFieldValueList";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -38,6 +41,7 @@ export interface BoardTask {
   section: string | null;
   tags: { "@id": string; title: string }[];
   assignees: AvatarUser[];
+  customFieldValues: CustomFieldValuePair[];
 }
 
 export interface BoardColumn {
@@ -49,6 +53,8 @@ export interface BoardColumn {
 
 interface TaskBoardProps {
   columns: BoardColumn[];
+  /** Custom fields to surface on cards (already filtered to board visibility). */
+  definitions: CustomFieldDefinition[];
   onOpen: (taskIri: string) => void;
   onMove: (taskIri: string, sectionIri: string | null) => void;
   onAddTask: (sectionIri: string | null) => void;
@@ -64,7 +70,54 @@ const dueLabel = (iso: string): string => {
   return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
 };
 
-const CardBody = ({ task }: { task: BoardTask }) => (
+const isEmptyValue = (v: unknown): boolean =>
+  v === null ||
+  v === undefined ||
+  v === "" ||
+  (Array.isArray(v) && v.length === 0);
+
+const CardCustomFields = ({
+  task,
+  definitions,
+}: {
+  task: BoardTask;
+  definitions: CustomFieldDefinition[];
+}) => {
+  const chips = definitions
+    .map((def) => ({
+      def,
+      value: task.customFieldValues.find((v) => v.definition === def["@id"])
+        ?.value,
+    }))
+    .filter(({ value }) => !isEmptyValue(value));
+  if (chips.length === 0) return null;
+  return (
+    <div className="flex flex-wrap gap-1">
+      {chips.map(({ def, value }) => (
+        <span
+          key={def["@id"]}
+          className="inline-flex items-center gap-1 rounded border bg-muted/40 px-1.5 py-0.5 text-[10px]"
+          data-testid="board-card-field"
+        >
+          <span className="text-muted-foreground">{def.name}</span>
+          <CustomFieldValueCell
+            definition={def}
+            value={value}
+            className="text-[10px] font-medium"
+          />
+        </span>
+      ))}
+    </div>
+  );
+};
+
+const CardBody = ({
+  task,
+  definitions,
+}: {
+  task: BoardTask;
+  definitions: CustomFieldDefinition[];
+}) => (
   <div className="space-y-1.5">
     <p
       className={cn(
@@ -74,6 +127,7 @@ const CardBody = ({ task }: { task: BoardTask }) => (
     >
       {task.title}
     </p>
+    <CardCustomFields task={task} definitions={definitions} />
     {(task.tags.length > 0 || task.dueDate || task.assignees.length > 0) && (
       <div className="flex flex-wrap items-center gap-1">
         {task.dueDate && (
@@ -104,9 +158,11 @@ const CardBody = ({ task }: { task: BoardTask }) => (
 
 const TaskCard = ({
   task,
+  definitions,
   onOpen,
 }: {
   task: BoardTask;
+  definitions: CustomFieldDefinition[];
   onOpen: (taskIri: string) => void;
 }) => {
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
@@ -125,18 +181,20 @@ const TaskCard = ({
       )}
       data-testid="board-card"
     >
-      <CardBody task={task} />
+      <CardBody task={task} definitions={definitions} />
     </button>
   );
 };
 
 const BoardColumnView = ({
   column,
+  definitions,
   onOpen,
   onAddTask,
   onDeleteSection,
 }: {
   column: BoardColumn;
+  definitions: CustomFieldDefinition[];
   onOpen: (taskIri: string) => void;
   onAddTask: (sectionIri: string | null) => void;
   onDeleteSection: (sectionIri: string) => void;
@@ -177,7 +235,12 @@ const BoardColumnView = ({
         )}
       >
         {column.tasks.map((task) => (
-          <TaskCard key={task["@id"]} task={task} onOpen={onOpen} />
+          <TaskCard
+            key={task["@id"]}
+            task={task}
+            definitions={definitions}
+            onOpen={onOpen}
+          />
         ))}
         <button
           type="button"
@@ -194,6 +257,7 @@ const BoardColumnView = ({
 
 const TaskBoard = ({
   columns,
+  definitions,
   onOpen,
   onMove,
   onAddTask,
@@ -235,6 +299,7 @@ const TaskBoard = ({
           <BoardColumnView
             key={column.key}
             column={column}
+            definitions={definitions}
             onOpen={onOpen}
             onAddTask={onAddTask}
             onDeleteSection={onDeleteSection}
@@ -252,7 +317,7 @@ const TaskBoard = ({
       <DragOverlay>
         {draggingTask ? (
           <div className="w-72 rounded-lg border bg-card p-2.5 shadow-lg">
-            <CardBody task={draggingTask} />
+            <CardBody task={draggingTask} definitions={definitions} />
           </div>
         ) : null}
       </DragOverlay>

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -333,6 +333,17 @@ const ProjectDetail = () => {
     [definitions, patchTask],
   );
 
+  // Definitions surfaced per view. The drawer always shows every field; the
+  // list and board honour each field's `visibility` setting (default "both").
+  const listDefinitions = useMemo(
+    () => definitions.filter((d) => (d.visibility ?? "both") !== "board"),
+    [definitions],
+  );
+  const boardDefinitions = useMemo(
+    () => definitions.filter((d) => (d.visibility ?? "both") !== "list"),
+    [definitions],
+  );
+
   const toggleComplete = async (task: ProjectTask) => {
     const completedOn = task.completedOn ? null : new Date().toISOString();
     setError(null);
@@ -965,6 +976,7 @@ const ProjectDetail = () => {
 
                   {view === "board" ? (
                     <TaskBoard
+                      definitions={boardDefinitions}
                       columns={sectionGroups.map((group) => ({
                         key: group.key,
                         sectionIri: group.section ? group.section["@id"] : null,
@@ -998,6 +1010,7 @@ const ProjectDetail = () => {
                     refreshKey={footerKey}
                     heading="Grand total"
                     className="mb-6 rounded-lg"
+                    visibleDefinitions={listDefinitions.map((d) => d["@id"])}
                   />
 
                   <div className="space-y-6" data-testid="project-task-list">
@@ -1015,7 +1028,7 @@ const ProjectDetail = () => {
                               : DEFAULT_SECTION_LABEL
                           }
                           tasks={group.tasks}
-                          definitions={definitions}
+                          definitions={listDefinitions}
                           projectId={project.id}
                           projectIri={project["@id"]}
                           spaceIri={projectSpaceIri(project)}
@@ -1052,6 +1065,7 @@ const ProjectDetail = () => {
                     refreshKey={footerKey}
                     heading="Grand total"
                     className="mt-6 rounded-lg"
+                    visibleDefinitions={listDefinitions.map((d) => d["@id"])}
                   />
                   </>
                   )}
@@ -1308,6 +1322,7 @@ const SectionBlock = ({
           projectId={projectId}
           filters={footerFilter}
           refreshKey={footerKey}
+          visibleDefinitions={definitions.map((d) => d["@id"])}
         />
       </div>
     </div>


### PR DESCRIPTION
## Description

Adds a per-field **Visibility** control to custom field definitions, choosing where a field's value is surfaced to readers:

- **List view** — only the project task-list columns/footer
- **Board view** — only the Kanban board cards
- **Both** (default) — everywhere

The task **detail drawer always shows every field** regardless of this setting, so values are never unreachable for editing. Existing fields default to `both`, so behaviour is unchanged until a field is explicitly narrowed.

A notable enabler: the Kanban board previously rendered **no** custom fields on cards at all, so the "board view" option would have been meaningless. Board cards now render `board`/`both` fields as compact read-only chips (reusing `CustomFieldValueCell`).

## Type of Change

- [x] New feature

## Component

- [x] API (PHP/Symfony)
- [x] PWA (Next.js)

## What changed

**Backend**
- `CustomFieldDefinition` — new `visibility` column (`VARCHAR(16)`, default `both`) with `VISIBILITY_*` constants, `Assert\Choice` validation, `Gedmo\Versioned` audit, and read/write serialization groups.
- Migration `Version20260621070000` — `ADD COLUMN visibility ... NOT NULL DEFAULT 'both'`.
- `ProjectCopyController` clones visibility; `McpEntitySerializer` + `GetCustomFieldsTool` expose it over MCP.

**PWA**
- `CustomFieldSheet` — segmented Visibility selector wired through state, re-seed, live preview, and the POST/PATCH payload.
- `CustomFieldsManager` — new Visibility column + carried in the duplicate payload.
- `projects/[id].tsx` — derives `listDefinitions`/`boardDefinitions`; list view filters columns/cells/colspans/footers, board receives board-visible fields.
- `CustomFieldFooterRow` — optional `visibleDefinitions` allow-list so board-only fields don't leak into list footer roll-ups.
- `TaskBoard` — renders custom-field chips on cards, filtered to board/both.

## How Has This Been Tested?

- Added API tests in `CustomFieldDefinitionTest`: visibility defaults to `both`, can be set to `board`, and an invalid value is rejected (422).
- Local Docker not run (environment constraint) — relying on CI (PHPUnit, PHPStan L10, PHPCS, Doctrine Schema, PWA typecheck, E2E).

## Notes for reviewers

- Minor cosmetic: multi-select option labels render at default size inside the small board chips (`CustomFieldValueCell` hardcodes `text-sm` on select options) — easy to tighten if desired.

## Checklist

- [x] My code follows the project's conventions
- [x] I have added tests that prove my feature works
- [ ] New and existing tests pass locally (run in CI)
- [x] I have updated documentation if needed