### PR TITLE
fix(pwa): log out and redirect to a "session expired" screen on 401

### DIFF
--- a/pwa/components/auth/AuthCard.tsx
+++ b/pwa/components/auth/AuthCard.tsx
@@ -147,6 +147,9 @@ const AuthCard = ({ defaultTab }: Props) => {
     typeof router.query.invite === "string" ? router.query.invite : undefined;
   const registered = router.query.registered === "true";
   const reset = router.query.reset === "true";
+  // Set by AuthContext's session-expiry redirect — drives the "you were
+  // signed out" banner so the user understands why they're back here.
+  const expired = router.query.expired === "1";
 
   // Whether the instance is in waitlist mode — drives the signup copy/flow and
   // the footer CTA on both entry points. Invite signups always run the normal
@@ -369,6 +372,7 @@ const AuthCard = ({ defaultTab }: Props) => {
               next={next}
               registered={registered}
               reset={reset}
+              expired={expired}
               onTwoFactorRequired={(email) => {
                 setTwoFactorEmail(email);
                 setStep("totp");

--- a/pwa/components/auth/SignInForm.tsx
+++ b/pwa/components/auth/SignInForm.tsx
@@ -32,6 +32,8 @@ interface Props {
   registered?: boolean;
   /** True when the user just reset their password. */
   reset?: boolean;
+  /** True when the user was bounced here by an expired session. */
+  expired?: boolean;
   /**
    * Called when `/auth/login` responds `requiresTwoFactor`. The parent
    * (AuthCard) swaps the form body + footer copy in lockstep — keeping the
@@ -42,13 +44,22 @@ interface Props {
   onTwoFactorRequired: (email: string) => void;
 }
 
-const SignInForm = ({ next, registered, reset, onTwoFactorRequired }: Props) => {
+const SignInForm = ({ next, registered, reset, expired, onTwoFactorRequired }: Props) => {
   const { login } = useAuth();
   const router = useRouter();
   const [ssoNotice, setSsoNotice] = useState<string | null>(null);
 
   return (
     <div className="space-y-4">
+      {expired && (
+        <Alert data-testid="session-expired">
+          <AlertTitle>Your session expired</AlertTitle>
+          <AlertDescription>
+            For your security you were signed out. Please sign in again to continue.
+          </AlertDescription>
+        </Alert>
+      )}
+
       {registered && (
         <Alert>
           <AlertDescription>

--- a/pwa/contexts/AuthContext.tsx
+++ b/pwa/contexts/AuthContext.tsx
@@ -1,7 +1,14 @@
 import React, { createContext, useContext, useState, useEffect, useCallback, ReactNode } from "react";
+import Router from "next/router";
 import { ENTRYPOINT } from "../config/entrypoint";
 import { trackEvent } from "../lib/analytics";
 import { fetchWithTimeout } from "../lib/fetchWithTimeout";
+import { signinHrefForCurrent } from "../lib/authRedirect";
+import {
+  armSessionExpiry,
+  installSessionExpiryInterceptor,
+  setSessionExpiredHandler,
+} from "../lib/sessionExpiry";
 
 export type NotificationFrequency = "realtime" | "hourly" | "daily";
 
@@ -273,6 +280,30 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     fetchMe();
   }, [fetchMe]);
+
+  // Install the global 401 detector once and register the handler that
+  // turns an expired session into a clean logout + redirect. Any API call
+  // that 401s while a session is armed (see below) lands here — we drop
+  // the local user and bounce to the sign-in screen flagged `expired=1`,
+  // preserving where they were via `?next=` so login returns them there.
+  useEffect(() => {
+    installSessionExpiryInterceptor();
+    setSessionExpiredHandler(() => {
+      setUser(null);
+      const target = signinHrefForCurrent(Router.asPath);
+      const href = target.includes("?") ? `${target}&expired=1` : `${target}?expired=1`;
+      Router.replace(href).catch(() => {});
+    });
+    return () => setSessionExpiredHandler(null);
+  }, []);
+
+  // Arm the detector only while we actually hold a session, so a 401 on
+  // the pre-login `/api/me` probe (a normal unauthenticated response)
+  // never reads as an expiry. Disarming also re-primes the one-shot guard,
+  // so a fresh sign-in can trigger the redirect again later.
+  useEffect(() => {
+    armSessionExpiry(user !== null);
+  }, [user]);
 
   const login = useCallback(async (email: string, password: string): Promise<LoginResult> => {
     setError(null);

--- a/pwa/lib/sessionExpiry.test.ts
+++ b/pwa/lib/sessionExpiry.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Behavioral tests for the global session-expiry detector. The module
+ * keeps process-wide state (installed once, armed flag, one-shot guard),
+ * so each case loads a fresh copy via `vi.resetModules()` + dynamic import
+ * and stands up a minimal fake `window` the interceptor can wrap.
+ */
+
+const ORIGIN = "https://app.test";
+
+type FetchStub = ReturnType<typeof vi.fn>;
+
+function installFakeWindow(status: number): FetchStub {
+  const fetchStub = vi.fn(async () => ({ status }) as unknown as Response);
+  // The detector reads window.location + window.fetch and reassigns the
+  // latter with its wrapper.
+  (globalThis as { window?: unknown }).window = {
+    location: { origin: ORIGIN, href: `${ORIGIN}/now` },
+    fetch: fetchStub,
+  };
+  return fetchStub;
+}
+
+async function loadModule() {
+  vi.resetModules();
+  return import("./sessionExpiry");
+}
+
+afterEach(() => {
+  delete (globalThis as { window?: unknown }).window;
+  vi.restoreAllMocks();
+});
+
+describe("session expiry detector", () => {
+  beforeEach(() => {
+    installFakeWindow(401);
+  });
+
+  it("ignores a 401 when no session is armed", async () => {
+    const mod = await loadModule();
+    const handler = vi.fn();
+    mod.setSessionExpiredHandler(handler);
+    mod.installSessionExpiryInterceptor();
+
+    await window.fetch(`${ORIGIN}/api/me`);
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("fires once when an armed session 401s on a protected endpoint", async () => {
+    const mod = await loadModule();
+    const handler = vi.fn();
+    mod.setSessionExpiredHandler(handler);
+    mod.installSessionExpiryInterceptor();
+    mod.armSessionExpiry(true);
+
+    await window.fetch(`${ORIGIN}/tasks`);
+    await window.fetch(`${ORIGIN}/projects`);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("never fires on auth endpoints even when armed", async () => {
+    const mod = await loadModule();
+    const handler = vi.fn();
+    mod.setSessionExpiredHandler(handler);
+    mod.installSessionExpiryInterceptor();
+    mod.armSessionExpiry(true);
+
+    await window.fetch(`${ORIGIN}/auth/login`);
+    await window.fetch(`${ORIGIN}/auth/2fa-check`);
+    await window.fetch(`${ORIGIN}/auth/change-password`);
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("re-arms after a disarm so a later session can expire again", async () => {
+    const mod = await loadModule();
+    const handler = vi.fn();
+    mod.setSessionExpiredHandler(handler);
+    mod.installSessionExpiryInterceptor();
+
+    mod.armSessionExpiry(true);
+    await window.fetch(`${ORIGIN}/tasks`);
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    // Logout (disarm re-primes the one-shot guard), then a new session.
+    mod.armSessionExpiry(false);
+    mod.armSessionExpiry(true);
+    await window.fetch(`${ORIGIN}/tasks`);
+
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
+  it("passes a non-401 response straight through untouched", async () => {
+    installFakeWindow(200);
+    const mod = await loadModule();
+    const handler = vi.fn();
+    mod.setSessionExpiredHandler(handler);
+    mod.installSessionExpiryInterceptor();
+    mod.armSessionExpiry(true);
+
+    const res = await window.fetch(`${ORIGIN}/tasks`);
+
+    expect(res.status).toBe(200);
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/pwa/lib/sessionExpiry.ts
+++ b/pwa/lib/sessionExpiry.ts
@@ -1,0 +1,106 @@
+/**
+ * Global "the session died" detector.
+ *
+ * Sessions on the API are server-side PHP sessions with no long lifetime,
+ * so an authenticated tab can have its cookie silently stop working — idle
+ * garbage collection, or a deploy that swaps the container out from under
+ * it. When that happens the next API call comes back 401. Without this the
+ * calling page just hangs on its loading state and the user can't tell
+ * they've been logged out until they manually refresh (the symptom that
+ * motivated #-session-expiry).
+ *
+ * This installs a one-time `window.fetch` wrapper that watches every
+ * same-origin API response. The first time an *armed* session sees a 401
+ * from a non-auth endpoint, it fires the registered handler exactly once —
+ * AuthContext clears the user and redirects to the "session expired"
+ * sign-in screen. Every API call in the app ultimately routes through
+ * `window.fetch` (raw `fetch`, `fetchWithTimeout`, and `apiClient` alike),
+ * so wrapping it once covers every call site without touching them.
+ *
+ * "Armed" = we currently believe we have a logged-in user. That guard is
+ * what keeps a 401 on the pre-login `/api/me` probe (a normal,
+ * unauthenticated response) from ever reading as an expiry.
+ */
+
+let armed = false;
+let fired = false;
+let handler: (() => void) | null = null;
+let installed = false;
+
+/** Flag we stamp on our wrapper so HMR / double-imports can't nest it. */
+const WRAPPED_FLAG = "__madoriSessionWrapped";
+
+type TaggedFetch = typeof window.fetch & { [WRAPPED_FLAG]?: boolean };
+
+/**
+ * Auth endpoints legitimately answer 401 (bad credentials, a 2FA step, a
+ * failed step-up) without meaning the established session expired — so a
+ * 401 from any of them must never trip the detector.
+ */
+const isExemptPath = (pathname: string): boolean => pathname.startsWith("/auth/");
+
+/** Register (or clear) the callback fired when an armed session expires. */
+export function setSessionExpiredHandler(fn: (() => void) | null): void {
+  handler = fn;
+}
+
+/**
+ * Toggle whether 401s should be treated as an expiry. AuthContext arms
+ * this whenever a user is present and disarms (which also re-primes the
+ * one-shot guard) when not, so the detector only ever acts on a session
+ * that was actually established.
+ */
+export function armSessionExpiry(value: boolean): void {
+  armed = value;
+  if (!value) fired = false;
+}
+
+function notifySessionExpired(): void {
+  if (!armed || fired || handler === null) return;
+  fired = true;
+  handler();
+}
+
+function resolveUrl(input: RequestInfo | URL): URL | null {
+  const raw =
+    typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.href
+        : input.url;
+  try {
+    return new URL(raw, window.location.href);
+  } catch {
+    return null;
+  }
+}
+
+/** Install the fetch interceptor exactly once (browser only). */
+export function installSessionExpiryInterceptor(): void {
+  if (installed || typeof window === "undefined") return;
+  installed = true;
+  if ((window.fetch as TaggedFetch)[WRAPPED_FLAG]) return;
+
+  const original = window.fetch.bind(window);
+  const wrapped = async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const res = await original(input, init);
+    // Reading `.status` doesn't consume the body, so the Response is
+    // handed back untouched for the real caller to parse.
+    if (res.status === 401) {
+      const url = resolveUrl(input);
+      if (
+        url !== null &&
+        url.origin === window.location.origin &&
+        !isExemptPath(url.pathname)
+      ) {
+        notifySessionExpired();
+      }
+    }
+    return res;
+  };
+  (wrapped as TaggedFetch)[WRAPPED_FLAG] = true;
+  window.fetch = wrapped as typeof window.fetch;
+}


### PR DESCRIPTION
## Problem

On production, an authenticated session can silently stop working — PHP session GC (~24 min idle), a deploy swapping the container (sessions live on the container's ephemeral filesystem, no persistent store), or a browser close. The next API call then returns `401`, but pages were left hanging on their loading state, so the user couldn't tell they'd been logged out until a manual refresh.

## Fix

A single global 401 detector instead of patching every page:

- **`pwa/lib/sessionExpiry.ts`** (new) — wraps `window.fetch` once. Every API call in the app routes through `window.fetch` (raw `fetch`, `fetchWithTimeout`, `apiClient` alike), so one wrapper covers every call site. On a same-origin `401` it fires **once**, but only when:
  - **armed** — a session is actually held (so the pre-login `/api/me` probe's normal `401` never trips it), and
  - the endpoint isn't under `/auth/` (login / 2FA / change-password legitimately `401` without meaning the session died).
- **`pwa/contexts/AuthContext.tsx`** — installs the detector, arms it whenever a user is present, and on expiry clears the user + `Router.replace('/signin?next=<where they were>&expired=1')`.
- **`AuthCard.tsx` / `SignInForm.tsx`** — read `?expired=1` and render a "Your session expired" banner; `next=` returns the user to the page they were on after re-login.

## Tests

`pwa/lib/sessionExpiry.test.ts` (vitest) covers the armed guard, the `/auth/` exemption, fire-once, re-arm after logout, and non-401 pass-through.

## Note

This fixes the **UX** (users now get told, instead of a stuck screen). The underlying churn — short session lifetime + no persistent session store across deploys — is a separate backend follow-up (Postgres session storage + a sane lifetime + optional `remember_me`).