### PR TITLE
feat(pwa): Tab-through tags/due/assignees in project add-task row

### DIFF
--- a/e2e/tests/projects.spec.js
+++ b/e2e/tests/projects.spec.js
@@ -126,6 +126,82 @@ test.describe("Projects", () => {
     await bobContext.close();
   });
 
+  test("the inline add-task row supports Tab between fields", async ({ page }) => {
+    await registerAndSignIn(page, uniqueEmail());
+
+    // Creating a project lands on its detail page, which opens on the Tasks
+    // tab in list view by default.
+    await page.goto(`${BASE_URL}/projects`);
+    await page.getByTestId("new-project-button").click();
+    const title = `Tab nav ${Date.now()}`;
+    await page.fill("#title", title);
+    await page.click('button[type="submit"]');
+    await expect(page).toHaveURL(/\/projects\/[a-f0-9-]+/);
+
+    // Open the inline add row in the default ("In progress") section.
+    await page.getByTestId("section-add-task").first().click();
+    const titleInput = page.getByTestId("project-new-task-title");
+    await expect(titleInput).toBeVisible();
+    await titleInput.click();
+    await titleInput.fill("Keyboard task");
+
+    // Tab walks the row in column order: title -> tags -> due -> assignees.
+    await page.keyboard.press("Tab");
+    await expect(page.getByLabel('Tags for "new task"')).toBeFocused();
+
+    await page.keyboard.press("Tab");
+    await expect(
+      page.getByRole("button", { name: "Due date for new task" }),
+    ).toBeFocused();
+
+    await page.keyboard.press("Tab");
+    await expect(page.getByLabel('Assignees for "new task"')).toBeFocused();
+
+    // Tabbing away from a non-empty title keeps the row open; Enter on the
+    // title still creates the task.
+    await titleInput.press("Enter");
+    await expect(
+      page.locator('[data-testid="project-task-item"]', { hasText: "Keyboard task" }),
+    ).toBeVisible();
+  });
+
+  test("tags staged in the add row are saved on the created task", async ({ page }) => {
+    const email = uniqueEmail();
+    await registerAndSignIn(page, email);
+
+    // Seed a tag so the tags combobox has something to pick.
+    const tagRes = await page.request.post(`${BASE_URL}/tags`, {
+      headers: { "Content-Type": "application/ld+json" },
+      data: { title: `urgent-${Date.now()}`, color: "#ef4444" },
+    });
+    expect(tagRes.ok()).toBeTruthy();
+    const tag = await tagRes.json();
+
+    await page.goto(`${BASE_URL}/projects`);
+    await page.getByTestId("new-project-button").click();
+    const title = `Tag staging ${Date.now()}`;
+    await page.fill("#title", title);
+    await page.click('button[type="submit"]');
+    await expect(page).toHaveURL(/\/projects\/[a-f0-9-]+/);
+
+    await page.getByTestId("section-add-task").first().click();
+    const titleInput = page.getByTestId("project-new-task-title");
+    await titleInput.fill("Tagged task");
+
+    // Stage a tag, then submit from the title input.
+    const tagsInput = page.getByLabel('Tags for "new task"');
+    await tagsInput.click();
+    await page.getByRole("option", { name: tag.title }).click();
+    await titleInput.press("Enter");
+
+    const item = page.locator('[data-testid="project-task-item"]', {
+      hasText: "Tagged task",
+    });
+    await expect(item).toBeVisible();
+    // The staged tag persisted onto the new task's row.
+    await expect(item.locator('[data-testid="task-tag"]', { hasText: tag.title })).toBeVisible();
+  });
+
   // Removed "account menu shows Projects link" — Projects is no
   // longer a top-level sidebar link after the sidebar redesign
   // (#nav-refresh). The /projects page is still reachable directly

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -153,6 +153,12 @@ const ProjectDetail = () => {
     undefined,
   );
   const [newTaskTitle, setNewTaskTitle] = useState("");
+  // Inline draft for the rest of the add row so the user can Tab from the title
+  // into tags / due / assignees before pressing Enter. Shared across sections
+  // since only one add row is open at a time.
+  const [newTaskTags, setNewTaskTags] = useState<TagOption[]>([]);
+  const [newTaskDue, setNewTaskDue] = useState<string | null>(null);
+  const [newTaskAssignees, setNewTaskAssignees] = useState<AssigneeOption[]>([]);
   const [isCreatingTask, setIsCreatingTask] = useState(false);
   const newTaskInputRef = useRef<HTMLInputElement | null>(null);
   // Bumped whenever the task set changes so the aggregate footer re-fetches.
@@ -368,6 +374,13 @@ const ProjectDetail = () => {
           project: project["@id"],
           // `addSection` is the IRI of the group being added to; null = default.
           ...(typeof addSection === "string" ? { section: addSection } : {}),
+          ...(newTaskTags.length
+            ? { tags: newTaskTags.map((t) => t["@id"]) }
+            : {}),
+          ...(newTaskDue ? { dueDate: newTaskDue } : {}),
+          ...(newTaskAssignees.length
+            ? { assignees: newTaskAssignees.map((u) => u["@id"]) }
+            : {}),
         }),
       });
       if (!res.ok) {
@@ -381,7 +394,7 @@ const ProjectDetail = () => {
       }
       const created: ProjectTask = await res.json();
       setTasks((prev) => [...prev, created]);
-      setNewTaskTitle("");
+      resetNewTaskDraft();
       requestAnimationFrame(() => newTaskInputRef.current?.focus());
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to create task.");
@@ -390,13 +403,34 @@ const ProjectDetail = () => {
     }
   };
 
+  const resetNewTaskDraft = () => {
+    setNewTaskTitle("");
+    setNewTaskTags([]);
+    setNewTaskDue(null);
+    setNewTaskAssignees([]);
+  };
+  // The comboboxes report selection as a list of IRIs; resolve them back to the
+  // loaded options so the draft holds full objects for rendering chips.
+  const handleNewTaskTags = (iris: string[]) =>
+    setNewTaskTags(
+      iris
+        .map((iri) => allTags.find((t) => t["@id"] === iri))
+        .filter((t): t is TagOption => Boolean(t)),
+    );
+  const handleNewTaskAssignees = (iris: string[]) =>
+    setNewTaskAssignees(
+      iris
+        .map((iri) => assignableUsers.find((u) => u["@id"] === iri))
+        .filter((u): u is AssigneeOption => Boolean(u)),
+    );
+
   const openAddRow = (section: string | null = null) => {
     setAddSection(section);
     requestAnimationFrame(() => newTaskInputRef.current?.focus());
   };
   const closeAddRow = () => {
     setAddSection(undefined);
-    setNewTaskTitle("");
+    resetNewTaskDraft();
   };
 
   const createSection = async () => {
@@ -1029,9 +1063,15 @@ const ProjectDetail = () => {
                           footerKey={footerKey}
                           addOpen={addSection === sectionIri}
                           newTaskTitle={newTaskTitle}
+                          newTaskTags={newTaskTags}
+                          newTaskDue={newTaskDue}
+                          newTaskAssignees={newTaskAssignees}
                           newTaskInputRef={newTaskInputRef}
                           isCreatingTask={isCreatingTask}
                           onNewTaskTitle={setNewTaskTitle}
+                          onNewTaskTags={handleNewTaskTags}
+                          onNewTaskDue={setNewTaskDue}
+                          onNewTaskAssignees={handleNewTaskAssignees}
                           onCreateTask={createTask}
                           onAddRow={() => openAddRow(sectionIri)}
                           onCloseAddRow={closeAddRow}
@@ -1114,9 +1154,15 @@ interface SectionBlockProps {
   footerKey: number;
   addOpen: boolean;
   newTaskTitle: string;
+  newTaskTags: TagOption[];
+  newTaskDue: string | null;
+  newTaskAssignees: AssigneeOption[];
   newTaskInputRef: RefObject<HTMLInputElement | null>;
   isCreatingTask: boolean;
   onNewTaskTitle: (value: string) => void;
+  onNewTaskTags: (iris: string[]) => void;
+  onNewTaskDue: (next: string | null) => void;
+  onNewTaskAssignees: (iris: string[]) => void;
   onCreateTask: () => void | Promise<void>;
   onAddRow: () => void;
   onCloseAddRow: () => void;
@@ -1143,9 +1189,15 @@ const SectionBlock = ({
   footerKey,
   addOpen,
   newTaskTitle,
+  newTaskTags,
+  newTaskDue,
+  newTaskAssignees,
   newTaskInputRef,
   isCreatingTask,
   onNewTaskTitle,
+  onNewTaskTags,
+  onNewTaskDue,
+  onNewTaskAssignees,
   onCreateTask,
   onAddRow,
   onCloseAddRow,
@@ -1156,7 +1208,6 @@ const SectionBlock = ({
   onRename,
   onDelete,
 }: SectionBlockProps) => {
-  const addColSpan = definitions.length + 4;
   const fullColSpan = definitions.length + 7;
   return (
     <div data-testid="project-section">
@@ -1267,22 +1318,56 @@ const SectionBlock = ({
                         onCloseAddRow();
                       }
                     }}
-                    onBlur={() => {
-                      if (!newTaskTitle.trim()) onCloseAddRow();
+                    onBlur={(e) => {
+                      if (newTaskTitle.trim()) return;
+                      // Keep the row open while the user Tabs to a sibling field
+                      // (tags / due / assignees) before submitting; only close
+                      // when focus leaves the add row entirely.
+                      const next = e.relatedTarget as HTMLElement | null;
+                      if (next?.closest('[data-testid="project-new-task-row"]'))
+                        return;
+                      onCloseAddRow();
                     }}
-                    placeholder="Task title, then Enter…"
+                    placeholder="Task title, then Tab or Enter…"
                     maxLength={255}
                     disabled={isCreatingTask}
                     className="h-8"
                     data-testid="project-new-task-title"
                   />
                 </td>
-                <td
-                  colSpan={addColSpan}
-                  className="px-2 py-2 text-xs text-muted-foreground"
-                >
-                  Enter to add · Esc to cancel
+                <td className="px-2 py-2 align-middle" data-testid="new-task-tags">
+                  <TagsCombobox
+                    value={newTaskTags}
+                    options={allTags}
+                    onChange={onNewTaskTags}
+                    subjectLabel="new task"
+                  />
                 </td>
+                {definitions.map((def) => (
+                  // Custom fields are set after the task exists; render an empty
+                  // cell so the inline fields stay aligned with the columns.
+                  <td key={def["@id"]} className="px-2 py-2 align-middle" />
+                ))}
+                <td className="px-2 py-2 align-middle" data-testid="new-task-due">
+                  <DueDateCell
+                    value={newTaskDue}
+                    onChange={onNewTaskDue}
+                    ariaLabel="Due date for new task"
+                    testIdPrefix="project-new-task-due"
+                  />
+                </td>
+                <td
+                  className="px-2 py-2 align-middle"
+                  data-testid="new-task-assignees"
+                >
+                  <AssigneesCombobox
+                    value={newTaskAssignees}
+                    options={assignableUsers}
+                    onChange={onNewTaskAssignees}
+                    subjectLabel="new task"
+                  />
+                </td>
+                <td className="px-2 py-2 align-middle" />
               </tr>
             )}
             {tasks.length === 0 && !addOpen && (


### PR DESCRIPTION
## Description

The inline "Add a task…" row on the **project detail page** was title-only by design — pressing **Tab** had no next field to land on, so you couldn't keyboard your way through setting details while entering a task.

This adds inline **Tags → Due date → Assignees** fields to that add row (reusing the same `TagsCombobox` / `DueDateCell` / `AssigneesCombobox` components the existing task rows use). Now you can type a title and **Tab straight through each field**, then press Enter to create.

Note: the **My Tasks (`/tasks`)** add row already had these inline fields and already supported Tab navigation — this only closes the gap on the project page.

## Type of Change

- [x] Bug fix
- [x] New feature

## Component

- [x] PWA (Next.js)
- [x] E2E Tests

## How Has This Been Tested?

Added two Playwright e2e tests in `e2e/tests/projects.spec.js`:
- **Tab navigation** — Tab walks the add row in column order (title → tags → due → assignees), and Enter on the title still creates the task after focus has moved through the other fields.
- **Tag staging** — a tag picked in the add row persists onto the created task.

node_modules isn't installed in this worktree, so the PWA typecheck/lint and the E2E suite run in CI rather than locally.

Reviewer notes:
- Draft state (`newTaskTags` / `newTaskDue` / `newTaskAssignees`) is folded into the create POST and reset on submit/cancel.
- Custom-field columns stay empty in the add row (still set after the task exists, matching the My Tasks row).
- The title's blur handler now keeps the row open when focus moves to a sibling field (via a `closest('[data-testid="project-new-task-row"]')` check), so Tabbing mid-entry no longer dismisses the row; it still closes when focus leaves the row entirely with an empty title.
- The Kanban board view's "Add task" is a plain button (no inline text entry), so it's unaffected.

## Checklist

- [x] My code follows the project's conventions
- [x] I have added tests that prove my fix or feature works
- [ ] New and existing tests pass locally (PHPUnit / `pnpm test:coverage`)
- [ ] New pure-logic helpers under `pwa/lib` are added to the coverage allowlist in `pwa/vitest.config.ts`
- [ ] I have updated documentation if needed