### PR TITLE
ci: don't fail auto-assign workflow when assignment fails

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign PR to author
+        continue-on-error: true
         run: gh pr edit "$PR_URL" --add-assignee "$PR_AUTHOR"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Description

The **Auto Assign PR** workflow runs `gh pr edit --add-assignee` to assign new PRs to their author. When that command fails (e.g. an outside contributor or a bot like Dependabot can't be added as an assignee), the step exits non-zero and the workflow is reported as failed — adding noise to the PR's checks even though nothing important broke.

This adds `continue-on-error: true` to the assign step so a failed assignment no longer marks CI as failed. The step still surfaces as failed in the logs, but the job (and overall PR status) stays green.

## Type of Change

- [x] Bug fix

## Component

- [x] Infrastructure (Docker/Helm)

## How Has This Been Tested?

YAML-only change to a GitHub Actions workflow. Will be exercised on the next `pull_request` opened event.

## Checklist

- [x] My code follows the project's conventions
- [x] I have updated documentation if needed