### PR TITLE
feat(pwa): project list & board view polish

### DIFF
--- a/pwa/components/custom-fields/CustomFieldFooterRow.tsx
+++ b/pwa/components/custom-fields/CustomFieldFooterRow.tsx
@@ -114,7 +114,10 @@ const CustomFieldFooterRow = ({
   return (
     <Card
       className={cn(
-        heading ? "rounded-lg" : "rounded-t-none border-t-0",
+        // Per-section footer (no heading) sits flush inside the section
+        // table's rounded, clipped wrapper — just a top divider, no border or
+        // rounding of its own. Standalone (heading) footers keep their card.
+        heading ? "rounded-lg" : "rounded-none border-0 border-t",
         className,
       )}
       data-testid="custom-field-footer-row"

--- a/pwa/components/custom-fields/CustomFieldFooterRow.tsx
+++ b/pwa/components/custom-fields/CustomFieldFooterRow.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 import { ENTRYPOINT } from "@/config/entrypoint";
 import { Card, CardContent } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
+import TaskTableColumns from "@/components/projects/TaskTableColumns";
+import type { CustomFieldDefinition } from "./types";
 import type { FooterResponse, FooterRow } from "./types";
 
 /**
@@ -26,6 +28,12 @@ interface Props {
   /** When set, only footers for these definition IRIs are shown — keeps the
    *  list footer in step with the list's `visibility`-filtered columns. */
   visibleDefinitions?: string[];
+  /** When set, render a column-aligned bar (a `table-fixed` table sharing the
+   *  section tables' columns via {@link TaskTableColumns}) so each total sits
+   *  under its custom-field column. Used for the grand-total bars. */
+  columns?: CustomFieldDefinition[];
+  /** Stronger styling for the grand-total bars. */
+  prominent?: boolean;
 }
 
 const formatValue = (row: FooterRow): string => {
@@ -77,6 +85,8 @@ const CustomFieldFooterRow = ({
   heading,
   className,
   visibleDefinitions,
+  columns,
+  prominent,
 }: Props) => {
   const [rows, setRows] = useState<FooterRow[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -110,6 +120,51 @@ const CustomFieldFooterRow = ({
     : rows;
 
   if (error || visibleRows.length === 0) return null;
+
+  // Column-aligned bar: a table-fixed table sharing the section tables'
+  // columns, so each total lands under its custom-field column.
+  if (columns) {
+    const valueByDef = new Map(rows.map((row) => [row.definition, row]));
+    return (
+      <div
+        className={cn(
+          "overflow-hidden rounded-lg border",
+          prominent && "border-foreground/25 bg-muted/70",
+          className,
+        )}
+        data-testid="custom-field-footer-row"
+      >
+        <div className="overflow-x-auto">
+          <table className="w-full table-fixed text-sm">
+            <TaskTableColumns definitions={columns} />
+            <tbody>
+              <tr className={cn(prominent && "font-semibold")}>
+                <td className="px-3 py-2.5" />
+                <td className="px-1 py-2.5" />
+                <td className="px-2 py-2.5" />
+                <td className="px-2 py-2.5" />
+                {columns.map((def) => {
+                  const row = valueByDef.get(def["@id"]);
+                  return (
+                    <td
+                      key={def["@id"]}
+                      className="truncate px-2 py-2.5 tabular-nums"
+                      data-testid="custom-field-footer-cell"
+                    >
+                      {row ? formatValue(row) : ""}
+                    </td>
+                  );
+                })}
+                <td className="px-2 py-2.5" />
+                <td className="px-2 py-2.5" />
+                <td className="px-2 py-2.5" />
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <Card

--- a/pwa/components/custom-fields/CustomFieldFooterRow.tsx
+++ b/pwa/components/custom-fields/CustomFieldFooterRow.tsx
@@ -34,6 +34,9 @@ interface Props {
   columns?: CustomFieldDefinition[];
   /** Stronger styling for the grand-total bars. */
   prominent?: boolean;
+  /** Render as a bare table (no card wrapper) to sit inside a section table's
+   *  scroll container as a flush, column-aligned footer. */
+  flush?: boolean;
 }
 
 const formatValue = (row: FooterRow): string => {
@@ -87,6 +90,7 @@ const CustomFieldFooterRow = ({
   visibleDefinitions,
   columns,
   prominent,
+  flush,
 }: Props) => {
   const [rows, setRows] = useState<FooterRow[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -121,10 +125,62 @@ const CustomFieldFooterRow = ({
 
   if (error || visibleRows.length === 0) return null;
 
-  // Column-aligned bar: a table-fixed table sharing the section tables'
-  // columns, so each total lands under its custom-field column.
+  // Column-aligned aggregate bar: a table-fixed table sharing the section
+  // tables' columns, so each aggregate lands under its custom-field column.
+  // Each cell stacks the aggregate type over its value (no field name — the
+  // column header conveys that). Used for both per-section and grand totals.
   if (columns) {
     const valueByDef = new Map(rows.map((row) => [row.definition, row]));
+    const cells = (
+      <>
+        <td className="px-3 py-2" />
+        <td className="px-1 py-2" />
+        <td className="px-2 py-2" />
+        <td className="px-2 py-2" />
+        {columns.map((def) => {
+          const row = valueByDef.get(def["@id"]);
+          return (
+            <td
+              key={def["@id"]}
+              className="px-2 py-2 align-top"
+              data-testid="custom-field-footer-cell"
+            >
+              {row && (
+                <div className="flex flex-col leading-tight">
+                  <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                    {row.label ?? row.kind}
+                  </span>
+                  <span className="truncate tabular-nums font-semibold">
+                    {formatValue(row)}
+                  </span>
+                </div>
+              )}
+            </td>
+          );
+        })}
+        <td className="px-2 py-2" />
+        <td className="px-2 py-2" />
+        <td className="px-2 py-2" />
+      </>
+    );
+
+    // Flush: a bare table that lives inside a section table's scroll container,
+    // lining up with that table's columns and scrolling with it.
+    if (flush) {
+      return (
+        <table
+          className="w-full table-fixed border-t text-sm"
+          data-testid="custom-field-footer-row"
+        >
+          <TaskTableColumns definitions={columns} />
+          <tbody>
+            <tr>{cells}</tr>
+          </tbody>
+        </table>
+      );
+    }
+
+    // Standalone grand-total bar.
     return (
       <div
         className={cn(
@@ -138,27 +194,7 @@ const CustomFieldFooterRow = ({
           <table className="w-full table-fixed text-sm">
             <TaskTableColumns definitions={columns} />
             <tbody>
-              <tr className={cn(prominent && "font-semibold")}>
-                <td className="px-3 py-2.5" />
-                <td className="px-1 py-2.5" />
-                <td className="px-2 py-2.5" />
-                <td className="px-2 py-2.5" />
-                {columns.map((def) => {
-                  const row = valueByDef.get(def["@id"]);
-                  return (
-                    <td
-                      key={def["@id"]}
-                      className="truncate px-2 py-2.5 tabular-nums"
-                      data-testid="custom-field-footer-cell"
-                    >
-                      {row ? formatValue(row) : ""}
-                    </td>
-                  );
-                })}
-                <td className="px-2 py-2.5" />
-                <td className="px-2 py-2.5" />
-                <td className="px-2 py-2.5" />
-              </tr>
+              <tr>{cells}</tr>
             </tbody>
           </table>
         </div>

--- a/pwa/components/projects/TaskBoard.tsx
+++ b/pwa/components/projects/TaskBoard.tsx
@@ -201,7 +201,10 @@ const BoardColumnView = ({
 }) => {
   const { setNodeRef, isOver } = useDroppable({ id: `${COL_PREFIX}${column.key}` });
   return (
-    <div className="flex w-72 shrink-0 flex-col" data-testid="board-column">
+    <div
+      className="flex w-72 shrink-0 flex-col rounded-xl bg-muted/40 p-2"
+      data-testid="board-column"
+    >
       <div className="mb-2 flex items-center gap-2 px-1">
         <span className="text-sm font-semibold">{column.title}</span>
         <span className="text-xs text-muted-foreground">{column.tasks.length}</span>
@@ -230,8 +233,8 @@ const BoardColumnView = ({
       <div
         ref={setNodeRef}
         className={cn(
-          "flex min-h-24 flex-1 flex-col gap-2 rounded-lg border border-dashed border-transparent bg-muted/30 p-2 transition",
-          isOver && "border-foreground/30 bg-muted/60",
+          "flex min-h-24 flex-1 flex-col gap-2 rounded-lg p-1 transition",
+          isOver && "bg-foreground/5 ring-1 ring-inset ring-foreground/15",
         )}
       >
         {column.tasks.map((task) => (

--- a/pwa/components/projects/TaskTableColumns.tsx
+++ b/pwa/components/projects/TaskTableColumns.tsx
@@ -1,0 +1,32 @@
+import type { CustomFieldDefinition } from "@/components/custom-fields/types";
+
+/**
+ * Shared `<colgroup>` for the project list view's tables, so the per-section
+ * tables and the grand-total bar line up column-for-column. Every table that
+ * uses it must be `table-fixed`. Column order mirrors the section table:
+ *
+ *   checkbox · # · Task · Tags · [custom fields…] · Due · Assignees · actions
+ *
+ * The Task column carries no width so `table-fixed` gives it the remaining
+ * space; everything else is fixed so the columns are identical across tables.
+ */
+const TaskTableColumns = ({
+  definitions,
+}: {
+  definitions: CustomFieldDefinition[];
+}) => (
+  <colgroup>
+    <col className="w-8" />
+    <col className="w-10" />
+    <col />
+    <col className="w-44" />
+    {definitions.map((d) => (
+      <col key={d["@id"]} className="w-32" />
+    ))}
+    <col className="w-32" />
+    <col className="w-44" />
+    <col className="w-10" />
+  </colgroup>
+);
+
+export default TaskTableColumns;

--- a/pwa/components/tasks/value-editors.tsx
+++ b/pwa/components/tasks/value-editors.tsx
@@ -190,7 +190,7 @@ const TextMultiValue = ({ value, onChange, disabled }: ValueEditorProps) => {
     setDraft("");
   };
   return (
-    <div className="flex flex-wrap items-center gap-1.5 rounded-md border border-input bg-transparent px-2.5 py-1.5">
+    <div className="flex flex-wrap items-center gap-1.5 rounded-md border border-input bg-transparent px-2.5 py-1.5 dark:bg-input/30">
       {items.map((item) => (
         <span
           key={item}

--- a/pwa/components/ui/input.tsx
+++ b/pwa/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLI
       <input
         type={type}
         className={cn(
-          "flex h-9 w-full rounded-md border border-input bg-muted px-3 py-1 text-sm shadow-sm file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-white aria-invalid:border-destructive aria-invalid:focus-visible:border-destructive disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm dark:bg-input/30 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-white aria-invalid:border-destructive aria-invalid:focus-visible:border-destructive disabled:cursor-not-allowed disabled:opacity-50",
           className,
         )}
         ref={ref}

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -134,11 +134,9 @@ const ProjectDetail = () => {
   const [notFound, setNotFound] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Which detail tab is active — controlled so the header's "New task" button
-  // can show on the Tasks tab only.
-  const [activeTab, setActiveTab] = useState("tasks");
-  // Tasks tab view mode: the list (grouped tables) or the Kanban board.
-  const [view, setView] = useState<"list" | "board">("list");
+  // Which detail tab is active (list | board | activity | settings) —
+  // controlled so the header's "New task" button shows on the List tab only.
+  const [activeTab, setActiveTab] = useState("list");
   // Settings sub-section (left menu like the user settings page).
   const [settingsSection, setSettingsSection] = useState<
     "privacy" | "fields" | "danger"
@@ -644,8 +642,6 @@ const ProjectDetail = () => {
     return groups;
   }, [tasks, sections]);
 
-  const openCount = tasks.filter((t) => !t.completedOn).length;
-
   if (authLoading || !isAuthenticated) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-muted">
@@ -714,7 +710,7 @@ const ProjectDetail = () => {
                     <Lock className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
                   )}
                 </div>
-                {activeTab === "tasks" && (
+                {activeTab === "list" && (
                   <div className="flex items-center">
                     <Button
                       size="sm"
@@ -759,10 +755,8 @@ const ProjectDetail = () => {
 
               <Tabs value={activeTab} onValueChange={setActiveTab}>
                 <TabsList variant="line">
-                  <TabsTrigger value="tasks">
-                    Tasks{" "}
-                    <span className="ml-1 text-xs text-muted-foreground">{openCount}</span>
-                  </TabsTrigger>
+                  <TabsTrigger value="list">List</TabsTrigger>
+                  <TabsTrigger value="board">Board</TabsTrigger>
                   <TabsTrigger value="activity">Activity</TabsTrigger>
                   <TabsTrigger value="settings" data-testid="project-settings-tab">
                     Settings
@@ -989,57 +983,7 @@ const ProjectDetail = () => {
                   />
                 </TabsContent>
 
-                <TabsContent value="tasks" className="mt-4">
-                  {/* List / Board view toggle. */}
-                  <div className="mb-4 inline-flex rounded-md border p-0.5">
-                    {(["list", "board"] as const).map((mode) => (
-                      <button
-                        key={mode}
-                        type="button"
-                        onClick={() => setView(mode)}
-                        className={cn(
-                          "rounded px-3 py-1 text-sm capitalize transition-colors",
-                          view === mode
-                            ? "bg-muted font-medium text-foreground"
-                            : "text-muted-foreground hover:text-foreground",
-                        )}
-                        data-testid={`view-${mode}`}
-                      >
-                        {mode}
-                      </button>
-                    ))}
-                  </div>
-
-                  {view === "board" ? (
-                    <TaskBoard
-                      definitions={boardDefinitions}
-                      columns={sectionGroups.map((group) => ({
-                        key: group.key,
-                        sectionIri: group.section ? group.section["@id"] : null,
-                        title: group.section
-                          ? group.section.title
-                          : DEFAULT_SECTION_LABEL,
-                        tasks: group.tasks,
-                      }))}
-                      onOpen={(taskIri) => {
-                        const task = tasks.find((t) => t["@id"] === taskIri);
-                        if (task) openTaskDetail(task);
-                      }}
-                      onMove={moveTaskToSection}
-                      onAddTask={(sectionIri) => {
-                        setView("list");
-                        openAddRow(sectionIri);
-                      }}
-                      onAddSection={() => void createSection()}
-                      onDeleteSection={(sectionIri) => {
-                        const section = sections.find(
-                          (s) => s["@id"] === sectionIri,
-                        );
-                        if (section) void deleteSection(section);
-                      }}
-                    />
-                  ) : (
-                  <>
+                <TabsContent value="list" className="mt-4">
                   {/* Grand totals across the whole board — top. */}
                   <CustomFieldFooterRow
                     projectId={project.id}
@@ -1109,8 +1053,36 @@ const ProjectDetail = () => {
                     className="mt-6 rounded-lg"
                     visibleDefinitions={listDefinitions.map((d) => d["@id"])}
                   />
-                  </>
-                  )}
+                </TabsContent>
+
+                <TabsContent value="board" className="mt-4">
+                  <TaskBoard
+                    definitions={boardDefinitions}
+                    columns={sectionGroups.map((group) => ({
+                      key: group.key,
+                      sectionIri: group.section ? group.section["@id"] : null,
+                      title: group.section
+                        ? group.section.title
+                        : DEFAULT_SECTION_LABEL,
+                      tasks: group.tasks,
+                    }))}
+                    onOpen={(taskIri) => {
+                      const task = tasks.find((t) => t["@id"] === taskIri);
+                      if (task) openTaskDetail(task);
+                    }}
+                    onMove={moveTaskToSection}
+                    onAddTask={(sectionIri) => {
+                      setActiveTab("list");
+                      openAddRow(sectionIri);
+                    }}
+                    onAddSection={() => void createSection()}
+                    onDeleteSection={(sectionIri) => {
+                      const section = sections.find(
+                        (s) => s["@id"] === sectionIri,
+                      );
+                      if (section) void deleteSection(section);
+                    }}
+                  />
                 </TabsContent>
 
                 <TabsContent value="activity" className="mt-4">

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -1200,11 +1200,11 @@ const SectionBlock = ({
   const fullColSpan = definitions.length + 7;
   return (
     <div data-testid="project-section">
-      {/* Only user-created sections get a header (editable title, count,
-          add-task, delete). The default "In progress" group renders just its
-          table — adding there goes through the top-right "New task" button. */}
-      {section && (
-        <div className="mb-1.5 flex items-center gap-2">
+      {/* Every section shows a title above its table. User-created sections
+          get an editable title + Add task + delete menu; the default
+          "In progress" group shows a static title (add via "New task"). */}
+      <div className="mb-1.5 flex items-center gap-2">
+        {section ? (
           <input
             defaultValue={title}
             onBlur={(e) => void onRename(section, e.target.value)}
@@ -1215,38 +1215,48 @@ const SectionBlock = ({
             aria-label="Section title"
             data-testid="section-title-input"
           />
-          <span className="text-xs text-muted-foreground">{tasks.length}</span>
-          <button
-            type="button"
-            onClick={onAddRow}
-            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
-            data-testid="section-add-task"
+        ) : (
+          <span
+            className="px-1 text-sm font-semibold"
+            data-testid="section-title"
           >
-            <Plus className="h-3.5 w-3.5" /> Add task
-          </button>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button
-                type="button"
-                className="ml-auto rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-                aria-label="Section actions"
-                data-testid="section-menu"
-              >
-                <MoreHorizontal className="h-4 w-4" />
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem
-                onClick={() => void onDelete(section)}
-                className="text-destructive"
-                data-testid="section-delete"
-              >
-                <Trash2 className="mr-2 h-4 w-4" /> Delete section
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-      )}
+            {title}
+          </span>
+        )}
+        {section && (
+          <>
+            <button
+              type="button"
+              onClick={onAddRow}
+              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+              data-testid="section-add-task"
+            >
+              <Plus className="h-3.5 w-3.5" /> Add task
+            </button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  className="ml-auto rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                  aria-label="Section actions"
+                  data-testid="section-menu"
+                >
+                  <MoreHorizontal className="h-4 w-4" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  onClick={() => void onDelete(section)}
+                  className="text-destructive"
+                  data-testid="section-delete"
+                >
+                  <Trash2 className="mr-2 h-4 w-4" /> Delete section
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </>
+        )}
+      </div>
 
       <div className="overflow-hidden rounded-lg border">
         <div className="overflow-x-auto">

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -710,12 +710,6 @@ const ProjectDetail = () => {
               <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
                 <div className="flex items-center gap-3">
                   <h1 className="text-2xl font-bold">{project.title}</h1>
-                  {definitions.length > 0 && (
-                    <Badge variant="secondary" className="font-normal">
-                      {definitions.length} custom field
-                      {definitions.length === 1 ? "" : "s"}
-                    </Badge>
-                  )}
                   {space?.isPersonal && (
                     <Lock className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
                   )}

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -1389,13 +1389,16 @@ const SectionBlock = ({
             )}
           </tbody>
         </table>
-        </div>
+        {/* Per-section aggregates: a flush, column-aligned footer inside the
+            same scroll container so it lines up with the columns above. */}
         <CustomFieldFooterRow
           projectId={projectId}
           filters={footerFilter}
           refreshKey={footerKey}
-          visibleDefinitions={definitions.map((d) => d["@id"])}
+          columns={definitions}
+          flush
         />
+        </div>
       </div>
     </div>
   );

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -9,6 +9,7 @@ import { ENTRYPOINT } from "@/config/entrypoint";
 import { signinHrefForCurrent } from "@/lib/authRedirect";
 import ActivityPanel from "@/components/activity/ActivityPanel";
 import TaskBoard from "@/components/projects/TaskBoard";
+import TaskTableColumns from "@/components/projects/TaskTableColumns";
 import CustomFieldFooterRow from "@/components/custom-fields/CustomFieldFooterRow";
 import CustomFieldsManager from "@/components/custom-fields/CustomFieldsManager";
 import { CustomFieldValueEditor } from "@/components/tasks/value-editors";
@@ -988,9 +989,9 @@ const ProjectDetail = () => {
                   <CustomFieldFooterRow
                     projectId={project.id}
                     refreshKey={footerKey}
-                    heading="Grand total"
-                    className="mb-6 rounded-lg"
-                    visibleDefinitions={listDefinitions.map((d) => d["@id"])}
+                    columns={listDefinitions}
+                    prominent
+                    className="mb-6"
                   />
 
                   <div className="space-y-6" data-testid="project-task-list">
@@ -1049,9 +1050,9 @@ const ProjectDetail = () => {
                   <CustomFieldFooterRow
                     projectId={project.id}
                     refreshKey={footerKey}
-                    heading="Grand total"
-                    className="mt-6 rounded-lg"
-                    visibleDefinitions={listDefinitions.map((d) => d["@id"])}
+                    columns={listDefinitions}
+                    prominent
+                    className="mt-6"
                   />
                 </TabsContent>
 
@@ -1249,7 +1250,8 @@ const SectionBlock = ({
 
       <div className="overflow-hidden rounded-lg border">
         <div className="overflow-x-auto">
-        <table className="w-full text-sm">
+        <table className="w-full table-fixed text-sm">
+          <TaskTableColumns definitions={definitions} />
           <thead>
             <tr className="border-b text-xs uppercase tracking-wide text-muted-foreground">
               <th className="w-8 px-3 py-2" />
@@ -1259,7 +1261,7 @@ const SectionBlock = ({
               {definitions.map((def) => (
                 <th
                   key={def["@id"]}
-                  className="px-2 py-2 text-left font-medium whitespace-nowrap"
+                  className="truncate px-2 py-2 text-left font-medium"
                 >
                   {def.name}
                 </th>

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -1247,7 +1247,8 @@ const SectionBlock = ({
         </div>
       )}
 
-      <div className="overflow-x-auto rounded-t-lg border">
+      <div className="overflow-hidden rounded-lg border">
+        <div className="overflow-x-auto">
         <table className="w-full text-sm">
           <thead>
             <tr className="border-b text-xs uppercase tracking-wide text-muted-foreground">
@@ -1376,6 +1377,7 @@ const SectionBlock = ({
             )}
           </tbody>
         </table>
+        </div>
         <CustomFieldFooterRow
           projectId={projectId}
           filters={footerFilter}

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -1227,8 +1227,11 @@ const SectionBlock = ({
   const fullColSpan = definitions.length + 7;
   return (
     <div data-testid="project-section">
-      <div className="mb-1.5 flex items-center gap-2">
-        {section ? (
+      {/* Only user-created sections get a header (editable title, count,
+          add-task, delete). The default "In progress" group renders just its
+          table — adding there goes through the top-right "New task" button. */}
+      {section && (
+        <div className="mb-1.5 flex items-center gap-2">
           <input
             defaultValue={title}
             onBlur={(e) => void onRename(section, e.target.value)}
@@ -1239,19 +1242,15 @@ const SectionBlock = ({
             aria-label="Section title"
             data-testid="section-title-input"
           />
-        ) : (
-          <span className="px-1 text-sm font-semibold">{title}</span>
-        )}
-        <span className="text-xs text-muted-foreground">{tasks.length}</span>
-        <button
-          type="button"
-          onClick={onAddRow}
-          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
-          data-testid="section-add-task"
-        >
-          <Plus className="h-3.5 w-3.5" /> Add task
-        </button>
-        {section && (
+          <span className="text-xs text-muted-foreground">{tasks.length}</span>
+          <button
+            type="button"
+            onClick={onAddRow}
+            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+            data-testid="section-add-task"
+          >
+            <Plus className="h-3.5 w-3.5" /> Add task
+          </button>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <button
@@ -1273,8 +1272,8 @@ const SectionBlock = ({
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
-        )}
-      </div>
+        </div>
+      )}
 
       <div className="overflow-x-auto rounded-t-lg border">
         <table className="w-full text-sm">


### PR DESCRIPTION
Project detail view (list + board) UI polish:

- Drop the custom-field count badge next to the project title.
- Promote List/Board to top-level tabs (List · Board · Activity · Settings); drop the Tasks open-count badge and the in-content view toggle.
- Section titles above every list-view section (incl. the default "In progress"), no count badge.
- Round the section table's bottom corners (clipping wrapper) regardless of footer.
- Each Kanban board column now has its own muted background; white cards stand out.
- Consistent input background — align `<Input>` to the shadcn field convention (`bg-transparent dark:bg-input/30`) so inputs match comboboxes/selects everywhere.
- Aggregates (per-section + grand totals) are column-aligned with a two-row layout: aggregate type (e.g. `sum`) on top, value below — no field name.