### PR TITLE
test(e2e): fix project add-task row tests after the section-header change

### DIFF
--- a/e2e/tests/projects.spec.js
+++ b/e2e/tests/projects.spec.js
@@ -139,7 +139,7 @@ test.describe("Projects", () => {
     await expect(page).toHaveURL(/\/projects\/[a-f0-9-]+/);
 
     // Open the inline add row in the default ("In progress") section.
-    await page.getByTestId("section-add-task").first().click();
+    await page.getByTestId("project-new-task").click();
     const titleInput = page.getByTestId("project-new-task-title");
     await expect(titleInput).toBeVisible();
     await titleInput.click();
@@ -184,7 +184,7 @@ test.describe("Projects", () => {
     await page.click('button[type="submit"]');
     await expect(page).toHaveURL(/\/projects\/[a-f0-9-]+/);
 
-    await page.getByTestId("section-add-task").first().click();
+    await page.getByTestId("project-new-task").click();
     const titleInput = page.getByTestId("project-new-task-title");
     await titleInput.fill("Tagged task");
 


### PR DESCRIPTION
The default section's inline 'Add task' button was removed (#520); adding to the default group goes through the top-right 'New task' button now. Point the two add-row e2e tests at `project-new-task` instead of `section-add-task`. Fixes the E2E check that #520 merged red (admin).