### PR TITLE
fix(settings): keep long token/secret values inside the modal

### DIFF
--- a/pwa/components/account/TwoFactorSetupDialog.tsx
+++ b/pwa/components/account/TwoFactorSetupDialog.tsx
@@ -164,7 +164,7 @@ const ScanStep = ({ qrDataUri, secret, onVerified }: ScanStepProps) => (
       <div className="text-center">
         <p className="text-xs text-muted-foreground">Or enter this key manually:</p>
         <code
-          className="text-sm font-mono bg-muted rounded px-2 py-1 inline-block mt-1 select-all"
+          className="text-sm font-mono bg-muted rounded px-2 py-1 inline-block mt-1 max-w-full break-all select-all"
           data-testid="2fa-secret"
         >
           {secret}

--- a/pwa/components/settings/CreateApiTokenDialog.tsx
+++ b/pwa/components/settings/CreateApiTokenDialog.tsx
@@ -154,14 +154,14 @@ const CreateApiTokenDialog = ({
                 Madori stores only a hash and can&apos;t display it again.
               </DialogDescription>
             </DialogHeader>
-            <div className="flex items-center gap-2 rounded-md border bg-muted/40 p-2">
+            <div className="flex items-start gap-2 rounded-md border bg-muted/40 p-2">
               <code
-                className="min-w-0 flex-1 truncate font-mono text-sm"
+                className="min-w-0 flex-1 break-all font-mono text-sm leading-relaxed"
                 data-testid="api-token-plaintext"
               >
                 {created.plainToken}
               </code>
-              <Button type="button" size="sm" variant="outline" onClick={() => void copyToken()}>
+              <Button type="button" size="sm" variant="outline" className="shrink-0" onClick={() => void copyToken()}>
                 {copied ? (
                   <>
                     <Check className="mr-1 h-3.5 w-3.5" /> Copied


### PR DESCRIPTION
## What

The **Token created** dialog shows the one-time API token (`madori_pat_…`), which is long enough that it doesn't fit on a single line. It was clipped with `truncate`, hiding most of the token behind an ellipsis, and in narrower layouts the value overflowed past the bordered box (see report).

## Fix

- `pwa/components/settings/CreateApiTokenDialog.tsx` — swap `truncate` → `break-all` so the full token wraps and stays inside the box (you can now read the whole one-time value, not just the first chunk). Container is `items-start` and the Copy button is `shrink-0` so it stays put when the token wraps to two lines.
- `pwa/components/account/TwoFactorSetupDialog.tsx` — the same class of "secret string in a modal": added `max-w-full break-all` to the 2FA manual-entry key so it can't overflow on a narrow viewport.

Recovery-code grids were left as-is — those codes are short and already lay out in a 2-col grid.

## Testing

UI-only Tailwind class change; no behavior or test contract change (the `api-token-plaintext` / `2fa-secret` testids are unchanged).