### PR TITLE
feat(billing): exempt admins from the MCP daily cap (still tracked)

### DIFF
--- a/api/src/Controller/UsageController.php
+++ b/api/src/Controller/UsageController.php
@@ -38,6 +38,9 @@ class UsageController extends AbstractController
             'freeMcpDailyLimit' => $this->usageLimiter->freeMcpDailyLimit(),
             'remaining' => $this->usageLimiter->remainingMcpCalls($user),
             'entitled' => $this->usageLimiter->isUserEntitled($user),
+            // Admins are tracked but never capped — surfaced so the UI can show
+            // the unlimited state with the right reason.
+            'admin' => $this->usageLimiter->isAdmin($user),
             'enforcementEnabled' => $this->usageLimiter->isEnforcementEnabled(),
         ]);
     }

--- a/api/src/Service/UsageLimiter.php
+++ b/api/src/Service/UsageLimiter.php
@@ -65,6 +65,26 @@ final class UsageLimiter
     }
 
     /**
+     * True for platform admins. Their usage is still counted (so we can see
+     * what they consume), but they are exempt from the free MCP throughput cap
+     * — operating the instance shouldn't be rate-limited by the freemium gate.
+     */
+    public function isAdmin(User $user): bool
+    {
+        return in_array('ROLE_ADMIN', $user->getRoles(), true);
+    }
+
+    /**
+     * Whether the user's MCP throughput is uncapped: an entitled (paid Team)
+     * member or a platform admin. Distinct from {@see $enforcementEnabled},
+     * which suppresses the cap globally while the gate ships dark.
+     */
+    private function hasUnlimitedMcp(User $user): bool
+    {
+        return $this->isUserEntitled($user) || $this->isAdmin($user);
+    }
+
+    /**
      * Today's (UTC) count of metered MCP tool calls for this user.
      */
     public function mcpCallsToday(User $user): int
@@ -95,7 +115,7 @@ final class UsageLimiter
      */
     public function remainingMcpCalls(User $user): ?int
     {
-        if (!$this->enforcementEnabled || $this->isUserEntitled($user)) {
+        if (!$this->enforcementEnabled || $this->hasUnlimitedMcp($user)) {
             return null;
         }
 
@@ -108,7 +128,7 @@ final class UsageLimiter
      */
     public function isMcpCallAllowed(User $user): bool
     {
-        if (!$this->enforcementEnabled || $this->isUserEntitled($user)) {
+        if (!$this->enforcementEnabled || $this->hasUnlimitedMcp($user)) {
             return true;
         }
 

--- a/api/tests/Service/UsageLimiterTest.php
+++ b/api/tests/Service/UsageLimiterTest.php
@@ -93,6 +93,27 @@ class UsageLimiterTest extends KernelTestCase
         $this->assertNull($limiter->remainingMcpCalls($alice));
     }
 
+    public function testAdminIsUncappedButStillCounted(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $admin->setRoles(['ROLE_USER', 'ROLE_ADMIN']);
+        $this->em->flush();
+
+        $limiter = $this->limiter(mcpLimit: 1, memberLimit: 5);
+
+        // Two calls, well past the cap of 1 — but admins aren't capped.
+        $this->recorder->recordMcpCall($admin);
+        $this->recorder->recordMcpCall($admin);
+
+        $this->assertTrue($limiter->isAdmin($admin));
+        $this->assertFalse($limiter->isUserEntitled($admin));
+        $this->assertTrue($limiter->isMcpCallAllowed($admin));
+        $this->assertNull($limiter->remainingMcpCalls($admin));
+
+        // Tracking is unaffected — their usage is still recorded.
+        $this->assertSame(2, $limiter->mcpCallsToday($admin));
+    }
+
     public function testCanceledSubscriptionDoesNotEntitle(): void
     {
         $alice = $this->createUser('alice@example.com');

--- a/docs/developer/billing.md
+++ b/docs/developer/billing.md
@@ -26,6 +26,12 @@ subscription**. "Entitling" = status in
 so a transient payment hiccup doesn't instantly lock a team out; only a
 terminal `canceled`/`unpaid` revokes).
 
+**Admin exemption:** platform admins (`ROLE_ADMIN`) are never capped on MCP
+throughput — operating the instance shouldn't be rate-limited by the freemium
+gate. Their usage is *still counted* (so it shows up in usage reports and the
+settings panel); only the cap check is bypassed (`UsageLimiter::isAdmin()`,
+folded into the same unlimited path as entitlement).
+
 Only programmatic **MCP** traffic is metered — the PWA's own
 cookie-authenticated REST calls are never counted. Counting itself stays in the
 existing `UsageRecorder`/`UserUsageCounter` (off the request latency path);

--- a/pwa/components/settings/UsageSummary.tsx
+++ b/pwa/components/settings/UsageSummary.tsx
@@ -8,6 +8,7 @@ interface Usage {
   freeMcpDailyLimit: number;
   remaining: number | null;
   entitled: boolean;
+  admin: boolean;
   enforcementEnabled: boolean;
 }
 
@@ -42,7 +43,10 @@ const UsageSummary = () => {
 
   if (!usage) return null;
 
-  const unlimited = usage.entitled;
+  // Admins are uncapped but we still surface today's count so their usage
+  // stays visible; entitled (Team) members get the plain "Unlimited" state.
+  const adminUncapped = usage.admin && !usage.entitled;
+  const unlimited = usage.entitled || usage.admin;
   const used = usage.mcpCallsToday;
   const limit = usage.freeMcpDailyLimit;
   const pct = unlimited ? 0 : Math.min(100, Math.round((used / Math.max(1, limit)) * 100));
@@ -55,7 +59,15 @@ const UsageSummary = () => {
           <Gauge className="h-4 w-4 text-muted-foreground" aria-hidden />
           MCP usage today
         </p>
-        {unlimited ? (
+        {adminUncapped ? (
+          <span className="inline-flex items-center gap-1.5 text-sm font-medium">
+            <span className="tabular-nums text-foreground">{used} today</span>
+            <span className="inline-flex items-center gap-1 text-violet-600">
+              <InfinityIcon className="h-4 w-4" aria-hidden />
+              No limit
+            </span>
+          </span>
+        ) : unlimited ? (
           <span className="inline-flex items-center gap-1 text-sm font-medium text-violet-600">
             <InfinityIcon className="h-4 w-4" aria-hidden />
             Unlimited
@@ -92,7 +104,9 @@ const UsageSummary = () => {
       )}
       {unlimited && (
         <p className="mt-2 text-xs text-muted-foreground">
-          You&apos;re on a Team space — unlimited MCP &amp; API throughput.
+          {usage.entitled
+            ? "You're on a Team space — unlimited MCP & API throughput."
+            : "Admin account — no MCP cap. Today's calls are still tracked above."}
         </p>
       )}
     </div>


### PR DESCRIPTION
## What

Platform admins (`ROLE_ADMIN`) operate the instance — rate-limiting their automation behind the freemium gate is wrong. Admins are now **uncapped** on MCP throughput, but their usage is **still counted** so it stays visible in usage reports and the settings panel.

## Changes

**API**
- `App\Service\UsageLimiter` — new `isAdmin()` + a private `hasUnlimitedMcp()` (`entitled OR admin`) that gates both `isMcpCallAllowed()` and `remainingMcpCalls()`. Counting (`UsageRecorder` / `mcpCallsToday`) is untouched — the dispatch chokepoint in `McpController` records on every successful call regardless.
- `GET /me/usage` now returns an `admin` flag so the UI can show the right "unlimited" reason.

**PWA** — `UsageSummary` renders an admin as **`N today · No limit`** (the running count stays visible) instead of hiding it behind a plain "Unlimited", with admin-specific footer copy.

**Docs** — billing.md gets an "Admin exemption" note.

## Tests

`UsageLimiterTest::testAdminIsUncappedButStillCounted` — an admin two calls past a cap of 1 is still allowed, `remaining` is null, `isUserEntitled` is false, and `mcpCallsToday` is 2 (tracking intact).

## Note

Independent of the API-token PRs (#524 / #525) — branched off `main`. Couldn't run the PHP/PWA suites locally in this environment; relying on CI.