### PR TITLE
feat(settings): edit an API token's permissions after creation

### DIFF
--- a/api/src/Entity/ApiToken.php
+++ b/api/src/Entity/ApiToken.php
@@ -6,6 +6,7 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
 use App\Repository\ApiTokenRepository;
 use App\Security\Access\AccessPolicy;
@@ -57,6 +58,14 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
             // POST is the only moment the plaintext bearer is visible.
             // Subsequent GETs use the stricter `api_token:read` group.
             normalizationContext: ['groups' => ['api_token:read', 'api_token:create']],
+        ),
+        // Editing is limited to the human-managed fields (name / accessPolicy /
+        // expiresAt via the `api_token:write` group). The secret itself is
+        // immutable — there's no way to rotate the plaintext in place; revoke
+        // and re-create instead. `validateAccessPolicy()` re-runs on update.
+        new Patch(
+            uriTemplate: '/api-tokens/{id}',
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getUser() == user)",
         ),
         new Delete(
             uriTemplate: '/api-tokens/{id}',

--- a/api/tests/Api/ApiTokenApiTest.php
+++ b/api/tests/Api/ApiTokenApiTest.php
@@ -52,6 +52,95 @@ class ApiTokenApiTest extends ApiTestCase
         $this->assertCount(0, $remaining);
     }
 
+    public function testPatchUpdatesAccessPolicy(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        $client->request('POST', '/api-tokens', [
+            'json' => [
+                'name' => 'ci',
+                'accessPolicy' => ['categories' => ['tasks' => 'view'], 'items' => []],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+        $created = $client->getResponse();
+        self::assertNotNull($created);
+        $iri = $this->stringField($created->toArray(), '@id');
+
+        // Tighten tasks to edit and drop the token to a different name.
+        $client->request('PATCH', $iri, [
+            'json' => [
+                'name' => 'ci-renamed',
+                'accessPolicy' => ['categories' => ['tasks' => 'edit', 'projects' => 'view'], 'items' => []],
+            ],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(200);
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+        $this->assertSame('ci-renamed', $this->stringField($body, 'name'));
+        $policy = $body['accessPolicy'];
+        $this->assertIsArray($policy);
+        $categories = $policy['categories'];
+        $this->assertIsArray($categories);
+        $this->assertSame('edit', $categories['tasks']);
+        $this->assertSame('view', $categories['projects']);
+
+        // The POST response must never echo the plaintext on a later read.
+        $this->assertArrayNotHasKey('plainToken', $body);
+    }
+
+    public function testPatchRejectsInvalidAccessPolicy(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        $client->request('POST', '/api-tokens', [
+            'json' => ['name' => 'ci'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+        $created = $client->getResponse();
+        self::assertNotNull($created);
+        $iri = $this->stringField($created->toArray(), '@id');
+
+        $client->request('PATCH', $iri, [
+            'json' => ['accessPolicy' => ['categories' => ['tasks' => 'bogus'], 'items' => []]],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testPatchRejectsForeignToken(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        $client->request('POST', '/api-tokens', [
+            'json' => ['name' => 'alice-token'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+        $created = $client->getResponse();
+        self::assertNotNull($created);
+        $iri = $this->stringField($created->toArray(), '@id');
+
+        $client->loginUser($bob);
+        $client->request('PATCH', $iri, [
+            'json' => ['name' => 'hijacked'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        // Owner-scoped security expression hides the row from a non-owner.
+        $this->assertResponseStatusCodeSame(404);
+    }
+
     public function testCreateRejectsInvalidAccessPolicy(): void
     {
         $alice = $this->createUser('alice@example.com');

--- a/pwa/components/settings/ApiTokensTable.tsx
+++ b/pwa/components/settings/ApiTokensTable.tsx
@@ -17,6 +17,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import CreateApiTokenDialog from "./CreateApiTokenDialog";
+import EditApiTokenDialog from "./EditApiTokenDialog";
 
 const formatDate = (iso: string | null): string =>
   iso ? new Date(iso).toLocaleDateString() : "—";
@@ -31,6 +32,7 @@ const ApiTokensTable = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
+  const [editing, setEditing] = useState<ApiTokenRow | null>(null);
 
   const load = useCallback(async () => {
     setIsLoading(true);
@@ -149,6 +151,15 @@ const ApiTokensTable = () => {
                       type="button"
                       variant="ghost"
                       size="sm"
+                      onClick={() => setEditing(t)}
+                      data-testid="api-token-edit"
+                    >
+                      Edit
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
                       className="text-destructive hover:text-destructive"
                       onClick={() => void revoke(t)}
                       data-testid="api-token-revoke"
@@ -167,6 +178,18 @@ const ApiTokensTable = () => {
         open={createOpen}
         onOpenChange={setCreateOpen}
         onCreated={() => void load()}
+      />
+
+      <EditApiTokenDialog
+        token={editing}
+        onOpenChange={(open) => {
+          if (!open) setEditing(null);
+        }}
+        onSaved={(updated) =>
+          setTokens((prev) =>
+            prev.map((t) => (t["@id"] === updated["@id"] ? updated : t)),
+          )
+        }
       />
     </div>
   );

--- a/pwa/components/settings/CreateApiTokenDialog.tsx
+++ b/pwa/components/settings/CreateApiTokenDialog.tsx
@@ -20,59 +20,12 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
-import PermissionTree, {
-  type PermissionLevel,
-  type PermissionNode,
-} from "@/components/common/PermissionTree";
-
-const LEVELS: PermissionLevel[] = [
-  { value: "none", label: "None" },
-  { value: "view", label: "View" },
-  { value: "edit", label: "Edit" },
-];
-
-const NODES: PermissionNode[] = [
-  {
-    key: "content",
-    label: "Content",
-    description: "tasks, projects, pages, discussions, comments, files",
-    children: [
-      { key: "tasks", label: "Tasks" },
-      { key: "projects", label: "Projects" },
-      { key: "pages", label: "Pages" },
-      { key: "discussions", label: "Discussions" },
-      { key: "comments", label: "Comments" },
-      { key: "files", label: "Files" },
-    ],
-  },
-  {
-    key: "settings",
-    label: "Settings",
-    description: "notifications, profile, security",
-    children: [
-      { key: "notifications", label: "Notifications" },
-      { key: "profile", label: "Profile" },
-      { key: "security", label: "Security" },
-    ],
-  },
-];
-
-const ALL_CATEGORIES = [
-  "tasks",
-  "projects",
-  "pages",
-  "discussions",
-  "comments",
-  "notifications",
-  "files",
-  "profile",
-  "security",
-];
-
-// When a token is restricted, start everything at read-only — a useful,
-// least-surprising baseline the user tightens or loosens.
-const defaultAccess = (): Record<string, string> =>
-  Object.fromEntries(ALL_CATEGORIES.map((c) => [c, "view"]));
+import {
+  TOKEN_PERMISSION_LEVELS,
+  TOKEN_PERMISSION_NODES,
+  defaultTokenAccess,
+} from "@/lib/tokenPermissions";
+import PermissionTree from "@/components/common/PermissionTree";
 
 interface CreateApiTokenDialogProps {
   open: boolean;
@@ -89,7 +42,7 @@ const CreateApiTokenDialog = ({
   const [name, setName] = useState("");
   const [expiry, setExpiry] = useState("90");
   const [restricted, setRestricted] = useState(false);
-  const [access, setAccess] = useState<Record<string, string>>(defaultAccess);
+  const [access, setAccess] = useState<Record<string, string>>(defaultTokenAccess);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [created, setCreated] = useState<CreatedApiToken | null>(null);
@@ -99,7 +52,7 @@ const CreateApiTokenDialog = ({
     setName("");
     setExpiry("90");
     setRestricted(false);
-    setAccess(defaultAccess());
+    setAccess(defaultTokenAccess());
     setError(null);
     setCreated(null);
     setCopied(false);
@@ -246,8 +199,8 @@ const CreateApiTokenDialog = ({
               {restricted ? (
                 <div className="rounded-md border p-3">
                   <PermissionTree
-                    levels={LEVELS}
-                    nodes={NODES}
+                    levels={TOKEN_PERMISSION_LEVELS}
+                    nodes={TOKEN_PERMISSION_NODES}
                     values={access}
                     masterLabel="Token can access"
                     onChange={setAccess}

--- a/pwa/components/settings/EditApiTokenDialog.tsx
+++ b/pwa/components/settings/EditApiTokenDialog.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+import {
+  updateApiToken,
+  type ApiTokenRow,
+  type TokenAccessPolicy,
+} from "@/lib/apiTokens";
+import {
+  TOKEN_PERMISSION_LEVELS,
+  TOKEN_PERMISSION_NODES,
+  defaultTokenAccess,
+} from "@/lib/tokenPermissions";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Switch } from "@/components/ui/switch";
+import PermissionTree from "@/components/common/PermissionTree";
+
+interface EditApiTokenDialogProps {
+  /** The token to edit, or null when the dialog is closed. */
+  token: ApiTokenRow | null;
+  onOpenChange: (open: boolean) => void;
+  /** Called with the updated token so the table can refresh in place. */
+  onSaved: (token: ApiTokenRow) => void;
+}
+
+/**
+ * Edits an existing token's permissions. The secret is immutable — this only
+ * touches the access policy (the same none/view/edit category tree as the
+ * create flow). Per-item overrides that may already exist on the policy are
+ * preserved untouched; only the category grants are editable here.
+ */
+const EditApiTokenDialog = ({
+  token,
+  onOpenChange,
+  onSaved,
+}: EditApiTokenDialogProps) => {
+  const [restricted, setRestricted] = useState(false);
+  const [access, setAccess] = useState<Record<string, string>>(defaultTokenAccess);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Seed the form from the token each time the dialog opens for a new row.
+  useEffect(() => {
+    if (!token) return;
+    const policy = token.accessPolicy;
+    setRestricted(policy !== null);
+    setAccess(
+      policy
+        ? { ...defaultTokenAccess(), ...policy.categories }
+        : defaultTokenAccess(),
+    );
+    setError(null);
+  }, [token]);
+
+  const save = async () => {
+    if (!token) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      // Keep any per-item overrides the policy already carried; only the
+      // category grants are editable from this dialog.
+      const items = token.accessPolicy?.items ?? {};
+      const nextPolicy: TokenAccessPolicy | null = restricted
+        ? { categories: access, items }
+        : null;
+      const updated = await updateApiToken(token["@id"], {
+        accessPolicy: nextPolicy,
+      });
+      onSaved(updated);
+      onOpenChange(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update token.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={token !== null} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit token permissions</DialogTitle>
+          <DialogDescription>
+            Adjust what{" "}
+            <span className="font-medium text-foreground">{token?.name}</span>{" "}
+            can do. The secret itself can&apos;t be changed — revoke and
+            re-create to rotate it.
+          </DialogDescription>
+        </DialogHeader>
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <p className="text-sm font-medium">Restrict permissions</p>
+              <p className="text-xs text-muted-foreground">
+                Off = the token can do everything you can. On = limit it per
+                category.
+              </p>
+            </div>
+            <Switch
+              checked={restricted}
+              onCheckedChange={setRestricted}
+              aria-label="Restrict token permissions"
+              data-testid="edit-api-token-restrict"
+            />
+          </div>
+          {restricted ? (
+            <div className="rounded-md border p-3">
+              <PermissionTree
+                levels={TOKEN_PERMISSION_LEVELS}
+                nodes={TOKEN_PERMISSION_NODES}
+                values={access}
+                masterLabel="Token can access"
+                onChange={setAccess}
+              />
+            </div>
+          ) : null}
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={() => void save()}
+            disabled={submitting}
+            data-testid="edit-api-token-save"
+          >
+            {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : "Save changes"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default EditApiTokenDialog;

--- a/pwa/lib/apiTokens.ts
+++ b/pwa/lib/apiTokens.ts
@@ -81,6 +81,28 @@ export const createApiToken = async (input: {
   return res.json();
 };
 
+export const updateApiToken = async (
+  iri: string,
+  patch: Partial<Pick<ApiTokenRow, "name" | "accessPolicy" | "expiresAt">>,
+): Promise<ApiTokenRow> => {
+  const res = await fetch(`${ENTRYPOINT}${iri}`, {
+    method: "PATCH",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/merge-patch+json",
+      Accept: "application/ld+json",
+    },
+    body: JSON.stringify(patch),
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(
+      data["hydra:description"] || data.detail || "Failed to update token.",
+    );
+  }
+  return res.json();
+};
+
 export const revokeApiToken = async (iri: string): Promise<void> => {
   const res = await fetch(`${ENTRYPOINT}${iri}`, {
     method: "DELETE",

--- a/pwa/lib/tokenPermissions.ts
+++ b/pwa/lib/tokenPermissions.ts
@@ -1,0 +1,58 @@
+import type {
+  PermissionLevel,
+  PermissionNode,
+} from "@/components/common/PermissionTree";
+
+/**
+ * Shared permission config for the API-token create + edit dialogs. Both the
+ * "Generate token" and "Edit permissions" flows render the same none/view/edit
+ * tree, so the level + node definitions live here rather than being duplicated.
+ */
+export const TOKEN_PERMISSION_LEVELS: PermissionLevel[] = [
+  { value: "none", label: "None" },
+  { value: "view", label: "View" },
+  { value: "edit", label: "Edit" },
+];
+
+export const TOKEN_PERMISSION_NODES: PermissionNode[] = [
+  {
+    key: "content",
+    label: "Content",
+    description: "tasks, projects, pages, discussions, comments, files",
+    children: [
+      { key: "tasks", label: "Tasks" },
+      { key: "projects", label: "Projects" },
+      { key: "pages", label: "Pages" },
+      { key: "discussions", label: "Discussions" },
+      { key: "comments", label: "Comments" },
+      { key: "files", label: "Files" },
+    ],
+  },
+  {
+    key: "settings",
+    label: "Settings",
+    description: "notifications, profile, security",
+    children: [
+      { key: "notifications", label: "Notifications" },
+      { key: "profile", label: "Profile" },
+      { key: "security", label: "Security" },
+    ],
+  },
+];
+
+export const TOKEN_CATEGORIES = [
+  "tasks",
+  "projects",
+  "pages",
+  "discussions",
+  "comments",
+  "notifications",
+  "files",
+  "profile",
+  "security",
+];
+
+// When a token is restricted, start everything at read-only — a useful,
+// least-surprising baseline the user tightens or loosens.
+export const defaultTokenAccess = (): Record<string, string> =>
+  Object.fromEntries(TOKEN_CATEGORIES.map((c) => [c, "view"]));


### PR DESCRIPTION
## What

API tokens were write-once for their access policy — you could create a restricted token but never adjust its permissions without revoking and re-issuing (which rotates the secret and breaks every client using it). This adds in-place permission editing.

## Changes

**API** — `api/src/Entity/ApiToken.php`
- New `Patch` operation, same owner/admin security as `Get`/`Delete`, reusing the existing `api_token:write` group (`name` / `accessPolicy` / `expiresAt`). `validateAccessPolicy()` already runs on update, so an invalid policy `422`s on edit too. The token secret stays immutable (revoke + re-create to rotate).

**PWA**
- `EditApiTokenDialog` reuses the create flow's none/view/edit `PermissionTree` to retarget the policy in place.
- An **Edit** action beside **Revoke** in the tokens table; saves patch the row in state (no refetch).
- Per-item overrides already on a policy are preserved (the dialog edits category grants only, matching create).
- Shared permission config extracted to `pwa/lib/tokenPermissions.ts` so create + edit can't drift.

## Tests

`ApiTokenApiTest`: `testPatchUpdatesAccessPolicy`, `testPatchRejectsInvalidAccessPolicy`, `testPatchRejectsForeignToken` (non-owner `404`).

## Note

Replaces #525 (auto-closed when its stacked base branch was deleted on #524's merge). Rebased onto `main` — now a clean edit-only diff.