### PR TITLE
fix(pwa): feedback board polish, admin sidebar & impersonation UX

### DIFF
--- a/api/src/DataFixtures/FeedbackFixtures.php
+++ b/api/src/DataFixtures/FeedbackFixtures.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace App\DataFixtures;
+
+use App\Entity\Comment;
+use App\Entity\Feedback;
+use App\Entity\FeedbackVote;
+use App\Entity\User;
+use App\Repository\FeedbackRepository;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+
+/**
+ * Demo data for the in-app feedback board. Seeds a spread of bug reports
+ * and feature requests across every workflow status, owned by the various
+ * fixture users, with a realistic distribution of up/down votes and a few
+ * comment threads — enough to exercise the board's sort-by-score,
+ * status/type filters, "your vote" highlight, and comment counts after a
+ * fresh `doctrine:fixtures:load`.
+ *
+ * Ticket numbers are pulled from the same `feedback_ticket_seq` the
+ * {@see FeedbackOwnerProcessor} uses, so the sequence stays in step with
+ * the seeded rows and the first ticket filed through the UI continues the
+ * count instead of colliding.
+ */
+class FeedbackFixtures extends Fixture implements DependentFixtureInterface
+{
+    public function __construct(
+        private FeedbackRepository $feedbackRepository,
+    ) {
+    }
+
+    public function getDependencies(): array
+    {
+        return [UserFixtures::class];
+    }
+
+    public function load(ObjectManager $manager): void
+    {
+        $users = [
+            'uma' => $this->getReference(UserFixtures::USER_REFERENCE, User::class),
+            'ada' => $this->getReference(UserFixtures::ADMIN_REFERENCE, User::class),
+            'noah' => $this->getReference('user-noah', User::class),
+            'emma' => $this->getReference('user-emma', User::class),
+            'liam' => $this->getReference('user-liam', User::class),
+            'ava' => $this->getReference('user-ava', User::class),
+        ];
+
+        // Each ticket: owner key, type, status, title, description, the
+        // voters (key => +1 | -1), and an optional comment thread
+        // (list of [author key, body]).
+        $tickets = [
+            [
+                'owner' => 'uma',
+                'type' => Feedback::TYPE_FEATURE,
+                'status' => Feedback::STATUS_PLANNED,
+                'title' => 'Dark mode across the whole app',
+                'description' => "The marketing site is dark but the app itself is light-only. "
+                    . "A proper dark theme (respecting the OS preference) would make late-night "
+                    . "sessions a lot easier on the eyes.",
+                'votes' => ['noah' => 1, 'emma' => 1, 'liam' => 1, 'ava' => 1, 'ada' => 1],
+                'comments' => [
+                    ['ada', "Great call — this is on the roadmap for next quarter."],
+                    ['noah', "+1, the task drawer especially is blinding at night."],
+                ],
+            ],
+            [
+                'owner' => 'noah',
+                'type' => Feedback::TYPE_BUG,
+                'status' => Feedback::STATUS_OPEN,
+                'title' => 'Task drawer closes when I click the date picker',
+                'description' => "Opening a task, then clicking the due-date field, sometimes closes "
+                    . "the whole drawer instead of opening the calendar. Happens about half the time "
+                    . "in Firefox.",
+                'votes' => ['uma' => 1, 'emma' => 1, 'liam' => 1],
+                'comments' => [
+                    ['emma', "Reproduced on my end too — only when the drawer was just reopened."],
+                ],
+            ],
+            [
+                'owner' => 'emma',
+                'type' => Feedback::TYPE_FEATURE,
+                'status' => Feedback::STATUS_IN_PROGRESS,
+                'title' => 'Keyboard shortcuts for navigation',
+                'description' => "A ⌘K command palette exists for search, but moving between Tasks, "
+                    . "Projects, and Pages still needs the mouse. Vim-style `g t` / `g p` jumps would "
+                    . "be lovely.",
+                'votes' => ['uma' => 1, 'noah' => 1, 'ava' => 1],
+                'comments' => [],
+            ],
+            [
+                'owner' => 'liam',
+                'type' => Feedback::TYPE_FEATURE,
+                'status' => Feedback::STATUS_SHIPPED,
+                'title' => 'Export all space data as a single archive',
+                'description' => "For backups and GDPR requests it would help to download everything "
+                    . "in a space — projects, tasks, pages, discussions, attachments — as one zip.",
+                'votes' => ['uma' => 1, 'emma' => 1, 'ada' => 1, 'ava' => 1],
+                'comments' => [
+                    ['ada', "Shipped! Space admins can now export from Space settings → Export."],
+                ],
+            ],
+            [
+                'owner' => 'ava',
+                'type' => Feedback::TYPE_BUG,
+                'status' => Feedback::STATUS_OPEN,
+                'title' => 'Avatar initials are unreadable on light personal colors',
+                'description' => "When a user picks a pale avatar color the white initials nearly "
+                    . "disappear. The contrast check at signup doesn't seem to catch the lightest "
+                    . "swatches.",
+                'votes' => ['noah' => 1, 'liam' => -1],
+                'comments' => [],
+            ],
+            [
+                'owner' => 'uma',
+                'type' => Feedback::TYPE_FEATURE,
+                'status' => Feedback::STATUS_DECLINED,
+                'title' => 'Built-in Pomodoro timer',
+                'description' => "A focus timer that ticks down inside the app and auto-starts the "
+                    . "next task. Would keep me off a second tab.",
+                'votes' => ['emma' => 1, 'noah' => -1, 'liam' => -1, 'ada' => -1],
+                'comments' => [
+                    ['ada', "Declining for now — it's a bit outside the core scope, and there are "
+                        . "great standalone tools for this. Revisit if demand grows."],
+                ],
+            ],
+            [
+                'owner' => 'ada',
+                'type' => Feedback::TYPE_BUG,
+                'status' => Feedback::STATUS_IN_PROGRESS,
+                'title' => 'Mercure reconnect storm after the laptop wakes from sleep',
+                'description' => "After closing the lid and reopening, the live-update connection "
+                    . "hammers the server with reconnect attempts for a few seconds before settling. "
+                    . "Should back off exponentially.",
+                'votes' => ['uma' => 1, 'liam' => 1],
+                'comments' => [],
+            ],
+            [
+                'owner' => 'emma',
+                'type' => Feedback::TYPE_FEATURE,
+                'status' => Feedback::STATUS_OPEN,
+                'title' => "Recurrence rule for \"every weekday\"",
+                'description' => "Daily recurrence includes weekends. A one-click \"every weekday "
+                    . "(Mon–Fri)\" option would save building a custom weekly rule with five days "
+                    . "ticked.",
+                'votes' => ['uma' => 1, 'noah' => 1, 'liam' => 1, 'ava' => 1],
+                'comments' => [],
+            ],
+        ];
+
+        foreach ($tickets as $spec) {
+            $ticket = new Feedback();
+            $ticket->setOwner($users[$spec['owner']]);
+            $ticket->setType($spec['type']);
+            $ticket->setStatus($spec['status']);
+            $ticket->setTitle($spec['title']);
+            $ticket->setDescription($spec['description']);
+            $ticket->setTicketNumber($this->feedbackRepository->nextTicketNumber());
+            $manager->persist($ticket);
+
+            foreach ($spec['votes'] as $voterKey => $value) {
+                $vote = (new FeedbackVote())
+                    ->setFeedback($ticket)
+                    ->setUser($users[$voterKey])
+                    ->setValue($value);
+                $manager->persist($vote);
+            }
+
+            foreach ($spec['comments'] as [$authorKey, $body]) {
+                $comment = (new Comment())
+                    ->setFeedback($ticket)
+                    ->setAuthor($users[$authorKey])
+                    ->setBody($body);
+                $manager->persist($comment);
+            }
+        }
+
+        $manager->flush();
+    }
+}

--- a/api/src/DataFixtures/UserFixtures.php
+++ b/api/src/DataFixtures/UserFixtures.php
@@ -37,6 +37,31 @@ class UserFixtures extends Fixture
     ];
 
     /**
+     * Demo opt-in to admin impersonation for the non-admin fixture users
+     * (Uma + the team). Production accounts start with this OFF
+     * ({@see User::DEFAULT_PREFERENCES}) — an admin can't switch into an
+     * account until its owner consents — so the demo would otherwise show
+     * "Couldn't switch user." on every attempt. Enabling consent + full
+     * per-category access here makes the impersonation flow exercisable end
+     * to end on a fixture DB. {@see setPreferences()} merges over the
+     * defaults, so only these two keys need to be stored.
+     *
+     * @var array<string, mixed>
+     */
+    private const DEMO_IMPERSONATION_PREFS = [
+        'canBeImpersonated' => true,
+        'impersonationAccess' => [
+            'tasks' => 'edit',
+            'projects' => 'edit',
+            'pages' => 'edit',
+            'discussions' => 'edit',
+            'comments' => 'edit',
+            'notifications' => 'edit',
+            'files' => 'edit',
+        ],
+    ];
+
+    /**
      * Hardcoded TOTP secret for the Uma fixture user so dev / E2E flows can
      * pre-pair an authenticator once and reuse the same QR across fixture
      * reloads. Valid base32 (A-Z, 2-7), length matches what
@@ -91,6 +116,7 @@ class UserFixtures extends Fixture
         $user->setFamilyName('User');
         $user->setPersonalizedColor($this->colorService->pick());
         $user->setPassword($this->passwordHasher->hashPassword($user, 'user123'));
+        $user->setPreferences(self::DEMO_IMPERSONATION_PREFS);
 
         // Pre-enable TOTP 2FA on Uma so the sign-in flow exercises the
         // challenge step without a manual pairing step every fixture reload.
@@ -120,6 +146,12 @@ class UserFixtures extends Fixture
             $member->setFamilyName($spec['family']);
             $member->setPersonalizedColor($this->colorService->pick());
             $member->setPassword($teamPasswordHash);
+            // Ava deliberately stays opted OUT of impersonation so the admin
+            // users page demonstrates the disabled "this user has not enabled
+            // impersonation" state alongside the opted-in members.
+            if ('user-ava' !== $spec['reference']) {
+                $member->setPreferences(self::DEMO_IMPERSONATION_PREFS);
+            }
             $manager->persist($member);
             $teamUsers[$spec['reference']] = $member;
         }

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -564,6 +564,20 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TwoFact
     }
 
     /**
+     * Read-only mirror of {@see canBeImpersonated()} for the API. Exposed
+     * only under `user:read` — emitted by the admin-gated `/users`
+     * collection and the user's own item, never by the embedded user chips
+     * (which serialize under project:read / space:read / … instead) — so an
+     * admin can tell which accounts have opted in before attempting a
+     * switch, without leaking the flag onto every comment/task author chip.
+     */
+    #[Groups(['user:read'])]
+    public function getCanBeImpersonated(): bool
+    {
+        return $this->canBeImpersonated();
+    }
+
+    /**
      * The access level ('none' | 'view' | 'edit') an impersonating admin
      * has for the given content category. Unknown / malformed values fall
      * back to the safe default 'none'. Read by

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -78,11 +78,21 @@ services:
       # Repo-root docs/ surfaced inside the container so scripts/sync-docs.mjs
       # can find a source when predev / prebuild runs from /srv/app.
       - ./docs:/srv/docs:ro
+    # Next 16 defaults `next dev` to Turbopack, whose file watcher relies on
+    # inotify and ignores WATCHPACK_POLLING. inotify events do NOT cross Docker
+    # Desktop's Windows/WSL bind mount, so edits never trigger a recompile —
+    # routes go stale and hot reload silently dies. Force the webpack dev
+    # server, which DOES honor the polling flag below. Linux/macOS devs with
+    # working native file events can drop this override for Turbopack's speed.
+    command: sh -c "pnpm install; pnpm run dev --webpack"
     environment:
       API_PLATFORM_CREATE_CLIENT_ENTRYPOINT: http://php
       API_PLATFORM_CREATE_CLIENT_OUTPUT: .
-      # On Linux, you may want to comment the following line for improved performance
+      # Poll the filesystem instead of relying on inotify (which doesn't fire
+      # over the Windows/WSL bind mount). Honored by the webpack dev server
+      # selected above. On native Linux you may comment this out for perf.
       WATCHPACK_POLLING: "true"
+      CHOKIDAR_USEPOLLING: "true"
 
 ###> doctrine/doctrine-bundle ###
   database:

--- a/pwa/components/common/Footer.tsx
+++ b/pwa/components/common/Footer.tsx
@@ -97,14 +97,12 @@ const Footer = () => (
               </a>
             </li>
             <li>
-              <a
-                href="https://github.com/roboparker/Aura/issues"
-                target="_blank"
-                rel="noopener noreferrer"
+              <Link
+                href="/feedback"
                 className="text-foreground hover:underline"
               >
-                Report an issue
-              </a>
+                Feedback
+              </Link>
             </li>
           </ul>
         </div>

--- a/pwa/components/common/SidebarNav.tsx
+++ b/pwa/components/common/SidebarNav.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { useEffect, useState, type ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { ChevronDown, Plus } from "lucide-react";
+import { ChevronDown, Plus, ShieldCheck } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
 import { apiGetCollection } from "@/lib/apiClient";
@@ -221,6 +221,101 @@ const ContentSection = ({ section, spaceIri, wrap }: ContentSectionProps) => {
   );
 };
 
+interface AdminLink {
+  href: string;
+  label: string;
+  /** Path prefix used to highlight the active row. */
+  match: string;
+  /** External (Caddy-served) link rendered as a plain <a>. */
+  external?: boolean;
+}
+
+/**
+ * Admin tooling as a collapsible nav section, mirroring {@see ContentSection}:
+ * a colored icon + heading with a persisted collapse chevron, over the static
+ * admin links. Lives inline in the scrollable nav (not pinned to the foot) so
+ * it reads as just another section of the left menu.
+ */
+const AdminSection = ({ wrap }: { wrap: (children: ReactNode) => ReactNode }) => {
+  const router = useRouter();
+
+  const storageKey = "madori.navCollapsed.admin";
+  const [collapsed, setCollapsed] = useState(false);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    setCollapsed(window.localStorage.getItem(storageKey) === "1");
+  }, []);
+
+  const toggle = () =>
+    setCollapsed((c) => {
+      const next = !c;
+      try {
+        window.localStorage.setItem(storageKey, next ? "1" : "0");
+      } catch {
+        // Storage-disabled browsers: state still toggles for the session.
+      }
+      return next;
+    });
+
+  const links: AdminLink[] = [
+    { href: "/admin/users", label: "Users", match: "/admin/users" },
+    { href: "/admin/waitlist", label: "Waitlist", match: "/admin/waitlist" },
+    { href: "/admin/segments", label: "Segments", match: "/admin/segments" },
+    { href: "/feedback", label: "Feedback", match: "/feedback" },
+    ...ADMIN_EXTERNAL_LINKS.map((l) => ({ ...l, match: l.href, external: true })),
+  ];
+
+  return (
+    <div className="mt-3 first:mt-0">
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={!collapsed}
+        aria-label={`${collapsed ? "Expand" : "Collapse"} Admin`}
+        className="flex w-full items-center gap-1.5 px-3 pb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground hover:text-foreground"
+      >
+        <ShieldCheck className="size-3.5 shrink-0 text-amber-600 dark:text-amber-400" />
+        <span className="truncate">Admin</span>
+        <ChevronDown
+          className={cn(
+            "ml-auto size-3.5 transition-transform",
+            collapsed && "-rotate-90",
+          )}
+        />
+      </button>
+
+      {!collapsed &&
+        links.map((link) => {
+          const active = router.pathname.startsWith(link.match);
+          const inner = (
+            <Button
+              asChild
+              variant="ghost"
+              size="sm"
+              className={cn(
+                "w-full min-w-0 justify-start font-normal",
+                active && "bg-accent text-accent-foreground",
+              )}
+            >
+              {link.external ? (
+                <a href={link.href} target="_blank" rel="noopener noreferrer">
+                  {/* pl-5 ≈ heading icon (size-3.5) + gap-1.5, lining the row
+                      text up under the heading label. */}
+                  <span className="truncate pl-5">{link.label}</span>
+                </a>
+              ) : (
+                <Link href={link.href}>
+                  <span className="truncate pl-5">{link.label}</span>
+                </Link>
+              )}
+            </Button>
+          );
+          return <span key={link.href}>{wrap(inner)}</span>;
+        })}
+    </div>
+  );
+};
+
 /**
  * Shared navigation contents used by both the persistent left-side
  * `<Sidebar>` (`md:` and up) and the mobile-only Sheet variant in the
@@ -233,7 +328,6 @@ const SidebarNav = ({
 }: SidebarNavProps) => {
   const { user, isAuthenticated } = useAuth();
   const { activeSpace } = useActiveSpace();
-  const router = useRouter();
   const isAdmin = user?.roles?.includes("ROLE_ADMIN");
   const wrap = itemWrapper ?? ((c) => c);
 
@@ -257,78 +351,9 @@ const SidebarNav = ({
               wrap={wrap}
             />
           ))}
-      </nav>
 
-      {/* Admin tooling is pinned to the foot of the sidebar, below the
-          (scrollable) space content, separated by a divider. */}
-      {isAdmin && (
-        <div className="flex flex-col gap-0.5 border-t px-2 py-3">
-          <p className="px-3 pb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-            Admin
-          </p>
-            <span>
-              {wrap(
-                <Button
-                  asChild
-                  variant="ghost"
-                  size="sm"
-                  className={cn(
-                    "justify-start w-full",
-                    router.pathname.startsWith("/admin/users") &&
-                      "bg-accent text-accent-foreground",
-                  )}
-                >
-                  <Link href="/admin/users">Users</Link>
-                </Button>,
-              )}
-            </span>
-            <span>
-              {wrap(
-                <Button
-                  asChild
-                  variant="ghost"
-                  size="sm"
-                  className={cn(
-                    "justify-start w-full",
-                    router.pathname.startsWith("/admin/waitlist") &&
-                      "bg-accent text-accent-foreground",
-                  )}
-                >
-                  <Link href="/admin/waitlist">Waitlist</Link>
-                </Button>,
-              )}
-            </span>
-            <span>
-              {wrap(
-                <Button
-                  asChild
-                  variant="ghost"
-                  size="sm"
-                  className={cn(
-                    "justify-start w-full",
-                    router.pathname.startsWith("/admin/segments") &&
-                      "bg-accent text-accent-foreground",
-                  )}
-                >
-                  <Link href="/admin/segments">Segments</Link>
-                </Button>,
-              )}
-            </span>
-            {ADMIN_EXTERNAL_LINKS.map(({ href, label }) => (
-              <Button
-                key={href}
-                asChild
-                variant="ghost"
-                size="sm"
-                className="justify-start w-full"
-              >
-                <a href={href} target="_blank" rel="noopener noreferrer">
-                  {label}
-                </a>
-              </Button>
-            ))}
-        </div>
-      )}
+        {isAdmin && <AdminSection wrap={wrap} />}
+      </nav>
     </div>
   );
 };

--- a/pwa/contexts/AuthContext.tsx
+++ b/pwa/contexts/AuthContext.tsx
@@ -492,6 +492,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       { credentials: "include" },
     );
     if (!res.ok) {
+      // A 403 here means the target hasn't opted in to impersonation — the
+      // firewall denies the switch (ImpersonationVoter). The response is an
+      // HTML error page, not JSON, so surface a clear, actionable message
+      // instead of the generic fallback. Switch-out ("_exit") never hits
+      // the consent check, so this only fires when starting one.
+      if (res.status === 403) {
+        throw new Error(
+          "This user hasn't enabled impersonation. They need to turn on " +
+            "“Allow administrators to impersonate me” under Settings → " +
+            "Security before you can switch into their account.",
+        );
+      }
       const data = await res.json().catch(() => ({}));
       throw new Error(data.error || data.detail || "Couldn't switch user.");
     }

--- a/pwa/pages/admin/users.tsx
+++ b/pwa/pages/admin/users.tsx
@@ -37,6 +37,8 @@ interface AdminUser {
   personalizedColor: string;
   avatarUrls?: { thumb?: string; profile?: string } | null;
   roles?: string[];
+  /** Whether this user has opted in to admin impersonation. */
+  canBeImpersonated?: boolean;
 }
 
 const isAdminUser = (u: AdminUser): boolean =>
@@ -171,6 +173,8 @@ const AdminUsers: NextPage = () => {
               <div className="space-y-2">
                 {visible.map((u) => {
                   const isSelf = u.id === user?.id;
+                  const optedIn = u.canBeImpersonated === true;
+                  const canImpersonate = !isSelf && optedIn;
                   return (
                     <div
                       key={u.id}
@@ -191,13 +195,27 @@ const AdminUsers: NextPage = () => {
                           {u.email}
                         </p>
                       </div>
+                      {!isSelf && !optedIn && (
+                        <span
+                          className="hidden text-xs text-muted-foreground sm:inline"
+                          data-testid="users-impersonation-disabled"
+                        >
+                          This user has not enabled impersonation
+                        </span>
+                      )}
                       <Button
                         variant="ghost"
                         size="icon"
-                        disabled={isSelf}
+                        disabled={!canImpersonate}
                         onClick={() => setTarget(u)}
                         aria-label={`Impersonate ${displayName(u)}`}
-                        title={isSelf ? "That's you" : "Impersonate"}
+                        title={
+                          isSelf
+                            ? "That's you"
+                            : optedIn
+                              ? "Impersonate"
+                              : "This user has not enabled impersonation"
+                        }
                         data-testid="users-impersonate"
                       >
                         <VenetianMask className="h-4 w-4" />

--- a/pwa/pages/dev/components/footer.tsx
+++ b/pwa/pages/dev/components/footer.tsx
@@ -4,7 +4,7 @@ import ComponentDoc from "@/components/dev/ComponentDoc";
 const FooterPage = () => (
   <ComponentDoc
     name="Footer"
-    description="Static site footer rendered at the bottom of the app shell by Layout. Three link columns — Product (Home, Guides, Privacy, Terms), Developers (API reference, API guide, Architecture, Component library), and Project (GitHub, Report an issue) — over an AGPL-3.0 license line. No props."
+    description="Static site footer rendered at the bottom of the app shell by Layout. Three link columns — Product (Home, Guides, Privacy, Terms), Developers (API reference, API guide, Architecture, Component library), and Project (GitHub, Feedback) — over an AGPL-3.0 license line. No props."
     importPath={`import Footer from "@/components/common/Footer";`}
     examples={[
       {

--- a/pwa/pages/feedback/[id].tsx
+++ b/pwa/pages/feedback/[id].tsx
@@ -2,7 +2,7 @@ import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useState } from "react";
-import { ArrowLeft, MessageSquare, Pencil, Trash2 } from "lucide-react";
+import { MessageSquare, Pencil, Trash2 } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { signinHrefForCurrent } from "@/lib/authRedirect";
 import { ApiError, apiGet, apiGetCollection, apiSend } from "@/lib/apiClient";
@@ -237,12 +237,6 @@ const FeedbackDetailPage = () => {
       </Head>
       <main className="min-h-screen bg-muted">
         <div className="max-w-3xl mx-auto px-4 py-8 space-y-4">
-          <Button asChild variant="link" size="sm" className="px-0 h-auto">
-            <Link href="/feedback" data-testid="feedback-back-link">
-              <ArrowLeft className="h-3.5 w-3.5 mr-1" /> Feedback
-            </Link>
-          </Button>
-
           {notFound ? (
             <Card>
               <CardContent className="pt-6">
@@ -284,22 +278,6 @@ const FeedbackDetailPage = () => {
                       {ticket.title}
                     </h1>
                   )}
-                  <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
-                    <span className="flex items-center gap-2">
-                      <UserAvatar user={ticket.owner} size="sm" />
-                      <span className="font-medium text-foreground">
-                        {displayName(ticket.owner)}
-                      </span>
-                    </span>
-                    <span>filed {formatRelative(ticket.createdAt)}</span>
-                    {ticket.updatedAt && (
-                      <span className="italic">· edited {formatRelative(ticket.updatedAt)}</span>
-                    )}
-                    <span className="flex items-center gap-1">
-                      <MessageSquare className="h-3.5 w-3.5" />
-                      {comments.length} {comments.length === 1 ? "comment" : "comments"}
-                    </span>
-                  </div>
                 </div>
               </div>
 
@@ -307,7 +285,25 @@ const FeedbackDetailPage = () => {
               <Card>
                 <CardContent className="pt-6 space-y-4">
                   {!editing ? (
-                    <MarkdownView source={ticket.description} className="text-sm" />
+                    <>
+                      <MarkdownView source={ticket.description} className="text-sm" />
+                      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-t pt-3 text-sm text-muted-foreground">
+                        <span className="flex items-center gap-2">
+                          <UserAvatar user={ticket.owner} size="sm" />
+                          <span className="font-medium text-foreground">
+                            {displayName(ticket.owner)}
+                          </span>
+                        </span>
+                        <span>filed {formatRelative(ticket.createdAt)}</span>
+                        {ticket.updatedAt && (
+                          <span className="italic">· edited {formatRelative(ticket.updatedAt)}</span>
+                        )}
+                        <span className="flex items-center gap-1">
+                          <MessageSquare className="h-3.5 w-3.5" />
+                          {comments.length} {comments.length === 1 ? "comment" : "comments"}
+                        </span>
+                      </div>
+                    </>
                   ) : (
                     <div className="space-y-3">
                       <div className="space-y-1.5">

--- a/pwa/pages/feedback/index.tsx
+++ b/pwa/pages/feedback/index.tsx
@@ -5,8 +5,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { MessageSquare, MessagesSquare, Plus } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { signinHrefForCurrent } from "@/lib/authRedirect";
-import { apiGetCollection, apiSend } from "@/lib/apiClient";
-import { displayName } from "@/lib/userDisplay";
+import { apiGetCollection } from "@/lib/apiClient";
 import {
   STATUS_META,
   STATUS_ORDER,
@@ -17,8 +16,6 @@ import {
   type FeedbackStatus,
   type FeedbackType,
 } from "@/lib/feedbackTypes";
-import VoteControl from "@/components/feedback/VoteControl";
-import UserAvatar from "@/components/user/UserAvatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -64,31 +61,6 @@ const FeedbackBoardPage = () => {
   useEffect(() => {
     if (isAuthenticated) void load();
   }, [isAuthenticated, load]);
-
-  const handleVote = useCallback(
-    async (ticket: Feedback, value: 1 | -1) => {
-      // Optimistic isn't required — the endpoint returns the authoritative
-      // score + myVote, so we just patch the row from the response.
-      try {
-        const res = await apiSend<{ score: number; myVote: number }>(
-          "POST",
-          `/feedback/${ticket.id}/vote`,
-          { body: { value }, errorMessage: "Failed to vote." },
-        );
-        if (!res) return;
-        setTickets((prev) =>
-          prev.map((t) =>
-            t["@id"] === ticket["@id"]
-              ? { ...t, score: res.score, myVote: res.myVote }
-              : t,
-          ),
-        );
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to vote.");
-      }
-    },
-    [],
-  );
 
   const visible = useMemo(() => {
     const filtered = tickets.filter(
@@ -146,51 +118,31 @@ const FeedbackBoardPage = () => {
           </header>
 
           {/* Filters */}
-          <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
-            <FilterRow label="Type">
-              <FilterPill
-                active={typeFilter === "all"}
-                onClick={() => setTypeFilter("all")}
-              >
-                All
-              </FilterPill>
-              {TYPE_ORDER.map((t) => (
-                <FilterPill
-                  key={t}
-                  active={typeFilter === t}
-                  onClick={() => setTypeFilter(t)}
-                >
-                  {TYPE_META[t].label}
-                </FilterPill>
-              ))}
-            </FilterRow>
-
-            <FilterRow label="Status">
-              <FilterPill
-                active={statusFilter === "all"}
-                onClick={() => setStatusFilter("all")}
-              >
-                All
-              </FilterPill>
-              {STATUS_ORDER.map((s) => (
-                <FilterPill
-                  key={s}
-                  active={statusFilter === s}
-                  onClick={() => setStatusFilter(s)}
-                >
-                  {STATUS_META[s].label}
-                </FilterPill>
-              ))}
-            </FilterRow>
-
-            <FilterRow label="Sort">
-              <FilterPill active={sort === "votes"} onClick={() => setSort("votes")}>
-                Most votes
-              </FilterPill>
-              <FilterPill active={sort === "recent"} onClick={() => setSort("recent")}>
-                Most recent
-              </FilterPill>
-            </FilterRow>
+          <div className="flex flex-wrap items-center gap-3">
+            <SegmentGroup
+              value={typeFilter}
+              options={[
+                { value: "all", label: "All" },
+                ...TYPE_ORDER.map((t) => ({ value: t, label: TYPE_META[t].label })),
+              ]}
+              onChange={(v) => setTypeFilter(v as TypeFilter)}
+            />
+            <SegmentGroup
+              value={statusFilter}
+              options={[
+                { value: "all", label: "All" },
+                ...STATUS_ORDER.map((s) => ({ value: s, label: STATUS_META[s].label })),
+              ]}
+              onChange={(v) => setStatusFilter(v as StatusFilter)}
+            />
+            <SegmentGroup
+              value={sort}
+              options={[
+                { value: "votes", label: "Most votes" },
+                { value: "recent", label: "Most recent" },
+              ]}
+              onChange={(v) => setSort(v as SortKey)}
+            />
           </div>
 
           {error && (
@@ -226,11 +178,26 @@ const FeedbackBoardPage = () => {
                 <li key={ticket["@id"]}>
                   <Card className="transition-colors hover:border-cyan-600/40">
                     <CardContent className="flex items-start gap-4 py-4">
-                      <VoteControl
-                        score={ticket.score}
-                        myVote={ticket.myVote}
-                        onVote={(v) => void handleVote(ticket, v)}
-                      />
+                      <div
+                        className="inline-flex min-w-10 flex-col items-center justify-center text-center"
+                        data-testid="vote-score"
+                      >
+                        <span
+                          className={cn(
+                            "text-base font-semibold tabular-nums",
+                            ticket.myVote === 1
+                              ? "text-emerald-600 dark:text-emerald-400"
+                              : ticket.myVote === -1
+                                ? "text-rose-600 dark:text-rose-400"
+                                : "text-foreground",
+                          )}
+                        >
+                          {ticket.score}
+                        </span>
+                        <span className="text-[11px] text-muted-foreground">
+                          {Math.abs(ticket.score) === 1 ? "vote" : "votes"}
+                        </span>
+                      </div>
                       <div className="min-w-0 flex-1 space-y-1">
                         <div className="flex flex-wrap items-center gap-2">
                           <span className="text-xs font-medium text-muted-foreground tabular-nums">
@@ -251,10 +218,6 @@ const FeedbackBoardPage = () => {
                           {ticket.title}
                         </Link>
                         <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
-                          <span className="flex items-center gap-1.5">
-                            <UserAvatar user={ticket.owner} size="sm" />
-                            {displayName(ticket.owner)}
-                          </span>
                           <span>{formatRelative(ticket.createdAt)}</span>
                           <span className="flex items-center gap-1">
                             <MessageSquare className="h-3.5 w-3.5" />
@@ -274,42 +237,36 @@ const FeedbackBoardPage = () => {
   );
 };
 
-const FilterRow = ({
-  label,
-  children,
+const SegmentGroup = ({
+  value,
+  options,
+  onChange,
 }: {
-  label: string;
-  children: React.ReactNode;
+  value: string;
+  options: { value: string; label: string }[];
+  onChange: (value: string) => void;
 }) => (
-  <div className="flex items-center gap-2">
-    <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-      {label}
-    </span>
-    <div className="flex flex-wrap items-center gap-1">{children}</div>
+  <div className="inline-flex items-center divide-x divide-input overflow-hidden rounded-full border border-input">
+    {options.map((o) => {
+      const active = o.value === value;
+      return (
+        <button
+          key={o.value}
+          type="button"
+          onClick={() => onChange(o.value)}
+          aria-pressed={active}
+          className={cn(
+            "px-3 py-1.5 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+            active
+              ? "bg-cyan-700 text-white hover:bg-cyan-800"
+              : "bg-background text-muted-foreground hover:bg-accent",
+          )}
+        >
+          {o.label}
+        </button>
+      );
+    })}
   </div>
-);
-
-const FilterPill = ({
-  active,
-  onClick,
-  children,
-}: {
-  active: boolean;
-  onClick: () => void;
-  children: React.ReactNode;
-}) => (
-  <button
-    type="button"
-    onClick={onClick}
-    className={cn(
-      "rounded-full px-3 py-1 text-xs font-medium transition-colors",
-      active
-        ? "bg-cyan-700 text-white"
-        : "bg-background text-muted-foreground hover:bg-accent border border-input",
-    )}
-  >
-    {children}
-  </button>
 );
 
 export default FeedbackBoardPage;

--- a/pwa/pages/feedback/new.tsx
+++ b/pwa/pages/feedback/new.tsx
@@ -2,7 +2,6 @@ import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
-import { ArrowLeft } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { signinHrefForCurrent } from "@/lib/authRedirect";
 import { apiSend } from "@/lib/apiClient";
@@ -75,12 +74,6 @@ const NewFeedbackPage = () => {
       </Head>
       <main className="min-h-screen bg-muted">
         <div className="max-w-2xl mx-auto px-4 py-8 space-y-4">
-          <Button asChild variant="link" size="sm" className="px-0 h-auto">
-            <Link href="/feedback">
-              <ArrowLeft className="h-3.5 w-3.5 mr-1" /> Feedback
-            </Link>
-          </Button>
-
           <h1 className="text-2xl font-bold">New feedback</h1>
 
           <Card>


### PR DESCRIPTION
﻿## Summary

A batch of fixes and polish on the newly-merged in-app Feedback board, plus related admin/impersonation and dev-tooling improvements.

### Feedback board
- Footer "Report an issue" link now points at the in-app /feedback board.
- New FeedbackFixtures seeds 8 demo tickets (both types, all statuses) with votes + comment threads.
- List view: removed voting controls, the up/down chevrons, and the creator chip; filters are now joined segmented button groups.
- Detail view: removed the redundant back link; moved the author/time meta below the description.

### Admin & impersonation
- Admin tools moved from the pinned sidebar footer into a collapsible, colored-icon sidebar section; added a Feedback entry.
- canBeImpersonated exposed under user:read (admin-gated /users only).
- Admin users list disables the impersonate icon and shows "This user has not enabled impersonation" for opted-out users; clearer 403 message on switch.
- Demo team opted in to impersonation (Ava left opted out to show the disabled state). The consent gate itself is unchanged.

### Dev tooling
- Dev PWA now runs the webpack dev server so edits hot-reload over the Docker Desktop Windows/WSL bind mount (Turbopack ignores WATCHPACK_POLLING).

## Testing
- PWA typecheck + lint: clean. API PHPStan (level 10 + strict) + PHPCS on changed files: clean.
- Fixtures reload verified; feedback rows, votes, comments, and per-user impersonation flags confirmed via the API.
