### PR TITLE
test(e2e): fix project add-task Tab-order spec after #527 column reorder

### DIFF
--- a/e2e/tests/projects.spec.js
+++ b/e2e/tests/projects.spec.js
@@ -145,10 +145,7 @@ test.describe("Projects", () => {
     await titleInput.click();
     await titleInput.fill("Keyboard task");
 
-    // Tab walks the row in column order: title -> tags -> due -> assignees.
-    await page.keyboard.press("Tab");
-    await expect(page.getByLabel('Tags for "new task"')).toBeFocused();
-
+    // Tab walks the row in column order: title -> due -> assignees -> tags.
     await page.keyboard.press("Tab");
     await expect(
       page.getByRole("button", { name: "Due date for new task" }),
@@ -156,6 +153,9 @@ test.describe("Projects", () => {
 
     await page.keyboard.press("Tab");
     await expect(page.getByLabel('Assignees for "new task"')).toBeFocused();
+
+    await page.keyboard.press("Tab");
+    await expect(page.getByLabel('Tags for "new task"')).toBeFocused();
 
     // Tabbing away from a non-empty title keeps the row open; Enter on the
     // title still creates the task.


### PR DESCRIPTION
﻿## Summary

Fixes the E2E failure that has been red on `main` since #527.

#527 ("refactor(projects): tidy list view footers and column order") intentionally reordered the project task table columns to **Name -> Due -> Assignees -> Tags**, but did not update `tests/projects.spec.js`, which still asserted the old Tab order (`title -> tags -> due -> assignees`). The `the inline add-task row supports Tab between fields` test has failed on every `main` push since.

This updates the spec's Tab walk to match the shipped column order. Test-only change.
