### PR TITLE
Promote main to production (feedback board, token permissions, billing, fixes)

### DIFF
--- a/api/config/packages/doctrine.yaml
+++ b/api/config/packages/doctrine.yaml
@@ -12,8 +12,11 @@ doctrine:
         # provisioned by a migration with auto_setup disabled, so the ORM
         # never learns about it. Exclude it from schema introspection or
         # doctrine:schema:validate / migrations:diff would flag it as an
-        # untracked table that schema:update would drop.
-        schema_filter: ~^(?!messenger_messages)~
+        # untracked table that schema:update would drop. Same treatment for
+        # feedback_ticket_seq: a standalone Postgres sequence (created by a
+        # migration, read via nextval in App\State\FeedbackOwnerProcessor)
+        # that no entity's ID generator owns, so the ORM never tracks it.
+        schema_filter: ~^(?!messenger_messages|feedback_ticket_seq)~
 
         # doctrine/dbal 4 dropped the legacy `array` type. Gedmo's
         # AbstractLogEntry still declares its `data` column as

--- a/api/migrations/Version20260622120000.php
+++ b/api/migrations/Version20260622120000.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * In-app feedback board (#feedback): bug reports + feature requests.
+ *
+ * Instance-level, not space-scoped — every authenticated user shares one
+ * board. `feedback` holds the tickets; `feedback_vote` the one-per-user
+ * up/down votes; `feedback_ticket_seq` hands out the monotonic,
+ * concurrency-safe human-facing ticket numbers (App\State\FeedbackOwnerProcessor
+ * pulls nextval on create). The sequence is excluded from Doctrine schema
+ * introspection in doctrine.yaml so schema:validate doesn't flag it as
+ * untracked.
+ */
+final class Version20260622120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add feedback + feedback_vote tables and the feedback ticket-number sequence.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE SEQUENCE feedback_ticket_seq INCREMENT BY 1 MINVALUE 1 START 1');
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE feedback (
+                id UUID NOT NULL,
+                owner_id UUID NOT NULL,
+                ticket_number INT NOT NULL,
+                title VARCHAR(200) NOT NULL,
+                description TEXT NOT NULL,
+                type VARCHAR(16) NOT NULL,
+                status VARCHAR(16) DEFAULT 'open' NOT NULL,
+                created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                updated_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL,
+                PRIMARY KEY(id)
+            )
+        SQL);
+        $this->addSql('CREATE UNIQUE INDEX uniq_feedback_ticket_number ON feedback (ticket_number)');
+        $this->addSql('CREATE INDEX idx_feedback_owner ON feedback (owner_id)');
+        $this->addSql('CREATE INDEX idx_feedback_status ON feedback (status)');
+        $this->addSql('CREATE INDEX idx_feedback_type ON feedback (type)');
+        $this->addSql(<<<'SQL'
+            ALTER TABLE feedback
+                ADD CONSTRAINT fk_feedback_owner FOREIGN KEY (owner_id)
+                REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE feedback_vote (
+                id UUID NOT NULL,
+                feedback_id UUID NOT NULL,
+                user_id UUID NOT NULL,
+                value SMALLINT NOT NULL,
+                voted_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                PRIMARY KEY(id)
+            )
+        SQL);
+        $this->addSql('CREATE UNIQUE INDEX uniq_feedback_vote ON feedback_vote (feedback_id, user_id)');
+        $this->addSql('CREATE INDEX idx_feedback_vote_feedback ON feedback_vote (feedback_id)');
+        $this->addSql(<<<'SQL'
+            ALTER TABLE feedback_vote
+                ADD CONSTRAINT fk_feedback_vote_feedback FOREIGN KEY (feedback_id)
+                REFERENCES feedback (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE feedback_vote
+                ADD CONSTRAINT fk_feedback_vote_user FOREIGN KEY (user_id)
+                REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE feedback_vote DROP CONSTRAINT fk_feedback_vote_feedback');
+        $this->addSql('ALTER TABLE feedback_vote DROP CONSTRAINT fk_feedback_vote_user');
+        $this->addSql('DROP TABLE feedback_vote');
+        $this->addSql('ALTER TABLE feedback DROP CONSTRAINT fk_feedback_owner');
+        $this->addSql('DROP TABLE feedback');
+        $this->addSql('DROP SEQUENCE feedback_ticket_seq');
+    }
+}

--- a/api/migrations/Version20260622195706.php
+++ b/api/migrations/Version20260622195706.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds `feedback` as a fourth polymorphic parent for comments, so the
+ * in-app feedback board reuses the unified Comment thread (#228). Mirrors
+ * the existing task / page / discussion FKs: a nullable `feedback_id`
+ * with cascade-on-delete plus a per-parent created-at index. The
+ * discriminator column is already VARCHAR(16) (`'feedback'` fits), so it
+ * only recreates `chk_comment_parent_exactly_one` to cover the new arm.
+ */
+final class Version20260622195706 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add feedback parent FK to comment; extend exactly-one-parent CHECK.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE comment ADD feedback_id UUID DEFAULT NULL');
+        $this->addSql('ALTER TABLE comment ADD CONSTRAINT FK_9474526CD249A887 FOREIGN KEY (feedback_id) REFERENCES feedback (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('CREATE INDEX IDX_9474526CD249A887 ON comment (feedback_id)');
+        $this->addSql('CREATE INDEX idx_comment_feedback_created ON comment (feedback_id, created_at)');
+
+        // Extend the exactly-one-parent invariant to cover the new
+        // feedback arm.
+        $this->addSql('ALTER TABLE comment DROP CONSTRAINT chk_comment_parent_exactly_one');
+        $this->addSql(<<<'SQL'
+            ALTER TABLE comment
+            ADD CONSTRAINT chk_comment_parent_exactly_one
+            CHECK (
+                (commentable_type = 'task' AND task_id IS NOT NULL AND page_id IS NULL AND discussion_id IS NULL AND feedback_id IS NULL)
+                OR (commentable_type = 'page' AND page_id IS NOT NULL AND task_id IS NULL AND discussion_id IS NULL AND feedback_id IS NULL)
+                OR (commentable_type = 'discussion' AND discussion_id IS NOT NULL AND task_id IS NULL AND page_id IS NULL AND feedback_id IS NULL)
+                OR (commentable_type = 'feedback' AND feedback_id IS NOT NULL AND task_id IS NULL AND page_id IS NULL AND discussion_id IS NULL)
+            )
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE comment DROP CONSTRAINT chk_comment_parent_exactly_one');
+        $this->addSql(<<<'SQL'
+            ALTER TABLE comment
+            ADD CONSTRAINT chk_comment_parent_exactly_one
+            CHECK (
+                (commentable_type = 'task' AND task_id IS NOT NULL AND page_id IS NULL AND discussion_id IS NULL)
+                OR (commentable_type = 'page' AND page_id IS NOT NULL AND task_id IS NULL AND discussion_id IS NULL)
+                OR (commentable_type = 'discussion' AND discussion_id IS NOT NULL AND task_id IS NULL AND page_id IS NULL)
+            )
+        SQL);
+
+        $this->addSql('ALTER TABLE comment DROP CONSTRAINT FK_9474526CD249A887');
+        $this->addSql('DROP INDEX IDX_9474526CD249A887');
+        $this->addSql('DROP INDEX idx_comment_feedback_created');
+        $this->addSql('ALTER TABLE comment DROP feedback_id');
+    }
+}

--- a/api/src/Controller/CommentsMercureTokenController.php
+++ b/api/src/Controller/CommentsMercureTokenController.php
@@ -3,6 +3,7 @@
 namespace App\Controller;
 
 use App\Entity\Discussion;
+use App\Entity\Feedback;
 use App\Entity\Page;
 use App\Entity\Task;
 use App\Entity\User;
@@ -66,8 +67,18 @@ class CommentsMercureTokenController extends AbstractController
         return $this->mint($id, $request, $user, Discussion::class, '/discussions/');
     }
 
+    #[Route(
+        '/feedback/{id}/comments/mercure-token',
+        name: 'feedback_comments_mercure_token',
+        methods: ['GET'],
+    )]
+    public function feedback(string $id, Request $request, #[CurrentUser] ?User $user): Response
+    {
+        return $this->mint($id, $request, $user, Feedback::class, '/feedback/');
+    }
+
     /**
-     * @param class-string<Task|Page|Discussion> $entityClass
+     * @param class-string<Task|Page|Discussion|Feedback> $entityClass
      */
     private function mint(
         string $id,
@@ -99,13 +110,18 @@ class CommentsMercureTokenController extends AbstractController
         return new JsonResponse(['topic' => $topic]);
     }
 
-    private function canRead(Task|Page|Discussion $parent, User $user): bool
+    private function canRead(Task|Page|Discussion|Feedback $parent, User $user): bool
     {
         if ($this->isGranted('ROLE_ADMIN')) {
             return true;
         }
         if ($parent instanceof Task) {
             return $parent->isAccessibleBy($user);
+        }
+        // Feedback is an instance-level board: every authenticated user
+        // can read every ticket (the caller is already authenticated here).
+        if ($parent instanceof Feedback) {
+            return true;
         }
         $space = $parent->getSpace();
         return null !== $space && $space->hasMember($user);

--- a/api/src/Controller/FeedbackVoteController.php
+++ b/api/src/Controller/FeedbackVoteController.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\FeedbackVote;
+use App\Entity\User;
+use App\Repository\FeedbackRepository;
+use App\Repository\FeedbackVoteRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Up/down voting on a feedback ticket. Exactly one vote per user per
+ * ticket, expressed as a toggle:
+ *
+ *   - no vote yet            → create the vote          (added)
+ *   - same direction again   → clear it                 (cleared)
+ *   - opposite direction     → flip it                  (updated)
+ *
+ * The (feedback, user) unique constraint on {@see FeedbackVote} backs the
+ * invariant; this controller is the only writer. Any ROLE_USER can vote
+ * on any ticket — the board is instance-level, so there's no membership
+ * gate, only authentication. The response carries the recomputed net
+ * score and the caller's resulting own vote so the PWA can update the
+ * control without a re-fetch.
+ */
+class FeedbackVoteController extends AbstractController
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private FeedbackRepository $feedbackRepository,
+        private FeedbackVoteRepository $voteRepository,
+    ) {
+    }
+
+    #[Route('/feedback/{id}/vote', name: 'feedback_vote', methods: ['POST'])]
+    public function vote(string $id, Request $request, #[CurrentUser] ?User $user): JsonResponse
+    {
+        $this->denyAccessUnlessGranted('ROLE_USER');
+        if (null === $user) {
+            return $this->json(['error' => 'Not authenticated.'], 401);
+        }
+        if (!Uuid::isValid($id)) {
+            return $this->json(['error' => 'Feedback not found.'], 404);
+        }
+
+        $feedback = $this->feedbackRepository->find($id);
+        if (null === $feedback) {
+            return $this->json(['error' => 'Feedback not found.'], 404);
+        }
+
+        $payload = $request->toArray();
+        $value = $payload['value'] ?? null;
+        if (!is_int($value) || !in_array($value, FeedbackVote::VALUES, true)) {
+            return $this->json(['error' => 'Vote value must be 1 or -1.'], 422);
+        }
+
+        $existing = $this->voteRepository->findOneForUser($feedback, $user);
+
+        if (null === $existing) {
+            $vote = new FeedbackVote();
+            $vote->setFeedback($feedback);
+            $vote->setUser($user);
+            $vote->setValue($value);
+            $this->em->persist($vote);
+            $status = 'added';
+            $myVote = $value;
+        } elseif ($existing->getValue() === $value) {
+            // Re-voting the same direction clears the vote.
+            $this->em->remove($existing);
+            $status = 'cleared';
+            $myVote = 0;
+        } else {
+            $existing->setValue($value);
+            $status = 'updated';
+            $myVote = $value;
+        }
+
+        $this->em->flush();
+
+        return $this->json([
+            'status' => $status,
+            'myVote' => $myVote,
+            'score' => $this->voteRepository->scoreFor($feedback),
+        ]);
+    }
+}

--- a/api/src/Controller/UsageController.php
+++ b/api/src/Controller/UsageController.php
@@ -38,6 +38,9 @@ class UsageController extends AbstractController
             'freeMcpDailyLimit' => $this->usageLimiter->freeMcpDailyLimit(),
             'remaining' => $this->usageLimiter->remainingMcpCalls($user),
             'entitled' => $this->usageLimiter->isUserEntitled($user),
+            // Admins are tracked but never capped — surfaced so the UI can show
+            // the unlimited state with the right reason.
+            'admin' => $this->usageLimiter->isAdmin($user),
             'enforcementEnabled' => $this->usageLimiter->isEnforcementEnabled(),
         ]);
     }

--- a/api/src/DataFixtures/FeedbackFixtures.php
+++ b/api/src/DataFixtures/FeedbackFixtures.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace App\DataFixtures;
+
+use App\Entity\Comment;
+use App\Entity\Feedback;
+use App\Entity\FeedbackVote;
+use App\Entity\User;
+use App\Repository\FeedbackRepository;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+
+/**
+ * Demo data for the in-app feedback board. Seeds a spread of bug reports
+ * and feature requests across every workflow status, owned by the various
+ * fixture users, with a realistic distribution of up/down votes and a few
+ * comment threads — enough to exercise the board's sort-by-score,
+ * status/type filters, "your vote" highlight, and comment counts after a
+ * fresh `doctrine:fixtures:load`.
+ *
+ * Ticket numbers are pulled from the same `feedback_ticket_seq` the
+ * {@see FeedbackOwnerProcessor} uses, so the sequence stays in step with
+ * the seeded rows and the first ticket filed through the UI continues the
+ * count instead of colliding.
+ */
+class FeedbackFixtures extends Fixture implements DependentFixtureInterface
+{
+    public function __construct(
+        private FeedbackRepository $feedbackRepository,
+    ) {
+    }
+
+    public function getDependencies(): array
+    {
+        return [UserFixtures::class];
+    }
+
+    public function load(ObjectManager $manager): void
+    {
+        $users = [
+            'uma' => $this->getReference(UserFixtures::USER_REFERENCE, User::class),
+            'ada' => $this->getReference(UserFixtures::ADMIN_REFERENCE, User::class),
+            'noah' => $this->getReference('user-noah', User::class),
+            'emma' => $this->getReference('user-emma', User::class),
+            'liam' => $this->getReference('user-liam', User::class),
+            'ava' => $this->getReference('user-ava', User::class),
+        ];
+
+        // Each ticket: owner key, type, status, title, description, the
+        // voters (key => +1 | -1), and an optional comment thread
+        // (list of [author key, body]).
+        $tickets = [
+            [
+                'owner' => 'uma',
+                'type' => Feedback::TYPE_FEATURE,
+                'status' => Feedback::STATUS_PLANNED,
+                'title' => 'Dark mode across the whole app',
+                'description' => "The marketing site is dark but the app itself is light-only. "
+                    . "A proper dark theme (respecting the OS preference) would make late-night "
+                    . "sessions a lot easier on the eyes.",
+                'votes' => ['noah' => 1, 'emma' => 1, 'liam' => 1, 'ava' => 1, 'ada' => 1],
+                'comments' => [
+                    ['ada', "Great call — this is on the roadmap for next quarter."],
+                    ['noah', "+1, the task drawer especially is blinding at night."],
+                ],
+            ],
+            [
+                'owner' => 'noah',
+                'type' => Feedback::TYPE_BUG,
+                'status' => Feedback::STATUS_OPEN,
+                'title' => 'Task drawer closes when I click the date picker',
+                'description' => "Opening a task, then clicking the due-date field, sometimes closes "
+                    . "the whole drawer instead of opening the calendar. Happens about half the time "
+                    . "in Firefox.",
+                'votes' => ['uma' => 1, 'emma' => 1, 'liam' => 1],
+                'comments' => [
+                    ['emma', "Reproduced on my end too — only when the drawer was just reopened."],
+                ],
+            ],
+            [
+                'owner' => 'emma',
+                'type' => Feedback::TYPE_FEATURE,
+                'status' => Feedback::STATUS_IN_PROGRESS,
+                'title' => 'Keyboard shortcuts for navigation',
+                'description' => "A ⌘K command palette exists for search, but moving between Tasks, "
+                    . "Projects, and Pages still needs the mouse. Vim-style `g t` / `g p` jumps would "
+                    . "be lovely.",
+                'votes' => ['uma' => 1, 'noah' => 1, 'ava' => 1],
+                'comments' => [],
+            ],
+            [
+                'owner' => 'liam',
+                'type' => Feedback::TYPE_FEATURE,
+                'status' => Feedback::STATUS_SHIPPED,
+                'title' => 'Export all space data as a single archive',
+                'description' => "For backups and GDPR requests it would help to download everything "
+                    . "in a space — projects, tasks, pages, discussions, attachments — as one zip.",
+                'votes' => ['uma' => 1, 'emma' => 1, 'ada' => 1, 'ava' => 1],
+                'comments' => [
+                    ['ada', "Shipped! Space admins can now export from Space settings → Export."],
+                ],
+            ],
+            [
+                'owner' => 'ava',
+                'type' => Feedback::TYPE_BUG,
+                'status' => Feedback::STATUS_OPEN,
+                'title' => 'Avatar initials are unreadable on light personal colors',
+                'description' => "When a user picks a pale avatar color the white initials nearly "
+                    . "disappear. The contrast check at signup doesn't seem to catch the lightest "
+                    . "swatches.",
+                'votes' => ['noah' => 1, 'liam' => -1],
+                'comments' => [],
+            ],
+            [
+                'owner' => 'uma',
+                'type' => Feedback::TYPE_FEATURE,
+                'status' => Feedback::STATUS_DECLINED,
+                'title' => 'Built-in Pomodoro timer',
+                'description' => "A focus timer that ticks down inside the app and auto-starts the "
+                    . "next task. Would keep me off a second tab.",
+                'votes' => ['emma' => 1, 'noah' => -1, 'liam' => -1, 'ada' => -1],
+                'comments' => [
+                    ['ada', "Declining for now — it's a bit outside the core scope, and there are "
+                        . "great standalone tools for this. Revisit if demand grows."],
+                ],
+            ],
+            [
+                'owner' => 'ada',
+                'type' => Feedback::TYPE_BUG,
+                'status' => Feedback::STATUS_IN_PROGRESS,
+                'title' => 'Mercure reconnect storm after the laptop wakes from sleep',
+                'description' => "After closing the lid and reopening, the live-update connection "
+                    . "hammers the server with reconnect attempts for a few seconds before settling. "
+                    . "Should back off exponentially.",
+                'votes' => ['uma' => 1, 'liam' => 1],
+                'comments' => [],
+            ],
+            [
+                'owner' => 'emma',
+                'type' => Feedback::TYPE_FEATURE,
+                'status' => Feedback::STATUS_OPEN,
+                'title' => "Recurrence rule for \"every weekday\"",
+                'description' => "Daily recurrence includes weekends. A one-click \"every weekday "
+                    . "(Mon–Fri)\" option would save building a custom weekly rule with five days "
+                    . "ticked.",
+                'votes' => ['uma' => 1, 'noah' => 1, 'liam' => 1, 'ava' => 1],
+                'comments' => [],
+            ],
+        ];
+
+        foreach ($tickets as $spec) {
+            $ticket = new Feedback();
+            $ticket->setOwner($users[$spec['owner']]);
+            $ticket->setType($spec['type']);
+            $ticket->setStatus($spec['status']);
+            $ticket->setTitle($spec['title']);
+            $ticket->setDescription($spec['description']);
+            $ticket->setTicketNumber($this->feedbackRepository->nextTicketNumber());
+            $manager->persist($ticket);
+
+            foreach ($spec['votes'] as $voterKey => $value) {
+                $vote = (new FeedbackVote())
+                    ->setFeedback($ticket)
+                    ->setUser($users[$voterKey])
+                    ->setValue($value);
+                $manager->persist($vote);
+            }
+
+            foreach ($spec['comments'] as [$authorKey, $body]) {
+                $comment = (new Comment())
+                    ->setFeedback($ticket)
+                    ->setAuthor($users[$authorKey])
+                    ->setBody($body);
+                $manager->persist($comment);
+            }
+        }
+
+        $manager->flush();
+    }
+}

--- a/api/src/DataFixtures/UserFixtures.php
+++ b/api/src/DataFixtures/UserFixtures.php
@@ -37,6 +37,31 @@ class UserFixtures extends Fixture
     ];
 
     /**
+     * Demo opt-in to admin impersonation for the non-admin fixture users
+     * (Uma + the team). Production accounts start with this OFF
+     * ({@see User::DEFAULT_PREFERENCES}) — an admin can't switch into an
+     * account until its owner consents — so the demo would otherwise show
+     * "Couldn't switch user." on every attempt. Enabling consent + full
+     * per-category access here makes the impersonation flow exercisable end
+     * to end on a fixture DB. {@see setPreferences()} merges over the
+     * defaults, so only these two keys need to be stored.
+     *
+     * @var array<string, mixed>
+     */
+    private const DEMO_IMPERSONATION_PREFS = [
+        'canBeImpersonated' => true,
+        'impersonationAccess' => [
+            'tasks' => 'edit',
+            'projects' => 'edit',
+            'pages' => 'edit',
+            'discussions' => 'edit',
+            'comments' => 'edit',
+            'notifications' => 'edit',
+            'files' => 'edit',
+        ],
+    ];
+
+    /**
      * Hardcoded TOTP secret for the Uma fixture user so dev / E2E flows can
      * pre-pair an authenticator once and reuse the same QR across fixture
      * reloads. Valid base32 (A-Z, 2-7), length matches what
@@ -91,6 +116,7 @@ class UserFixtures extends Fixture
         $user->setFamilyName('User');
         $user->setPersonalizedColor($this->colorService->pick());
         $user->setPassword($this->passwordHasher->hashPassword($user, 'user123'));
+        $user->setPreferences(self::DEMO_IMPERSONATION_PREFS);
 
         // Pre-enable TOTP 2FA on Uma so the sign-in flow exercises the
         // challenge step without a manual pairing step every fixture reload.
@@ -120,6 +146,12 @@ class UserFixtures extends Fixture
             $member->setFamilyName($spec['family']);
             $member->setPersonalizedColor($this->colorService->pick());
             $member->setPassword($teamPasswordHash);
+            // Ava deliberately stays opted OUT of impersonation so the admin
+            // users page demonstrates the disabled "this user has not enabled
+            // impersonation" state alongside the opted-in members.
+            if ('user-ava' !== $spec['reference']) {
+                $member->setPreferences(self::DEMO_IMPERSONATION_PREFS);
+            }
             $manager->persist($member);
             $teamUsers[$spec['reference']] = $member;
         }

--- a/api/src/Doctrine/CommentAccessExtension.php
+++ b/api/src/Doctrine/CommentAccessExtension.php
@@ -107,15 +107,20 @@ final class CommentAccessExtension implements QueryCollectionExtensionInterface,
             SpaceGroupMembership::class,
         );
 
+        // Feedback branch: the feedback board is instance-level, so any
+        // authenticated user (already guaranteed above) can read every
+        // ticket's comments — the branch just needs the FK to be set.
         $queryBuilder
             ->leftJoin(sprintf('%s.task', $rootAlias), 'ca_task')
             ->leftJoin('ca_task.project', 'ca_project')
             ->leftJoin(sprintf('%s.page', $rootAlias), 'ca_page')
             ->leftJoin(sprintf('%s.discussion', $rootAlias), 'ca_discussion')
+            ->leftJoin(sprintf('%s.feedback', $rootAlias), 'ca_feedback')
             ->andWhere(sprintf(
                 '(ca_task.id IS NOT NULL AND (%s OR EXISTS(%s) OR EXISTS(%s)))
                  OR (ca_page.id IS NOT NULL AND (EXISTS(%s) OR EXISTS(%s)))
-                 OR (ca_discussion.id IS NOT NULL AND (EXISTS(%s) OR EXISTS(%s)))',
+                 OR (ca_discussion.id IS NOT NULL AND (EXISTS(%s) OR EXISTS(%s)))
+                 OR ca_feedback.id IS NOT NULL',
                 $taskOwnerCheck,
                 $taskSpaceDirect,
                 $taskSpaceGroup,

--- a/api/src/Entity/ApiToken.php
+++ b/api/src/Entity/ApiToken.php
@@ -6,6 +6,7 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
 use App\Repository\ApiTokenRepository;
 use App\Security\Access\AccessPolicy;
@@ -57,6 +58,14 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
             // POST is the only moment the plaintext bearer is visible.
             // Subsequent GETs use the stricter `api_token:read` group.
             normalizationContext: ['groups' => ['api_token:read', 'api_token:create']],
+        ),
+        // Editing is limited to the human-managed fields (name / accessPolicy /
+        // expiresAt via the `api_token:write` group). The secret itself is
+        // immutable — there's no way to rotate the plaintext in place; revoke
+        // and re-create instead. `validateAccessPolicy()` re-runs on update.
+        new Patch(
+            uriTemplate: '/api-tokens/{id}',
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getUser() == user)",
         ),
         new Delete(
             uriTemplate: '/api-tokens/{id}',

--- a/api/src/Entity/Comment.php
+++ b/api/src/Entity/Comment.php
@@ -77,13 +77,14 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
     denormalizationContext: ['groups' => ['comment:write']],
     order: ['createdAt' => 'ASC'],
 )]
-#[ApiFilter(SearchFilter::class, properties: ['task' => 'exact', 'page' => 'exact', 'discussion' => 'exact', 'commentableType' => 'exact'])]
+#[ApiFilter(SearchFilter::class, properties: ['task' => 'exact', 'page' => 'exact', 'discussion' => 'exact', 'feedback' => 'exact', 'commentableType' => 'exact'])]
 #[ApiFilter(OrderFilter::class, properties: ['createdAt'], arguments: ['orderParameterName' => 'order'])]
 #[ORM\Entity(repositoryClass: CommentRepository::class)]
 #[ORM\Table(name: 'comment')]
 #[ORM\Index(columns: ['task_id', 'created_at'], name: 'idx_comment_task_created')]
 #[ORM\Index(columns: ['page_id', 'created_at'], name: 'idx_comment_page_created')]
 #[ORM\Index(columns: ['discussion_id', 'created_at'], name: 'idx_comment_discussion_created')]
+#[ORM\Index(columns: ['feedback_id', 'created_at'], name: 'idx_comment_feedback_created')]
 #[ORM\Index(columns: ['search_vector'], name: 'idx_comment_search_vector', flags: ['gin'])]
 #[ORM\HasLifecycleCallbacks]
 class Comment
@@ -93,8 +94,14 @@ class Comment
     public const TYPE_TASK = 'task';
     public const TYPE_PAGE = 'page';
     public const TYPE_DISCUSSION = 'discussion';
+    public const TYPE_FEEDBACK = 'feedback';
 
-    public const ALLOWED_TYPES = [self::TYPE_TASK, self::TYPE_PAGE, self::TYPE_DISCUSSION];
+    public const ALLOWED_TYPES = [
+        self::TYPE_TASK,
+        self::TYPE_PAGE,
+        self::TYPE_DISCUSSION,
+        self::TYPE_FEEDBACK,
+    ];
 
     #[ORM\Id]
     #[ORM\Column(type: 'uuid', unique: true)]
@@ -111,7 +118,7 @@ class Comment
      * the FK trio.
      */
     #[ORM\Column(name: 'commentable_type', length: 16)]
-    #[Assert\Choice(choices: self::ALLOWED_TYPES, message: 'Parent type must be task, page, or discussion.')]
+    #[Assert\Choice(choices: self::ALLOWED_TYPES, message: 'Parent type must be task, page, discussion, or feedback.')]
     #[Groups(['comment:read'])]
     private string $commentableType = self::TYPE_TASK;
 
@@ -129,6 +136,11 @@ class Comment
     #[ORM\JoinColumn(name: 'discussion_id', nullable: true, onDelete: 'CASCADE')]
     #[Groups(['comment:read', 'comment:write'])]
     private ?Discussion $discussion = null;
+
+    #[ORM\ManyToOne(targetEntity: Feedback::class)]
+    #[ORM\JoinColumn(name: 'feedback_id', nullable: true, onDelete: 'CASCADE')]
+    #[Groups(['comment:read', 'comment:write'])]
+    private ?Feedback $feedback = null;
 
     /**
      * Author is set server-side by {@see CommentAuthorProcessor} on
@@ -197,6 +209,8 @@ class Comment
             $this->commentableType = self::TYPE_PAGE;
         } elseif (null !== $this->discussion) {
             $this->commentableType = self::TYPE_DISCUSSION;
+        } elseif (null !== $this->feedback) {
+            $this->commentableType = self::TYPE_FEEDBACK;
         }
     }
 
@@ -222,6 +236,7 @@ class Comment
             $this->commentableType = self::TYPE_TASK;
             $this->page = null;
             $this->discussion = null;
+            $this->feedback = null;
         }
         return $this;
     }
@@ -238,6 +253,7 @@ class Comment
             $this->commentableType = self::TYPE_PAGE;
             $this->task = null;
             $this->discussion = null;
+            $this->feedback = null;
         }
         return $this;
     }
@@ -254,19 +270,37 @@ class Comment
             $this->commentableType = self::TYPE_DISCUSSION;
             $this->task = null;
             $this->page = null;
+            $this->feedback = null;
+        }
+        return $this;
+    }
+
+    public function getFeedback(): ?Feedback
+    {
+        return $this->feedback;
+    }
+
+    public function setFeedback(?Feedback $feedback): static
+    {
+        $this->feedback = $feedback;
+        if (null !== $feedback) {
+            $this->commentableType = self::TYPE_FEEDBACK;
+            $this->task = null;
+            $this->page = null;
+            $this->discussion = null;
         }
         return $this;
     }
 
     /**
-     * Returns the parent entity (Task, Page, or Discussion) the
-     * comment is attached to, or null if none is set yet (during
+     * Returns the parent entity (Task, Page, Discussion, or Feedback)
+     * the comment is attached to, or null if none is set yet (during
      * denormalization). Lets callers reach the parent without
      * branching on `commentableType`.
      */
-    public function getCommentable(): Task|Page|Discussion|null
+    public function getCommentable(): Task|Page|Discussion|Feedback|null
     {
-        return $this->task ?? $this->page ?? $this->discussion;
+        return $this->task ?? $this->page ?? $this->discussion ?? $this->feedback;
     }
 
     public function getAuthor(): ?User
@@ -319,14 +353,21 @@ class Comment
             $space = $this->discussion->getSpace();
             return null !== $space && $space->hasMember($user);
         }
+        // Feedback is an instance-level board: any authenticated user can
+        // read every ticket, so its comments are readable too.
+        if (null !== $this->feedback) {
+            return true;
+        }
         return false;
     }
 
     /**
      * Whether `$user` qualifies for the per-parent delete-escalation
      * path: task owner on a task comment, space admin on a page or
-     * discussion comment. Author-self deletion is handled by the
-     * security expression separately.
+     * discussion comment. Feedback comments have no extra escalation —
+     * author-self and platform admin (the security expression) are the
+     * only deleters. Author-self deletion is handled by the security
+     * expression separately.
      */
     public function isDeletableBy(User $user): bool
     {
@@ -359,7 +400,8 @@ class Comment
     {
         $set = (null !== $this->task ? 1 : 0)
             + (null !== $this->page ? 1 : 0)
-            + (null !== $this->discussion ? 1 : 0);
+            + (null !== $this->discussion ? 1 : 0)
+            + (null !== $this->feedback ? 1 : 0);
 
         if ($set > 1) {
             $context->buildViolation('A comment cannot reference more than one parent.')
@@ -368,7 +410,7 @@ class Comment
             return;
         }
         if (0 === $set) {
-            $context->buildViolation('A comment must reference a task, a page, or a discussion.')
+            $context->buildViolation('A comment must reference a task, a page, a discussion, or a feedback ticket.')
                 ->atPath('task')
                 ->addViolation();
         }

--- a/api/src/Entity/Feedback.php
+++ b/api/src/Entity/Feedback.php
@@ -12,6 +12,9 @@ use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
 use App\Repository\FeedbackRepository;
+use App\State\FeedbackAggregateProvider;
+use App\State\FeedbackOwnerProcessor;
+use App\State\FeedbackUpdateProcessor;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Uid\Uuid;
@@ -48,18 +51,22 @@ use Symfony\Component\Validator\Constraints as Assert;
         new GetCollection(
             uriTemplate: '/feedback',
             security: "is_granted('ROLE_USER')",
+            provider: FeedbackAggregateProvider::class,
         ),
         new Post(
             uriTemplate: '/feedback',
             security: "is_granted('ROLE_USER')",
+            processor: FeedbackOwnerProcessor::class,
         ),
         new Get(
             uriTemplate: '/feedback/{id}',
             security: "is_granted('ROLE_USER')",
+            provider: FeedbackAggregateProvider::class,
         ),
         new Patch(
             uriTemplate: '/feedback/{id}',
             security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getOwner() == user)",
+            processor: FeedbackUpdateProcessor::class,
         ),
         new Delete(
             uriTemplate: '/feedback/{id}',

--- a/api/src/Entity/Feedback.php
+++ b/api/src/Entity/Feedback.php
@@ -1,0 +1,319 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Doctrine\Orm\Filter\OrderFilter;
+use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
+use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use App\Repository\FeedbackRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * An in-app feedback ticket — a bug report or a feature request.
+ *
+ * Instance-level (app-wide), NOT space-scoped: every authenticated user
+ * sees and interacts with one shared board, the same way the waitlist
+ * toggle and {@see Segment} cohorts are properties of the whole
+ * deployment rather than of a space. There is therefore no access
+ * extension — visibility is "any ROLE_USER" and the only per-row gate is
+ * owner-or-admin on edit/delete (plus admin-only on the status field).
+ *
+ * Each ticket carries an auto-generated, monotonic {@see $ticketNumber}
+ * stamped server-side by {@see FeedbackOwnerProcessor} from a dedicated
+ * Postgres sequence (concurrency-safe, unlike MAX()+1) and read-only on
+ * the wire afterwards — the same "stamp once on create" contract as the
+ * group slug.
+ *
+ * Tickets survive their author's account deletion:
+ * {@see \App\Service\AccountDeletionService} reassigns {@see $owner} to
+ * the never-deletable "Former member" sentinel, exactly like tasks /
+ * projects / pages, so the board's history stays intact.
+ *
+ * Reads are enriched by {@see FeedbackAggregateProvider} with the vote
+ * {@see $score}, the caller's own {@see $myVote}, and the
+ * {@see $commentCount} — all computed in a batched pass, no N+1.
+ */
+#[ApiResource(
+    shortName: 'Feedback',
+    operations: [
+        new GetCollection(
+            uriTemplate: '/feedback',
+            security: "is_granted('ROLE_USER')",
+        ),
+        new Post(
+            uriTemplate: '/feedback',
+            security: "is_granted('ROLE_USER')",
+        ),
+        new Get(
+            uriTemplate: '/feedback/{id}',
+            security: "is_granted('ROLE_USER')",
+        ),
+        new Patch(
+            uriTemplate: '/feedback/{id}',
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getOwner() == user)",
+        ),
+        new Delete(
+            uriTemplate: '/feedback/{id}',
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getOwner() == user)",
+        ),
+    ],
+    normalizationContext: ['groups' => ['feedback:read']],
+    denormalizationContext: ['groups' => ['feedback:write']],
+    order: ['createdAt' => 'DESC'],
+)]
+#[ApiFilter(SearchFilter::class, properties: ['type' => 'exact', 'status' => 'exact'])]
+#[ApiFilter(OrderFilter::class, properties: ['createdAt', 'ticketNumber'])]
+#[ORM\Entity(repositoryClass: FeedbackRepository::class)]
+#[ORM\Table(name: 'feedback')]
+#[ORM\UniqueConstraint(name: 'uniq_feedback_ticket_number', columns: ['ticket_number'])]
+#[ORM\Index(columns: ['owner_id'], name: 'idx_feedback_owner')]
+#[ORM\Index(columns: ['status'], name: 'idx_feedback_status')]
+#[ORM\Index(columns: ['type'], name: 'idx_feedback_type')]
+#[ORM\HasLifecycleCallbacks]
+class Feedback
+{
+    public const TYPE_BUG = 'bug';
+    public const TYPE_FEATURE = 'feature';
+    public const TYPES = [self::TYPE_BUG, self::TYPE_FEATURE];
+
+    public const STATUS_OPEN = 'open';
+    public const STATUS_PLANNED = 'planned';
+    public const STATUS_IN_PROGRESS = 'in_progress';
+    public const STATUS_SHIPPED = 'shipped';
+    public const STATUS_DECLINED = 'declined';
+    public const STATUSES = [
+        self::STATUS_OPEN,
+        self::STATUS_PLANNED,
+        self::STATUS_IN_PROGRESS,
+        self::STATUS_SHIPPED,
+        self::STATUS_DECLINED,
+    ];
+
+    public const MAX_TITLE_LENGTH = 200;
+    public const MAX_DESCRIPTION_LENGTH = 50_000;
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
+    #[Groups(['feedback:read'])]
+    private ?Uuid $id = null;
+
+    /**
+     * Human-facing sequential reference ("#42"). Stamped once on create
+     * by {@see FeedbackOwnerProcessor} from the `feedback_ticket_seq`
+     * sequence; never accepted from the client and never changes — so
+     * it's out of every write group.
+     */
+    #[ORM\Column(name: 'ticket_number', type: 'integer', unique: true)]
+    #[Groups(['feedback:read'])]
+    private ?int $ticketNumber = null;
+
+    #[ORM\Column(length: self::MAX_TITLE_LENGTH)]
+    #[Assert\NotBlank(message: 'Title is required.')]
+    #[Assert\Length(
+        max: self::MAX_TITLE_LENGTH,
+        maxMessage: 'Title cannot be longer than {{ limit }} characters.',
+    )]
+    #[Groups(['feedback:read', 'feedback:write'])]
+    private string $title = '';
+
+    #[ORM\Column(type: 'text')]
+    #[Assert\NotBlank(message: 'Description is required.')]
+    #[Assert\Length(
+        max: self::MAX_DESCRIPTION_LENGTH,
+        maxMessage: 'Description cannot be longer than {{ limit }} characters.',
+    )]
+    #[Groups(['feedback:read', 'feedback:write'])]
+    private string $description = '';
+
+    /**
+     * `bug` or `feature`. Settable on create + edit (an author can
+     * recategorise their own ticket); the admin-only field is the
+     * status below, enforced by {@see FeedbackUpdateProcessor}.
+     */
+    #[ORM\Column(length: 16)]
+    #[Assert\Choice(choices: self::TYPES, message: 'Type must be "bug" or "feature".')]
+    #[Groups(['feedback:read', 'feedback:write'])]
+    private string $type = self::TYPE_BUG;
+
+    /**
+     * Workflow state. In `feedback:write` so it appears in the schema and
+     * round-trips, but {@see FeedbackUpdateProcessor} rejects a change by
+     * a non-admin — only platform admins move a ticket along the board.
+     */
+    #[ORM\Column(length: 16, options: ['default' => self::STATUS_OPEN])]
+    #[Assert\Choice(choices: self::STATUSES, message: 'Unknown status.')]
+    #[Groups(['feedback:read', 'feedback:write'])]
+    private string $status = self::STATUS_OPEN;
+
+    /**
+     * The user who filed the ticket — stamped server-side on POST, never
+     * trusted from the payload (same as Discussion.author). Reassigned to
+     * the "Former member" sentinel on account deletion rather than
+     * cascade-deleted, so the ticket survives.
+     */
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    #[Groups(['feedback:read'])]
+    private ?User $owner = null;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    #[Groups(['feedback:read'])]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    #[Groups(['feedback:read'])]
+    private ?\DateTimeImmutable $updatedAt = null;
+
+    /**
+     * Aggregate vote score (sum of +1 / -1 votes) — computed at read
+     * time by {@see FeedbackAggregateProvider}, never persisted.
+     */
+    private int $score = 0;
+
+    /**
+     * The calling user's own vote on this ticket: 1, -1, or 0 when they
+     * haven't voted. Set per-request by the aggregate provider.
+     */
+    private int $myVote = 0;
+
+    private int $commentCount = 0;
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    #[ORM\PreUpdate]
+    public function onPreUpdate(): void
+    {
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTicketNumber(): ?int
+    {
+        return $this->ticketNumber;
+    }
+
+    public function setTicketNumber(?int $ticketNumber): static
+    {
+        $this->ticketNumber = $ticketNumber;
+        return $this;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): static
+    {
+        $this->title = $title;
+        return $this;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): static
+    {
+        $this->description = $description;
+        return $this;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function setType(string $type): static
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(string $status): static
+    {
+        $this->status = $status;
+        return $this;
+    }
+
+    public function getOwner(): ?User
+    {
+        return $this->owner;
+    }
+
+    public function setOwner(?User $owner): static
+    {
+        $this->owner = $owner;
+        return $this;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): ?\DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    #[Groups(['feedback:read'])]
+    public function getScore(): int
+    {
+        return $this->score;
+    }
+
+    public function setScore(int $score): static
+    {
+        $this->score = $score;
+        return $this;
+    }
+
+    #[Groups(['feedback:read'])]
+    public function getMyVote(): int
+    {
+        return $this->myVote;
+    }
+
+    public function setMyVote(int $myVote): static
+    {
+        $this->myVote = $myVote;
+        return $this;
+    }
+
+    #[Groups(['feedback:read'])]
+    public function getCommentCount(): int
+    {
+        return $this->commentCount;
+    }
+
+    public function setCommentCount(int $commentCount): static
+    {
+        $this->commentCount = $commentCount;
+        return $this;
+    }
+}

--- a/api/src/Entity/FeedbackVote.php
+++ b/api/src/Entity/FeedbackVote.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\FeedbackVoteRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * One user's vote on one feedback ticket. Not an API resource — votes
+ * are mutated only through {@see \App\Controller\FeedbackVoteController}
+ * ("POST /feedback/{id}/vote"), which enforces the one-vote-per-ticket
+ * toggle, and read back in aggregate by {@see \App\State\FeedbackAggregateProvider}.
+ *
+ * {@see $value} is +1 (up) or -1 (down); there's no zero row — clearing a
+ * vote deletes the row. The unique constraint on (feedback, user)
+ * guarantees a single vote per user per ticket. Both FKs cascade on
+ * delete, so removing a ticket or a user reaps their votes.
+ */
+#[ORM\Entity(repositoryClass: FeedbackVoteRepository::class)]
+#[ORM\Table(name: 'feedback_vote')]
+#[ORM\UniqueConstraint(name: 'uniq_feedback_vote', columns: ['feedback_id', 'user_id'])]
+#[ORM\Index(columns: ['feedback_id'], name: 'idx_feedback_vote_feedback')]
+class FeedbackVote
+{
+    public const VALUE_UP = 1;
+    public const VALUE_DOWN = -1;
+    public const VALUES = [self::VALUE_UP, self::VALUE_DOWN];
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
+    private ?Uuid $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Feedback::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private ?Feedback $feedback = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private ?User $user = null;
+
+    #[ORM\Column(type: 'smallint')]
+    private int $value = self::VALUE_UP;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $votedAt;
+
+    public function __construct()
+    {
+        $this->votedAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?Uuid
+    {
+        return $this->id;
+    }
+
+    public function getFeedback(): ?Feedback
+    {
+        return $this->feedback;
+    }
+
+    public function setFeedback(?Feedback $feedback): static
+    {
+        $this->feedback = $feedback;
+        return $this;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(?User $user): static
+    {
+        $this->user = $user;
+        return $this;
+    }
+
+    public function getValue(): int
+    {
+        return $this->value;
+    }
+
+    public function setValue(int $value): static
+    {
+        $this->value = $value;
+        return $this;
+    }
+
+    public function getVotedAt(): \DateTimeImmutable
+    {
+        return $this->votedAt;
+    }
+}

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -50,7 +50,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TwoFact
     #[ORM\Column(type: 'uuid', unique: true)]
     #[ORM\GeneratedValue(strategy: 'CUSTOM')]
     #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
-    #[Groups(['user:read', 'project:read', 'group:read', 'task:read', 'comment:read', 'discussion:read', 'space:read', 'page:read', 'notification:read', 'segment:read'])]
+    #[Groups(['user:read', 'project:read', 'group:read', 'task:read', 'comment:read', 'discussion:read', 'feedback:read', 'space:read', 'page:read', 'notification:read', 'segment:read'])]
     private ?Uuid $id = null;
 
     // Settable on signup (`user:create`), but not on PATCH — changes
@@ -58,7 +58,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TwoFact
     #[ORM\Column(length: 180, unique: true)]
     #[Assert\NotBlank]
     #[Assert\Email]
-    #[Groups(['user:read', 'user:create', 'project:read', 'group:read', 'task:read', 'comment:read', 'discussion:read', 'space:read', 'page:read', 'notification:read', 'segment:read'])]
+    #[Groups(['user:read', 'user:create', 'project:read', 'group:read', 'task:read', 'comment:read', 'discussion:read', 'feedback:read', 'space:read', 'page:read', 'notification:read', 'segment:read'])]
     private string $email = '';
 
     #[ORM\Column]
@@ -104,18 +104,18 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TwoFact
     #[ORM\Column(length: 100)]
     #[Assert\NotBlank(message: 'Given name is required.')]
     #[Assert\Length(max: 100)]
-    #[Groups(['user:read', 'user:write', 'project:read', 'group:read', 'task:read', 'comment:read', 'discussion:read', 'space:read', 'page:read', 'notification:read', 'segment:read'])]
+    #[Groups(['user:read', 'user:write', 'project:read', 'group:read', 'task:read', 'comment:read', 'discussion:read', 'feedback:read', 'space:read', 'page:read', 'notification:read', 'segment:read'])]
     private string $givenName = '';
 
     #[ORM\Column(length: 100)]
     #[Assert\NotBlank(message: 'Family name is required.')]
     #[Assert\Length(max: 100)]
-    #[Groups(['user:read', 'user:write', 'project:read', 'group:read', 'task:read', 'comment:read', 'discussion:read', 'space:read', 'page:read', 'notification:read', 'segment:read'])]
+    #[Groups(['user:read', 'user:write', 'project:read', 'group:read', 'task:read', 'comment:read', 'discussion:read', 'feedback:read', 'space:read', 'page:read', 'notification:read', 'segment:read'])]
     private string $familyName = '';
 
     #[ORM\Column(length: 100, nullable: true)]
     #[Assert\Length(max: 100)]
-    #[Groups(['user:read', 'user:write', 'project:read', 'group:read', 'task:read', 'comment:read', 'discussion:read', 'space:read', 'page:read', 'notification:read', 'segment:read'])]
+    #[Groups(['user:read', 'user:write', 'project:read', 'group:read', 'task:read', 'comment:read', 'discussion:read', 'feedback:read', 'space:read', 'page:read', 'notification:read', 'segment:read'])]
     private ?string $nickname = null;
 
     /**
@@ -129,7 +129,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TwoFact
         choices: AvatarColorService::PALETTE,
         message: 'Pick a color from the available palette.',
     )]
-    #[Groups(['user:read', 'user:write', 'user:create', 'project:read', 'group:read', 'task:read', 'comment:read', 'discussion:read', 'space:read', 'page:read', 'notification:read', 'segment:read'])]
+    #[Groups(['user:read', 'user:write', 'user:create', 'project:read', 'group:read', 'task:read', 'comment:read', 'discussion:read', 'feedback:read', 'space:read', 'page:read', 'notification:read', 'segment:read'])]
     private string $personalizedColor = AvatarColorService::PALETTE[0];
 
     /**
@@ -506,7 +506,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TwoFact
      *
      * @return array<string, string>|null
      */
-    #[Groups(['user:read', 'project:read', 'group:read', 'task:read', 'comment:read', 'discussion:read', 'space:read', 'page:read', 'notification:read'])]
+    #[Groups(['user:read', 'project:read', 'group:read', 'task:read', 'comment:read', 'discussion:read', 'feedback:read', 'space:read', 'page:read', 'notification:read'])]
     public function getAvatarUrls(): ?array
     {
         return $this->avatar?->getVariantUrls();

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -564,6 +564,20 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TwoFact
     }
 
     /**
+     * Read-only mirror of {@see canBeImpersonated()} for the API. Exposed
+     * only under `user:read` — emitted by the admin-gated `/users`
+     * collection and the user's own item, never by the embedded user chips
+     * (which serialize under project:read / space:read / … instead) — so an
+     * admin can tell which accounts have opted in before attempting a
+     * switch, without leaking the flag onto every comment/task author chip.
+     */
+    #[Groups(['user:read'])]
+    public function getCanBeImpersonated(): bool
+    {
+        return $this->canBeImpersonated();
+    }
+
+    /**
      * The access level ('none' | 'view' | 'edit') an impersonating admin
      * has for the given content category. Unknown / malformed values fall
      * back to the safe default 'none'. Read by

--- a/api/src/Mcp/McpEntitySerializer.php
+++ b/api/src/Mcp/McpEntitySerializer.php
@@ -172,6 +172,7 @@ final class McpEntitySerializer
             'taskId' => null === $comment->getTask() ? null : (string) $comment->getTask()->getId(),
             'pageId' => null === $comment->getPage() ? null : (string) $comment->getPage()->getId(),
             'discussionId' => null === $comment->getDiscussion() ? null : (string) $comment->getDiscussion()->getId(),
+            'feedbackId' => null === $comment->getFeedback() ? null : (string) $comment->getFeedback()->getId(),
             'body' => $comment->getBody(),
             'author' => $this->userSummary($comment->getAuthor()),
             'createdAt' => $comment->getCreatedAt()->format(\DateTimeInterface::ATOM),

--- a/api/src/Repository/CommentRepository.php
+++ b/api/src/Repository/CommentRepository.php
@@ -46,6 +46,8 @@ final class CommentRepository extends ServiceEntityRepository
             $qb->andWhere('c.page = :parent')->setParameter('parent', $comment->getPage());
         } elseif (null !== $comment->getDiscussion()) {
             $qb->andWhere('c.discussion = :parent')->setParameter('parent', $comment->getDiscussion());
+        } elseif (null !== $comment->getFeedback()) {
+            $qb->andWhere('c.feedback = :parent')->setParameter('parent', $comment->getFeedback());
         } else {
             return [];
         }

--- a/api/src/Repository/FeedbackRepository.php
+++ b/api/src/Repository/FeedbackRepository.php
@@ -24,7 +24,8 @@ final class FeedbackRepository extends ServiceEntityRepository
     public function nextTicketNumber(): int
     {
         $connection = $this->getEntityManager()->getConnection();
+        $value = $connection->fetchOne("SELECT nextval('feedback_ticket_seq')");
 
-        return (int) $connection->fetchOne("SELECT nextval('feedback_ticket_seq')");
+        return is_numeric($value) ? (int) $value : 0;
     }
 }

--- a/api/src/Repository/FeedbackRepository.php
+++ b/api/src/Repository/FeedbackRepository.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Feedback;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Feedback>
+ */
+final class FeedbackRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Feedback::class);
+    }
+
+    /**
+     * Next value of the dedicated `feedback_ticket_seq` sequence. Used by
+     * {@see \App\State\FeedbackOwnerProcessor} to stamp a concurrency-safe
+     * monotonic ticket number on each new ticket.
+     */
+    public function nextTicketNumber(): int
+    {
+        $connection = $this->getEntityManager()->getConnection();
+
+        return (int) $connection->fetchOne("SELECT nextval('feedback_ticket_seq')");
+    }
+}

--- a/api/src/Repository/FeedbackVoteRepository.php
+++ b/api/src/Repository/FeedbackVoteRepository.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Feedback;
+use App\Entity\FeedbackVote;
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<FeedbackVote>
+ */
+final class FeedbackVoteRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, FeedbackVote::class);
+    }
+
+    public function findOneForUser(Feedback $feedback, User $user): ?FeedbackVote
+    {
+        return $this->findOneBy(['feedback' => $feedback, 'user' => $user]);
+    }
+
+    /**
+     * Aggregate score (sum of +1 / -1 votes) for a single ticket.
+     */
+    public function scoreFor(Feedback $feedback): int
+    {
+        $sum = $this->createQueryBuilder('v')
+            ->select('COALESCE(SUM(v.value), 0)')
+            ->where('v.feedback = :feedback')
+            ->setParameter('feedback', $feedback)
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        return (int) $sum;
+    }
+}

--- a/api/src/Service/AccountDeletionService.php
+++ b/api/src/Service/AccountDeletionService.php
@@ -6,6 +6,7 @@ namespace App\Service;
 
 use App\Entity\Comment;
 use App\Entity\Discussion;
+use App\Entity\Feedback;
 use App\Entity\MediaObject;
 use App\Entity\Page;
 use App\Entity\Project;
@@ -22,7 +23,8 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
  *
  * Every authorship FK on User is `onDelete: CASCADE` and non-null, so a naive
  * `EntityManager::remove($user)` would erase their tasks, projects, pages,
- * discussions, comments and media. Instead we reassign those FKs to a reserved
+ * discussions, comments, feedback tickets and media. Instead we reassign those
+ * FKs to a reserved
  * "Former member" sentinel inside a transaction *before* removing the user, so
  * the content stays published under an anonymized author. Memberships, API
  * tokens, sessions, notifications, invites and personal tags clear via their
@@ -55,6 +57,7 @@ final class AccountDeletionService
             $this->reassign(Page::class, 'createdBy', $user, $sentinel);
             $this->reassign(Discussion::class, 'author', $user, $sentinel);
             $this->reassign(Comment::class, 'author', $user, $sentinel);
+            $this->reassign(Feedback::class, 'owner', $user, $sentinel);
             $this->reassign(MediaObject::class, 'owner', $user, $sentinel);
 
             $this->handleSpaces($user, $userId);

--- a/api/src/Service/CommentActivityNotifier.php
+++ b/api/src/Service/CommentActivityNotifier.php
@@ -78,6 +78,9 @@ final class CommentActivityNotifier
         if (null !== $comment->getPage()) {
             return $comment->getPage()->getCreatedBy();
         }
+        if (null !== $comment->getFeedback()) {
+            return $comment->getFeedback()->getOwner();
+        }
 
         return null;
     }
@@ -92,6 +95,9 @@ final class CommentActivityNotifier
         }
         if (null !== $comment->getPage()) {
             return $comment->getPage()->getTitle();
+        }
+        if (null !== $comment->getFeedback()) {
+            return $comment->getFeedback()->getTitle();
         }
 
         return 'a thread';

--- a/api/src/Service/CommentMentionService.php
+++ b/api/src/Service/CommentMentionService.php
@@ -158,6 +158,18 @@ final class CommentMentionService
                     $bag[$this->localPart($member)] = $member;
                 }
             }
+            return $bag;
+        }
+
+        // Feedback is instance-level with no bounded membership, so the
+        // mentionable set is just the ticket owner — enough to let a
+        // commenter @-ping the person who filed it.
+        $feedback = $comment->getFeedback();
+        if (null !== $feedback) {
+            $owner = $feedback->getOwner();
+            if (null !== $owner) {
+                $bag[$this->localPart($owner)] = $owner;
+            }
         }
         return $bag;
     }
@@ -191,6 +203,10 @@ final class CommentMentionService
         $discussion = $comment->getDiscussion();
         if (null !== $discussion) {
             return sprintf('%s mentioned you on "%s"', $name, $discussion->getTitle());
+        }
+        $feedback = $comment->getFeedback();
+        if (null !== $feedback) {
+            return sprintf('%s mentioned you on "%s"', $name, $feedback->getTitle());
         }
         return sprintf('%s mentioned you', $name);
     }

--- a/api/src/Service/CommentMercurePublisher.php
+++ b/api/src/Service/CommentMercurePublisher.php
@@ -97,6 +97,10 @@ final class CommentMercurePublisher
         if (null !== $discussion && null !== $discussion->getId()) {
             return '/discussions/' . $discussion->getId();
         }
+        $feedback = $comment->getFeedback();
+        if (null !== $feedback && null !== $feedback->getId()) {
+            return '/feedback/' . $feedback->getId();
+        }
         return null;
     }
 

--- a/api/src/Service/UsageLimiter.php
+++ b/api/src/Service/UsageLimiter.php
@@ -65,6 +65,26 @@ final class UsageLimiter
     }
 
     /**
+     * True for platform admins. Their usage is still counted (so we can see
+     * what they consume), but they are exempt from the free MCP throughput cap
+     * — operating the instance shouldn't be rate-limited by the freemium gate.
+     */
+    public function isAdmin(User $user): bool
+    {
+        return in_array('ROLE_ADMIN', $user->getRoles(), true);
+    }
+
+    /**
+     * Whether the user's MCP throughput is uncapped: an entitled (paid Team)
+     * member or a platform admin. Distinct from {@see $enforcementEnabled},
+     * which suppresses the cap globally while the gate ships dark.
+     */
+    private function hasUnlimitedMcp(User $user): bool
+    {
+        return $this->isUserEntitled($user) || $this->isAdmin($user);
+    }
+
+    /**
      * Today's (UTC) count of metered MCP tool calls for this user.
      */
     public function mcpCallsToday(User $user): int
@@ -95,7 +115,7 @@ final class UsageLimiter
      */
     public function remainingMcpCalls(User $user): ?int
     {
-        if (!$this->enforcementEnabled || $this->isUserEntitled($user)) {
+        if (!$this->enforcementEnabled || $this->hasUnlimitedMcp($user)) {
             return null;
         }
 
@@ -108,7 +128,7 @@ final class UsageLimiter
      */
     public function isMcpCallAllowed(User $user): bool
     {
-        if (!$this->enforcementEnabled || $this->isUserEntitled($user)) {
+        if (!$this->enforcementEnabled || $this->hasUnlimitedMcp($user)) {
             return true;
         }
 

--- a/api/src/State/FeedbackAggregateProvider.php
+++ b/api/src/State/FeedbackAggregateProvider.php
@@ -5,6 +5,7 @@ namespace App\State;
 use ApiPlatform\Metadata\CollectionOperationInterface;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
+use App\Entity\Comment;
 use App\Entity\Feedback;
 use App\Entity\FeedbackVote;
 use App\Entity\User;
@@ -75,12 +76,42 @@ final class FeedbackAggregateProvider implements ProviderInterface
 
         $scores = $this->loadScores($tickets);
         $myVotes = $this->loadMyVotes($tickets);
+        $commentCounts = $this->loadCommentCounts($tickets);
 
         foreach ($tickets as $ticket) {
             $key = (string) $ticket->getId();
             $ticket->setScore($scores[$key] ?? 0);
             $ticket->setMyVote($myVotes[$key] ?? 0);
+            $ticket->setCommentCount($commentCounts[$key] ?? 0);
         }
+    }
+
+    /**
+     * Comment count per ticket in one grouped query.
+     *
+     * @param list<Feedback> $tickets
+     *
+     * @return array<string, int>
+     */
+    private function loadCommentCounts(array $tickets): array
+    {
+        /** @var list<array{fid: string|null, cnt: int<0, max>}> $rows */
+        $rows = $this->em->createQuery(
+            'SELECT IDENTITY(c.feedback) AS fid, COUNT(c.id) AS cnt
+             FROM ' . Comment::class . ' c
+             WHERE c.feedback IN (:tickets)
+             GROUP BY c.feedback',
+        )->setParameter('tickets', $tickets)->getResult();
+
+        $map = [];
+        foreach ($rows as $row) {
+            if (null === $row['fid']) {
+                continue;
+            }
+            $map[$row['fid']] = $row['cnt'];
+        }
+
+        return $map;
     }
 
     /**

--- a/api/src/State/FeedbackAggregateProvider.php
+++ b/api/src/State/FeedbackAggregateProvider.php
@@ -123,7 +123,8 @@ final class FeedbackAggregateProvider implements ProviderInterface
      */
     private function loadScores(array $tickets): array
     {
-        /** @var list<array{fid: string|null, total: int|string|null}> $rows */
+        // IDENTITY(v.feedback) is non-null (the FK is non-nullable), so
+        // phpstan-doctrine infers `fid` as a plain string here.
         $rows = $this->em->createQuery(
             'SELECT IDENTITY(v.feedback) AS fid, SUM(v.value) AS total
              FROM ' . FeedbackVote::class . ' v
@@ -133,9 +134,6 @@ final class FeedbackAggregateProvider implements ProviderInterface
 
         $map = [];
         foreach ($rows as $row) {
-            if (null === $row['fid']) {
-                continue;
-            }
             $map[$row['fid']] = (int) $row['total'];
         }
 
@@ -157,7 +155,6 @@ final class FeedbackAggregateProvider implements ProviderInterface
             return [];
         }
 
-        /** @var list<array{fid: string|null, value: int}> $rows */
         $rows = $this->em->createQuery(
             'SELECT IDENTITY(v.feedback) AS fid, v.value AS value
              FROM ' . FeedbackVote::class . ' v
@@ -169,9 +166,6 @@ final class FeedbackAggregateProvider implements ProviderInterface
 
         $map = [];
         foreach ($rows as $row) {
-            if (null === $row['fid']) {
-                continue;
-            }
             $map[$row['fid']] = $row['value'];
         }
 

--- a/api/src/State/FeedbackAggregateProvider.php
+++ b/api/src/State/FeedbackAggregateProvider.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace App\State;
+
+use ApiPlatform\Metadata\CollectionOperationInterface;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\Entity\Feedback;
+use App\Entity\FeedbackVote;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Enriches feedback reads with the two vote aggregates the board needs —
+ * the net {@see Feedback::getScore() score} and the caller's own
+ * {@see Feedback::getMyVote() vote} — without an N+1.
+ *
+ * Mirrors {@see DiscussionAggregateProvider}: delegate to the stock
+ * Doctrine providers (so access scoping, pagination, filters, and item
+ * 404s behave exactly as before), then run one grouped SUM over the page
+ * of tickets for the score and one query for this user's votes on that
+ * page. The transient fields are serialized under `feedback:read`.
+ *
+ * @implements ProviderInterface<Feedback>
+ */
+final class FeedbackAggregateProvider implements ProviderInterface
+{
+    /**
+     * @param ProviderInterface<Feedback> $collectionProvider
+     * @param ProviderInterface<Feedback> $itemProvider
+     */
+    public function __construct(
+        #[Autowire(service: 'api_platform.doctrine.orm.state.collection_provider')]
+        private ProviderInterface $collectionProvider,
+        #[Autowire(service: 'api_platform.doctrine.orm.state.item_provider')]
+        private ProviderInterface $itemProvider,
+        private EntityManagerInterface $em,
+        private Security $security,
+    ) {
+    }
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
+    {
+        if ($operation instanceof CollectionOperationInterface) {
+            $data = $this->collectionProvider->provide($operation, $uriVariables, $context);
+            if (is_iterable($data)) {
+                $tickets = [];
+                foreach ($data as $ticket) {
+                    $tickets[] = $ticket;
+                }
+                $this->enrich($tickets);
+            }
+
+            return $data;
+        }
+
+        $item = $this->itemProvider->provide($operation, $uriVariables, $context);
+        if ($item instanceof Feedback) {
+            $this->enrich([$item]);
+        }
+
+        return $item;
+    }
+
+    /**
+     * @param list<Feedback> $tickets
+     */
+    private function enrich(array $tickets): void
+    {
+        if ([] === $tickets) {
+            return;
+        }
+
+        $scores = $this->loadScores($tickets);
+        $myVotes = $this->loadMyVotes($tickets);
+
+        foreach ($tickets as $ticket) {
+            $key = (string) $ticket->getId();
+            $ticket->setScore($scores[$key] ?? 0);
+            $ticket->setMyVote($myVotes[$key] ?? 0);
+        }
+    }
+
+    /**
+     * Net vote score per ticket in one grouped query.
+     *
+     * @param list<Feedback> $tickets
+     *
+     * @return array<string, int>
+     */
+    private function loadScores(array $tickets): array
+    {
+        /** @var list<array{fid: string|null, total: int|string|null}> $rows */
+        $rows = $this->em->createQuery(
+            'SELECT IDENTITY(v.feedback) AS fid, SUM(v.value) AS total
+             FROM ' . FeedbackVote::class . ' v
+             WHERE v.feedback IN (:tickets)
+             GROUP BY v.feedback',
+        )->setParameter('tickets', $tickets)->getResult();
+
+        $map = [];
+        foreach ($rows as $row) {
+            if (null === $row['fid']) {
+                continue;
+            }
+            $map[$row['fid']] = (int) $row['total'];
+        }
+
+        return $map;
+    }
+
+    /**
+     * The current user's own vote (1 / -1) per ticket, in one query. An
+     * absent row means "no vote" and is left at 0 by the caller.
+     *
+     * @param list<Feedback> $tickets
+     *
+     * @return array<string, int>
+     */
+    private function loadMyVotes(array $tickets): array
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            return [];
+        }
+
+        /** @var list<array{fid: string|null, value: int}> $rows */
+        $rows = $this->em->createQuery(
+            'SELECT IDENTITY(v.feedback) AS fid, v.value AS value
+             FROM ' . FeedbackVote::class . ' v
+             WHERE v.feedback IN (:tickets) AND v.user = :user',
+        )
+            ->setParameter('tickets', $tickets)
+            ->setParameter('user', $user)
+            ->getResult();
+
+        $map = [];
+        foreach ($rows as $row) {
+            if (null === $row['fid']) {
+                continue;
+            }
+            $map[$row['fid']] = $row['value'];
+        }
+
+        return $map;
+    }
+}

--- a/api/src/State/FeedbackOwnerProcessor.php
+++ b/api/src/State/FeedbackOwnerProcessor.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\Entity\Feedback;
+use App\Repository\FeedbackRepository;
+use App\Security\AuthenticatedUserResolver;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Stamps a new feedback ticket with its owner (the current user) and a
+ * monotonic ticket number pulled from the `feedback_ticket_seq`
+ * sequence, then hands off to the default Doctrine persist processor.
+ *
+ * Both fields are set server-side and read-only on the wire — the same
+ * trust model as DiscussionAuthorProcessor (author) and
+ * UserGroupOwnerProcessor (slug). Using a DB sequence for the number
+ * keeps it concurrency-safe: two simultaneous POSTs get distinct values
+ * without a MAX()+1 race or a unique-constraint retry loop.
+ *
+ * @implements ProcessorInterface<Feedback, Feedback>
+ */
+final class FeedbackOwnerProcessor implements ProcessorInterface
+{
+    /**
+     * @param ProcessorInterface<Feedback, Feedback> $persistProcessor
+     */
+    public function __construct(
+        #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
+        private ProcessorInterface $persistProcessor,
+        private AuthenticatedUserResolver $auth,
+        private FeedbackRepository $feedbackRepository,
+    ) {
+    }
+
+    /**
+     * @param Feedback $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Feedback
+    {
+        $user = $this->auth->requireUser('submit feedback');
+
+        $data->setOwner($user);
+        if (null === $data->getTicketNumber()) {
+            $data->setTicketNumber($this->feedbackRepository->nextTicketNumber());
+        }
+
+        return $this->persistProcessor->process($data, $operation, $uriVariables, $context);
+    }
+}

--- a/api/src/State/FeedbackUpdateProcessor.php
+++ b/api/src/State/FeedbackUpdateProcessor.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\Entity\Feedback;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+/**
+ * Guards the admin-only `status` field on a feedback ticket edit.
+ *
+ * The Patch security expression already lets the owner OR an admin edit a
+ * ticket (title / description / type), but moving a ticket along the
+ * board — open → planned → in_progress → shipped / declined — is a
+ * platform-admin action. Rather than maintaining a separate
+ * denormalization group per role, this processor compares the incoming
+ * status against the persisted one (`previous_data`) and 403s a non-admin
+ * who tries to change it, then defers to the default persist processor.
+ *
+ * @implements ProcessorInterface<Feedback, Feedback>
+ */
+final class FeedbackUpdateProcessor implements ProcessorInterface
+{
+    /**
+     * @param ProcessorInterface<Feedback, Feedback> $persistProcessor
+     */
+    public function __construct(
+        #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
+        private ProcessorInterface $persistProcessor,
+        private Security $security,
+    ) {
+    }
+
+    /**
+     * @param Feedback $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Feedback
+    {
+        $previous = $context['previous_data'] ?? null;
+        if (
+            $previous instanceof Feedback
+            && $previous->getStatus() !== $data->getStatus()
+            && !$this->security->isGranted('ROLE_ADMIN')
+        ) {
+            throw new AccessDeniedHttpException('Only an administrator can change a ticket\'s status.');
+        }
+
+        return $this->persistProcessor->process($data, $operation, $uriVariables, $context);
+    }
+}

--- a/api/tests/Api/ApiTokenApiTest.php
+++ b/api/tests/Api/ApiTokenApiTest.php
@@ -52,6 +52,95 @@ class ApiTokenApiTest extends ApiTestCase
         $this->assertCount(0, $remaining);
     }
 
+    public function testPatchUpdatesAccessPolicy(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        $client->request('POST', '/api-tokens', [
+            'json' => [
+                'name' => 'ci',
+                'accessPolicy' => ['categories' => ['tasks' => 'view'], 'items' => []],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+        $created = $client->getResponse();
+        self::assertNotNull($created);
+        $iri = $this->stringField($created->toArray(), '@id');
+
+        // Tighten tasks to edit and drop the token to a different name.
+        $client->request('PATCH', $iri, [
+            'json' => [
+                'name' => 'ci-renamed',
+                'accessPolicy' => ['categories' => ['tasks' => 'edit', 'projects' => 'view'], 'items' => []],
+            ],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(200);
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+        $this->assertSame('ci-renamed', $this->stringField($body, 'name'));
+        $policy = $body['accessPolicy'];
+        $this->assertIsArray($policy);
+        $categories = $policy['categories'];
+        $this->assertIsArray($categories);
+        $this->assertSame('edit', $categories['tasks']);
+        $this->assertSame('view', $categories['projects']);
+
+        // The POST response must never echo the plaintext on a later read.
+        $this->assertArrayNotHasKey('plainToken', $body);
+    }
+
+    public function testPatchRejectsInvalidAccessPolicy(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        $client->request('POST', '/api-tokens', [
+            'json' => ['name' => 'ci'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+        $created = $client->getResponse();
+        self::assertNotNull($created);
+        $iri = $this->stringField($created->toArray(), '@id');
+
+        $client->request('PATCH', $iri, [
+            'json' => ['accessPolicy' => ['categories' => ['tasks' => 'bogus'], 'items' => []]],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testPatchRejectsForeignToken(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        $client->request('POST', '/api-tokens', [
+            'json' => ['name' => 'alice-token'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+        $created = $client->getResponse();
+        self::assertNotNull($created);
+        $iri = $this->stringField($created->toArray(), '@id');
+
+        $client->loginUser($bob);
+        $client->request('PATCH', $iri, [
+            'json' => ['name' => 'hijacked'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        // Owner-scoped security expression hides the row from a non-owner.
+        $this->assertResponseStatusCodeSame(404);
+    }
+
     public function testCreateRejectsInvalidAccessPolicy(): void
     {
         $alice = $this->createUser('alice@example.com');

--- a/api/tests/Api/FeedbackCommentTest.php
+++ b/api/tests/Api/FeedbackCommentTest.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Entity\Comment;
+use App\Entity\Feedback;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Covers the `feedback` arm of the unified Comment entity (#228): a
+ * comment can hang off a feedback ticket, every authenticated user can
+ * read it (the board is instance-level), the author can edit, and a
+ * platform admin can delete.
+ */
+class FeedbackCommentTest extends ApiTestCase
+{
+    use JsonBodyAssertions;
+
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->em = $em;
+        $this->em->createQuery('DELETE FROM App\Entity\Comment')->execute();
+        $this->em->createQuery('DELETE FROM App\Entity\Feedback')->execute();
+        $this->em->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testCommentOnFeedbackCreatesAndSetsDiscriminator(): void
+    {
+        $user = $this->makeUser('user@example.com');
+        $feedback = $this->makeFeedback($user);
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        $client->request('POST', '/comments', [
+            'json' => ['feedback' => '/feedback/' . $feedback->getId(), 'body' => 'Great idea!'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+        $body = $this->body($client);
+        $this->assertSame('feedback', $this->stringField($body, 'commentableType'));
+    }
+
+    public function testAnyAuthenticatedUserCanReadFeedbackComments(): void
+    {
+        $author = $this->makeUser('author@example.com');
+        $feedback = $this->makeFeedback($author);
+        $client = static::createClient();
+        $client->loginUser($author);
+        $client->request('POST', '/comments', [
+            'json' => ['feedback' => '/feedback/' . $feedback->getId(), 'body' => 'First'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+
+        // A different user (no shared space, no membership) can list it —
+        // the board is instance-level.
+        $other = $this->makeUser('other@example.com');
+        $client->loginUser($other);
+        $client->request('GET', '/comments?feedback=/feedback/' . $feedback->getId());
+        $this->assertResponseIsSuccessful();
+        $this->assertCount(1, $this->members($client));
+    }
+
+    public function testAuthorEditsAndAdminDeletes(): void
+    {
+        $author = $this->makeUser('author@example.com');
+        $admin = $this->makeUser('admin@example.com', ['ROLE_ADMIN']);
+        $feedback = $this->makeFeedback($author);
+
+        $client = static::createClient();
+        $client->loginUser($author);
+        $client->request('POST', '/comments', [
+            'json' => ['feedback' => '/feedback/' . $feedback->getId(), 'body' => 'Typo here'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $iri = $this->stringField($this->body($client), '@id');
+
+        // Author edits.
+        $client->request('PATCH', $iri, [
+            'json' => ['body' => 'Fixed'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseIsSuccessful();
+        $this->assertSame('Fixed', $this->stringField($this->body($client), 'body'));
+
+        // Admin deletes.
+        $client->loginUser($admin);
+        $client->request('DELETE', $iri);
+        $this->assertResponseStatusCodeSame(204);
+    }
+
+    public function testFeedbackReadExposesCommentCount(): void
+    {
+        $user = $this->makeUser('user@example.com');
+        $feedback = $this->makeFeedback($user);
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        foreach (['one', 'two'] as $text) {
+            $client->request('POST', '/comments', [
+                'json' => ['feedback' => '/feedback/' . $feedback->getId(), 'body' => $text],
+                'headers' => ['Content-Type' => 'application/ld+json'],
+            ]);
+        }
+
+        $client->request('GET', '/feedback/' . $feedback->getId());
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(2, $this->intField($this->body($client), 'commentCount'));
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    private function members(Client $client): array
+    {
+        $body = $this->body($client);
+        $member = $body['member'] ?? $body['hydra:member'] ?? [];
+        $this->assertIsArray($member);
+
+        return array_values($member);
+    }
+
+    /**
+     * @return array<int|string, mixed>
+     */
+    private function body(Client $client): array
+    {
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+
+        return $response->toArray(false);
+    }
+
+    private function makeFeedback(User $owner): Feedback
+    {
+        $feedback = new Feedback();
+        $feedback->setOwner($owner);
+        $feedback->setTitle('Commentable ticket');
+        $feedback->setDescription('Body');
+        $feedback->setType(Feedback::TYPE_BUG);
+        $feedback->setTicketNumber(
+            static::getContainer()->get(\App\Repository\FeedbackRepository::class)->nextTicketNumber(),
+        );
+        $this->em->persist($feedback);
+        $this->em->flush();
+
+        return $feedback;
+    }
+
+    /**
+     * @param list<string> $roles
+     */
+    private function makeUser(string $email, array $roles = []): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles($roles);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $this->em->persist($user);
+        $this->em->flush();
+
+        return $user;
+    }
+}

--- a/api/tests/Api/FeedbackTest.php
+++ b/api/tests/Api/FeedbackTest.php
@@ -1,0 +1,286 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Entity\Feedback;
+use App\Entity\User;
+use App\Service\AccountDeletionService;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+class FeedbackTest extends ApiTestCase
+{
+    use JsonBodyAssertions;
+
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->em = $em;
+        $this->em->createQuery('DELETE FROM App\Entity\FeedbackVote')->execute();
+        $this->em->createQuery('DELETE FROM App\Entity\Comment')->execute();
+        $this->em->createQuery('DELETE FROM App\Entity\Feedback')->execute();
+        $this->em->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testAnonymousCannotListOrCreate(): void
+    {
+        $client = static::createClient();
+
+        $client->request('GET', '/feedback');
+        $this->assertResponseStatusCodeSame(401);
+
+        $client->request('POST', '/feedback', [
+            'json' => ['title' => 'X', 'description' => 'Y', 'type' => 'bug'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(401);
+    }
+
+    public function testCreateStampsOwnerStatusAndSequentialTicketNumber(): void
+    {
+        $user = $this->makeUser('user@example.com');
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        $first = $this->createTicket($client, 'Dark mode please', 'feature');
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertSame('open', $this->stringField($first, 'status'));
+        $this->assertSame('feature', $this->stringField($first, 'type'));
+        $owner = $this->arrayField($first, 'owner');
+        $this->assertSame('user@example.com', $this->stringField($owner, 'email'));
+        // Aggregates present on create-time read.
+        $this->assertSame(0, $this->intField($first, 'score'));
+        $this->assertSame(0, $this->intField($first, 'myVote'));
+
+        $second = $this->createTicket($client, 'Crash on save', 'bug');
+        $this->assertResponseStatusCodeSame(201);
+
+        // Ticket numbers are monotonic (sequence-backed), not necessarily 1/2
+        // since the sequence persists across the suite.
+        $this->assertGreaterThan(
+            $this->intField($first, 'ticketNumber'),
+            $this->intField($second, 'ticketNumber'),
+        );
+    }
+
+    public function testClientCannotForgeTicketNumberOrOwner(): void
+    {
+        $a = $this->makeUser('a@example.com');
+        $b = $this->makeUser('b@example.com');
+        $client = static::createClient();
+        $client->loginUser($a);
+
+        $client->request('POST', '/feedback', [
+            'json' => [
+                'title' => 'Forged',
+                'description' => 'Trying to forge fields',
+                'type' => 'bug',
+                'ticketNumber' => 99999,
+                'owner' => '/users/' . $b->getId(),
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+
+        $body = $this->body($client);
+        $this->assertNotSame(99999, $this->intField($body, 'ticketNumber'));
+        $owner = $this->arrayField($body, 'owner');
+        $this->assertSame('a@example.com', $this->stringField($owner, 'email'));
+    }
+
+    public function testValidationRejectsBadTypeAndBlankTitle(): void
+    {
+        $user = $this->makeUser('user@example.com');
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        $client->request('POST', '/feedback', [
+            'json' => ['title' => '', 'description' => 'desc', 'type' => 'bug'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+
+        $client->request('POST', '/feedback', [
+            'json' => ['title' => 'T', 'description' => 'D', 'type' => 'wat'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testTypeAndStatusFiltering(): void
+    {
+        $user = $this->makeUser('user@example.com');
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        $this->createTicket($client, 'Bug one', 'bug');
+        $this->createTicket($client, 'Feature one', 'feature');
+
+        $client->request('GET', '/feedback?type=bug');
+        $this->assertResponseIsSuccessful();
+        $members = $this->members($client);
+        $this->assertCount(1, $members);
+
+        $client->request('GET', '/feedback?status=shipped');
+        $this->assertResponseIsSuccessful();
+        $this->assertCount(0, $this->members($client));
+    }
+
+    public function testOwnerCanEditTitleButNotStatus(): void
+    {
+        $user = $this->makeUser('user@example.com');
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        $ticket = $this->createTicket($client, 'Editable', 'bug');
+        $iri = $this->stringField($ticket, '@id');
+
+        // Owner edits the title — allowed.
+        $client->request('PATCH', $iri, [
+            'json' => ['title' => 'Edited title'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseIsSuccessful();
+        $this->assertSame('Edited title', $this->stringField($this->body($client), 'title'));
+
+        // Owner tries to move the status — forbidden (admin-only field).
+        $client->request('PATCH', $iri, [
+            'json' => ['status' => 'shipped'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testAdminCanChangeStatus(): void
+    {
+        $owner = $this->makeUser('owner@example.com');
+        $admin = $this->makeUser('admin@example.com', ['ROLE_ADMIN']);
+
+        $client = static::createClient();
+        $client->loginUser($owner);
+        $ticket = $this->createTicket($client, 'Status move', 'feature');
+        $iri = $this->stringField($ticket, '@id');
+
+        $client->loginUser($admin);
+        $client->request('PATCH', $iri, [
+            'json' => ['status' => 'planned'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseIsSuccessful();
+        $this->assertSame('planned', $this->stringField($this->body($client), 'status'));
+    }
+
+    public function testNonOwnerCannotEditOrDelete(): void
+    {
+        $owner = $this->makeUser('owner@example.com');
+        $other = $this->makeUser('other@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($owner);
+        $ticket = $this->createTicket($client, 'Mine', 'bug');
+        $iri = $this->stringField($ticket, '@id');
+
+        $client->loginUser($other);
+        $client->request('PATCH', $iri, [
+            'json' => ['title' => 'Hijack'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(403);
+
+        $client->request('DELETE', $iri);
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testOwnerCanDelete(): void
+    {
+        $owner = $this->makeUser('owner@example.com');
+        $client = static::createClient();
+        $client->loginUser($owner);
+        $ticket = $this->createTicket($client, 'Delete me', 'bug');
+        $iri = $this->stringField($ticket, '@id');
+
+        $client->request('DELETE', $iri);
+        $this->assertResponseStatusCodeSame(204);
+    }
+
+    public function testTicketSurvivesOwnerAccountDeletion(): void
+    {
+        $owner = $this->makeUser('owner@example.com');
+        $client = static::createClient();
+        $client->loginUser($owner);
+        $ticket = $this->createTicket($client, 'Outlives me', 'feature');
+        $ticketId = $this->stringField($ticket, 'id');
+
+        $service = static::getContainer()->get(AccountDeletionService::class);
+        $service->deleteAccount($owner);
+
+        $this->em->clear();
+        $survivor = $this->em->getRepository(Feedback::class)->find($ticketId);
+        $this->assertNotNull($survivor);
+        $this->assertSame(
+            AccountDeletionService::SENTINEL_EMAIL,
+            $survivor->getOwner()?->getEmail(),
+        );
+    }
+
+    /**
+     * @return array<int|string, mixed>
+     */
+    private function createTicket(Client $client, string $title, string $type): array
+    {
+        $client->request('POST', '/feedback', [
+            'json' => ['title' => $title, 'description' => 'Some description', 'type' => $type],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        return $this->body($client);
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    private function members(Client $client): array
+    {
+        $body = $this->body($client);
+        $member = $body['member'] ?? $body['hydra:member'] ?? [];
+        $this->assertIsArray($member);
+
+        return array_values($member);
+    }
+
+    /**
+     * @return array<int|string, mixed>
+     */
+    private function body(Client $client): array
+    {
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+
+        return $response->toArray(false);
+    }
+
+    /**
+     * @param list<string> $roles
+     */
+    private function makeUser(string $email, array $roles = []): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles($roles);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $this->em->persist($user);
+        $this->em->flush();
+
+        return $user;
+    }
+}

--- a/api/tests/Api/FeedbackVoteTest.php
+++ b/api/tests/Api/FeedbackVoteTest.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Entity\Feedback;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+class FeedbackVoteTest extends ApiTestCase
+{
+    use JsonBodyAssertions;
+
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->em = $em;
+        $this->em->createQuery('DELETE FROM App\Entity\FeedbackVote')->execute();
+        $this->em->createQuery('DELETE FROM App\Entity\Feedback')->execute();
+        $this->em->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testVoteToggleClearsAndFlips(): void
+    {
+        $user = $this->makeUser('voter@example.com');
+        $feedback = $this->makeFeedback($user);
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        $voteUrl = '/feedback/' . $feedback->getId() . '/vote';
+
+        // Up-vote → created.
+        $body = $this->vote($client, $voteUrl, 1);
+        $this->assertSame('added', $this->stringField($body, 'status'));
+        $this->assertSame(1, $this->intField($body, 'myVote'));
+        $this->assertSame(1, $this->intField($body, 'score'));
+
+        // Same direction again → cleared.
+        $body = $this->vote($client, $voteUrl, 1);
+        $this->assertSame('cleared', $this->stringField($body, 'status'));
+        $this->assertSame(0, $this->intField($body, 'myVote'));
+        $this->assertSame(0, $this->intField($body, 'score'));
+
+        // Up again, then flip to down → updated.
+        $this->vote($client, $voteUrl, 1);
+        $body = $this->vote($client, $voteUrl, -1);
+        $this->assertSame('updated', $this->stringField($body, 'status'));
+        $this->assertSame(-1, $this->intField($body, 'myVote'));
+        $this->assertSame(-1, $this->intField($body, 'score'));
+    }
+
+    public function testScoreAggregatesAcrossUsersAndMyVoteIsPerCaller(): void
+    {
+        $alice = $this->makeUser('alice@example.com');
+        $bob = $this->makeUser('bob@example.com');
+        $feedback = $this->makeFeedback($alice);
+        $voteUrl = '/feedback/' . $feedback->getId() . '/vote';
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $this->vote($client, $voteUrl, 1);
+
+        $client->loginUser($bob);
+        $this->vote($client, $voteUrl, 1);
+
+        // Net score is 2; Bob's own vote is +1 on the read.
+        $client->request('GET', '/feedback/' . $feedback->getId());
+        $this->assertResponseIsSuccessful();
+        $body = $this->body($client);
+        $this->assertSame(2, $this->intField($body, 'score'));
+        $this->assertSame(1, $this->intField($body, 'myVote'));
+
+        // A non-voting reader sees the score but myVote 0.
+        $carol = $this->makeUser('carol@example.com');
+        $client->loginUser($carol);
+        $client->request('GET', '/feedback/' . $feedback->getId());
+        $body = $this->body($client);
+        $this->assertSame(2, $this->intField($body, 'score'));
+        $this->assertSame(0, $this->intField($body, 'myVote'));
+    }
+
+    public function testInvalidVoteValueRejected(): void
+    {
+        $user = $this->makeUser('voter@example.com');
+        $feedback = $this->makeFeedback($user);
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        $client->request('POST', '/feedback/' . $feedback->getId() . '/vote', [
+            'json' => ['value' => 5],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testVoteOnUnknownTicketIs404(): void
+    {
+        $user = $this->makeUser('voter@example.com');
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        $client->request('POST', '/feedback/019ef0eb-0000-7000-8000-000000000000/vote', [
+            'json' => ['value' => 1],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testAnonymousCannotVote(): void
+    {
+        $user = $this->makeUser('voter@example.com');
+        $feedback = $this->makeFeedback($user);
+        $client = static::createClient();
+
+        $client->request('POST', '/feedback/' . $feedback->getId() . '/vote', [
+            'json' => ['value' => 1],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(401);
+    }
+
+    /**
+     * @return array<int|string, mixed>
+     */
+    private function vote(Client $client, string $url, int $value): array
+    {
+        $client->request('POST', $url, [
+            'json' => ['value' => $value],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        return $this->body($client);
+    }
+
+    /**
+     * @return array<int|string, mixed>
+     */
+    private function body(Client $client): array
+    {
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+
+        return $response->toArray(false);
+    }
+
+    private function makeFeedback(User $owner): Feedback
+    {
+        $feedback = new Feedback();
+        $feedback->setOwner($owner);
+        $feedback->setTitle('Votable ticket');
+        $feedback->setDescription('Body');
+        $feedback->setType(Feedback::TYPE_FEATURE);
+        $feedback->setTicketNumber(
+            static::getContainer()->get(\App\Repository\FeedbackRepository::class)->nextTicketNumber(),
+        );
+        $this->em->persist($feedback);
+        $this->em->flush();
+
+        return $feedback;
+    }
+
+    private function makeUser(string $email): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $this->em->persist($user);
+        $this->em->flush();
+
+        return $user;
+    }
+}

--- a/api/tests/Service/UsageLimiterTest.php
+++ b/api/tests/Service/UsageLimiterTest.php
@@ -93,6 +93,27 @@ class UsageLimiterTest extends KernelTestCase
         $this->assertNull($limiter->remainingMcpCalls($alice));
     }
 
+    public function testAdminIsUncappedButStillCounted(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $admin->setRoles(['ROLE_USER', 'ROLE_ADMIN']);
+        $this->em->flush();
+
+        $limiter = $this->limiter(mcpLimit: 1, memberLimit: 5);
+
+        // Two calls, well past the cap of 1 — but admins aren't capped.
+        $this->recorder->recordMcpCall($admin);
+        $this->recorder->recordMcpCall($admin);
+
+        $this->assertTrue($limiter->isAdmin($admin));
+        $this->assertFalse($limiter->isUserEntitled($admin));
+        $this->assertTrue($limiter->isMcpCallAllowed($admin));
+        $this->assertNull($limiter->remainingMcpCalls($admin));
+
+        // Tracking is unaffected — their usage is still recorded.
+        $this->assertSame(2, $limiter->mcpCallsToday($admin));
+    }
+
     public function testCanceledSubscriptionDoesNotEntitle(): void
     {
         $alice = $this->createUser('alice@example.com');

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -78,11 +78,21 @@ services:
       # Repo-root docs/ surfaced inside the container so scripts/sync-docs.mjs
       # can find a source when predev / prebuild runs from /srv/app.
       - ./docs:/srv/docs:ro
+    # Next 16 defaults `next dev` to Turbopack, whose file watcher relies on
+    # inotify and ignores WATCHPACK_POLLING. inotify events do NOT cross Docker
+    # Desktop's Windows/WSL bind mount, so edits never trigger a recompile —
+    # routes go stale and hot reload silently dies. Force the webpack dev
+    # server, which DOES honor the polling flag below. Linux/macOS devs with
+    # working native file events can drop this override for Turbopack's speed.
+    command: sh -c "pnpm install; pnpm run dev --webpack"
     environment:
       API_PLATFORM_CREATE_CLIENT_ENTRYPOINT: http://php
       API_PLATFORM_CREATE_CLIENT_OUTPUT: .
-      # On Linux, you may want to comment the following line for improved performance
+      # Poll the filesystem instead of relying on inotify (which doesn't fire
+      # over the Windows/WSL bind mount). Honored by the webpack dev server
+      # selected above. On native Linux you may comment this out for perf.
       WATCHPACK_POLLING: "true"
+      CHOKIDAR_USEPOLLING: "true"
 
 ###> doctrine/doctrine-bundle ###
   database:

--- a/docs/developer/billing.md
+++ b/docs/developer/billing.md
@@ -26,6 +26,12 @@ subscription**. "Entitling" = status in
 so a transient payment hiccup doesn't instantly lock a team out; only a
 terminal `canceled`/`unpaid` revokes).
 
+**Admin exemption:** platform admins (`ROLE_ADMIN`) are never capped on MCP
+throughput — operating the instance shouldn't be rate-limited by the freemium
+gate. Their usage is *still counted* (so it shows up in usage reports and the
+settings panel); only the cap check is bypassed (`UsageLimiter::isAdmin()`,
+folded into the same unlimited path as entitlement).
+
 Only programmatic **MCP** traffic is metered — the PWA's own
 cookie-authenticated REST calls are never counted. Counting itself stays in the
 existing `UsageRecorder`/`UserUsageCounter` (off the request latency path);

--- a/e2e/tests/projects.spec.js
+++ b/e2e/tests/projects.spec.js
@@ -145,10 +145,7 @@ test.describe("Projects", () => {
     await titleInput.click();
     await titleInput.fill("Keyboard task");
 
-    // Tab walks the row in column order: title -> tags -> due -> assignees.
-    await page.keyboard.press("Tab");
-    await expect(page.getByLabel('Tags for "new task"')).toBeFocused();
-
+    // Tab walks the row in column order: title -> due -> assignees -> tags.
     await page.keyboard.press("Tab");
     await expect(
       page.getByRole("button", { name: "Due date for new task" }),
@@ -156,6 +153,9 @@ test.describe("Projects", () => {
 
     await page.keyboard.press("Tab");
     await expect(page.getByLabel('Assignees for "new task"')).toBeFocused();
+
+    await page.keyboard.press("Tab");
+    await expect(page.getByLabel('Tags for "new task"')).toBeFocused();
 
     // Tabbing away from a non-empty title keeps the row open; Enter on the
     // title still creates the task.

--- a/pwa/components/account/TwoFactorSetupDialog.tsx
+++ b/pwa/components/account/TwoFactorSetupDialog.tsx
@@ -164,7 +164,7 @@ const ScanStep = ({ qrDataUri, secret, onVerified }: ScanStepProps) => (
       <div className="text-center">
         <p className="text-xs text-muted-foreground">Or enter this key manually:</p>
         <code
-          className="text-sm font-mono bg-muted rounded px-2 py-1 inline-block mt-1 select-all"
+          className="text-sm font-mono bg-muted rounded px-2 py-1 inline-block mt-1 max-w-full break-all select-all"
           data-testid="2fa-secret"
         >
           {secret}

--- a/pwa/components/common/Footer.tsx
+++ b/pwa/components/common/Footer.tsx
@@ -97,14 +97,12 @@ const Footer = () => (
               </a>
             </li>
             <li>
-              <a
-                href="https://github.com/roboparker/Aura/issues"
-                target="_blank"
-                rel="noopener noreferrer"
+              <Link
+                href="/feedback"
                 className="text-foreground hover:underline"
               >
-                Report an issue
-              </a>
+                Feedback
+              </Link>
             </li>
           </ul>
         </div>

--- a/pwa/components/common/SidebarNav.tsx
+++ b/pwa/components/common/SidebarNav.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { useEffect, useState, type ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { ChevronDown, Plus } from "lucide-react";
+import { ChevronDown, Plus, ShieldCheck } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
 import { apiGetCollection } from "@/lib/apiClient";
@@ -221,6 +221,101 @@ const ContentSection = ({ section, spaceIri, wrap }: ContentSectionProps) => {
   );
 };
 
+interface AdminLink {
+  href: string;
+  label: string;
+  /** Path prefix used to highlight the active row. */
+  match: string;
+  /** External (Caddy-served) link rendered as a plain <a>. */
+  external?: boolean;
+}
+
+/**
+ * Admin tooling as a collapsible nav section, mirroring {@see ContentSection}:
+ * a colored icon + heading with a persisted collapse chevron, over the static
+ * admin links. Lives inline in the scrollable nav (not pinned to the foot) so
+ * it reads as just another section of the left menu.
+ */
+const AdminSection = ({ wrap }: { wrap: (children: ReactNode) => ReactNode }) => {
+  const router = useRouter();
+
+  const storageKey = "madori.navCollapsed.admin";
+  const [collapsed, setCollapsed] = useState(false);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    setCollapsed(window.localStorage.getItem(storageKey) === "1");
+  }, []);
+
+  const toggle = () =>
+    setCollapsed((c) => {
+      const next = !c;
+      try {
+        window.localStorage.setItem(storageKey, next ? "1" : "0");
+      } catch {
+        // Storage-disabled browsers: state still toggles for the session.
+      }
+      return next;
+    });
+
+  const links: AdminLink[] = [
+    { href: "/admin/users", label: "Users", match: "/admin/users" },
+    { href: "/admin/waitlist", label: "Waitlist", match: "/admin/waitlist" },
+    { href: "/admin/segments", label: "Segments", match: "/admin/segments" },
+    { href: "/feedback", label: "Feedback", match: "/feedback" },
+    ...ADMIN_EXTERNAL_LINKS.map((l) => ({ ...l, match: l.href, external: true })),
+  ];
+
+  return (
+    <div className="mt-3 first:mt-0">
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={!collapsed}
+        aria-label={`${collapsed ? "Expand" : "Collapse"} Admin`}
+        className="flex w-full items-center gap-1.5 px-3 pb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground hover:text-foreground"
+      >
+        <ShieldCheck className="size-3.5 shrink-0 text-amber-600 dark:text-amber-400" />
+        <span className="truncate">Admin</span>
+        <ChevronDown
+          className={cn(
+            "ml-auto size-3.5 transition-transform",
+            collapsed && "-rotate-90",
+          )}
+        />
+      </button>
+
+      {!collapsed &&
+        links.map((link) => {
+          const active = router.pathname.startsWith(link.match);
+          const inner = (
+            <Button
+              asChild
+              variant="ghost"
+              size="sm"
+              className={cn(
+                "w-full min-w-0 justify-start font-normal",
+                active && "bg-accent text-accent-foreground",
+              )}
+            >
+              {link.external ? (
+                <a href={link.href} target="_blank" rel="noopener noreferrer">
+                  {/* pl-5 ≈ heading icon (size-3.5) + gap-1.5, lining the row
+                      text up under the heading label. */}
+                  <span className="truncate pl-5">{link.label}</span>
+                </a>
+              ) : (
+                <Link href={link.href}>
+                  <span className="truncate pl-5">{link.label}</span>
+                </Link>
+              )}
+            </Button>
+          );
+          return <span key={link.href}>{wrap(inner)}</span>;
+        })}
+    </div>
+  );
+};
+
 /**
  * Shared navigation contents used by both the persistent left-side
  * `<Sidebar>` (`md:` and up) and the mobile-only Sheet variant in the
@@ -233,7 +328,6 @@ const SidebarNav = ({
 }: SidebarNavProps) => {
   const { user, isAuthenticated } = useAuth();
   const { activeSpace } = useActiveSpace();
-  const router = useRouter();
   const isAdmin = user?.roles?.includes("ROLE_ADMIN");
   const wrap = itemWrapper ?? ((c) => c);
 
@@ -257,78 +351,9 @@ const SidebarNav = ({
               wrap={wrap}
             />
           ))}
-      </nav>
 
-      {/* Admin tooling is pinned to the foot of the sidebar, below the
-          (scrollable) space content, separated by a divider. */}
-      {isAdmin && (
-        <div className="flex flex-col gap-0.5 border-t px-2 py-3">
-          <p className="px-3 pb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-            Admin
-          </p>
-            <span>
-              {wrap(
-                <Button
-                  asChild
-                  variant="ghost"
-                  size="sm"
-                  className={cn(
-                    "justify-start w-full",
-                    router.pathname.startsWith("/admin/users") &&
-                      "bg-accent text-accent-foreground",
-                  )}
-                >
-                  <Link href="/admin/users">Users</Link>
-                </Button>,
-              )}
-            </span>
-            <span>
-              {wrap(
-                <Button
-                  asChild
-                  variant="ghost"
-                  size="sm"
-                  className={cn(
-                    "justify-start w-full",
-                    router.pathname.startsWith("/admin/waitlist") &&
-                      "bg-accent text-accent-foreground",
-                  )}
-                >
-                  <Link href="/admin/waitlist">Waitlist</Link>
-                </Button>,
-              )}
-            </span>
-            <span>
-              {wrap(
-                <Button
-                  asChild
-                  variant="ghost"
-                  size="sm"
-                  className={cn(
-                    "justify-start w-full",
-                    router.pathname.startsWith("/admin/segments") &&
-                      "bg-accent text-accent-foreground",
-                  )}
-                >
-                  <Link href="/admin/segments">Segments</Link>
-                </Button>,
-              )}
-            </span>
-            {ADMIN_EXTERNAL_LINKS.map(({ href, label }) => (
-              <Button
-                key={href}
-                asChild
-                variant="ghost"
-                size="sm"
-                className="justify-start w-full"
-              >
-                <a href={href} target="_blank" rel="noopener noreferrer">
-                  {label}
-                </a>
-              </Button>
-            ))}
-        </div>
-      )}
+        {isAdmin && <AdminSection wrap={wrap} />}
+      </nav>
     </div>
   );
 };

--- a/pwa/components/common/UserMenu.tsx
+++ b/pwa/components/common/UserMenu.tsx
@@ -4,6 +4,7 @@ import {
   ChevronDown,
   ListChecks,
   LogOut,
+  MessagesSquare,
   Settings,
   Users,
   VenetianMask,
@@ -26,6 +27,7 @@ import { cn } from "@/lib/utils";
 const USER_MENU_LINKS = [
   { href: "/my-tasks", label: "My Tasks", icon: ListChecks },
   { href: "/groups", label: "Manage Groups", icon: Users },
+  { href: "/feedback", label: "Feedback", icon: MessagesSquare },
   { href: "/settings/profile", label: "Settings", icon: Settings },
 ];
 

--- a/pwa/components/custom-fields/CustomFieldFooterRow.tsx
+++ b/pwa/components/custom-fields/CustomFieldFooterRow.tsx
@@ -137,6 +137,8 @@ const CustomFieldFooterRow = ({
         <td className="px-1 py-2" />
         <td className="px-2 py-2" />
         <td className="px-2 py-2" />
+        <td className="px-2 py-2" />
+        <td className="px-2 py-2" />
         {columns.map((def) => {
           const row = valueByDef.get(def["@id"]);
           return (
@@ -158,8 +160,6 @@ const CustomFieldFooterRow = ({
             </td>
           );
         })}
-        <td className="px-2 py-2" />
-        <td className="px-2 py-2" />
         <td className="px-2 py-2" />
       </>
     );

--- a/pwa/components/dev/registry.ts
+++ b/pwa/components/dev/registry.ts
@@ -12,7 +12,8 @@ export type RegistryEntry = {
     | "Discussions"
     | "Custom fields"
     | "Groups"
-    | "Notifications";
+    | "Notifications"
+    | "Feedback";
   description: string;
 };
 
@@ -70,4 +71,5 @@ export const componentRegistry: RegistryEntry[] = [
   { slug: "custom-fields-manager", name: "CustomFieldsManager", category: "Custom fields", description: "Owner-managed list + composer for per-project custom field definitions." },
   { slug: "group-tile", name: "GroupTile", category: "Groups", description: "Square colored tile with a grid glyph for a UserGroup avatar." },
   { slug: "notification-row", name: "NotificationRow", category: "Notifications", description: "Inbox row with unread/read/selected states and hover quick-actions." },
+  { slug: "vote-control", name: "VoteControl", category: "Feedback", description: "Up/down vote control with net score and the caller's own highlighted vote; clear/flip toggle owned by the parent." },
 ];

--- a/pwa/components/feedback/VoteControl.tsx
+++ b/pwa/components/feedback/VoteControl.tsx
@@ -1,0 +1,100 @@
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Up/down vote control for a feedback ticket. Presentational: it renders
+ * the current net score with an up and a down button, highlights the
+ * caller's own vote, and calls `onVote(1 | -1)` — the parent owns the API
+ * round-trip and the optimistic update. Re-clicking the active direction
+ * is the server-side "clear" toggle; the parent just forwards the same
+ * value and the API decides.
+ *
+ * Vertical by default (board row / detail header); pass
+ * `orientation="horizontal"` for a compact inline pill.
+ */
+export interface VoteControlProps {
+  score: number;
+  /** The current user's vote: 1, -1, or 0. */
+  myVote: number;
+  onVote: (value: 1 | -1) => void;
+  disabled?: boolean;
+  orientation?: "vertical" | "horizontal";
+  size?: "sm" | "md";
+}
+
+const VoteControl = ({
+  score,
+  myVote,
+  onVote,
+  disabled = false,
+  orientation = "vertical",
+  size = "md",
+}: VoteControlProps) => {
+  const iconSize = size === "sm" ? "h-4 w-4" : "h-5 w-5";
+  const btnBase =
+    "flex items-center justify-center rounded-md transition-colors disabled:opacity-50 disabled:pointer-events-none hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+  const btnPad = size === "sm" ? "p-0.5" : "p-1";
+
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center select-none",
+        orientation === "vertical" ? "flex-col gap-0.5" : "flex-row gap-1",
+      )}
+      data-testid="vote-control"
+    >
+      <button
+        type="button"
+        onClick={() => onVote(1)}
+        disabled={disabled}
+        aria-pressed={myVote === 1}
+        aria-label="Upvote"
+        className={cn(
+          btnBase,
+          btnPad,
+          myVote === 1
+            ? "text-emerald-600 dark:text-emerald-400"
+            : "text-muted-foreground",
+        )}
+        data-testid="vote-up"
+      >
+        <ChevronUp className={iconSize} />
+      </button>
+
+      <span
+        className={cn(
+          "min-w-6 text-center font-semibold tabular-nums",
+          size === "sm" ? "text-sm" : "text-base",
+          myVote === 1
+            ? "text-emerald-600 dark:text-emerald-400"
+            : myVote === -1
+              ? "text-rose-600 dark:text-rose-400"
+              : "text-foreground",
+        )}
+        data-testid="vote-score"
+      >
+        {score}
+      </span>
+
+      <button
+        type="button"
+        onClick={() => onVote(-1)}
+        disabled={disabled}
+        aria-pressed={myVote === -1}
+        aria-label="Downvote"
+        className={cn(
+          btnBase,
+          btnPad,
+          myVote === -1
+            ? "text-rose-600 dark:text-rose-400"
+            : "text-muted-foreground",
+        )}
+        data-testid="vote-down"
+      >
+        <ChevronDown className={iconSize} />
+      </button>
+    </div>
+  );
+};
+
+export default VoteControl;

--- a/pwa/components/projects/TaskTableColumns.tsx
+++ b/pwa/components/projects/TaskTableColumns.tsx
@@ -5,7 +5,7 @@ import type { CustomFieldDefinition } from "@/components/custom-fields/types";
  * tables and the grand-total bar line up column-for-column. Every table that
  * uses it must be `table-fixed`. Column order mirrors the section table:
  *
- *   checkbox · # · Task · Tags · [custom fields…] · Due · Assignees · actions
+ *   checkbox · # · Task · Due · Assignees · Tags · [custom fields…] · actions
  *
  * The Task column carries no width so `table-fixed` gives it the remaining
  * space; everything else is fixed so the columns are identical across tables.
@@ -19,12 +19,12 @@ const TaskTableColumns = ({
     <col className="w-8" />
     <col className="w-10" />
     <col />
+    <col className="w-32" />
+    <col className="w-44" />
     <col className="w-44" />
     {definitions.map((d) => (
       <col key={d["@id"]} className="w-32" />
     ))}
-    <col className="w-32" />
-    <col className="w-44" />
     <col className="w-10" />
   </colgroup>
 );

--- a/pwa/components/settings/ApiTokensTable.tsx
+++ b/pwa/components/settings/ApiTokensTable.tsx
@@ -17,6 +17,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import CreateApiTokenDialog from "./CreateApiTokenDialog";
+import EditApiTokenDialog from "./EditApiTokenDialog";
 
 const formatDate = (iso: string | null): string =>
   iso ? new Date(iso).toLocaleDateString() : "—";
@@ -31,6 +32,7 @@ const ApiTokensTable = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
+  const [editing, setEditing] = useState<ApiTokenRow | null>(null);
 
   const load = useCallback(async () => {
     setIsLoading(true);
@@ -149,6 +151,15 @@ const ApiTokensTable = () => {
                       type="button"
                       variant="ghost"
                       size="sm"
+                      onClick={() => setEditing(t)}
+                      data-testid="api-token-edit"
+                    >
+                      Edit
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
                       className="text-destructive hover:text-destructive"
                       onClick={() => void revoke(t)}
                       data-testid="api-token-revoke"
@@ -167,6 +178,18 @@ const ApiTokensTable = () => {
         open={createOpen}
         onOpenChange={setCreateOpen}
         onCreated={() => void load()}
+      />
+
+      <EditApiTokenDialog
+        token={editing}
+        onOpenChange={(open) => {
+          if (!open) setEditing(null);
+        }}
+        onSaved={(updated) =>
+          setTokens((prev) =>
+            prev.map((t) => (t["@id"] === updated["@id"] ? updated : t)),
+          )
+        }
       />
     </div>
   );

--- a/pwa/components/settings/CreateApiTokenDialog.tsx
+++ b/pwa/components/settings/CreateApiTokenDialog.tsx
@@ -20,59 +20,12 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
-import PermissionTree, {
-  type PermissionLevel,
-  type PermissionNode,
-} from "@/components/common/PermissionTree";
-
-const LEVELS: PermissionLevel[] = [
-  { value: "none", label: "None" },
-  { value: "view", label: "View" },
-  { value: "edit", label: "Edit" },
-];
-
-const NODES: PermissionNode[] = [
-  {
-    key: "content",
-    label: "Content",
-    description: "tasks, projects, pages, discussions, comments, files",
-    children: [
-      { key: "tasks", label: "Tasks" },
-      { key: "projects", label: "Projects" },
-      { key: "pages", label: "Pages" },
-      { key: "discussions", label: "Discussions" },
-      { key: "comments", label: "Comments" },
-      { key: "files", label: "Files" },
-    ],
-  },
-  {
-    key: "settings",
-    label: "Settings",
-    description: "notifications, profile, security",
-    children: [
-      { key: "notifications", label: "Notifications" },
-      { key: "profile", label: "Profile" },
-      { key: "security", label: "Security" },
-    ],
-  },
-];
-
-const ALL_CATEGORIES = [
-  "tasks",
-  "projects",
-  "pages",
-  "discussions",
-  "comments",
-  "notifications",
-  "files",
-  "profile",
-  "security",
-];
-
-// When a token is restricted, start everything at read-only — a useful,
-// least-surprising baseline the user tightens or loosens.
-const defaultAccess = (): Record<string, string> =>
-  Object.fromEntries(ALL_CATEGORIES.map((c) => [c, "view"]));
+import {
+  TOKEN_PERMISSION_LEVELS,
+  TOKEN_PERMISSION_NODES,
+  defaultTokenAccess,
+} from "@/lib/tokenPermissions";
+import PermissionTree from "@/components/common/PermissionTree";
 
 interface CreateApiTokenDialogProps {
   open: boolean;
@@ -89,7 +42,7 @@ const CreateApiTokenDialog = ({
   const [name, setName] = useState("");
   const [expiry, setExpiry] = useState("90");
   const [restricted, setRestricted] = useState(false);
-  const [access, setAccess] = useState<Record<string, string>>(defaultAccess);
+  const [access, setAccess] = useState<Record<string, string>>(defaultTokenAccess);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [created, setCreated] = useState<CreatedApiToken | null>(null);
@@ -99,7 +52,7 @@ const CreateApiTokenDialog = ({
     setName("");
     setExpiry("90");
     setRestricted(false);
-    setAccess(defaultAccess());
+    setAccess(defaultTokenAccess());
     setError(null);
     setCreated(null);
     setCopied(false);
@@ -246,8 +199,8 @@ const CreateApiTokenDialog = ({
               {restricted ? (
                 <div className="rounded-md border p-3">
                   <PermissionTree
-                    levels={LEVELS}
-                    nodes={NODES}
+                    levels={TOKEN_PERMISSION_LEVELS}
+                    nodes={TOKEN_PERMISSION_NODES}
                     values={access}
                     masterLabel="Token can access"
                     onChange={setAccess}

--- a/pwa/components/settings/CreateApiTokenDialog.tsx
+++ b/pwa/components/settings/CreateApiTokenDialog.tsx
@@ -154,14 +154,14 @@ const CreateApiTokenDialog = ({
                 Madori stores only a hash and can&apos;t display it again.
               </DialogDescription>
             </DialogHeader>
-            <div className="flex items-center gap-2 rounded-md border bg-muted/40 p-2">
+            <div className="flex items-start gap-2 rounded-md border bg-muted/40 p-2">
               <code
-                className="min-w-0 flex-1 truncate font-mono text-sm"
+                className="min-w-0 flex-1 break-all font-mono text-sm leading-relaxed"
                 data-testid="api-token-plaintext"
               >
                 {created.plainToken}
               </code>
-              <Button type="button" size="sm" variant="outline" onClick={() => void copyToken()}>
+              <Button type="button" size="sm" variant="outline" className="shrink-0" onClick={() => void copyToken()}>
                 {copied ? (
                   <>
                     <Check className="mr-1 h-3.5 w-3.5" /> Copied

--- a/pwa/components/settings/EditApiTokenDialog.tsx
+++ b/pwa/components/settings/EditApiTokenDialog.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+import {
+  updateApiToken,
+  type ApiTokenRow,
+  type TokenAccessPolicy,
+} from "@/lib/apiTokens";
+import {
+  TOKEN_PERMISSION_LEVELS,
+  TOKEN_PERMISSION_NODES,
+  defaultTokenAccess,
+} from "@/lib/tokenPermissions";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Switch } from "@/components/ui/switch";
+import PermissionTree from "@/components/common/PermissionTree";
+
+interface EditApiTokenDialogProps {
+  /** The token to edit, or null when the dialog is closed. */
+  token: ApiTokenRow | null;
+  onOpenChange: (open: boolean) => void;
+  /** Called with the updated token so the table can refresh in place. */
+  onSaved: (token: ApiTokenRow) => void;
+}
+
+/**
+ * Edits an existing token's permissions. The secret is immutable — this only
+ * touches the access policy (the same none/view/edit category tree as the
+ * create flow). Per-item overrides that may already exist on the policy are
+ * preserved untouched; only the category grants are editable here.
+ */
+const EditApiTokenDialog = ({
+  token,
+  onOpenChange,
+  onSaved,
+}: EditApiTokenDialogProps) => {
+  const [restricted, setRestricted] = useState(false);
+  const [access, setAccess] = useState<Record<string, string>>(defaultTokenAccess);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Seed the form from the token each time the dialog opens for a new row.
+  useEffect(() => {
+    if (!token) return;
+    const policy = token.accessPolicy;
+    setRestricted(policy !== null);
+    setAccess(
+      policy
+        ? { ...defaultTokenAccess(), ...policy.categories }
+        : defaultTokenAccess(),
+    );
+    setError(null);
+  }, [token]);
+
+  const save = async () => {
+    if (!token) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      // Keep any per-item overrides the policy already carried; only the
+      // category grants are editable from this dialog.
+      const items = token.accessPolicy?.items ?? {};
+      const nextPolicy: TokenAccessPolicy | null = restricted
+        ? { categories: access, items }
+        : null;
+      const updated = await updateApiToken(token["@id"], {
+        accessPolicy: nextPolicy,
+      });
+      onSaved(updated);
+      onOpenChange(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update token.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={token !== null} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit token permissions</DialogTitle>
+          <DialogDescription>
+            Adjust what{" "}
+            <span className="font-medium text-foreground">{token?.name}</span>{" "}
+            can do. The secret itself can&apos;t be changed — revoke and
+            re-create to rotate it.
+          </DialogDescription>
+        </DialogHeader>
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <p className="text-sm font-medium">Restrict permissions</p>
+              <p className="text-xs text-muted-foreground">
+                Off = the token can do everything you can. On = limit it per
+                category.
+              </p>
+            </div>
+            <Switch
+              checked={restricted}
+              onCheckedChange={setRestricted}
+              aria-label="Restrict token permissions"
+              data-testid="edit-api-token-restrict"
+            />
+          </div>
+          {restricted ? (
+            <div className="rounded-md border p-3">
+              <PermissionTree
+                levels={TOKEN_PERMISSION_LEVELS}
+                nodes={TOKEN_PERMISSION_NODES}
+                values={access}
+                masterLabel="Token can access"
+                onChange={setAccess}
+              />
+            </div>
+          ) : null}
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={() => void save()}
+            disabled={submitting}
+            data-testid="edit-api-token-save"
+          >
+            {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : "Save changes"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default EditApiTokenDialog;

--- a/pwa/components/settings/UsageSummary.tsx
+++ b/pwa/components/settings/UsageSummary.tsx
@@ -8,6 +8,7 @@ interface Usage {
   freeMcpDailyLimit: number;
   remaining: number | null;
   entitled: boolean;
+  admin: boolean;
   enforcementEnabled: boolean;
 }
 
@@ -42,7 +43,10 @@ const UsageSummary = () => {
 
   if (!usage) return null;
 
-  const unlimited = usage.entitled;
+  // Admins are uncapped but we still surface today's count so their usage
+  // stays visible; entitled (Team) members get the plain "Unlimited" state.
+  const adminUncapped = usage.admin && !usage.entitled;
+  const unlimited = usage.entitled || usage.admin;
   const used = usage.mcpCallsToday;
   const limit = usage.freeMcpDailyLimit;
   const pct = unlimited ? 0 : Math.min(100, Math.round((used / Math.max(1, limit)) * 100));
@@ -55,7 +59,15 @@ const UsageSummary = () => {
           <Gauge className="h-4 w-4 text-muted-foreground" aria-hidden />
           MCP usage today
         </p>
-        {unlimited ? (
+        {adminUncapped ? (
+          <span className="inline-flex items-center gap-1.5 text-sm font-medium">
+            <span className="tabular-nums text-foreground">{used} today</span>
+            <span className="inline-flex items-center gap-1 text-violet-600">
+              <InfinityIcon className="h-4 w-4" aria-hidden />
+              No limit
+            </span>
+          </span>
+        ) : unlimited ? (
           <span className="inline-flex items-center gap-1 text-sm font-medium text-violet-600">
             <InfinityIcon className="h-4 w-4" aria-hidden />
             Unlimited
@@ -92,7 +104,9 @@ const UsageSummary = () => {
       )}
       {unlimited && (
         <p className="mt-2 text-xs text-muted-foreground">
-          You&apos;re on a Team space — unlimited MCP &amp; API throughput.
+          {usage.entitled
+            ? "You're on a Team space — unlimited MCP & API throughput."
+            : "Admin account — no MCP cap. Today's calls are still tracked above."}
         </p>
       )}
     </div>

--- a/pwa/contexts/AuthContext.tsx
+++ b/pwa/contexts/AuthContext.tsx
@@ -492,6 +492,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       { credentials: "include" },
     );
     if (!res.ok) {
+      // A 403 here means the target hasn't opted in to impersonation — the
+      // firewall denies the switch (ImpersonationVoter). The response is an
+      // HTML error page, not JSON, so surface a clear, actionable message
+      // instead of the generic fallback. Switch-out ("_exit") never hits
+      // the consent check, so this only fires when starting one.
+      if (res.status === 403) {
+        throw new Error(
+          "This user hasn't enabled impersonation. They need to turn on " +
+            "“Allow administrators to impersonate me” under Settings → " +
+            "Security before you can switch into their account.",
+        );
+      }
       const data = await res.json().catch(() => ({}));
       throw new Error(data.error || data.detail || "Couldn't switch user.");
     }

--- a/pwa/lib/apiTokens.ts
+++ b/pwa/lib/apiTokens.ts
@@ -81,6 +81,28 @@ export const createApiToken = async (input: {
   return res.json();
 };
 
+export const updateApiToken = async (
+  iri: string,
+  patch: Partial<Pick<ApiTokenRow, "name" | "accessPolicy" | "expiresAt">>,
+): Promise<ApiTokenRow> => {
+  const res = await fetch(`${ENTRYPOINT}${iri}`, {
+    method: "PATCH",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/merge-patch+json",
+      Accept: "application/ld+json",
+    },
+    body: JSON.stringify(patch),
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(
+      data["hydra:description"] || data.detail || "Failed to update token.",
+    );
+  }
+  return res.json();
+};
+
 export const revokeApiToken = async (iri: string): Promise<void> => {
   const res = await fetch(`${ENTRYPOINT}${iri}`, {
     method: "DELETE",

--- a/pwa/lib/feedbackTypes.ts
+++ b/pwa/lib/feedbackTypes.ts
@@ -1,0 +1,115 @@
+import type { AvatarUser } from "@/components/user/UserAvatar";
+
+/**
+ * Shared types + display metadata for the in-app feedback board. The
+ * server is the source of truth for the allowed values (App\Entity\Feedback);
+ * these mirror them for the PWA. Kept free of any `node:` imports so it's
+ * safe to import from client components.
+ */
+
+export type FeedbackType = "bug" | "feature";
+
+export type FeedbackStatus =
+  | "open"
+  | "planned"
+  | "in_progress"
+  | "shipped"
+  | "declined";
+
+/** The ticket owner, embedded under feedback:read for chip rendering. */
+export type FeedbackOwner = AvatarUser & { "@id": string; id: string };
+
+export interface Feedback {
+  "@id": string;
+  id: string;
+  ticketNumber: number;
+  title: string;
+  description: string;
+  type: FeedbackType;
+  status: FeedbackStatus;
+  owner: FeedbackOwner;
+  createdAt: string;
+  updatedAt: string | null;
+  /** Net vote score (sum of +1 / -1). */
+  score: number;
+  /** The current user's own vote: 1, -1, or 0. */
+  myVote: number;
+  commentCount: number;
+}
+
+export const TYPE_ORDER: FeedbackType[] = ["bug", "feature"];
+
+export const TYPE_META: Record<
+  FeedbackType,
+  { label: string; badgeClass: string }
+> = {
+  bug: {
+    label: "Bug",
+    badgeClass:
+      "bg-rose-100 text-rose-700 dark:bg-rose-950 dark:text-rose-300",
+  },
+  feature: {
+    label: "Feature",
+    badgeClass:
+      "bg-violet-100 text-violet-700 dark:bg-violet-950 dark:text-violet-300",
+  },
+};
+
+export const STATUS_ORDER: FeedbackStatus[] = [
+  "open",
+  "planned",
+  "in_progress",
+  "shipped",
+  "declined",
+];
+
+export const STATUS_META: Record<
+  FeedbackStatus,
+  { label: string; badgeClass: string }
+> = {
+  open: {
+    label: "Open",
+    badgeClass:
+      "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300",
+  },
+  planned: {
+    label: "Planned",
+    badgeClass:
+      "bg-sky-100 text-sky-700 dark:bg-sky-950 dark:text-sky-300",
+  },
+  in_progress: {
+    label: "In progress",
+    badgeClass:
+      "bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-300",
+  },
+  shipped: {
+    label: "Shipped",
+    badgeClass:
+      "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300",
+  },
+  declined: {
+    label: "Declined",
+    badgeClass:
+      "bg-rose-100 text-rose-700 dark:bg-rose-950 dark:text-rose-300",
+  },
+};
+
+export const typeLabel = (t: FeedbackType): string => TYPE_META[t].label;
+export const statusLabel = (s: FeedbackStatus): string => STATUS_META[s].label;
+
+/** Relative-time formatter shared by the board + detail surfaces. */
+const RELATIVE = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+
+export const formatRelative = (iso: string): string => {
+  const ts = new Date(iso).getTime();
+  if (Number.isNaN(ts)) return "";
+  const diffSec = Math.round((ts - Date.now()) / 1000);
+  const abs = Math.abs(diffSec);
+  if (abs < 60) return RELATIVE.format(diffSec, "second");
+  if (abs < 3600) return RELATIVE.format(Math.round(diffSec / 60), "minute");
+  if (abs < 86400) return RELATIVE.format(Math.round(diffSec / 3600), "hour");
+  if (abs < 2592000) return RELATIVE.format(Math.round(diffSec / 86400), "day");
+  if (abs < 31536000)
+    return RELATIVE.format(Math.round(diffSec / 2592000), "month");
+  return RELATIVE.format(Math.round(diffSec / 31536000), "year");
+};

--- a/pwa/lib/tokenPermissions.ts
+++ b/pwa/lib/tokenPermissions.ts
@@ -1,0 +1,58 @@
+import type {
+  PermissionLevel,
+  PermissionNode,
+} from "@/components/common/PermissionTree";
+
+/**
+ * Shared permission config for the API-token create + edit dialogs. Both the
+ * "Generate token" and "Edit permissions" flows render the same none/view/edit
+ * tree, so the level + node definitions live here rather than being duplicated.
+ */
+export const TOKEN_PERMISSION_LEVELS: PermissionLevel[] = [
+  { value: "none", label: "None" },
+  { value: "view", label: "View" },
+  { value: "edit", label: "Edit" },
+];
+
+export const TOKEN_PERMISSION_NODES: PermissionNode[] = [
+  {
+    key: "content",
+    label: "Content",
+    description: "tasks, projects, pages, discussions, comments, files",
+    children: [
+      { key: "tasks", label: "Tasks" },
+      { key: "projects", label: "Projects" },
+      { key: "pages", label: "Pages" },
+      { key: "discussions", label: "Discussions" },
+      { key: "comments", label: "Comments" },
+      { key: "files", label: "Files" },
+    ],
+  },
+  {
+    key: "settings",
+    label: "Settings",
+    description: "notifications, profile, security",
+    children: [
+      { key: "notifications", label: "Notifications" },
+      { key: "profile", label: "Profile" },
+      { key: "security", label: "Security" },
+    ],
+  },
+];
+
+export const TOKEN_CATEGORIES = [
+  "tasks",
+  "projects",
+  "pages",
+  "discussions",
+  "comments",
+  "notifications",
+  "files",
+  "profile",
+  "security",
+];
+
+// When a token is restricted, start everything at read-only — a useful,
+// least-surprising baseline the user tightens or loosens.
+export const defaultTokenAccess = (): Record<string, string> =>
+  Object.fromEntries(TOKEN_CATEGORIES.map((c) => [c, "view"]));

--- a/pwa/pages/admin/users.tsx
+++ b/pwa/pages/admin/users.tsx
@@ -37,6 +37,8 @@ interface AdminUser {
   personalizedColor: string;
   avatarUrls?: { thumb?: string; profile?: string } | null;
   roles?: string[];
+  /** Whether this user has opted in to admin impersonation. */
+  canBeImpersonated?: boolean;
 }
 
 const isAdminUser = (u: AdminUser): boolean =>
@@ -171,6 +173,8 @@ const AdminUsers: NextPage = () => {
               <div className="space-y-2">
                 {visible.map((u) => {
                   const isSelf = u.id === user?.id;
+                  const optedIn = u.canBeImpersonated === true;
+                  const canImpersonate = !isSelf && optedIn;
                   return (
                     <div
                       key={u.id}
@@ -191,13 +195,27 @@ const AdminUsers: NextPage = () => {
                           {u.email}
                         </p>
                       </div>
+                      {!isSelf && !optedIn && (
+                        <span
+                          className="hidden text-xs text-muted-foreground sm:inline"
+                          data-testid="users-impersonation-disabled"
+                        >
+                          This user has not enabled impersonation
+                        </span>
+                      )}
                       <Button
                         variant="ghost"
                         size="icon"
-                        disabled={isSelf}
+                        disabled={!canImpersonate}
                         onClick={() => setTarget(u)}
                         aria-label={`Impersonate ${displayName(u)}`}
-                        title={isSelf ? "That's you" : "Impersonate"}
+                        title={
+                          isSelf
+                            ? "That's you"
+                            : optedIn
+                              ? "Impersonate"
+                              : "This user has not enabled impersonation"
+                        }
                         data-testid="users-impersonate"
                       >
                         <VenetianMask className="h-4 w-4" />

--- a/pwa/pages/dev/components/footer.tsx
+++ b/pwa/pages/dev/components/footer.tsx
@@ -4,7 +4,7 @@ import ComponentDoc from "@/components/dev/ComponentDoc";
 const FooterPage = () => (
   <ComponentDoc
     name="Footer"
-    description="Static site footer rendered at the bottom of the app shell by Layout. Three link columns — Product (Home, Guides, Privacy, Terms), Developers (API reference, API guide, Architecture, Component library), and Project (GitHub, Report an issue) — over an AGPL-3.0 license line. No props."
+    description="Static site footer rendered at the bottom of the app shell by Layout. Three link columns — Product (Home, Guides, Privacy, Terms), Developers (API reference, API guide, Architecture, Component library), and Project (GitHub, Feedback) — over an AGPL-3.0 license line. No props."
     importPath={`import Footer from "@/components/common/Footer";`}
     examples={[
       {

--- a/pwa/pages/dev/components/vote-control.tsx
+++ b/pwa/pages/dev/components/vote-control.tsx
@@ -1,0 +1,67 @@
+import { useState } from "react";
+import VoteControl from "@/components/feedback/VoteControl";
+import ComponentDoc from "@/components/dev/ComponentDoc";
+
+/**
+ * Interactive demo wrapper — the control is presentational, so the doc
+ * owns the vote state to show the toggle (re-click clears, opposite
+ * flips) the way the feedback pages drive it against the API.
+ */
+const Demo = ({
+  orientation,
+  size,
+}: {
+  orientation?: "vertical" | "horizontal";
+  size?: "sm" | "md";
+}) => {
+  const [myVote, setMyVote] = useState(0);
+  const [score, setScore] = useState(12);
+
+  const vote = (value: 1 | -1) => {
+    if (myVote === value) {
+      setScore((s) => s - value);
+      setMyVote(0);
+    } else {
+      setScore((s) => s - myVote + value);
+      setMyVote(value);
+    }
+  };
+
+  return (
+    <VoteControl
+      score={score}
+      myVote={myVote}
+      onVote={vote}
+      orientation={orientation}
+      size={size}
+    />
+  );
+};
+
+const VoteControlPage = () => (
+  <ComponentDoc
+    name="VoteControl"
+    description="Up/down vote control for a feedback ticket. Presentational: it shows the net score and highlights the caller's own vote, calling onVote(1 | -1) — the parent owns the API round-trip and the clear/flip toggle. Vertical by default; horizontal for a compact inline pill."
+    importPath={`import VoteControl from "@/components/feedback/VoteControl";`}
+    examples={[
+      {
+        title: "Vertical (default)",
+        description: "Click the same arrow twice to clear; the opposite arrow flips.",
+        code: `<VoteControl score={score} myVote={myVote} onVote={vote} />`,
+        preview: (
+          <div className="flex items-center gap-8">
+            <Demo />
+            <Demo size="sm" />
+          </div>
+        ),
+      },
+      {
+        title: "Horizontal",
+        code: `<VoteControl orientation="horizontal" score={score} myVote={myVote} onVote={vote} />`,
+        preview: <Demo orientation="horizontal" />,
+      },
+    ]}
+  />
+);
+
+export default VoteControlPage;

--- a/pwa/pages/feedback/[id].tsx
+++ b/pwa/pages/feedback/[id].tsx
@@ -1,0 +1,466 @@
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useCallback, useEffect, useState } from "react";
+import { ArrowLeft, MessageSquare, Pencil, Trash2 } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { signinHrefForCurrent } from "@/lib/authRedirect";
+import { ApiError, apiGet, apiGetCollection, apiSend } from "@/lib/apiClient";
+import { displayName } from "@/lib/userDisplay";
+import {
+  STATUS_META,
+  STATUS_ORDER,
+  TYPE_META,
+  TYPE_ORDER,
+  formatRelative,
+  type Feedback,
+  type FeedbackStatus,
+  type FeedbackType,
+} from "@/lib/feedbackTypes";
+import VoteControl from "@/components/feedback/VoteControl";
+import MarkdownEditor from "@/components/editor/MarkdownEditor";
+import MarkdownView from "@/components/editor/MarkdownView";
+import UserAvatar from "@/components/user/UserAvatar";
+import CommentsPanel, {
+  type Comment as CommentRow,
+} from "@/components/common/CommentsPanel";
+import { useCommentLiveUpdates } from "@/lib/useCommentLiveUpdates";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+
+const FeedbackDetailPage = () => {
+  const { user, isAuthenticated, isLoading: authLoading } = useAuth();
+  const router = useRouter();
+  const { id } = router.query;
+  const fid = typeof id === "string" ? id : null;
+
+  const [ticket, setTicket] = useState<Feedback | null>(null);
+  const [comments, setComments] = useState<CommentRow[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [editing, setEditing] = useState(false);
+  const [editTitle, setEditTitle] = useState("");
+  const [editType, setEditType] = useState<FeedbackType>("feature");
+  const [editBody, setEditBody] = useState("");
+  const [editorKey, setEditorKey] = useState(0);
+  const [savingEdit, setSavingEdit] = useState(false);
+  const [editError, setEditError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) {
+      router.replace(signinHrefForCurrent(router.asPath));
+    }
+  }, [authLoading, isAuthenticated, router]);
+
+  const load = useCallback(async () => {
+    if (!fid) return;
+    setError(null);
+    setIsLoading(true);
+    try {
+      const data = await apiGet<Feedback>(`/feedback/${encodeURIComponent(fid)}`);
+      setTicket(data);
+      const rows = await apiGetCollection<CommentRow>(
+        `/comments?feedback=${encodeURIComponent(data["@id"])}&itemsPerPage=100`,
+      );
+      setComments(rows);
+    } catch (err) {
+      if (err instanceof ApiError && (err.status === 404 || err.status === 403)) {
+        setNotFound(true);
+        return;
+      }
+      setError(err instanceof Error ? err.message : "Failed to load.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [fid]);
+
+  useEffect(() => {
+    if (isAuthenticated && fid) void load();
+  }, [isAuthenticated, fid, load]);
+
+  const patch = useCallback(
+    async (body: Partial<Pick<Feedback, "title" | "type" | "status">> & { description?: string }) => {
+      if (!ticket) return null;
+      const updated = await apiSend<Feedback>("PATCH", ticket["@id"], {
+        body,
+        contentType: "application/merge-patch+json",
+        errorMessage: "Failed to update.",
+      });
+      if (updated) setTicket(updated);
+      return updated;
+    },
+    [ticket],
+  );
+
+  const handleVote = async (value: 1 | -1) => {
+    if (!ticket) return;
+    try {
+      const res = await apiSend<{ score: number; myVote: number }>(
+        "POST",
+        `/feedback/${ticket.id}/vote`,
+        { body: { value }, errorMessage: "Failed to vote." },
+      );
+      if (res) setTicket({ ...ticket, score: res.score, myVote: res.myVote });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to vote.");
+    }
+  };
+
+  const startEdit = () => {
+    if (!ticket) return;
+    setEditTitle(ticket.title);
+    setEditType(ticket.type);
+    setEditBody(ticket.description);
+    setEditorKey((k) => k + 1);
+    setEditing(true);
+    setEditError(null);
+  };
+
+  const saveEdit = async () => {
+    const trimTitle = editTitle.trim();
+    const trimBody = editBody.trim();
+    if (!trimTitle || !trimBody) return;
+    setSavingEdit(true);
+    setEditError(null);
+    try {
+      await patch({ title: trimTitle, type: editType, description: editBody });
+      setEditing(false);
+    } catch (err) {
+      setEditError(err instanceof Error ? err.message : "Failed to save.");
+    } finally {
+      setSavingEdit(false);
+    }
+  };
+
+  const changeStatus = async (status: FeedbackStatus) => {
+    setBusy(true);
+    setError(null);
+    try {
+      await patch({ status });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update status.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const remove = async () => {
+    if (!ticket) return;
+    if (!window.confirm(`Delete "${ticket.title}"? This can't be undone.`)) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await apiSend("DELETE", ticket["@id"], { errorMessage: "Failed to delete." });
+      void router.replace("/feedback");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete.");
+      setBusy(false);
+    }
+  };
+
+  // --- Comments ---
+  const handleCreateComment = async (body: string): Promise<void> => {
+    if (!ticket) return;
+    const created = await apiSend<CommentRow>("POST", "/comments", {
+      body: { feedback: ticket["@id"], body },
+      errorMessage: "Failed to post comment.",
+    });
+    if (created) {
+      setComments((prev) =>
+        prev.some((c) => c["@id"] === created["@id"]) ? prev : [...prev, created],
+      );
+    }
+  };
+
+  const handleEditComment = async (comment: CommentRow, body: string): Promise<void> => {
+    const updated = await apiSend<CommentRow>("PATCH", comment["@id"], {
+      body: { body },
+      contentType: "application/merge-patch+json",
+      errorMessage: "Failed to save comment.",
+    });
+    if (updated) {
+      setComments((prev) => prev.map((c) => (c["@id"] === updated["@id"] ? updated : c)));
+    }
+  };
+
+  const handleDeleteComment = async (comment: CommentRow): Promise<void> => {
+    await apiSend("DELETE", comment["@id"], { errorMessage: "Failed to delete comment." });
+    setComments((prev) => prev.filter((c) => c["@id"] !== comment["@id"]));
+  };
+
+  useCommentLiveUpdates(ticket?.["@id"] ?? null, !!ticket, (event) => {
+    if (event.type === "delete") {
+      setComments((prev) => prev.filter((c) => c["@id"] !== event.id));
+      return;
+    }
+    const incoming = event.comment as unknown as CommentRow;
+    setComments((prev) => {
+      const idx = prev.findIndex((c) => c["@id"] === incoming["@id"]);
+      if (idx === -1) {
+        if (event.type !== "create") return prev;
+        return [...prev, incoming];
+      }
+      const next = [...prev];
+      next[idx] = incoming;
+      return next;
+    });
+  });
+
+  if (authLoading || !user) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-muted">
+        <p className="text-muted-foreground">Loading…</p>
+      </div>
+    );
+  }
+
+  const isAdmin = !!user.roles?.includes("ROLE_ADMIN");
+  const currentUserIri = `/users/${user.id}`;
+  const isOwner = !!ticket && ticket.owner["@id"] === currentUserIri;
+  const canEdit = isOwner || isAdmin;
+  const canDelete = isOwner || isAdmin;
+
+  return (
+    <>
+      <Head>
+        <title>
+          {ticket ? `${ticket.title} - Madori` : "Feedback - Madori"}
+        </title>
+      </Head>
+      <main className="min-h-screen bg-muted">
+        <div className="max-w-3xl mx-auto px-4 py-8 space-y-4">
+          <Button asChild variant="link" size="sm" className="px-0 h-auto">
+            <Link href="/feedback" data-testid="feedback-back-link">
+              <ArrowLeft className="h-3.5 w-3.5 mr-1" /> Feedback
+            </Link>
+          </Button>
+
+          {notFound ? (
+            <Card>
+              <CardContent className="pt-6">
+                <p className="text-muted-foreground">
+                  Feedback not found, or you don&apos;t have access.
+                </p>
+                <Button asChild variant="link" className="px-0">
+                  <Link href="/feedback">Back to feedback</Link>
+                </Button>
+              </CardContent>
+            </Card>
+          ) : isLoading || !ticket ? (
+            <p className="text-muted-foreground">Loading…</p>
+          ) : (
+            <div className="space-y-4" data-testid="feedback-detail">
+              <div className="flex items-start gap-4">
+                <VoteControl
+                  score={ticket.score}
+                  myVote={ticket.myVote}
+                  onVote={(v) => void handleVote(v)}
+                />
+                <div className="min-w-0 flex-1 space-y-2">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-xs font-medium text-muted-foreground tabular-nums">
+                      #{ticket.ticketNumber}
+                    </span>
+                    <Badge className={cn("border-0", TYPE_META[ticket.type].badgeClass)}>
+                      {TYPE_META[ticket.type].label}
+                    </Badge>
+                    <Badge className={cn("border-0", STATUS_META[ticket.status].badgeClass)}>
+                      {STATUS_META[ticket.status].label}
+                    </Badge>
+                  </div>
+                  {!editing && (
+                    <h1
+                      className="text-2xl font-bold leading-tight"
+                      data-testid="feedback-detail-title"
+                    >
+                      {ticket.title}
+                    </h1>
+                  )}
+                  <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
+                    <span className="flex items-center gap-2">
+                      <UserAvatar user={ticket.owner} size="sm" />
+                      <span className="font-medium text-foreground">
+                        {displayName(ticket.owner)}
+                      </span>
+                    </span>
+                    <span>filed {formatRelative(ticket.createdAt)}</span>
+                    {ticket.updatedAt && (
+                      <span className="italic">· edited {formatRelative(ticket.updatedAt)}</span>
+                    )}
+                    <span className="flex items-center gap-1">
+                      <MessageSquare className="h-3.5 w-3.5" />
+                      {comments.length} {comments.length === 1 ? "comment" : "comments"}
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              {/* Body / edit */}
+              <Card>
+                <CardContent className="pt-6 space-y-4">
+                  {!editing ? (
+                    <MarkdownView source={ticket.description} className="text-sm" />
+                  ) : (
+                    <div className="space-y-3">
+                      <div className="space-y-1.5">
+                        <Label>Type</Label>
+                        <div className="flex gap-2">
+                          {TYPE_ORDER.map((t) => (
+                            <button
+                              key={t}
+                              type="button"
+                              onClick={() => setEditType(t)}
+                              className={cn(
+                                "rounded-md border px-3 py-1.5 text-sm font-medium transition-colors",
+                                editType === t
+                                  ? "border-cyan-700 bg-cyan-700 text-white"
+                                  : "border-input bg-background hover:bg-accent",
+                              )}
+                            >
+                              {TYPE_META[t].label}
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                      <div className="space-y-1.5">
+                        <Label htmlFor="edit-title">Title</Label>
+                        <Input
+                          id="edit-title"
+                          value={editTitle}
+                          onChange={(e) => setEditTitle(e.target.value)}
+                          maxLength={200}
+                          required
+                        />
+                      </div>
+                      <MarkdownEditor
+                        key={editorKey}
+                        ariaLabel="Edit feedback description"
+                        value={editBody}
+                        onChange={setEditBody}
+                      />
+                      {editError && (
+                        <Alert variant="destructive">
+                          <AlertDescription>{editError}</AlertDescription>
+                        </Alert>
+                      )}
+                      <div className="flex gap-2">
+                        <Button
+                          type="button"
+                          size="sm"
+                          onClick={() => void saveEdit()}
+                          disabled={savingEdit || !editTitle.trim() || !editBody.trim()}
+                          data-testid="feedback-save-edit"
+                        >
+                          {savingEdit ? "Saving…" : "Save"}
+                        </Button>
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="outline"
+                          onClick={() => setEditing(false)}
+                          disabled={savingEdit}
+                        >
+                          Cancel
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+
+              {error && (
+                <Alert variant="destructive">
+                  <AlertDescription>{error}</AlertDescription>
+                </Alert>
+              )}
+
+              {/* Manage toolbar */}
+              {!editing && (canEdit || canDelete || isAdmin) && (
+                <div
+                  className="flex flex-wrap items-center gap-2 rounded-lg border border-border bg-background px-3 py-2"
+                  data-testid="feedback-manage"
+                >
+                  <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                    Manage
+                  </span>
+                  {canEdit && (
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      onClick={startEdit}
+                      disabled={busy}
+                      data-testid="feedback-edit"
+                    >
+                      <Pencil className="h-3.5 w-3.5 mr-1" /> Edit
+                    </Button>
+                  )}
+                  {isAdmin && (
+                    <label className="flex items-center gap-1.5 text-sm">
+                      <span className="text-muted-foreground">Status</span>
+                      <select
+                        value={ticket.status}
+                        onChange={(e) => void changeStatus(e.target.value as FeedbackStatus)}
+                        disabled={busy}
+                        className="h-8 rounded-md border border-input bg-background px-2 text-sm"
+                        data-testid="feedback-status-select"
+                        aria-label="Change status"
+                      >
+                        {STATUS_ORDER.map((s) => (
+                          <option key={s} value={s}>
+                            {STATUS_META[s].label}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  )}
+                  {canDelete && (
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => void remove()}
+                      disabled={busy}
+                      className="ml-auto text-destructive hover:text-destructive"
+                      data-testid="feedback-delete"
+                    >
+                      <Trash2 className="h-3.5 w-3.5 mr-1" /> Delete
+                    </Button>
+                  )}
+                </div>
+              )}
+
+              {/* Comments */}
+              <section className="space-y-3 pt-2">
+                <h2 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  <MessageSquare className="h-3.5 w-3.5" />
+                  {comments.length} {comments.length === 1 ? "comment" : "comments"}
+                </h2>
+                <CommentsPanel
+                  parentLabel={ticket.title}
+                  comments={comments}
+                  isLoading={false}
+                  currentUserIri={currentUserIri}
+                  canModerate={isAdmin}
+                  onCreate={handleCreateComment}
+                  onEdit={handleEditComment}
+                  onDelete={handleDeleteComment}
+                />
+              </section>
+            </div>
+          )}
+        </div>
+      </main>
+    </>
+  );
+};
+
+export default FeedbackDetailPage;

--- a/pwa/pages/feedback/[id].tsx
+++ b/pwa/pages/feedback/[id].tsx
@@ -2,7 +2,7 @@ import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useState } from "react";
-import { ArrowLeft, MessageSquare, Pencil, Trash2 } from "lucide-react";
+import { MessageSquare, Pencil, Trash2 } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { signinHrefForCurrent } from "@/lib/authRedirect";
 import { ApiError, apiGet, apiGetCollection, apiSend } from "@/lib/apiClient";
@@ -237,12 +237,6 @@ const FeedbackDetailPage = () => {
       </Head>
       <main className="min-h-screen bg-muted">
         <div className="max-w-3xl mx-auto px-4 py-8 space-y-4">
-          <Button asChild variant="link" size="sm" className="px-0 h-auto">
-            <Link href="/feedback" data-testid="feedback-back-link">
-              <ArrowLeft className="h-3.5 w-3.5 mr-1" /> Feedback
-            </Link>
-          </Button>
-
           {notFound ? (
             <Card>
               <CardContent className="pt-6">
@@ -284,22 +278,6 @@ const FeedbackDetailPage = () => {
                       {ticket.title}
                     </h1>
                   )}
-                  <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
-                    <span className="flex items-center gap-2">
-                      <UserAvatar user={ticket.owner} size="sm" />
-                      <span className="font-medium text-foreground">
-                        {displayName(ticket.owner)}
-                      </span>
-                    </span>
-                    <span>filed {formatRelative(ticket.createdAt)}</span>
-                    {ticket.updatedAt && (
-                      <span className="italic">· edited {formatRelative(ticket.updatedAt)}</span>
-                    )}
-                    <span className="flex items-center gap-1">
-                      <MessageSquare className="h-3.5 w-3.5" />
-                      {comments.length} {comments.length === 1 ? "comment" : "comments"}
-                    </span>
-                  </div>
                 </div>
               </div>
 
@@ -307,7 +285,25 @@ const FeedbackDetailPage = () => {
               <Card>
                 <CardContent className="pt-6 space-y-4">
                   {!editing ? (
-                    <MarkdownView source={ticket.description} className="text-sm" />
+                    <>
+                      <MarkdownView source={ticket.description} className="text-sm" />
+                      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-t pt-3 text-sm text-muted-foreground">
+                        <span className="flex items-center gap-2">
+                          <UserAvatar user={ticket.owner} size="sm" />
+                          <span className="font-medium text-foreground">
+                            {displayName(ticket.owner)}
+                          </span>
+                        </span>
+                        <span>filed {formatRelative(ticket.createdAt)}</span>
+                        {ticket.updatedAt && (
+                          <span className="italic">· edited {formatRelative(ticket.updatedAt)}</span>
+                        )}
+                        <span className="flex items-center gap-1">
+                          <MessageSquare className="h-3.5 w-3.5" />
+                          {comments.length} {comments.length === 1 ? "comment" : "comments"}
+                        </span>
+                      </div>
+                    </>
                   ) : (
                     <div className="space-y-3">
                       <div className="space-y-1.5">

--- a/pwa/pages/feedback/index.tsx
+++ b/pwa/pages/feedback/index.tsx
@@ -1,0 +1,315 @@
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { MessageSquare, MessagesSquare, Plus } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { signinHrefForCurrent } from "@/lib/authRedirect";
+import { apiGetCollection, apiSend } from "@/lib/apiClient";
+import { displayName } from "@/lib/userDisplay";
+import {
+  STATUS_META,
+  STATUS_ORDER,
+  TYPE_META,
+  TYPE_ORDER,
+  formatRelative,
+  type Feedback,
+  type FeedbackStatus,
+  type FeedbackType,
+} from "@/lib/feedbackTypes";
+import VoteControl from "@/components/feedback/VoteControl";
+import UserAvatar from "@/components/user/UserAvatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+type TypeFilter = FeedbackType | "all";
+type StatusFilter = FeedbackStatus | "all";
+type SortKey = "votes" | "recent";
+
+const FeedbackBoardPage = () => {
+  const { user, isAuthenticated, isLoading: authLoading } = useAuth();
+  const router = useRouter();
+
+  const [tickets, setTickets] = useState<Feedback[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+  const [sort, setSort] = useState<SortKey>("votes");
+
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) {
+      router.replace(signinHrefForCurrent(router.asPath));
+    }
+  }, [authLoading, isAuthenticated, router]);
+
+  const load = useCallback(async () => {
+    setError(null);
+    setIsLoading(true);
+    try {
+      const data = await apiGetCollection<Feedback>("/feedback?itemsPerPage=100", {
+        errorMessage: "Failed to load feedback.",
+      });
+      setTickets(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load feedback.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isAuthenticated) void load();
+  }, [isAuthenticated, load]);
+
+  const handleVote = useCallback(
+    async (ticket: Feedback, value: 1 | -1) => {
+      // Optimistic isn't required — the endpoint returns the authoritative
+      // score + myVote, so we just patch the row from the response.
+      try {
+        const res = await apiSend<{ score: number; myVote: number }>(
+          "POST",
+          `/feedback/${ticket.id}/vote`,
+          { body: { value }, errorMessage: "Failed to vote." },
+        );
+        if (!res) return;
+        setTickets((prev) =>
+          prev.map((t) =>
+            t["@id"] === ticket["@id"]
+              ? { ...t, score: res.score, myVote: res.myVote }
+              : t,
+          ),
+        );
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to vote.");
+      }
+    },
+    [],
+  );
+
+  const visible = useMemo(() => {
+    const filtered = tickets.filter(
+      (t) =>
+        (typeFilter === "all" || t.type === typeFilter) &&
+        (statusFilter === "all" || t.status === statusFilter),
+    );
+    const sorted = [...filtered];
+    if (sort === "votes") {
+      sorted.sort(
+        (a, b) =>
+          b.score - a.score ||
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      );
+    } else {
+      sorted.sort(
+        (a, b) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      );
+    }
+    return sorted;
+  }, [tickets, typeFilter, statusFilter, sort]);
+
+  if (authLoading || !user) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-muted">
+        <p className="text-muted-foreground">Loading…</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Feedback - Madori</title>
+      </Head>
+      <main className="min-h-screen bg-muted">
+        <div className="max-w-5xl mx-auto px-4 py-8 space-y-6">
+          <header className="flex flex-wrap items-start justify-between gap-3">
+            <div className="space-y-1">
+              <div className="flex items-center gap-2">
+                <MessagesSquare className="h-6 w-6 text-cyan-600 dark:text-cyan-400" />
+                <h1 className="text-2xl font-bold">Feedback</h1>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                Report a bug or request a feature. Vote on what matters to you —
+                the team works the board from the top.
+              </p>
+            </div>
+            <Button asChild>
+              <Link href="/feedback/new" data-testid="feedback-new-link">
+                <Plus className="h-4 w-4" /> New feedback
+              </Link>
+            </Button>
+          </header>
+
+          {/* Filters */}
+          <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
+            <FilterRow label="Type">
+              <FilterPill
+                active={typeFilter === "all"}
+                onClick={() => setTypeFilter("all")}
+              >
+                All
+              </FilterPill>
+              {TYPE_ORDER.map((t) => (
+                <FilterPill
+                  key={t}
+                  active={typeFilter === t}
+                  onClick={() => setTypeFilter(t)}
+                >
+                  {TYPE_META[t].label}
+                </FilterPill>
+              ))}
+            </FilterRow>
+
+            <FilterRow label="Status">
+              <FilterPill
+                active={statusFilter === "all"}
+                onClick={() => setStatusFilter("all")}
+              >
+                All
+              </FilterPill>
+              {STATUS_ORDER.map((s) => (
+                <FilterPill
+                  key={s}
+                  active={statusFilter === s}
+                  onClick={() => setStatusFilter(s)}
+                >
+                  {STATUS_META[s].label}
+                </FilterPill>
+              ))}
+            </FilterRow>
+
+            <FilterRow label="Sort">
+              <FilterPill active={sort === "votes"} onClick={() => setSort("votes")}>
+                Most votes
+              </FilterPill>
+              <FilterPill active={sort === "recent"} onClick={() => setSort("recent")}>
+                Most recent
+              </FilterPill>
+            </FilterRow>
+          </div>
+
+          {error && (
+            <Card>
+              <CardContent className="pt-6">
+                <p className="text-sm text-destructive">{error}</p>
+              </CardContent>
+            </Card>
+          )}
+
+          {isLoading ? (
+            <p className="text-muted-foreground">Loading…</p>
+          ) : visible.length === 0 ? (
+            <Card>
+              <CardContent className="pt-6 text-center space-y-3">
+                <p className="text-muted-foreground">
+                  {tickets.length === 0
+                    ? "No feedback yet — be the first to file one."
+                    : "Nothing matches these filters."}
+                </p>
+                {tickets.length === 0 && (
+                  <Button asChild variant="outline">
+                    <Link href="/feedback/new">
+                      <Plus className="h-4 w-4" /> New feedback
+                    </Link>
+                  </Button>
+                )}
+              </CardContent>
+            </Card>
+          ) : (
+            <ul className="space-y-2" data-testid="feedback-list">
+              {visible.map((ticket) => (
+                <li key={ticket["@id"]}>
+                  <Card className="transition-colors hover:border-cyan-600/40">
+                    <CardContent className="flex items-start gap-4 py-4">
+                      <VoteControl
+                        score={ticket.score}
+                        myVote={ticket.myVote}
+                        onVote={(v) => void handleVote(ticket, v)}
+                      />
+                      <div className="min-w-0 flex-1 space-y-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="text-xs font-medium text-muted-foreground tabular-nums">
+                            #{ticket.ticketNumber}
+                          </span>
+                          <Badge className={cn("border-0", TYPE_META[ticket.type].badgeClass)}>
+                            {TYPE_META[ticket.type].label}
+                          </Badge>
+                          <Badge className={cn("border-0", STATUS_META[ticket.status].badgeClass)}>
+                            {STATUS_META[ticket.status].label}
+                          </Badge>
+                        </div>
+                        <Link
+                          href={`/feedback/${ticket.id}`}
+                          className="block font-semibold leading-tight hover:underline"
+                          data-testid="feedback-row-title"
+                        >
+                          {ticket.title}
+                        </Link>
+                        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                          <span className="flex items-center gap-1.5">
+                            <UserAvatar user={ticket.owner} size="sm" />
+                            {displayName(ticket.owner)}
+                          </span>
+                          <span>{formatRelative(ticket.createdAt)}</span>
+                          <span className="flex items-center gap-1">
+                            <MessageSquare className="h-3.5 w-3.5" />
+                            {ticket.commentCount}
+                          </span>
+                        </div>
+                      </div>
+                    </CardContent>
+                  </Card>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </main>
+    </>
+  );
+};
+
+const FilterRow = ({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) => (
+  <div className="flex items-center gap-2">
+    <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+      {label}
+    </span>
+    <div className="flex flex-wrap items-center gap-1">{children}</div>
+  </div>
+);
+
+const FilterPill = ({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={cn(
+      "rounded-full px-3 py-1 text-xs font-medium transition-colors",
+      active
+        ? "bg-cyan-700 text-white"
+        : "bg-background text-muted-foreground hover:bg-accent border border-input",
+    )}
+  >
+    {children}
+  </button>
+);
+
+export default FeedbackBoardPage;

--- a/pwa/pages/feedback/index.tsx
+++ b/pwa/pages/feedback/index.tsx
@@ -5,8 +5,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { MessageSquare, MessagesSquare, Plus } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { signinHrefForCurrent } from "@/lib/authRedirect";
-import { apiGetCollection, apiSend } from "@/lib/apiClient";
-import { displayName } from "@/lib/userDisplay";
+import { apiGetCollection } from "@/lib/apiClient";
 import {
   STATUS_META,
   STATUS_ORDER,
@@ -17,8 +16,6 @@ import {
   type FeedbackStatus,
   type FeedbackType,
 } from "@/lib/feedbackTypes";
-import VoteControl from "@/components/feedback/VoteControl";
-import UserAvatar from "@/components/user/UserAvatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -64,31 +61,6 @@ const FeedbackBoardPage = () => {
   useEffect(() => {
     if (isAuthenticated) void load();
   }, [isAuthenticated, load]);
-
-  const handleVote = useCallback(
-    async (ticket: Feedback, value: 1 | -1) => {
-      // Optimistic isn't required — the endpoint returns the authoritative
-      // score + myVote, so we just patch the row from the response.
-      try {
-        const res = await apiSend<{ score: number; myVote: number }>(
-          "POST",
-          `/feedback/${ticket.id}/vote`,
-          { body: { value }, errorMessage: "Failed to vote." },
-        );
-        if (!res) return;
-        setTickets((prev) =>
-          prev.map((t) =>
-            t["@id"] === ticket["@id"]
-              ? { ...t, score: res.score, myVote: res.myVote }
-              : t,
-          ),
-        );
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to vote.");
-      }
-    },
-    [],
-  );
 
   const visible = useMemo(() => {
     const filtered = tickets.filter(
@@ -146,51 +118,31 @@ const FeedbackBoardPage = () => {
           </header>
 
           {/* Filters */}
-          <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
-            <FilterRow label="Type">
-              <FilterPill
-                active={typeFilter === "all"}
-                onClick={() => setTypeFilter("all")}
-              >
-                All
-              </FilterPill>
-              {TYPE_ORDER.map((t) => (
-                <FilterPill
-                  key={t}
-                  active={typeFilter === t}
-                  onClick={() => setTypeFilter(t)}
-                >
-                  {TYPE_META[t].label}
-                </FilterPill>
-              ))}
-            </FilterRow>
-
-            <FilterRow label="Status">
-              <FilterPill
-                active={statusFilter === "all"}
-                onClick={() => setStatusFilter("all")}
-              >
-                All
-              </FilterPill>
-              {STATUS_ORDER.map((s) => (
-                <FilterPill
-                  key={s}
-                  active={statusFilter === s}
-                  onClick={() => setStatusFilter(s)}
-                >
-                  {STATUS_META[s].label}
-                </FilterPill>
-              ))}
-            </FilterRow>
-
-            <FilterRow label="Sort">
-              <FilterPill active={sort === "votes"} onClick={() => setSort("votes")}>
-                Most votes
-              </FilterPill>
-              <FilterPill active={sort === "recent"} onClick={() => setSort("recent")}>
-                Most recent
-              </FilterPill>
-            </FilterRow>
+          <div className="flex flex-wrap items-center gap-3">
+            <SegmentGroup
+              value={typeFilter}
+              options={[
+                { value: "all", label: "All" },
+                ...TYPE_ORDER.map((t) => ({ value: t, label: TYPE_META[t].label })),
+              ]}
+              onChange={(v) => setTypeFilter(v as TypeFilter)}
+            />
+            <SegmentGroup
+              value={statusFilter}
+              options={[
+                { value: "all", label: "All" },
+                ...STATUS_ORDER.map((s) => ({ value: s, label: STATUS_META[s].label })),
+              ]}
+              onChange={(v) => setStatusFilter(v as StatusFilter)}
+            />
+            <SegmentGroup
+              value={sort}
+              options={[
+                { value: "votes", label: "Most votes" },
+                { value: "recent", label: "Most recent" },
+              ]}
+              onChange={(v) => setSort(v as SortKey)}
+            />
           </div>
 
           {error && (
@@ -226,11 +178,26 @@ const FeedbackBoardPage = () => {
                 <li key={ticket["@id"]}>
                   <Card className="transition-colors hover:border-cyan-600/40">
                     <CardContent className="flex items-start gap-4 py-4">
-                      <VoteControl
-                        score={ticket.score}
-                        myVote={ticket.myVote}
-                        onVote={(v) => void handleVote(ticket, v)}
-                      />
+                      <div
+                        className="inline-flex min-w-10 flex-col items-center justify-center text-center"
+                        data-testid="vote-score"
+                      >
+                        <span
+                          className={cn(
+                            "text-base font-semibold tabular-nums",
+                            ticket.myVote === 1
+                              ? "text-emerald-600 dark:text-emerald-400"
+                              : ticket.myVote === -1
+                                ? "text-rose-600 dark:text-rose-400"
+                                : "text-foreground",
+                          )}
+                        >
+                          {ticket.score}
+                        </span>
+                        <span className="text-[11px] text-muted-foreground">
+                          {Math.abs(ticket.score) === 1 ? "vote" : "votes"}
+                        </span>
+                      </div>
                       <div className="min-w-0 flex-1 space-y-1">
                         <div className="flex flex-wrap items-center gap-2">
                           <span className="text-xs font-medium text-muted-foreground tabular-nums">
@@ -251,10 +218,6 @@ const FeedbackBoardPage = () => {
                           {ticket.title}
                         </Link>
                         <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
-                          <span className="flex items-center gap-1.5">
-                            <UserAvatar user={ticket.owner} size="sm" />
-                            {displayName(ticket.owner)}
-                          </span>
                           <span>{formatRelative(ticket.createdAt)}</span>
                           <span className="flex items-center gap-1">
                             <MessageSquare className="h-3.5 w-3.5" />
@@ -274,42 +237,36 @@ const FeedbackBoardPage = () => {
   );
 };
 
-const FilterRow = ({
-  label,
-  children,
+const SegmentGroup = ({
+  value,
+  options,
+  onChange,
 }: {
-  label: string;
-  children: React.ReactNode;
+  value: string;
+  options: { value: string; label: string }[];
+  onChange: (value: string) => void;
 }) => (
-  <div className="flex items-center gap-2">
-    <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-      {label}
-    </span>
-    <div className="flex flex-wrap items-center gap-1">{children}</div>
+  <div className="inline-flex items-center divide-x divide-input overflow-hidden rounded-full border border-input">
+    {options.map((o) => {
+      const active = o.value === value;
+      return (
+        <button
+          key={o.value}
+          type="button"
+          onClick={() => onChange(o.value)}
+          aria-pressed={active}
+          className={cn(
+            "px-3 py-1.5 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+            active
+              ? "bg-cyan-700 text-white hover:bg-cyan-800"
+              : "bg-background text-muted-foreground hover:bg-accent",
+          )}
+        >
+          {o.label}
+        </button>
+      );
+    })}
   </div>
-);
-
-const FilterPill = ({
-  active,
-  onClick,
-  children,
-}: {
-  active: boolean;
-  onClick: () => void;
-  children: React.ReactNode;
-}) => (
-  <button
-    type="button"
-    onClick={onClick}
-    className={cn(
-      "rounded-full px-3 py-1 text-xs font-medium transition-colors",
-      active
-        ? "bg-cyan-700 text-white"
-        : "bg-background text-muted-foreground hover:bg-accent border border-input",
-    )}
-  >
-    {children}
-  </button>
 );
 
 export default FeedbackBoardPage;

--- a/pwa/pages/feedback/new.tsx
+++ b/pwa/pages/feedback/new.tsx
@@ -1,0 +1,165 @@
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import { ArrowLeft } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { signinHrefForCurrent } from "@/lib/authRedirect";
+import { apiSend } from "@/lib/apiClient";
+import { trackEvent } from "@/lib/analytics";
+import {
+  TYPE_META,
+  TYPE_ORDER,
+  type Feedback,
+  type FeedbackType,
+} from "@/lib/feedbackTypes";
+import MarkdownEditor from "@/components/editor/MarkdownEditor";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+
+const NewFeedbackPage = () => {
+  const { user, isAuthenticated, isLoading: authLoading } = useAuth();
+  const router = useRouter();
+
+  const [title, setTitle] = useState("");
+  const [type, setType] = useState<FeedbackType>("feature");
+  const [description, setDescription] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) {
+      router.replace(signinHrefForCurrent(router.asPath));
+    }
+  }, [authLoading, isAuthenticated, router]);
+
+  const submit = async () => {
+    const trimTitle = title.trim();
+    const trimBody = description.trim();
+    if (!trimTitle || !trimBody) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const created = await apiSend<Feedback>("POST", "/feedback", {
+        body: { title: trimTitle, description, type },
+        errorMessage: "Failed to submit feedback.",
+      });
+      trackEvent("feedback-create");
+      if (created?.id) {
+        await router.push(`/feedback/${created.id}`);
+      } else {
+        await router.push("/feedback");
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to submit feedback.");
+      setSubmitting(false);
+    }
+  };
+
+  if (authLoading || !user) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-muted">
+        <p className="text-muted-foreground">Loading…</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>New feedback - Madori</title>
+      </Head>
+      <main className="min-h-screen bg-muted">
+        <div className="max-w-2xl mx-auto px-4 py-8 space-y-4">
+          <Button asChild variant="link" size="sm" className="px-0 h-auto">
+            <Link href="/feedback">
+              <ArrowLeft className="h-3.5 w-3.5 mr-1" /> Feedback
+            </Link>
+          </Button>
+
+          <h1 className="text-2xl font-bold">New feedback</h1>
+
+          <Card>
+            <CardContent className="pt-6 space-y-4">
+              <div className="space-y-1.5">
+                <Label>Type</Label>
+                <div className="flex gap-2" role="radiogroup" aria-label="Feedback type">
+                  {TYPE_ORDER.map((t) => (
+                    <button
+                      key={t}
+                      type="button"
+                      role="radio"
+                      aria-checked={type === t}
+                      onClick={() => setType(t)}
+                      className={cn(
+                        "rounded-md border px-4 py-2 text-sm font-medium transition-colors",
+                        type === t
+                          ? "border-cyan-700 bg-cyan-700 text-white"
+                          : "border-input bg-background hover:bg-accent",
+                      )}
+                      data-testid={`feedback-type-${t}`}
+                    >
+                      {TYPE_META[t].label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="feedback-title">Title</Label>
+                <Input
+                  id="feedback-title"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  placeholder={
+                    type === "bug"
+                      ? "Briefly, what went wrong?"
+                      : "Briefly, what would you like?"
+                  }
+                  maxLength={200}
+                  required
+                  data-testid="feedback-title"
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <Label>Description</Label>
+                <MarkdownEditor
+                  ariaLabel="Feedback description"
+                  value={description}
+                  onChange={setDescription}
+                />
+              </div>
+
+              {error && (
+                <Alert variant="destructive">
+                  <AlertDescription>{error}</AlertDescription>
+                </Alert>
+              )}
+
+              <div className="flex gap-2">
+                <Button
+                  type="button"
+                  onClick={() => void submit()}
+                  disabled={submitting || !title.trim() || !description.trim()}
+                  data-testid="feedback-submit"
+                >
+                  {submitting ? "Submitting…" : "Submit feedback"}
+                </Button>
+                <Button asChild variant="outline" disabled={submitting}>
+                  <Link href="/feedback">Cancel</Link>
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </main>
+    </>
+  );
+};
+
+export default NewFeedbackPage;

--- a/pwa/pages/feedback/new.tsx
+++ b/pwa/pages/feedback/new.tsx
@@ -2,7 +2,6 @@ import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
-import { ArrowLeft } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { signinHrefForCurrent } from "@/lib/authRedirect";
 import { apiSend } from "@/lib/apiClient";
@@ -75,12 +74,6 @@ const NewFeedbackPage = () => {
       </Head>
       <main className="min-h-screen bg-muted">
         <div className="max-w-2xl mx-auto px-4 py-8 space-y-4">
-          <Button asChild variant="link" size="sm" className="px-0 h-auto">
-            <Link href="/feedback">
-              <ArrowLeft className="h-3.5 w-3.5 mr-1" /> Feedback
-            </Link>
-          </Button>
-
           <h1 className="text-2xl font-bold">New feedback</h1>
 
           <Card>

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -985,15 +985,6 @@ const ProjectDetail = () => {
                 </TabsContent>
 
                 <TabsContent value="list" className="mt-4">
-                  {/* Grand totals across the whole board — top. */}
-                  <CustomFieldFooterRow
-                    projectId={project.id}
-                    refreshKey={footerKey}
-                    columns={listDefinitions}
-                    prominent
-                    className="mb-6"
-                  />
-
                   <div className="space-y-6" data-testid="project-task-list">
                     {sectionGroups.map((group) => {
                       const sectionIri = group.section
@@ -1046,14 +1037,17 @@ const ProjectDetail = () => {
                     })}
                   </div>
 
-                  {/* Grand totals across the whole board — bottom. */}
-                  <CustomFieldFooterRow
-                    projectId={project.id}
-                    refreshKey={footerKey}
-                    columns={listDefinitions}
-                    prominent
-                    className="mt-6"
-                  />
+                  {/* Grand totals across the whole board — only when
+                      there's more than one section to total across. */}
+                  {sectionGroups.length > 1 && (
+                    <CustomFieldFooterRow
+                      projectId={project.id}
+                      refreshKey={footerKey}
+                      columns={listDefinitions}
+                      prominent
+                      className="mt-6"
+                    />
+                  )}
                 </TabsContent>
 
                 <TabsContent value="board" className="mt-4">
@@ -1267,6 +1261,8 @@ const SectionBlock = ({
               <th className="w-8 px-3 py-2" />
               <th className="w-10 px-1 py-2 text-left font-medium">#</th>
               <th className="px-2 py-2 text-left font-medium">Task</th>
+              <th className="px-2 py-2 text-left font-medium">Due</th>
+              <th className="px-2 py-2 text-left font-medium">Assignees</th>
               <th className="px-2 py-2 text-left font-medium">Tags</th>
               {definitions.map((def) => (
                 <th
@@ -1276,8 +1272,6 @@ const SectionBlock = ({
                   {def.name}
                 </th>
               ))}
-              <th className="px-2 py-2 text-left font-medium">Due</th>
-              <th className="px-2 py-2 text-left font-medium">Assignees</th>
               <th className="w-10 px-2 py-2" />
             </tr>
           </thead>
@@ -1335,19 +1329,6 @@ const SectionBlock = ({
                     data-testid="project-new-task-title"
                   />
                 </td>
-                <td className="px-2 py-2 align-middle" data-testid="new-task-tags">
-                  <TagsCombobox
-                    value={newTaskTags}
-                    options={allTags}
-                    onChange={onNewTaskTags}
-                    subjectLabel="new task"
-                  />
-                </td>
-                {definitions.map((def) => (
-                  // Custom fields are set after the task exists; render an empty
-                  // cell so the inline fields stay aligned with the columns.
-                  <td key={def["@id"]} className="px-2 py-2 align-middle" />
-                ))}
                 <td className="px-2 py-2 align-middle" data-testid="new-task-due">
                   <DueDateCell
                     value={newTaskDue}
@@ -1367,6 +1348,19 @@ const SectionBlock = ({
                     subjectLabel="new task"
                   />
                 </td>
+                <td className="px-2 py-2 align-middle" data-testid="new-task-tags">
+                  <TagsCombobox
+                    value={newTaskTags}
+                    options={allTags}
+                    onChange={onNewTaskTags}
+                    subjectLabel="new task"
+                  />
+                </td>
+                {definitions.map((def) => (
+                  // Custom fields are set after the task exists; render an empty
+                  // cell so the inline fields stay aligned with the columns.
+                  <td key={def["@id"]} className="px-2 py-2 align-middle" />
+                ))}
                 <td className="px-2 py-2 align-middle" />
               </tr>
             )}
@@ -1461,26 +1455,6 @@ const ProjectTaskRow = ({
         </button>
       </td>
       <td className="px-2 py-2 align-middle">
-        <TagsCombobox
-          value={task.tags}
-          options={allTags}
-          onChange={(iris) => void patchTask(task, { tags: iris })}
-          subjectLabel={task.title}
-        />
-      </td>
-      {definitions.map((def) => (
-        <td key={def["@id"]} className="px-2 py-2 align-middle">
-          <ProjectCustomFieldCell
-            task={task}
-            definition={def}
-            projectIri={projectIri}
-            spaceIri={spaceIri}
-            users={assignableUsers}
-            onCustomFieldChange={onCustomFieldChange}
-          />
-        </td>
-      ))}
-      <td className="px-2 py-2 align-middle">
         <DueDateCell
           value={task.dueDate}
           onChange={(next) => void patchTask(task, { dueDate: next })}
@@ -1503,6 +1477,26 @@ const ProjectTaskRow = ({
           subjectLabel={task.title}
         />
       </td>
+      <td className="px-2 py-2 align-middle">
+        <TagsCombobox
+          value={task.tags}
+          options={allTags}
+          onChange={(iris) => void patchTask(task, { tags: iris })}
+          subjectLabel={task.title}
+        />
+      </td>
+      {definitions.map((def) => (
+        <td key={def["@id"]} className="px-2 py-2 align-middle">
+          <ProjectCustomFieldCell
+            task={task}
+            definition={def}
+            projectIri={projectIri}
+            spaceIri={spaceIri}
+            users={assignableUsers}
+            onCustomFieldChange={onCustomFieldChange}
+          />
+        </td>
+      ))}
       <td className="px-2 py-2 align-middle">
         <button
           type="button"


### PR DESCRIPTION
﻿## Promote `main` -> `production`

Merging this triggers the auto-deploy workflow. **Use a merge commit** (not squash) to keep `production` fast-forwardable, per the branching policy.

### Features
- **In-app Feedback board** (#523): bug/feature tickets at `/feedback` with up/down voting, statuses, comments, and account-deletion sentinel reassignment. Footer + admin/user menus link to it; demo fixtures seed the board.
- **API token permissions editing** (#528): edit a token's access policy after creation.
- **Billing** (#526): admins are exempt from the MCP daily cap (still tracked).

### Fixes & refactors
- **Feedback board polish + admin sidebar + impersonation UX** (#529): list/detail cleanup, admin tools as a sidebar section, impersonation consent surfaced in the admin users list (disabled state + clearer 403), demo users opted in (one left out to show the disabled state).
- **Projects list** (#527): tidy footers, reorder columns to Name -> Due -> Assignees -> Tags.
- **Settings** (#524): wrap long token/secret values so they don't overflow the modal.
- **E2E** (#530): align the add-task Tab-order spec with the new column layout.

### Notes
- New DB migration ships with the feedback feature (`feedback` + `feedback_vote` tables, `feedback_ticket_seq`). The deploy runs migrations as usual.
- Local dev fixtures changed (impersonation consent); no production data impact.
