### PR TITLE
security: scope /me/assignable-users to the caller's spaces

### DIFF
--- a/api/src/Controller/AssignableUsersController.php
+++ b/api/src/Controller/AssignableUsersController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller;
 
+use App\Doctrine\SpaceMembershipDql;
 use App\Entity\Project;
 use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
@@ -38,10 +39,18 @@ class AssignableUsersController extends AbstractController
         }
 
         $byId = [(string) $user->getId() => $user];
-        // The ProjectAccessExtension already scopes "projects the user
-        // can see" to those whose space they belong to, so a plain
-        // findAll here returns exactly the right set.
-        $projects = $this->em->getRepository(Project::class)->findAll();
+        // ProjectAccessExtension only scopes API Platform's collection data
+        // providers, NOT a raw Doctrine query — a plain findAll() here would
+        // leak the effective members of every space in the instance. Scope
+        // explicitly to projects whose space the caller belongs to (directly
+        // or via group), mirroring ProjectAccessExtension's predicate.
+        /** @var list<Project> $projects */
+        $projects = $this->em->getRepository(Project::class)
+            ->createQueryBuilder('project')
+            ->where(SpaceMembershipDql::userBelongsToProjectSpace('project'))
+            ->setParameter('user', $user)
+            ->getQuery()
+            ->getResult();
         foreach ($projects as $project) {
             foreach ($project->getEffectiveMembers() as $id => $member) {
                 $byId[$id] = $member;

--- a/api/tests/Api/TaskTest.php
+++ b/api/tests/Api/TaskTest.php
@@ -1378,6 +1378,46 @@ class TaskTest extends ApiTestCase
     }
 
     /**
+     * Guards the cross-space information leak fixed alongside this test:
+     * a user who is an effective member of a space the caller does NOT
+     * belong to must never surface in the caller's assignable-users list.
+     * The old controller did a raw `Project::findAll()` (unscoped by the
+     * access extension), so every effective member of every space in the
+     * instance leaked through.
+     */
+    public function testAssignableUsersExcludesMembersOfOtherSpaces(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $carol = $this->createUser('carol@example.com');
+
+        // Alice's own space, shared with Bob.
+        $this->createSharedProject($alice, [$alice, $bob], 'Alice Team');
+        // A separate space Alice has no part in — Carol + Dave only.
+        $dave = $this->createUser('dave@example.com');
+        $this->createSharedProject($carol, [$carol, $dave], 'Carol Team');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/me/assignable-users');
+
+        $this->assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+        $members = $body['member'] ?? null;
+        $this->assertIsArray($members);
+        $emails = array_map(
+            static fn (mixed $u): mixed => is_array($u) ? $u['email'] ?? null : null,
+            $members,
+        );
+        sort($emails);
+        $this->assertSame(['alice@example.com', 'bob@example.com'], $emails);
+        $this->assertNotContains('carol@example.com', $emails);
+        $this->assertNotContains('dave@example.com', $emails);
+    }
+
+    /**
      * @param User[] $members
      */
     private function createSharedProject(User $owner, array $members, string $title): Project


### PR DESCRIPTION
## Description

`GET /me/assignable-users` leaked user data across spaces. `AssignableUsersController` built its candidate list from `getRepository(Project::class)->findAll()`. The inline comment claimed `ProjectAccessExtension` scoped this, but that extension only applies to API Platform's collection data providers — **not** to a raw Doctrine query. The controller then unioned each project's `getEffectiveMembers()`, so the endpoint returned the `user:read` fields (name / email / avatar / color) of every effective member of **every space anywhere in the deployment** — a cross-tenant/cross-space information leak.

Verified on dev fixtures: signing in as `admin@madori.test` (deliberately *not* a member of Uma's "Launch team" space) returned all 6 fixture users, including the Launch-team members.

**Fix:** scope the project query with the same direct-or-via-group space-membership predicate used by the access extensions — `App\Doctrine\SpaceMembershipDql::userBelongsToProjectSpace()` — so only projects whose space the caller belongs to contribute candidates. The caller is still seeded into the result, and the hydra-collection response shape is unchanged. This mirrors the established pattern in `ListProjectsTool`, `CustomFieldFooterController`, etc.

## Type of Change

- [x] Bug fix

## Component

- [x] API (PHP/Symfony)

## How Has This Been Tested?

- Added `testAssignableUsersExcludesMembersOfOtherSpaces` in `api/tests/Api/TaskTest.php`: it puts two users in a space the caller has no part in and asserts they don't surface, while same-space members still do. The pre-existing test only covered a user in *no* project (which never leaked); this covers the actual cross-space scenario.
- Confirmed the new test **fails against the original `findAll()` controller** (the two foreign users leak through) and **passes with the fix** — a genuine regression guard.
- PHPStan level 10 + strict-rules: **No errors** on the changed files.
- PHPCS (PSR-12): **clean**.
- PHPUnit: all 3 `testAssignableUsers*` tests pass.

## Checklist

- [x] My code follows the project's conventions
- [x] I have added tests that prove my fix or feature works
- [x] New and existing tests pass locally (PHPUnit / `pnpm test:coverage`)
- [ ] New pure-logic helpers under `pwa/lib` are added to the coverage allowlist in `pwa/vitest.config.ts`
- [ ] I have updated documentation if needed