### PR TITLE
Promote main to production (assignable-users fix, list-view columns, field conversion)

### DIFF
--- a/api/config/services.yaml
+++ b/api/config/services.yaml
@@ -105,6 +105,8 @@ services:
             tags: ['app.mcp_tool']
         App\CustomField\Type\CustomFieldTypeInterface:
             tags: ['app.custom_field_type']
+        App\CustomField\Converter\CustomFieldTypeConverterInterface:
+            tags: ['app.custom_field_converter']
 
     App\Mcp\McpToolRegistry:
         arguments:
@@ -113,6 +115,10 @@ services:
     App\CustomField\CustomFieldTypeRegistry:
         arguments:
             $types: !tagged_iterator app.custom_field_type
+
+    App\CustomField\Converter\CustomFieldConverterRegistry:
+        arguments:
+            $converters: !tagged_iterator app.custom_field_converter
 
     # Replace stof's default actor provider with one that yields the
     # user's IRI (`/users/{uuid}`) instead of `getUserIdentifier()`

--- a/api/src/Controller/AssignableUsersController.php
+++ b/api/src/Controller/AssignableUsersController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller;
 
+use App\Doctrine\SpaceMembershipDql;
 use App\Entity\Project;
 use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
@@ -38,10 +39,18 @@ class AssignableUsersController extends AbstractController
         }
 
         $byId = [(string) $user->getId() => $user];
-        // The ProjectAccessExtension already scopes "projects the user
-        // can see" to those whose space they belong to, so a plain
-        // findAll here returns exactly the right set.
-        $projects = $this->em->getRepository(Project::class)->findAll();
+        // ProjectAccessExtension only scopes API Platform's collection data
+        // providers, NOT a raw Doctrine query — a plain findAll() here would
+        // leak the effective members of every space in the instance. Scope
+        // explicitly to projects whose space the caller belongs to (directly
+        // or via group), mirroring ProjectAccessExtension's predicate.
+        /** @var list<Project> $projects */
+        $projects = $this->em->getRepository(Project::class)
+            ->createQueryBuilder('project')
+            ->where(SpaceMembershipDql::userBelongsToProjectSpace('project'))
+            ->setParameter('user', $user)
+            ->getQuery()
+            ->getResult();
         foreach ($projects as $project) {
             foreach ($project->getEffectiveMembers() as $id => $member) {
                 $byId[$id] = $member;

--- a/api/src/CustomField/Converter/BooleanValueConverter.php
+++ b/api/src/CustomField/Converter/BooleanValueConverter.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\CustomField\Converter;
+
+/**
+ * Produces boolean values: identity from boolean, non-zero test from
+ * numbers, and the usual truthy/falsey words from text.
+ */
+final class BooleanValueConverter implements CustomFieldTypeConverterInterface
+{
+    public function __construct(private readonly ValueCoercions $coercions)
+    {
+    }
+
+    public function targetKind(): string
+    {
+        return 'boolean';
+    }
+
+    public function convert(mixed $value, ConversionContext $context): array
+    {
+        if ('boolean' === $context->fromKind) {
+            return [true, (bool) $value];
+        }
+
+        $number = $this->coercions->toNumber($value, $context->fromKind, $context->fromSubtype, $context->fromConfig);
+        if (null !== $number) {
+            return [true, 0.0 !== $number];
+        }
+
+        if ('text' === $context->fromKind && is_string($value)) {
+            $token = strtolower(trim($value));
+            if (in_array($token, ['true', '1', 'yes', 'y', 'on'], true)) {
+                return [true, true];
+            }
+            if (in_array($token, ['false', '0', 'no', 'n', 'off'], true)) {
+                return [true, false];
+            }
+        }
+
+        return [false, null];
+    }
+}

--- a/api/src/CustomField/Converter/ConversionContext.php
+++ b/api/src/CustomField/Converter/ConversionContext.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\CustomField\Converter;
+
+/**
+ * Immutable description of one value-conversion request, handed to a
+ * {@see CustomFieldTypeConverterInterface}. Carries the source type's
+ * (kind, subtype, config) and the target's (subtype, config) — the target
+ * kind is implied by which converter is resolved, so it isn't repeated.
+ */
+final class ConversionContext
+{
+    /**
+     * @param array<string, mixed> $fromConfig
+     * @param array<string, mixed> $toConfig
+     */
+    public function __construct(
+        public readonly string $fromKind,
+        public readonly string $fromSubtype,
+        public readonly array $fromConfig,
+        public readonly string $toSubtype,
+        public readonly array $toConfig,
+    ) {
+    }
+}

--- a/api/src/CustomField/Converter/CustomFieldConverterRegistry.php
+++ b/api/src/CustomField/Converter/CustomFieldConverterRegistry.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\CustomField\Converter;
+
+/**
+ * Lookup table over the tagged `app.custom_field_converter` services,
+ * keyed by the destination kind each one produces. Boots from a
+ * `!tagged_iterator`, so adding a converter for a new kind is wiring-free.
+ */
+final class CustomFieldConverterRegistry
+{
+    /** @var array<string, CustomFieldTypeConverterInterface> */
+    private array $byKind = [];
+
+    /**
+     * @param iterable<CustomFieldTypeConverterInterface> $converters
+     */
+    public function __construct(iterable $converters)
+    {
+        foreach ($converters as $converter) {
+            $kind = $converter->targetKind();
+            if (isset($this->byKind[$kind])) {
+                throw new \LogicException(sprintf(
+                    'Duplicate custom-field converter for kind "%s"; both %s and %s claim it.',
+                    $kind,
+                    $this->byKind[$kind]::class,
+                    $converter::class,
+                ));
+            }
+            $this->byKind[$kind] = $converter;
+        }
+    }
+
+    public function has(string $kind): bool
+    {
+        return isset($this->byKind[$kind]);
+    }
+
+    public function get(string $kind): CustomFieldTypeConverterInterface
+    {
+        return $this->byKind[$kind]
+            ?? throw new \InvalidArgumentException(sprintf('No custom-field converter for kind "%s".', $kind));
+    }
+}

--- a/api/src/CustomField/Converter/CustomFieldTypeConverterInterface.php
+++ b/api/src/CustomField/Converter/CustomFieldTypeConverterInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\CustomField\Converter;
+
+/**
+ * Converts a single stored scalar into a candidate value for one target
+ * field kind. Keyed by {@see targetKind()} — there is exactly one
+ * converter per destination kind (boolean, text, numeric, date, select,
+ * reference), and it knows how to build its own type from the various
+ * source kinds.
+ *
+ * Implementations are deliberately *lenient*: they return a best-effort
+ * candidate and leave final policing to the target type's own
+ * normalize() + validateValue(), run by
+ * {@see \App\CustomField\CustomFieldValueConverter}. So a converter need
+ * only answer "can this source scalar plausibly become my kind, and if so
+ * as what" — bounds, option membership, reference scope, URL shape, etc.
+ * are validated downstream.
+ *
+ * Implementations are auto-tagged `app.custom_field_converter` via
+ * `_instanceof` in services.yaml and resolved through
+ * {@see CustomFieldConverterRegistry}.
+ */
+interface CustomFieldTypeConverterInterface
+{
+    /**
+     * The destination kind this converter produces — one of
+     * boolean|text|numeric|date|select|reference.
+     */
+    public function targetKind(): string;
+
+    /**
+     * @return array{0: bool, 1: mixed} [true, <candidate>] when the scalar
+     *   can become this kind, or [false, null] when it can't.
+     */
+    public function convert(mixed $value, ConversionContext $context): array;
+}

--- a/api/src/CustomField/Converter/DateValueConverter.php
+++ b/api/src/CustomField/Converter/DateValueConverter.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\CustomField\Converter;
+
+/**
+ * Produces date / time / datetime values. Same-subtype and date↔datetime
+ * are the meaningful moves; time has no date component (and vice versa),
+ * so those crossings fail. Text is parsed leniently.
+ */
+final class DateValueConverter implements CustomFieldTypeConverterInterface
+{
+    public function __construct(private readonly ValueCoercions $coercions)
+    {
+    }
+
+    public function targetKind(): string
+    {
+        return 'date';
+    }
+
+    public function convert(mixed $value, ConversionContext $context): array
+    {
+        $fromKind = $context->fromKind;
+        $fromSubtype = $context->fromSubtype;
+        $toSubtype = $context->toSubtype;
+
+        if ('date' === $fromKind) {
+            if ('time' === $fromSubtype && 'time' !== $toSubtype) {
+                return [false, null];
+            }
+            if ('time' === $toSubtype && 'date' === $fromSubtype) {
+                return [false, null];
+            }
+        } elseif ('text' !== $fromKind) {
+            return [false, null];
+        }
+
+        $parsed = $this->coercions->parseDate($value, $fromKind, $fromSubtype);
+        if (null === $parsed) {
+            return [false, null];
+        }
+
+        $out = match ($toSubtype) {
+            'date' => $parsed->format('Y-m-d'),
+            'time' => $parsed->format('H:i'),
+            'datetime' => $parsed->format('Y-m-d\TH:i:sP'),
+            default => null,
+        };
+
+        return null === $out ? [false, null] : [true, $out];
+    }
+}

--- a/api/src/CustomField/Converter/NumericValueConverter.php
+++ b/api/src/CustomField/Converter/NumericValueConverter.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\CustomField\Converter;
+
+/**
+ * Produces numeric values. Anything readable as a number becomes an int
+ * (rounded to nearest), a float, or money (scaled to the target
+ * currency's minor units).
+ */
+final class NumericValueConverter implements CustomFieldTypeConverterInterface
+{
+    public function __construct(private readonly ValueCoercions $coercions)
+    {
+    }
+
+    public function targetKind(): string
+    {
+        return 'numeric';
+    }
+
+    public function convert(mixed $value, ConversionContext $context): array
+    {
+        $number = $this->coercions->toNumber($value, $context->fromKind, $context->fromSubtype, $context->fromConfig);
+        if (null === $number) {
+            return [false, null];
+        }
+
+        if ('int' === $context->toSubtype) {
+            return [true, (int) round($number)];
+        }
+        if ('float' === $context->toSubtype) {
+            return [true, $number];
+        }
+        if ('money' === $context->toSubtype) {
+            $currency = $context->toConfig['currency'] ?? null;
+            if (!is_string($currency) || '' === $currency) {
+                return [false, null];
+            }
+            $digits = $this->coercions->fractionDigits($currency);
+
+            return [true, [
+                'amount' => (int) round($number * (10 ** $digits)),
+                'currency' => strtoupper($currency),
+            ]];
+        }
+
+        return [false, null];
+    }
+}

--- a/api/src/CustomField/Converter/ReferenceValueConverter.php
+++ b/api/src/CustomField/Converter/ReferenceValueConverter.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\CustomField\Converter;
+
+/**
+ * Produces reference IRIs. Only same-target moves are possible (e.g. a
+ * single user reference ↔ a multi user reference) — a `/users/…` IRI
+ * can't become a task reference — so the source IRI must already carry
+ * the target subtype's path prefix. Downstream validation re-checks the
+ * target exists and is in the field's space.
+ */
+final class ReferenceValueConverter implements CustomFieldTypeConverterInterface
+{
+    private const PREFIXES = [
+        'user' => '/users/',
+        'task' => '/tasks/',
+        'project' => '/projects/',
+        'page' => '/pages/',
+        'discussion' => '/discussions/',
+    ];
+
+    public function targetKind(): string
+    {
+        return 'reference';
+    }
+
+    public function convert(mixed $value, ConversionContext $context): array
+    {
+        if ('reference' !== $context->fromKind || !is_string($value)) {
+            return [false, null];
+        }
+        $prefix = self::PREFIXES[$context->toSubtype] ?? null;
+        if (null !== $prefix && str_starts_with($value, $prefix)) {
+            return [true, $value];
+        }
+
+        return [false, null];
+    }
+}

--- a/api/src/CustomField/Converter/SelectValueConverter.php
+++ b/api/src/CustomField/Converter/SelectValueConverter.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\CustomField\Converter;
+
+/**
+ * Produces select option keys. A key already valid in the target options
+ * passes straight through; otherwise we bridge by matching the human
+ * label (so re-keyed option sets keep their picks). Text is matched
+ * against the target keys, then labels.
+ */
+final class SelectValueConverter implements CustomFieldTypeConverterInterface
+{
+    public function __construct(private readonly ValueCoercions $coercions)
+    {
+    }
+
+    public function targetKind(): string
+    {
+        return 'select';
+    }
+
+    public function convert(mixed $value, ConversionContext $context): array
+    {
+        if (!is_string($value)) {
+            return [false, null];
+        }
+
+        $toKeys = $this->coercions->selectKeys($context->toConfig);
+
+        if ('select' === $context->fromKind) {
+            if (in_array($value, $toKeys, true)) {
+                return [true, $value];
+            }
+            $label = $this->coercions->selectLabels($context->fromConfig)[$value] ?? null;
+            if (is_string($label)) {
+                $key = $this->coercions->keyForLabel($context->toConfig, $label);
+                if (null !== $key) {
+                    return [true, $key];
+                }
+            }
+
+            return [false, null];
+        }
+
+        if ('text' === $context->fromKind) {
+            if (in_array($value, $toKeys, true)) {
+                return [true, $value];
+            }
+            $key = $this->coercions->keyForLabel($context->toConfig, $value);
+            if (null !== $key) {
+                return [true, $key];
+            }
+        }
+
+        return [false, null];
+    }
+}

--- a/api/src/CustomField/Converter/TextValueConverter.php
+++ b/api/src/CustomField/Converter/TextValueConverter.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\CustomField\Converter;
+
+/**
+ * Produces text values by stringifying (almost) any source scalar. The
+ * url subtype's stricter shape is enforced downstream by the text
+ * strategy's validateValue(), so a non-URL string simply fails to survive
+ * the conversion to a url field.
+ */
+final class TextValueConverter implements CustomFieldTypeConverterInterface
+{
+    public function __construct(private readonly ValueCoercions $coercions)
+    {
+    }
+
+    public function targetKind(): string
+    {
+        return 'text';
+    }
+
+    public function convert(mixed $value, ConversionContext $context): array
+    {
+        $string = $this->coercions->stringify(
+            $value,
+            $context->fromKind,
+            $context->fromSubtype,
+            $context->fromConfig,
+        );
+
+        return null === $string ? [false, null] : [true, $string];
+    }
+}

--- a/api/src/CustomField/Converter/ValueCoercions.php
+++ b/api/src/CustomField/Converter/ValueCoercions.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\CustomField\Converter;
+
+use Symfony\Component\Intl\Currencies;
+
+/**
+ * Shared primitives for reading a source scalar as the building blocks
+ * the destination converters need — a number, a plain string, a parsed
+ * date — plus the currency / select-option helpers those readings lean
+ * on. Stateless; concentrating the source-side rules here keeps each
+ * {@see CustomFieldTypeConverterInterface} focused on shaping its own
+ * target type.
+ */
+final class ValueCoercions
+{
+    /**
+     * Read a scalar as a float for numeric/boolean targets, or null when
+     * it has no numeric meaning. Money divides by the currency's fraction
+     * digits to its major-unit value.
+     *
+     * @param array<string, mixed> $fromConfig
+     */
+    public function toNumber(mixed $value, string $fromKind, string $fromSubtype, array $fromConfig): ?float
+    {
+        if ('numeric' === $fromKind) {
+            if ('money' === $fromSubtype) {
+                if (!is_array($value)) {
+                    return null;
+                }
+                $amount = $value['amount'] ?? null;
+                $currency = $value['currency'] ?? null;
+                if (!is_int($amount) || !is_string($currency)) {
+                    return null;
+                }
+
+                return $amount / (10 ** $this->fractionDigits($currency));
+            }
+            if (is_int($value) || is_float($value)) {
+                return (float) $value;
+            }
+
+            return null;
+        }
+        if ('boolean' === $fromKind) {
+            if (true === $value) {
+                return 1.0;
+            }
+
+            return false === $value ? 0.0 : null;
+        }
+        if ('text' === $fromKind && is_string($value) && is_numeric(trim($value))) {
+            return (float) trim($value);
+        }
+
+        return null;
+    }
+
+    /**
+     * Render a scalar as plain text for text targets, or null when there's
+     * nothing meaningful to show. Money formats to "amount CCY", booleans
+     * to Yes/No, selects to their option label.
+     *
+     * @param array<string, mixed> $fromConfig
+     */
+    public function stringify(mixed $value, string $fromKind, string $fromSubtype, array $fromConfig): ?string
+    {
+        switch ($fromKind) {
+            case 'text':
+            case 'date':
+            case 'reference':
+                return is_string($value) ? $value : null;
+            case 'boolean':
+                if (true === $value) {
+                    return 'Yes';
+                }
+
+                return false === $value ? 'No' : null;
+            case 'numeric':
+                if ('money' === $fromSubtype) {
+                    if (!is_array($value)) {
+                        return null;
+                    }
+                    $amount = $value['amount'] ?? null;
+                    $currency = $value['currency'] ?? null;
+                    if (!is_int($amount) || !is_string($currency)) {
+                        return null;
+                    }
+                    $digits = $this->fractionDigits($currency);
+
+                    return number_format($amount / (10 ** $digits), $digits, '.', '')
+                        . ' ' . strtoupper($currency);
+                }
+                if (is_int($value)) {
+                    return (string) $value;
+                }
+
+                return is_float($value) ? $this->floatToString($value) : null;
+            case 'select':
+                if (!is_string($value)) {
+                    return null;
+                }
+
+                return $this->selectLabels($fromConfig)[$value] ?? $value;
+        }
+
+        return null;
+    }
+
+    /**
+     * Parse a source scalar into a date. Date kinds use their strict wire
+     * format; text falls back to lenient parsing.
+     */
+    public function parseDate(mixed $value, string $fromKind, string $fromSubtype): ?\DateTimeImmutable
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+        if ('date' === $fromKind) {
+            $format = match ($fromSubtype) {
+                'date' => 'Y-m-d',
+                'time' => 'H:i',
+                default => 'Y-m-d\TH:i:sP',
+            };
+            $parsed = \DateTimeImmutable::createFromFormat('!' . $format, $value);
+
+            return false === $parsed ? null : $parsed;
+        }
+        try {
+            return new \DateTimeImmutable($value);
+        } catch (\Exception) {
+            return null;
+        }
+    }
+
+    public function fractionDigits(string $currency): int
+    {
+        $currency = strtoupper($currency);
+
+        return Currencies::exists($currency) ? Currencies::getFractionDigits($currency) : 2;
+    }
+
+    public function floatToString(float $value): string
+    {
+        $string = rtrim(rtrim(sprintf('%.10F', $value), '0'), '.');
+
+        return '' === $string ? '0' : $string;
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     * @return list<string>
+     */
+    public function selectKeys(array $config): array
+    {
+        $options = $config['options'] ?? [];
+        if (!is_array($options)) {
+            return [];
+        }
+        $keys = [];
+        foreach ($options as $option) {
+            if (is_array($option) && is_string($key = $option['key'] ?? null)) {
+                $keys[] = $key;
+            }
+        }
+
+        return $keys;
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     * @return array<string, string>
+     */
+    public function selectLabels(array $config): array
+    {
+        $options = $config['options'] ?? [];
+        if (!is_array($options)) {
+            return [];
+        }
+        $labels = [];
+        foreach ($options as $option) {
+            if (
+                is_array($option)
+                && is_string($key = $option['key'] ?? null)
+                && is_string($label = $option['label'] ?? null)
+            ) {
+                $labels[$key] = $label;
+            }
+        }
+
+        return $labels;
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function keyForLabel(array $config, string $label): ?string
+    {
+        $needle = strtolower(trim($label));
+        foreach ($this->selectLabels($config) as $key => $optionLabel) {
+            if (strtolower(trim($optionLabel)) === $needle) {
+                return $key;
+            }
+        }
+
+        return null;
+    }
+}

--- a/api/src/CustomField/CustomFieldValueConverter.php
+++ b/api/src/CustomField/CustomFieldValueConverter.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\CustomField;
+
+use App\CustomField\Converter\ConversionContext;
+use App\CustomField\Converter\CustomFieldConverterRegistry;
+use App\Entity\CustomFieldDefinition;
+
+/**
+ * Orchestrates best-effort conversion of a stored
+ * {@see \App\Entity\CustomFieldValue} value when a definition's
+ * (kind, subtype, config) changes — so editing a field "Integer" →
+ * "Money", or toggling single ↔ multi, keeps the data instead of silently
+ * orphaning it.
+ *
+ * This class owns the envelope; the per-kind shaping rules live in the
+ * tagged {@see \App\CustomField\Converter\CustomFieldTypeConverterInterface}
+ * services resolved through {@see CustomFieldConverterRegistry} (one per
+ * destination kind). The flow is lenient in, strict out:
+ *
+ *   1. decompose the value into scalar elements (single or multi);
+ *   2. ask the target kind's converter to shape each element — anything
+ *      it can't represent is dropped;
+ *   3. reassemble into the target's single/multi shape (de-duping the
+ *      member-unique kinds);
+ *   4. run the candidate through the **target type strategy's own
+ *      normalize() + validateValue()** — only values the target would
+ *      actually accept survive.
+ *
+ * A value that ends up with nothing is reported unconvertible so the
+ * caller can confirm deletion.
+ */
+final class CustomFieldValueConverter
+{
+    public function __construct(
+        private readonly CustomFieldTypeRegistry $types,
+        private readonly CustomFieldConverterRegistry $converters,
+    ) {
+    }
+
+    /**
+     * @return array{0: bool, 1: mixed} [true, <converted value>] when the
+     *   value survives (possibly reshaped), or [false, null] when it can't
+     *   be represented in the target type and should be dropped.
+     */
+    public function convert(mixed $value, CustomFieldDefinition $from, CustomFieldDefinition $to): array
+    {
+        if (null === $value) {
+            return [true, null];
+        }
+
+        $toKey = $to->getTypeKey();
+        $toKind = $to->getKind();
+        if (!$this->types->has($toKey) || !$this->converters->has($toKind)) {
+            return [false, null];
+        }
+
+        $converter = $this->converters->get($toKind);
+        $context = new ConversionContext(
+            $from->getKind(),
+            $from->getSubtype(),
+            $from->getConfig(),
+            $to->getSubtype(),
+            $to->getConfig(),
+        );
+
+        $elements = ($this->isMulti($from) && is_array($value)) ? array_values($value) : [$value];
+
+        $converted = [];
+        foreach ($elements as $element) {
+            if (null === $element) {
+                continue;
+            }
+            [$ok, $candidate] = $converter->convert($element, $context);
+            if ($ok) {
+                $converted[] = $candidate;
+            }
+        }
+
+        if ([] === $converted) {
+            return [false, null];
+        }
+
+        if ($this->isMulti($to)) {
+            // Selects + references reject duplicate members; numeric/text
+            // multis legitimately allow repeats, so only de-dupe the former.
+            if ('select' === $toKind || 'reference' === $toKind) {
+                $converted = array_values(array_unique($converted, SORT_REGULAR));
+            }
+            $candidate = $converted;
+        } else {
+            $candidate = $converted[0];
+        }
+
+        $strategy = $this->types->get($toKey);
+        $normalized = $strategy->normalize($candidate, $to->getConfig());
+        if ([] !== $strategy->validateValue($normalized, $to->getConfig(), $to)) {
+            return [false, null];
+        }
+
+        return [true, $normalized];
+    }
+
+    /**
+     * Whether a definition stores a list rather than a single value.
+     */
+    public function isMulti(CustomFieldDefinition $def): bool
+    {
+        $kind = $def->getKind();
+        $subtype = $def->getSubtype();
+        if ('select' === $kind) {
+            return 'multi' === $subtype;
+        }
+        if ('boolean' === $kind) {
+            return false;
+        }
+        if ('numeric' === $kind && 'money' === $subtype) {
+            return false;
+        }
+
+        return true === ($def->getConfig()['multi'] ?? false);
+    }
+}

--- a/api/src/Entity/CustomFieldDefinition.php
+++ b/api/src/Entity/CustomFieldDefinition.php
@@ -14,6 +14,7 @@ use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
 use App\CustomField\CustomFieldKind;
 use App\Repository\CustomFieldDefinitionRepository;
+use App\State\CustomFieldDefinitionUpdateProcessor;
 use App\Validator\ValidCustomFieldDefinition;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
@@ -58,6 +59,7 @@ use Symfony\Component\Validator\Constraints as Assert;
         ),
         new Patch(
             security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getProject().isSpaceAdmin(user))",
+            processor: CustomFieldDefinitionUpdateProcessor::class,
         ),
         new Delete(
             security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getProject().isSpaceAdmin(user))",

--- a/api/src/State/CustomFieldDefinitionUpdateProcessor.php
+++ b/api/src/State/CustomFieldDefinitionUpdateProcessor.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\CustomField\CustomFieldTypeRegistry;
+use App\CustomField\CustomFieldValueConverter;
+use App\Entity\CustomFieldDefinition;
+use App\Entity\CustomFieldValue;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+
+/**
+ * Handles `PATCH /custom_field_definitions/{id}`. When the edit changes a
+ * field's value shape — its (kind, subtype), its single↔multi mode, a
+ * money field's currency, or a select field's option set — every existing
+ * {@see CustomFieldValue} for the definition is run through
+ * {@see CustomFieldValueConverter} so data is kept whenever it can be
+ * reshaped (e.g. Integer → Money scales to minor units).
+ *
+ * Values that can't be represented in the new type are deleted — but only
+ * after the caller opts in. Without `?confirmValueConversion=1` the
+ * request is rejected with 409 Conflict (and an `X-Conversion-Lost-Count`
+ * header) so the PWA can show a "these N values will be deleted" dialog
+ * before anything is destroyed. Nothing is persisted on the rejection
+ * path, so a declined confirmation leaves the field untouched.
+ *
+ * @implements ProcessorInterface<CustomFieldDefinition, CustomFieldDefinition>
+ */
+final class CustomFieldDefinitionUpdateProcessor implements ProcessorInterface
+{
+    /**
+     * @param ProcessorInterface<CustomFieldDefinition, CustomFieldDefinition> $persistProcessor
+     */
+    public function __construct(
+        #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
+        private ProcessorInterface $persistProcessor,
+        private EntityManagerInterface $em,
+        private CustomFieldValueConverter $converter,
+        private CustomFieldTypeRegistry $registry,
+        private RequestStack $requestStack,
+    ) {
+    }
+
+    /**
+     * @param CustomFieldDefinition $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): CustomFieldDefinition
+    {
+        $previous = $context['previous_data'] ?? null;
+        if ($previous instanceof CustomFieldDefinition && $this->shapeChanged($previous, $data)) {
+            $this->convertValues($previous, $data);
+        }
+
+        return $this->persistProcessor->process($data, $operation, $uriVariables, $context);
+    }
+
+    /**
+     * Whether the edit could invalidate existing values — i.e. the type
+     * key changed, the single↔multi mode flipped, a money field's currency
+     * moved, or a select field's option set changed. Pure config tweaks
+     * that leave the value shape intact (bounds, labels, colors) skip the
+     * conversion pass entirely.
+     */
+    private function shapeChanged(CustomFieldDefinition $from, CustomFieldDefinition $to): bool
+    {
+        if ($from->getTypeKey() !== $to->getTypeKey()) {
+            return true;
+        }
+        if ($this->converter->isMulti($from) !== $this->converter->isMulti($to)) {
+            return true;
+        }
+        if ('numeric' === $to->getKind() && 'money' === $to->getSubtype()) {
+            $fromCurrency = $from->getConfig()['currency'] ?? null;
+            $toCurrency = $to->getConfig()['currency'] ?? null;
+            $fromCurrency = is_string($fromCurrency) ? strtoupper($fromCurrency) : null;
+            $toCurrency = is_string($toCurrency) ? strtoupper($toCurrency) : null;
+
+            return $fromCurrency !== $toCurrency;
+        }
+        if ('select' === $to->getKind()) {
+            return ($from->getConfig()['options'] ?? null) !== ($to->getConfig()['options'] ?? null);
+        }
+
+        return false;
+    }
+
+    private function convertValues(CustomFieldDefinition $from, CustomFieldDefinition $to): void
+    {
+        /** @var list<CustomFieldValue> $values */
+        $values = $this->em->getRepository(CustomFieldValue::class)->findBy(['definition' => $to]);
+
+        $toDelete = [];
+        foreach ($values as $cfv) {
+            $current = $cfv->getValue();
+            if (null === $current) {
+                continue;
+            }
+            [$ok, $converted] = $this->converter->convert($current, $from, $to);
+            if ($ok) {
+                if ($converted !== $current) {
+                    $cfv->setValue($converted);
+                    // Set value_search here too so it lands in the same
+                    // change-set as `value`. An in-place CFV update is the
+                    // one path that fires the search subscriber's preUpdate
+                    // (task edits delete + re-insert instead), and that
+                    // path can't add `valueSearch` to the change-set on its
+                    // own — pre-setting it keeps the projection consistent.
+                    $cfv->setValueSearch($this->searchText($to, $converted));
+                }
+            } else {
+                $toDelete[] = $cfv;
+            }
+        }
+
+        if ([] === $toDelete) {
+            return;
+        }
+
+        if (!$this->confirmed()) {
+            $count = count($toDelete);
+            throw new ConflictHttpException(
+                sprintf(
+                    '%d task value%s cannot be converted to "%s" and will be deleted.',
+                    $count,
+                    1 === $count ? '' : 's',
+                    $to->getName(),
+                ),
+                null,
+                0,
+                ['X-Conversion-Lost-Count' => (string) $count],
+            );
+        }
+
+        foreach ($toDelete as $cfv) {
+            $this->em->remove($cfv);
+        }
+    }
+
+    /**
+     * The FTS projection for a converted value under the new type — mirrors
+     * {@see \App\CustomField\EventSubscriber\CustomFieldValueSearchSubscriber}'s
+     * empty-string-to-null normalization.
+     */
+    private function searchText(CustomFieldDefinition $definition, mixed $value): ?string
+    {
+        $key = $definition->getTypeKey();
+        if (!$this->registry->has($key)) {
+            return null;
+        }
+        $text = $this->registry->get($key)->searchText($value, $definition->getConfig());
+
+        return null === $text || '' === trim($text) ? null : $text;
+    }
+
+    /**
+     * The caller has acknowledged that unconvertible values will be
+     * deleted (the PWA re-sends the PATCH with this flag after the
+     * confirmation dialog).
+     */
+    private function confirmed(): bool
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        if (null === $request) {
+            return false;
+        }
+        $flag = $request->query->get('confirmValueConversion');
+
+        return '1' === $flag || 'true' === $flag;
+    }
+}

--- a/api/src/State/TaskOwnerProcessor.php
+++ b/api/src/State/TaskOwnerProcessor.php
@@ -41,6 +41,15 @@ final class TaskOwnerProcessor implements ProcessorInterface
 
         $data->setOwner($user);
 
+        // In a personal ("Private") space everything belongs to the one
+        // member, so a new task with no assignees defaults to its creator —
+        // saving the repetitive self-assign on a solo board. Shared spaces
+        // keep starting unassigned so the team picks who owns the work.
+        $space = $data->getProject()?->getSpace();
+        if ($data->getAssignees()->isEmpty() && true === $space?->getIsPersonal()) {
+            $data->addAssignee($user);
+        }
+
         $min = $this->tasks->findMinPositionForOwner($user);
         $data->setPosition(null === $min ? 0 : $min - 1);
 

--- a/api/tests/Api/CustomFieldConversionTest.php
+++ b/api/tests/Api/CustomFieldConversionTest.php
@@ -1,0 +1,263 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\CustomFieldDefinition;
+use App\Entity\CustomFieldValue;
+use App\Entity\Project;
+use App\Entity\Task;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Converting a custom field's (kind, subtype, config) migrates existing
+ * values when possible and only deletes the rest after the caller
+ * confirms — see {@see \App\State\CustomFieldDefinitionUpdateProcessor}
+ * and {@see \App\CustomField\CustomFieldValueConverter}.
+ */
+class CustomFieldConversionTest extends ApiTestCase
+{
+    use SpaceMembershipFixture;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\CustomFieldValue')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\CustomFieldDefinition')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testIntToMoneyScalesAndKeepsValues(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $field = $this->seedField($project, 'Estimate', 'numeric', 'int');
+        $task = $this->createTask($alice, $project, 'A');
+        $cfv = $this->seedValue($task, $field, 5);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/custom_field_definitions/' . $field->getId(), [
+            'json' => [
+                'kind' => 'numeric',
+                'subtype' => 'money',
+                'config' => ['currency' => 'USD'],
+            ],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $this->entityManager->clear();
+        $reloaded = $this->entityManager->getRepository(CustomFieldValue::class)->find($cfv->getId());
+        $this->assertNotNull($reloaded);
+        // 5 → 5.00 → 500 minor units.
+        $this->assertSame(['amount' => 500, 'currency' => 'USD'], $reloaded->getValue());
+    }
+
+    public function testDecimalToIntRoundsToNearest(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $field = $this->seedField($project, 'Score', 'numeric', 'float');
+        $task = $this->createTask($alice, $project, 'A');
+        $cfv = $this->seedValue($task, $field, 5.7);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/custom_field_definitions/' . $field->getId(), [
+            'json' => ['kind' => 'numeric', 'subtype' => 'int', 'config' => []],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $this->entityManager->clear();
+        $reloaded = $this->entityManager->getRepository(CustomFieldValue::class)->find($cfv->getId());
+        $this->assertNotNull($reloaded);
+        $this->assertSame(6, $reloaded->getValue());
+    }
+
+    public function testSingleToMultiWrapsValue(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $field = $this->seedField($project, 'Tags', 'text', 'text');
+        $task = $this->createTask($alice, $project, 'A');
+        $cfv = $this->seedValue($task, $field, 'urgent');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/custom_field_definitions/' . $field->getId(), [
+            'json' => ['kind' => 'text', 'subtype' => 'text', 'config' => ['multi' => true]],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $this->entityManager->clear();
+        $reloaded = $this->entityManager->getRepository(CustomFieldValue::class)->find($cfv->getId());
+        $this->assertNotNull($reloaded);
+        $this->assertSame(['urgent'], $reloaded->getValue());
+    }
+
+    public function testUnconvertibleWithoutConfirmationIsBlocked(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $field = $this->seedField($project, 'Notes', 'text', 'text');
+        $task = $this->createTask($alice, $project, 'A');
+        $cfv = $this->seedValue($task, $field, 'not a number');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        // text "not a number" can't become an int → blocked pending confirmation.
+        $client->request('PATCH', '/custom_field_definitions/' . $field->getId(), [
+            'json' => ['kind' => 'numeric', 'subtype' => 'int', 'config' => []],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(409);
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $this->assertSame(['1'], $response->getHeaders(false)['x-conversion-lost-count'] ?? []);
+
+        // Nothing was persisted: the field keeps its type and the value survives.
+        $this->entityManager->clear();
+        $stillText = $this->entityManager->getRepository(CustomFieldDefinition::class)->find($field->getId());
+        $this->assertNotNull($stillText);
+        $this->assertSame('text.text', $stillText->getTypeKey());
+        $this->assertNotNull($this->entityManager->getRepository(CustomFieldValue::class)->find($cfv->getId()));
+    }
+
+    public function testUnconvertibleWithConfirmationConvertsAndDeletes(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $field = $this->seedField($project, 'Notes', 'text', 'text');
+        $task = $this->createTask($alice, $project, 'A');
+        $cfv = $this->seedValue($task, $field, 'not a number');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/custom_field_definitions/' . $field->getId() . '?confirmValueConversion=1', [
+            'json' => ['kind' => 'numeric', 'subtype' => 'int', 'config' => []],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $this->entityManager->clear();
+        $this->assertNull($this->entityManager->getRepository(CustomFieldValue::class)->find($cfv->getId()));
+        $converted = $this->entityManager->getRepository(CustomFieldDefinition::class)->find($field->getId());
+        $this->assertNotNull($converted);
+        $this->assertSame('numeric.int', $converted->getTypeKey());
+    }
+
+    public function testConvertibleAndUnconvertibleMix(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $field = $this->seedField($project, 'Notes', 'text', 'text');
+        $task1 = $this->createTask($alice, $project, 'A');
+        $task2 = $this->createTask($alice, $project, 'B');
+        $keep = $this->seedValue($task1, $field, '42');
+        $drop = $this->seedValue($task2, $field, 'banana');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/custom_field_definitions/' . $field->getId() . '?confirmValueConversion=1', [
+            'json' => ['kind' => 'numeric', 'subtype' => 'int', 'config' => []],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $this->entityManager->clear();
+        $keepReloaded = $this->entityManager->getRepository(CustomFieldValue::class)->find($keep->getId());
+        $this->assertNotNull($keepReloaded);
+        $this->assertSame(42, $keepReloaded->getValue());
+        $this->assertNull($this->entityManager->getRepository(CustomFieldValue::class)->find($drop->getId()));
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function seedField(
+        Project $project,
+        string $name,
+        string $kind,
+        string $subtype,
+        array $config = [],
+    ): CustomFieldDefinition {
+        $field = new CustomFieldDefinition();
+        $field->setProject($project);
+        $field->setName($name);
+        $field->setKind($kind);
+        $field->setSubtype($subtype);
+        $field->setConfig($config);
+        $this->entityManager->persist($field);
+        $this->entityManager->flush();
+        return $field;
+    }
+
+    private function seedValue(Task $task, CustomFieldDefinition $definition, mixed $value): CustomFieldValue
+    {
+        $cfv = new CustomFieldValue();
+        $cfv->setTask($task);
+        $cfv->setDefinition($definition);
+        $cfv->setValue($value);
+        $this->entityManager->persist($cfv);
+        $this->entityManager->flush();
+        return $cfv;
+    }
+
+    private function createProject(User $owner, string $title): Project
+    {
+        $project = new Project();
+        $project->setOwner($owner);
+        $project->setTitle($title);
+        $this->addProjectMember($project, $owner);
+        $this->entityManager->persist($project);
+        $this->entityManager->flush();
+        return $project;
+    }
+
+    private function createTask(User $owner, Project $project, string $title): Task
+    {
+        $task = new Task();
+        $task->setOwner($owner);
+        $task->setProject($project);
+        $task->setTitle($title);
+        $this->entityManager->persist($task);
+        $this->entityManager->flush();
+        return $task;
+    }
+
+    /**
+     * @param string[] $roles
+     */
+    private function createUser(string $email, array $roles = ['ROLE_USER']): User
+    {
+        $container = static::getContainer();
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles($roles);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/api/tests/Api/TaskDefaultAssigneeTest.php
+++ b/api/tests/Api/TaskDefaultAssigneeTest.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\Project;
+use App\Entity\Space;
+use App\Entity\SpaceMembership;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * A new task created in a personal ("Private") space auto-assigns its
+ * creator, since that space has exactly one member — see
+ * {@see \App\State\TaskOwnerProcessor}. Shared spaces start unassigned.
+ */
+class TaskDefaultAssigneeTest extends ApiTestCase
+{
+    use SpaceMembershipFixture;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\SpaceMembership')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Space')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testPersonalSpaceTaskDefaultsToCreator(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $space = $this->createSpace($alice, personal: true);
+        $project = $this->createProject($alice, $space, 'Private board');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks', [
+            'json' => ['title' => 'Solo task', 'project' => '/projects/' . $project->getId()],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+
+        $assignees = $this->assigneeIris($client);
+        $this->assertSame(['/users/' . $alice->getId()], $assignees);
+    }
+
+    public function testSharedSpaceTaskStaysUnassigned(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $space = $this->createSpace($alice, personal: false);
+        $project = $this->createProject($alice, $space, 'Team board');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks', [
+            'json' => ['title' => 'Team task', 'project' => '/projects/' . $project->getId()],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+
+        $this->assertSame([], $this->assigneeIris($client));
+    }
+
+    public function testPersonalSpaceTaskKeepsExplicitAssignees(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $space = $this->createSpace($alice, personal: false);
+        $this->ensureSpaceMembership($space, $bob);
+        $project = $this->createProject($alice, $space, 'Board');
+
+        // Even though the default would add Alice, an explicit assignee list
+        // is respected as-is.
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks', [
+            'json' => [
+                'title' => 'Assigned to Bob',
+                'project' => '/projects/' . $project->getId(),
+                'assignees' => ['/users/' . $bob->getId()],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+
+        $this->assertSame(['/users/' . $bob->getId()], $this->assigneeIris($client));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function assigneeIris(\ApiPlatform\Symfony\Bundle\Test\Client $client): array
+    {
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+        $assignees = $body['assignees'] ?? null;
+        $this->assertIsArray($assignees);
+
+        return array_values(array_map(
+            static fn (mixed $a): string => is_array($a) && is_string($a['@id'] ?? null) ? $a['@id'] : '',
+            $assignees,
+        ));
+    }
+
+    private function createSpace(User $owner, bool $personal): Space
+    {
+        $space = (new Space())
+            ->setName($personal ? Space::PERSONAL_SPACE_NAME : 'Team')
+            ->setIsPersonal($personal)
+            ->setCreatedBy($owner);
+        if ($personal) {
+            $space->setVisibility(Space::VISIBILITY_PRIVATE);
+        }
+        $space->addUserMembership(
+            (new SpaceMembership())->setUser($owner)->setRole(Space::ROLE_ADMIN),
+        );
+        $this->entityManager->persist($space);
+        $this->entityManager->flush();
+
+        return $space;
+    }
+
+    private function createProject(User $owner, Space $space, string $title): Project
+    {
+        $project = new Project();
+        $project->setOwner($owner);
+        $project->setSpace($space);
+        $project->setTitle($title);
+        $this->entityManager->persist($project);
+        $this->entityManager->flush();
+
+        return $project;
+    }
+
+    /**
+     * @param string[] $roles
+     */
+    private function createUser(string $email, array $roles = ['ROLE_USER']): User
+    {
+        $container = static::getContainer();
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles($roles);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/api/tests/Api/TaskTest.php
+++ b/api/tests/Api/TaskTest.php
@@ -1378,6 +1378,46 @@ class TaskTest extends ApiTestCase
     }
 
     /**
+     * Guards the cross-space information leak fixed alongside this test:
+     * a user who is an effective member of a space the caller does NOT
+     * belong to must never surface in the caller's assignable-users list.
+     * The old controller did a raw `Project::findAll()` (unscoped by the
+     * access extension), so every effective member of every space in the
+     * instance leaked through.
+     */
+    public function testAssignableUsersExcludesMembersOfOtherSpaces(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $carol = $this->createUser('carol@example.com');
+
+        // Alice's own space, shared with Bob.
+        $this->createSharedProject($alice, [$alice, $bob], 'Alice Team');
+        // A separate space Alice has no part in — Carol + Dave only.
+        $dave = $this->createUser('dave@example.com');
+        $this->createSharedProject($carol, [$carol, $dave], 'Carol Team');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/me/assignable-users');
+
+        $this->assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+        $members = $body['member'] ?? null;
+        $this->assertIsArray($members);
+        $emails = array_map(
+            static fn (mixed $u): mixed => is_array($u) ? $u['email'] ?? null : null,
+            $members,
+        );
+        sort($emails);
+        $this->assertSame(['alice@example.com', 'bob@example.com'], $emails);
+        $this->assertNotContains('carol@example.com', $emails);
+        $this->assertNotContains('dave@example.com', $emails);
+    }
+
+    /**
      * @param User[] $members
      */
     private function createSharedProject(User $owner, array $members, string $title): Project

--- a/pwa/components/custom-fields/CustomFieldFooterRow.tsx
+++ b/pwa/components/custom-fields/CustomFieldFooterRow.tsx
@@ -3,7 +3,7 @@ import { ENTRYPOINT } from "@/config/entrypoint";
 import { Card, CardContent } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import TaskTableColumns from "@/components/projects/TaskTableColumns";
-import type { CustomFieldDefinition } from "./types";
+import type { ListColumn } from "@/components/projects/listColumns";
 import type { FooterResponse, FooterRow } from "./types";
 
 /**
@@ -30,8 +30,9 @@ interface Props {
   visibleDefinitions?: string[];
   /** When set, render a column-aligned bar (a `table-fixed` table sharing the
    *  section tables' columns via {@link TaskTableColumns}) so each total sits
-   *  under its custom-field column. Used for the grand-total bars. */
-  columns?: CustomFieldDefinition[];
+   *  under its custom-field column — in the same (possibly reordered) order as
+   *  the table above. Used for the per-section + grand-total bars. */
+  columns?: ListColumn[];
   /** Stronger styling for the grand-total bars. */
   prominent?: boolean;
   /** Render as a bare table (no card wrapper) to sit inside a section table's
@@ -133,17 +134,21 @@ const CustomFieldFooterRow = ({
     const valueByDef = new Map(rows.map((row) => [row.definition, row]));
     const cells = (
       <>
+        {/* checkbox + # — fixed leading columns, mirroring the task table. */}
         <td className="px-3 py-2" />
         <td className="px-1 py-2" />
-        <td className="px-2 py-2" />
-        <td className="px-2 py-2" />
-        <td className="px-2 py-2" />
-        <td className="px-2 py-2" />
-        {columns.map((def) => {
-          const row = valueByDef.get(def["@id"]);
+        {columns.map((column) => {
+          // Only custom-field columns can carry an aggregate; built-ins
+          // (Task / Due / Assignees / Tags) render an empty spacer so the
+          // totals stay aligned under their column after any reorder.
+          const def = column.definition;
+          const row = def ? valueByDef.get(def["@id"]) : undefined;
+          if (!def) {
+            return <td key={column.key} className="px-2 py-2" />;
+          }
           return (
             <td
-              key={def["@id"]}
+              key={column.key}
               className="px-2 py-2 align-top"
               data-testid="custom-field-footer-cell"
             >
@@ -172,7 +177,7 @@ const CustomFieldFooterRow = ({
           className="w-full table-fixed border-t text-sm"
           data-testid="custom-field-footer-row"
         >
-          <TaskTableColumns definitions={columns} />
+          <TaskTableColumns columns={columns} />
           <tbody>
             <tr>{cells}</tr>
           </tbody>
@@ -192,7 +197,7 @@ const CustomFieldFooterRow = ({
       >
         <div className="overflow-x-auto">
           <table className="w-full table-fixed text-sm">
-            <TaskTableColumns definitions={columns} />
+            <TaskTableColumns columns={columns} />
             <tbody>
               <tr>{cells}</tr>
             </tbody>

--- a/pwa/components/custom-fields/CustomFieldSheet.tsx
+++ b/pwa/components/custom-fields/CustomFieldSheet.tsx
@@ -9,6 +9,7 @@ import { Copy, MoreHorizontal, Trash2 } from "lucide-react";
 import { ENTRYPOINT } from "@/config/entrypoint";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+import ConfirmDialog from "@/components/common/ConfirmDialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -161,6 +162,10 @@ const CustomFieldSheet = ({
   const [submitting, setSubmitting] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // When a type change would orphan existing task values, the server
+  // replies 409 with the count; we hold it here to drive the confirm
+  // dialog, then retry the save with the confirmation flag.
+  const [conversionLost, setConversionLost] = useState<number | null>(null);
   const [optionStats, setOptionStats] = useState<Record<string, number>>({});
 
   // Live preview: build a definition from the current form state and render
@@ -280,55 +285,78 @@ const CustomFieldSheet = ({
     setFooter((prev) => ({ kind: fk, label: prev?.label }));
   };
 
+  // Performs the actual POST/PATCH. On edit, `confirmConversion` appends
+  // the flag that tells the server to delete values that can't be migrated
+  // to the new field type.
+  const sendSave = (confirmConversion: boolean): Promise<Response> => {
+    const body: Record<string, unknown> = {
+      name: name.trim(),
+      kind,
+      subtype,
+      config,
+      nullable,
+      footer,
+      visibility,
+    };
+    if (isEdit && initial) {
+      const url = `${ENTRYPOINT}${initial["@id"]}${
+        confirmConversion ? "?confirmValueConversion=1" : ""
+      }`;
+      return fetch(url, {
+        method: "PATCH",
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/merge-patch+json",
+          Accept: "application/ld+json",
+        },
+        body: JSON.stringify(body),
+      });
+    }
+    return fetch(`${ENTRYPOINT}/custom_field_definitions`, {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/ld+json" },
+      body: JSON.stringify({ ...body, project: projectIri, position: initialPosition }),
+    });
+  };
+
+  const finishSave = async (res: Response) => {
+    if (!res.ok) throw new Error(await errorMessage(res));
+    const saved: CustomFieldDefinition = await res.json();
+    onSaved(saved);
+    onOpenChange(false);
+  };
+
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    const trimmedName = name.trim();
-    if (!trimmedName) return;
+    if (!name.trim()) return;
 
     setSubmitting(true);
     setError(null);
     try {
-      const body: Record<string, unknown> = {
-        name: trimmedName,
-        kind,
-        subtype,
-        config,
-        nullable,
-        footer,
-        visibility,
-      };
-      let res: Response;
-      if (isEdit && initial) {
-        res = await fetch(`${ENTRYPOINT}${initial["@id"]}`, {
-          method: "PATCH",
-          credentials: "include",
-          headers: {
-            "Content-Type": "application/merge-patch+json",
-            Accept: "application/ld+json",
-          },
-          body: JSON.stringify(body),
-        });
-      } else {
-        res = await fetch(`${ENTRYPOINT}/custom_field_definitions`, {
-          method: "POST",
-          credentials: "include",
-          headers: { "Content-Type": "application/ld+json" },
-          body: JSON.stringify({
-            ...body,
-            project: projectIri,
-            position: initialPosition,
-          }),
-        });
+      const res = await sendSave(false);
+      // The type change would orphan some values — pause and confirm
+      // before anything is deleted.
+      if (isEdit && res.status === 409) {
+        const header = res.headers.get("X-Conversion-Lost-Count");
+        const count = header ? Number.parseInt(header, 10) : 0;
+        setConversionLost(Number.isFinite(count) && count > 0 ? count : 1);
+        return;
       }
-      if (!res.ok) throw new Error(await errorMessage(res));
-      const saved: CustomFieldDefinition = await res.json();
-      onSaved(saved);
-      onOpenChange(false);
+      await finishSave(res);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to save.");
     } finally {
       setSubmitting(false);
     }
+  };
+
+  // Retry the save after the user confirms the lossy conversion. Throws on
+  // failure so the ConfirmDialog keeps itself open and surfaces the error.
+  const confirmConversion = async () => {
+    const res = await sendSave(true);
+    await finishSave(res);
+    setConversionLost(null);
   };
 
   const handleDelete = async () => {
@@ -366,6 +394,7 @@ const CustomFieldSheet = ({
     // which would swallow clicks on those portaled popups. The
     // onInteractOutside guard keeps the drawer open when the user is
     // interacting with one of those popups rather than truly clicking out.
+    <>
     <Sheet open={open} onOpenChange={onOpenChange} modal={false}>
       <SheetContent
         side="right"
@@ -730,6 +759,23 @@ const CustomFieldSheet = ({
         </form>
       </SheetContent>
     </Sheet>
+    <ConfirmDialog
+      open={conversionLost !== null}
+      onOpenChange={(o) => {
+        if (!o) setConversionLost(null);
+      }}
+      title="Some values can't be converted"
+      description={
+        conversionLost === null
+          ? undefined
+          : `${conversionLost} task value${conversionLost === 1 ? "" : "s"} can't be converted to the new field type and will be permanently deleted. Values that can be converted are kept.`
+      }
+      confirmLabel="Convert & delete"
+      cancelLabel="Keep editing"
+      destructive
+      onConfirm={confirmConversion}
+    />
+    </>
   );
 };
 

--- a/pwa/components/projects/ColumnHeaderMenu.tsx
+++ b/pwa/components/projects/ColumnHeaderMenu.tsx
@@ -1,0 +1,385 @@
+import { useState } from "react";
+import { ArrowDown, ArrowUp, ChevronsUpDown, Filter } from "lucide-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
+import { displayName } from "@/lib/userDisplay";
+import { cn } from "@/lib/utils";
+import type { AssigneeOption } from "@/components/tasks/AssigneesCombobox";
+import type { TagOption } from "@/components/tasks/TagsCombobox";
+import {
+  isFilterActive,
+  type FilterValue,
+  type ListColumn,
+  type SortState,
+} from "./listColumns";
+
+interface ColumnHeaderMenuProps {
+  column: ListColumn;
+  sort: SortState | null;
+  filter: FilterValue | undefined;
+  onSetSort: (sort: SortState | null) => void;
+  onSetFilter: (key: string, value: FilterValue | null) => void;
+  assignableUsers: AssigneeOption[];
+  allTags: TagOption[];
+}
+
+/** A radio-style choice button used by the single-select filter kinds. */
+const Choice = ({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={cn(
+      "rounded-md px-2 py-1 text-left text-sm transition-colors",
+      active ? "bg-accent text-accent-foreground font-medium" : "hover:bg-accent",
+    )}
+  >
+    {children}
+  </button>
+);
+
+/** A checkbox row used by the multi-select filter kinds. */
+const CheckRow = ({
+  checked,
+  onChange,
+  children,
+}: {
+  checked: boolean;
+  onChange: (next: boolean) => void;
+  children: React.ReactNode;
+}) => (
+  <label className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1 text-sm hover:bg-accent">
+    <Checkbox
+      checked={checked}
+      onCheckedChange={(v) => onChange(v === true)}
+      className="size-4"
+    />
+    <span className="min-w-0 flex-1 truncate">{children}</span>
+  </label>
+);
+
+const ColumnHeaderMenu = ({
+  column,
+  sort,
+  filter,
+  onSetSort,
+  onSetFilter,
+  assignableUsers,
+  allTags,
+}: ColumnHeaderMenuProps) => {
+  const [open, setOpen] = useState(false);
+  const sortedHere = sort?.key === column.key;
+  const filtered = isFilterActive(filter);
+
+  const set = (value: FilterValue | null) => onSetFilter(column.key, value);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "-mx-1 flex w-full items-center gap-1 rounded px-1 py-0.5 text-left font-medium hover:bg-accent",
+            (sortedHere || filtered) && "text-foreground",
+          )}
+          aria-label={`${column.label} column options`}
+          data-testid={`column-header-${column.key}`}
+        >
+          <span className="truncate">{column.label}</span>
+          {sortedHere ? (
+            sort.dir === "asc" ? (
+              <ArrowUp className="size-3 shrink-0" />
+            ) : (
+              <ArrowDown className="size-3 shrink-0" />
+            )
+          ) : (
+            <ChevronsUpDown className="size-3 shrink-0 opacity-40" />
+          )}
+          {filtered && (
+            <Filter className="size-3 shrink-0 fill-current text-cyan-600 dark:text-cyan-400" />
+          )}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-60 p-2">
+        {column.sortable && (
+          <div className="mb-1 flex flex-col gap-0.5">
+            <Choice
+              active={sortedHere && sort.dir === "asc"}
+              onClick={() => onSetSort({ key: column.key, dir: "asc" })}
+            >
+              <span className="flex items-center gap-2">
+                <ArrowUp className="size-3.5" /> Sort ascending
+              </span>
+            </Choice>
+            <Choice
+              active={sortedHere && sort.dir === "desc"}
+              onClick={() => onSetSort({ key: column.key, dir: "desc" })}
+            >
+              <span className="flex items-center gap-2">
+                <ArrowDown className="size-3.5" /> Sort descending
+              </span>
+            </Choice>
+            {sortedHere && (
+              <Choice active={false} onClick={() => onSetSort(null)}>
+                <span className="text-muted-foreground">Clear sort</span>
+              </Choice>
+            )}
+          </div>
+        )}
+
+        {column.sortable && column.filter !== "presence" && (
+          <div className="my-1 h-px bg-border" />
+        )}
+
+        <FilterControls
+          column={column}
+          filter={filter}
+          set={set}
+          assignableUsers={assignableUsers}
+          allTags={allTags}
+        />
+
+        {filtered && (
+          <button
+            type="button"
+            onClick={() => set(null)}
+            className="mt-1 w-full rounded-md px-2 py-1 text-left text-sm text-muted-foreground hover:bg-accent"
+          >
+            Clear filter
+          </button>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+const FilterControls = ({
+  column,
+  filter,
+  set,
+  assignableUsers,
+  allTags,
+}: {
+  column: ListColumn;
+  filter: FilterValue | undefined;
+  set: (value: FilterValue | null) => void;
+  assignableUsers: AssigneeOption[];
+  allTags: TagOption[];
+}) => {
+  switch (column.filter) {
+    case "text": {
+      const query = filter?.kind === "text" ? filter.query : "";
+      return (
+        <Input
+          value={query}
+          onChange={(e) =>
+            set(e.target.value ? { kind: "text", query: e.target.value } : null)
+          }
+          placeholder={`Filter ${column.label.toLowerCase()}…`}
+          className="h-8"
+          aria-label={`Filter ${column.label}`}
+        />
+      );
+    }
+    case "due": {
+      const mode = filter?.kind === "due" ? filter.mode : "all";
+      const opts: Array<{ value: "all" | "has" | "none" | "overdue"; label: string }> = [
+        { value: "all", label: "Any" },
+        { value: "has", label: "Has a due date" },
+        { value: "none", label: "No due date" },
+        { value: "overdue", label: "Overdue" },
+      ];
+      return (
+        <div className="flex flex-col gap-0.5">
+          {opts.map((o) => (
+            <Choice
+              key={o.value}
+              active={mode === o.value}
+              onClick={() =>
+                set(o.value === "all" ? null : { kind: "due", mode: o.value })
+              }
+            >
+              {o.label}
+            </Choice>
+          ))}
+        </div>
+      );
+    }
+    case "date":
+    case "presence": {
+      const mode = filter?.kind === column.filter ? filter.mode : "all";
+      const opts: Array<{ value: "all" | "has" | "none"; label: string }> = [
+        { value: "all", label: "Any" },
+        { value: "has", label: "Has a value" },
+        { value: "none", label: "Empty" },
+      ];
+      return (
+        <div className="flex flex-col gap-0.5">
+          {opts.map((o) => (
+            <Choice
+              key={o.value}
+              active={mode === o.value}
+              onClick={() =>
+                set(
+                  o.value === "all"
+                    ? null
+                    : { kind: column.filter as "date" | "presence", mode: o.value },
+                )
+              }
+            >
+              {o.label}
+            </Choice>
+          ))}
+        </div>
+      );
+    }
+    case "boolean": {
+      const mode = filter?.kind === "boolean" ? filter.mode : "all";
+      const opts: Array<{ value: "all" | "true" | "false"; label: string }> = [
+        { value: "all", label: "Any" },
+        { value: "true", label: "Yes" },
+        { value: "false", label: "No" },
+      ];
+      return (
+        <div className="flex flex-col gap-0.5">
+          {opts.map((o) => (
+            <Choice
+              key={o.value}
+              active={mode === o.value}
+              onClick={() =>
+                set(o.value === "all" ? null : { kind: "boolean", mode: o.value })
+              }
+            >
+              {o.label}
+            </Choice>
+          ))}
+        </div>
+      );
+    }
+    case "assignees": {
+      const current =
+        filter?.kind === "assignees"
+          ? filter
+          : { kind: "assignees" as const, iris: [], unassigned: false };
+      const toggleIri = (iri: string, checked: boolean) => {
+        const iris = checked
+          ? [...current.iris, iri]
+          : current.iris.filter((x) => x !== iri);
+        const next = { kind: "assignees" as const, iris, unassigned: current.unassigned };
+        set(isAssigneesActive(next) ? next : null);
+      };
+      return (
+        <div className="flex max-h-56 flex-col gap-0.5 overflow-y-auto">
+          <CheckRow
+            checked={current.unassigned}
+            onChange={(v) => {
+              const next = { kind: "assignees" as const, iris: current.iris, unassigned: v };
+              set(isAssigneesActive(next) ? next : null);
+            }}
+          >
+            <span className="text-muted-foreground">Unassigned</span>
+          </CheckRow>
+          {assignableUsers.map((u) => (
+            <CheckRow
+              key={u["@id"]}
+              checked={current.iris.includes(u["@id"])}
+              onChange={(v) => toggleIri(u["@id"], v)}
+            >
+              {displayName(u)}
+            </CheckRow>
+          ))}
+        </div>
+      );
+    }
+    case "tags": {
+      const current =
+        filter?.kind === "tags"
+          ? filter
+          : { kind: "tags" as const, iris: [], untagged: false };
+      const toggleIri = (iri: string, checked: boolean) => {
+        const iris = checked
+          ? [...current.iris, iri]
+          : current.iris.filter((x) => x !== iri);
+        const next = { kind: "tags" as const, iris, untagged: current.untagged };
+        set(next.iris.length > 0 || next.untagged ? next : null);
+      };
+      return (
+        <div className="flex max-h-56 flex-col gap-0.5 overflow-y-auto">
+          <CheckRow
+            checked={current.untagged}
+            onChange={(v) => {
+              const next = { kind: "tags" as const, iris: current.iris, untagged: v };
+              set(next.iris.length > 0 || next.untagged ? next : null);
+            }}
+          >
+            <span className="text-muted-foreground">Untagged</span>
+          </CheckRow>
+          {allTags.map((t) => (
+            <CheckRow
+              key={t["@id"]}
+              checked={current.iris.includes(t["@id"])}
+              onChange={(v) => toggleIri(t["@id"], v)}
+            >
+              {t.title}
+            </CheckRow>
+          ))}
+        </div>
+      );
+    }
+    case "select": {
+      const options = column.definition?.config.options ?? [];
+      const current =
+        filter?.kind === "select"
+          ? filter
+          : { kind: "select" as const, keys: [], empty: false };
+      const toggleKey = (key: string, checked: boolean) => {
+        const keys = checked
+          ? [...current.keys, key]
+          : current.keys.filter((x) => x !== key);
+        const next = { kind: "select" as const, keys, empty: current.empty };
+        set(next.keys.length > 0 || next.empty ? next : null);
+      };
+      return (
+        <div className="flex max-h-56 flex-col gap-0.5 overflow-y-auto">
+          <CheckRow
+            checked={current.empty}
+            onChange={(v) => {
+              const next = { kind: "select" as const, keys: current.keys, empty: v };
+              set(next.keys.length > 0 || next.empty ? next : null);
+            }}
+          >
+            <span className="text-muted-foreground">Empty</span>
+          </CheckRow>
+          {options.map((o) => (
+            <CheckRow
+              key={o.key}
+              checked={current.keys.includes(o.key)}
+              onChange={(v) => toggleKey(o.key, v)}
+            >
+              {o.label}
+            </CheckRow>
+          ))}
+        </div>
+      );
+    }
+  }
+};
+
+const isAssigneesActive = (v: {
+  iris: string[];
+  unassigned: boolean;
+}): boolean => v.iris.length > 0 || v.unassigned;
+
+export default ColumnHeaderMenu;

--- a/pwa/components/projects/TaskTableColumns.tsx
+++ b/pwa/components/projects/TaskTableColumns.tsx
@@ -1,29 +1,21 @@
-import type { CustomFieldDefinition } from "@/components/custom-fields/types";
+import type { ListColumn } from "@/components/projects/listColumns";
 
 /**
  * Shared `<colgroup>` for the project list view's tables, so the per-section
  * tables and the grand-total bar line up column-for-column. Every table that
- * uses it must be `table-fixed`. Column order mirrors the section table:
+ * uses it must be `table-fixed`. Layout:
  *
- *   checkbox · # · Task · Due · Assignees · Tags · [custom fields…] · actions
+ *   checkbox · # · [data columns, in the user's order] · actions
  *
- * The Task column carries no width so `table-fixed` gives it the remaining
- * space; everything else is fixed so the columns are identical across tables.
+ * The data columns (Task / Due / Assignees / Tags / custom fields) carry
+ * their own width class; Task's is "" so `table-fixed` gives it the slack.
  */
-const TaskTableColumns = ({
-  definitions,
-}: {
-  definitions: CustomFieldDefinition[];
-}) => (
+const TaskTableColumns = ({ columns }: { columns: ListColumn[] }) => (
   <colgroup>
     <col className="w-8" />
     <col className="w-10" />
-    <col />
-    <col className="w-32" />
-    <col className="w-44" />
-    <col className="w-44" />
-    {definitions.map((d) => (
-      <col key={d["@id"]} className="w-32" />
+    {columns.map((column) => (
+      <col key={column.key} className={column.widthClass} />
     ))}
     <col className="w-10" />
   </colgroup>

--- a/pwa/components/projects/listColumns.ts
+++ b/pwa/components/projects/listColumns.ts
@@ -1,0 +1,342 @@
+import { displayName } from "@/lib/userDisplay";
+import type {
+  CustomFieldDefinition,
+  CustomFieldKind,
+} from "@/components/custom-fields/types";
+
+/**
+ * Column model for the project list view: a flat, ordered descriptor list
+ * (built-in columns + one per custom-field definition) plus the per-kind
+ * sort comparators and filter predicates the column header dropdowns drive.
+ * State (sort + filters, and later column order) is persisted per-project,
+ * per-browser by `useProjectListView`.
+ */
+
+/** A task as the list view sees it — only the bits these helpers read. */
+export interface ColumnTask {
+  "@id": string;
+  title: string;
+  dueDate: string | null;
+  completedOn: string | null;
+  assignees: Array<{
+    "@id": string;
+    givenName?: string | null;
+    familyName?: string | null;
+    nickname?: string | null;
+    email: string;
+  }>;
+  tags: Array<{ "@id": string; title: string }>;
+  customFieldValues: Array<{ definition: string; value: unknown }>;
+}
+
+/** How a column's header dropdown renders its filter, and how rows match it. */
+export type FilterKind =
+  | "text"
+  | "due"
+  | "date"
+  | "presence"
+  | "boolean"
+  | "assignees"
+  | "tags"
+  | "select";
+
+export interface ListColumn {
+  /** Stable id: a built-in key, or `cf:<definitionId>` for custom fields. */
+  key: string;
+  label: string;
+  sortable: boolean;
+  filter: FilterKind;
+  /** Tailwind width class for the shared `<colgroup>`; "" = flex (Task). */
+  widthClass: string;
+  /** Set for custom-field columns. */
+  definition?: CustomFieldDefinition;
+}
+
+export const BUILTIN_COLUMN_KEYS = ["task", "due", "assignees", "tags"] as const;
+
+export type SortDir = "asc" | "desc";
+export interface SortState {
+  key: string;
+  dir: SortDir;
+}
+
+export type FilterValue =
+  | { kind: "text"; query: string }
+  | { kind: "due"; mode: "all" | "has" | "none" | "overdue" }
+  | { kind: "date" | "presence"; mode: "all" | "has" | "none" }
+  | { kind: "boolean"; mode: "all" | "true" | "false" }
+  | { kind: "assignees"; iris: string[]; unassigned: boolean }
+  | { kind: "tags"; iris: string[]; untagged: boolean }
+  | { kind: "select"; keys: string[]; empty: boolean };
+
+export type FilterMap = Record<string, FilterValue>;
+
+/** The custom-field column id for a definition. */
+export const cfColumnKey = (def: CustomFieldDefinition): string =>
+  `cf:${def.id}`;
+
+const FILTER_FOR_KIND: Record<CustomFieldKind, FilterKind> = {
+  boolean: "boolean",
+  text: "text",
+  numeric: "presence",
+  date: "date",
+  select: "select",
+  reference: "presence",
+};
+
+/** Reference values are IRIs with no stable display order client-side. */
+const SORTABLE_KIND: Record<CustomFieldKind, boolean> = {
+  boolean: true,
+  text: true,
+  numeric: true,
+  date: true,
+  select: true,
+  reference: false,
+};
+
+/**
+ * Build the ordered column list from the project's custom-field
+ * definitions. Built-ins lead in their canonical order; custom fields
+ * follow in definition order (the caller can re-sequence the result).
+ */
+export const buildColumns = (
+  definitions: CustomFieldDefinition[],
+): ListColumn[] => {
+  const builtins: ListColumn[] = [
+    { key: "task", label: "Task", sortable: true, filter: "text", widthClass: "" },
+    { key: "due", label: "Due", sortable: true, filter: "due", widthClass: "w-32" },
+    { key: "assignees", label: "Assignees", sortable: true, filter: "assignees", widthClass: "w-44" },
+    { key: "tags", label: "Tags", sortable: true, filter: "tags", widthClass: "w-44" },
+  ];
+  const custom: ListColumn[] = definitions.map((def) => ({
+    key: cfColumnKey(def),
+    label: def.name,
+    sortable: SORTABLE_KIND[def.kind],
+    filter: FILTER_FOR_KIND[def.kind],
+    widthClass: "w-32",
+    definition: def,
+  }));
+  return [...builtins, ...custom];
+};
+
+/**
+ * Re-sequence the columns by a saved key order. Keys not in `order` (e.g.
+ * a custom field added since the order was saved) fall to the end in their
+ * natural order; stale keys in `order` are ignored. So a partial or
+ * outdated order degrades gracefully.
+ */
+export const orderColumns = (
+  columns: ListColumn[],
+  order: string[],
+): ListColumn[] => {
+  const byKey = new Map(columns.map((c) => [c.key, c]));
+  const seen = new Set<string>();
+  const out: ListColumn[] = [];
+  for (const key of order) {
+    const column = byKey.get(key);
+    if (column && !seen.has(key)) {
+      out.push(column);
+      seen.add(key);
+    }
+  }
+  for (const column of columns) {
+    if (!seen.has(column.key)) out.push(column);
+  }
+  return out;
+};
+
+const cfValue = (task: ColumnTask, def: CustomFieldDefinition): unknown =>
+  task.customFieldValues.find((v) => v.definition === def["@id"])?.value ?? null;
+
+const optionLabel = (def: CustomFieldDefinition, key: string): string => {
+  const opt = def.config.options?.find((o) => o.key === key);
+  return (opt?.label ?? key).toLowerCase();
+};
+
+/**
+ * Extract a comparable scalar for sorting. Returns null for "no value",
+ * which the comparator always sorts last regardless of direction.
+ */
+const sortValue = (task: ColumnTask, column: ListColumn): string | number | null => {
+  switch (column.key) {
+    case "task":
+      return task.title.toLowerCase();
+    case "due":
+      return task.dueDate ? new Date(task.dueDate).getTime() : null;
+    case "assignees":
+      return task.assignees[0] ? displayName(task.assignees[0]).toLowerCase() : null;
+    case "tags":
+      return task.tags[0] ? task.tags[0].title.toLowerCase() : null;
+  }
+
+  const def = column.definition;
+  if (!def) return null;
+  const raw = cfValue(task, def);
+  if (raw === null || raw === undefined || raw === "") return null;
+
+  switch (def.kind) {
+    case "boolean":
+      return raw === true ? 1 : 0;
+    case "numeric":
+      if (def.subtype === "money" && typeof raw === "object" && raw !== null) {
+        const amount = (raw as { amount?: unknown }).amount;
+        return typeof amount === "number" ? amount : null;
+      }
+      return typeof raw === "number" ? raw : null;
+    case "date":
+      return typeof raw === "string" ? raw : null;
+    case "text":
+      return typeof raw === "string" ? raw.toLowerCase() : null;
+    case "select": {
+      const key = Array.isArray(raw) ? raw[0] : raw;
+      return typeof key === "string" ? optionLabel(def, key) : null;
+    }
+    default:
+      return null;
+  }
+};
+
+/** Compare two tasks for the active sort. Nulls always sort last. */
+export const compareTasks = (
+  a: ColumnTask,
+  b: ColumnTask,
+  column: ListColumn,
+  dir: SortDir,
+): number => {
+  const av = sortValue(a, column);
+  const bv = sortValue(b, column);
+  if (av === null && bv === null) return 0;
+  if (av === null) return 1;
+  if (bv === null) return -1;
+  const base =
+    typeof av === "number" && typeof bv === "number"
+      ? av - bv
+      : String(av).localeCompare(String(bv));
+  return dir === "asc" ? base : -base;
+};
+
+/** Whether a filter value is anything other than its "no filter" default. */
+export const isFilterActive = (value: FilterValue | undefined): boolean => {
+  if (!value) return false;
+  switch (value.kind) {
+    case "text":
+      return value.query.trim() !== "";
+    case "due":
+    case "date":
+    case "presence":
+    case "boolean":
+      return value.mode !== "all";
+    case "assignees":
+      return value.iris.length > 0 || value.unassigned;
+    case "tags":
+      return value.iris.length > 0 || value.untagged;
+    case "select":
+      return value.keys.length > 0 || value.empty;
+  }
+};
+
+const isOverdue = (task: ColumnTask): boolean =>
+  task.dueDate !== null &&
+  task.completedOn === null &&
+  new Date(task.dueDate).getTime() < Date.now();
+
+/** Whether a task passes one column's filter. */
+const passesFilter = (
+  task: ColumnTask,
+  column: ListColumn,
+  value: FilterValue,
+): boolean => {
+  switch (value.kind) {
+    case "text": {
+      const q = value.query.trim().toLowerCase();
+      if (q === "") return true;
+      if (column.key === "task") return task.title.toLowerCase().includes(q);
+      const def = column.definition;
+      const raw = def ? cfValue(task, def) : null;
+      return typeof raw === "string" && raw.toLowerCase().includes(q);
+    }
+    case "due":
+      if (value.mode === "has") return task.dueDate !== null;
+      if (value.mode === "none") return task.dueDate === null;
+      if (value.mode === "overdue") return isOverdue(task);
+      return true;
+    case "date":
+    case "presence": {
+      if (value.mode === "all") return true;
+      const def = column.definition;
+      const raw = def ? cfValue(task, def) : null;
+      const empty =
+        raw === null ||
+        raw === undefined ||
+        raw === "" ||
+        (Array.isArray(raw) && raw.length === 0);
+      return value.mode === "has" ? !empty : empty;
+    }
+    case "boolean": {
+      if (value.mode === "all") return true;
+      const def = column.definition;
+      const raw = def ? cfValue(task, def) : null;
+      return value.mode === "true" ? raw === true : raw === false;
+    }
+    case "assignees": {
+      const ids = new Set(task.assignees.map((a) => a["@id"]));
+      const matchesSelected =
+        value.iris.length > 0 && value.iris.some((iri) => ids.has(iri));
+      const matchesUnassigned = value.unassigned && ids.size === 0;
+      return matchesSelected || matchesUnassigned;
+    }
+    case "tags": {
+      const ids = new Set(task.tags.map((t) => t["@id"]));
+      const matchesSelected =
+        value.iris.length > 0 && value.iris.some((iri) => ids.has(iri));
+      const matchesUntagged = value.untagged && ids.size === 0;
+      return matchesSelected || matchesUntagged;
+    }
+    case "select": {
+      const def = column.definition;
+      const raw = def ? cfValue(task, def) : null;
+      const keys = Array.isArray(raw)
+        ? raw.filter((k): k is string => typeof k === "string")
+        : typeof raw === "string"
+          ? [raw]
+          : [];
+      const matchesSelected =
+        value.keys.length > 0 && value.keys.some((k) => keys.includes(k));
+      const matchesEmpty = value.empty && keys.length === 0;
+      return matchesSelected || matchesEmpty;
+    }
+  }
+};
+
+/**
+ * Apply the active column filters (AND across columns) then the active
+ * sort to one section's task list. Pure — returns a new array.
+ */
+export const applyView = <T extends ColumnTask>(
+  tasks: T[],
+  columns: ListColumn[],
+  sort: SortState | null,
+  filters: FilterMap,
+): T[] => {
+  const active = columns
+    .map((c) => ({ column: c, value: filters[c.key] }))
+    .filter((e): e is { column: ListColumn; value: FilterValue } =>
+      isFilterActive(e.value),
+    );
+
+  let result = tasks;
+  if (active.length > 0) {
+    result = result.filter((task) =>
+      active.every(({ column, value }) => passesFilter(task, column, value)),
+    );
+  }
+
+  if (sort) {
+    const column = columns.find((c) => c.key === sort.key);
+    if (column?.sortable) {
+      result = [...result].sort((a, b) => compareTasks(a, b, column, sort.dir));
+    }
+  }
+
+  return result;
+};

--- a/pwa/lib/useProjectListView.ts
+++ b/pwa/lib/useProjectListView.ts
@@ -1,0 +1,111 @@
+import { useCallback, useEffect, useState } from "react";
+import type {
+  FilterMap,
+  FilterValue,
+  SortState,
+} from "@/components/projects/listColumns";
+
+/**
+ * Per-project, per-browser persistence for the list view's column sort and
+ * filters. Kept in localStorage (a personal view preference, not shared
+ * project state) under one key per project. Column order will join this
+ * shape when drag-to-reorder lands.
+ */
+export interface ProjectListView {
+  sort: SortState | null;
+  filters: FilterMap;
+  /** Saved column key order; [] = the natural/default order. */
+  order: string[];
+}
+
+interface UseProjectListView extends ProjectListView {
+  /** Set the active sort, or null to clear it. */
+  setSort: (sort: SortState | null) => void;
+  setFilter: (key: string, value: FilterValue | null) => void;
+  clearAllFilters: () => void;
+  setOrder: (order: string[]) => void;
+  activeFilterCount: number;
+}
+
+const storageKey = (projectId: string): string =>
+  `madori.project.${projectId}.listview`;
+
+const empty: ProjectListView = { sort: null, filters: {}, order: [] };
+
+function load(projectId: string): ProjectListView {
+  if (typeof window === "undefined") return empty;
+  try {
+    const raw = window.localStorage.getItem(storageKey(projectId));
+    if (!raw) return empty;
+    const parsed = JSON.parse(raw) as Partial<ProjectListView>;
+    return {
+      sort: parsed.sort ?? null,
+      filters: parsed.filters ?? {},
+      order: Array.isArray(parsed.order) ? parsed.order : [],
+    };
+  } catch {
+    return empty;
+  }
+}
+
+export function useProjectListView(projectId: string | null): UseProjectListView {
+  const [view, setView] = useState<ProjectListView>(empty);
+
+  // Hydrate after mount so SSR and the first paint agree, then load the
+  // stored view for this project.
+  useEffect(() => {
+    if (projectId) setView(load(projectId));
+  }, [projectId]);
+
+  const persist = useCallback(
+    (next: ProjectListView) => {
+      setView(next);
+      if (!projectId) return;
+      try {
+        window.localStorage.setItem(storageKey(projectId), JSON.stringify(next));
+      } catch {
+        // Storage-disabled browsers: state still applies for the session.
+      }
+    },
+    [projectId],
+  );
+
+  const setSort = useCallback(
+    (sort: SortState | null) => persist({ ...view, sort }),
+    [persist, view],
+  );
+
+  const setFilter = useCallback(
+    (key: string, value: FilterValue | null) => {
+      const filters = { ...view.filters };
+      if (value === null) {
+        delete filters[key];
+      } else {
+        filters[key] = value;
+      }
+      persist({ ...view, filters });
+    },
+    [persist, view],
+  );
+
+  const clearAllFilters = useCallback(
+    () => persist({ ...view, filters: {} }),
+    [persist, view],
+  );
+
+  const setOrder = useCallback(
+    (order: string[]) => persist({ ...view, order }),
+    [persist, view],
+  );
+
+  return {
+    sort: view.sort,
+    filters: view.filters,
+    order: view.order,
+    setSort,
+    setFilter,
+    clearAllFilters,
+    setOrder,
+    activeFilterCount: Object.keys(view.filters).length,
+  };
+}

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -10,6 +10,33 @@ import { signinHrefForCurrent } from "@/lib/authRedirect";
 import ActivityPanel from "@/components/activity/ActivityPanel";
 import TaskBoard from "@/components/projects/TaskBoard";
 import TaskTableColumns from "@/components/projects/TaskTableColumns";
+import ColumnHeaderMenu from "@/components/projects/ColumnHeaderMenu";
+import {
+  applyView,
+  buildColumns,
+  orderColumns,
+  type FilterMap,
+  type FilterValue,
+  type ListColumn,
+  type SortState,
+} from "@/components/projects/listColumns";
+import { useProjectListView } from "@/lib/useProjectListView";
+import {
+  DndContext,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  useSortable,
+  horizontalListSortingStrategy,
+  arrayMove,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { GripVertical } from "lucide-react";
 import CustomFieldFooterRow from "@/components/custom-fields/CustomFieldFooterRow";
 import CustomFieldsManager from "@/components/custom-fields/CustomFieldsManager";
 import { CustomFieldValueEditor } from "@/components/tasks/value-editors";
@@ -355,6 +382,36 @@ const ProjectDetail = () => {
   const boardDefinitions = useMemo(
     () => definitions.filter((d) => (d.visibility ?? "both") !== "list"),
     [definitions],
+  );
+
+  // The assignee picker must only offer users who can actually be assigned
+  // to this project's tasks — its space members — not the caller's whole
+  // assignable universe (which spans every space they're in). On a private
+  // board that narrows the list to just the user. `assignableUsers` carries
+  // the rich avatar/colour shape the picker needs, so we filter it by the
+  // project's member IRIs rather than using the bare `project.members`.
+  const projectAssignableUsers = useMemo(() => {
+    if (!project) return assignableUsers;
+    const memberIris = new Set(project.members.map((m) => m["@id"]));
+    return assignableUsers.filter((u) => memberIris.has(u["@id"]));
+  }, [assignableUsers, project]);
+
+  // Per-user, per-project list-view state (column order + sort + filters),
+  // persisted in localStorage. Applied within each section by SectionBlock.
+  const listView = useProjectListView(projectId);
+  const columns = useMemo(
+    () => orderColumns(buildColumns(listDefinitions), listView.order),
+    [listDefinitions, listView.order],
+  );
+  const handleColumnReorder = useCallback(
+    (activeKey: string, overKey: string) => {
+      const keys = columns.map((c) => c.key);
+      const from = keys.indexOf(activeKey);
+      const to = keys.indexOf(overKey);
+      if (from === -1 || to === -1 || from === to) return;
+      listView.setOrder(arrayMove(keys, from, to));
+    },
+    [columns, listView],
   );
 
   const toggleComplete = async (task: ProjectTask) => {
@@ -1000,12 +1057,17 @@ const ProjectDetail = () => {
                               : DEFAULT_SECTION_LABEL
                           }
                           tasks={group.tasks}
-                          definitions={listDefinitions}
+                          columns={columns}
                           projectId={project.id}
                           projectIri={project["@id"]}
                           spaceIri={projectSpaceIri(project)}
                           allTags={allTags}
-                          assignableUsers={assignableUsers}
+                          assignableUsers={projectAssignableUsers}
+                          sort={listView.sort}
+                          filters={listView.filters}
+                          onSetSort={listView.setSort}
+                          onSetFilter={listView.setFilter}
+                          onReorder={handleColumnReorder}
                           footerFilter={
                             sectionIri
                               ? `section=${encodeURIComponent(sectionIri)}`
@@ -1043,7 +1105,7 @@ const ProjectDetail = () => {
                     <CustomFieldFooterRow
                       projectId={project.id}
                       refreshKey={footerKey}
-                      columns={listDefinitions}
+                      columns={columns}
                       prominent
                       className="mt-6"
                     />
@@ -1094,7 +1156,7 @@ const ProjectDetail = () => {
         open={Boolean(activeTaskId)}
         onOpenChange={closeTaskDetail}
         currentUserIri={currentUserIri}
-        assignableUsers={assignableUsers}
+        assignableUsers={projectAssignableUsers}
         allTags={allTags}
         onTaskChanged={(updated) =>
           setTasks((prev) =>
@@ -1127,12 +1189,17 @@ interface SectionBlockProps {
   section: TaskSection | null;
   title: string;
   tasks: ProjectTask[];
-  definitions: CustomFieldDefinition[];
+  columns: ListColumn[];
   projectId: string;
   projectIri: string;
   spaceIri: string;
   allTags: TagOption[];
   assignableUsers: AssigneeOption[];
+  sort: SortState | null;
+  filters: FilterMap;
+  onSetSort: (sort: SortState | null) => void;
+  onSetFilter: (key: string, value: FilterValue | null) => void;
+  onReorder: (activeKey: string, overKey: string) => void;
   footerFilter: string;
   footerKey: number;
   addOpen: boolean;
@@ -1162,12 +1229,17 @@ const SectionBlock = ({
   section,
   title,
   tasks,
-  definitions,
+  columns,
   projectId,
   projectIri,
   spaceIri,
   allTags,
   assignableUsers,
+  sort,
+  filters,
+  onSetSort,
+  onSetFilter,
+  onReorder,
   footerFilter,
   footerKey,
   addOpen,
@@ -1191,7 +1263,26 @@ const SectionBlock = ({
   onRename,
   onDelete,
 }: SectionBlockProps) => {
-  const fullColSpan = definitions.length + 7;
+  // checkbox + # + each data column + trailing actions.
+  const fullColSpan = columns.length + 3;
+  // Sort + filter the section's rows per the active column view. Falls back
+  // to the raw list when nothing is set (the common case).
+  const visibleTasks = useMemo(
+    () => applyView(tasks, columns, sort, filters),
+    [tasks, columns, sort, filters],
+  );
+  const filtersActive = Object.keys(filters).length > 0;
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  );
+  const columnKeys = columns.map((c) => c.key);
+  const onDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (over && active.id !== over.id) {
+      onReorder(String(active.id), String(over.id));
+    }
+  };
+
   return (
     <div data-testid="project-section">
       {/* Every section shows a title above its table. User-created sections
@@ -1254,34 +1345,41 @@ const SectionBlock = ({
 
       <div className="overflow-hidden rounded-lg border">
         <div className="overflow-x-auto">
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={onDragEnd}
+        >
         <table className="w-full table-fixed text-sm">
-          <TaskTableColumns definitions={definitions} />
+          <TaskTableColumns columns={columns} />
           <thead>
             <tr className="border-b text-xs uppercase tracking-wide text-muted-foreground">
               <th className="w-8 px-3 py-2" />
               <th className="w-10 px-1 py-2 text-left font-medium">#</th>
-              <th className="px-2 py-2 text-left font-medium">Task</th>
-              <th className="px-2 py-2 text-left font-medium">Due</th>
-              <th className="px-2 py-2 text-left font-medium">Assignees</th>
-              <th className="px-2 py-2 text-left font-medium">Tags</th>
-              {definitions.map((def) => (
-                <th
-                  key={def["@id"]}
-                  className="truncate px-2 py-2 text-left font-medium"
-                >
-                  {def.name}
-                </th>
-              ))}
+              <SortableContext items={columnKeys} strategy={horizontalListSortingStrategy}>
+                {columns.map((column) => (
+                  <SortableHeaderCell
+                    key={column.key}
+                    column={column}
+                    sort={sort}
+                    filter={filters[column.key]}
+                    onSetSort={onSetSort}
+                    onSetFilter={onSetFilter}
+                    assignableUsers={assignableUsers}
+                    allTags={allTags}
+                  />
+                ))}
+              </SortableContext>
               <th className="w-10 px-2 py-2" />
             </tr>
           </thead>
           <tbody>
-            {tasks.map((task, i) => (
+            {visibleTasks.map((task, i) => (
               <ProjectTaskRow
                 key={task["@id"]}
                 task={task}
                 index={i}
-                definitions={definitions}
+                columns={columns}
                 allTags={allTags}
                 assignableUsers={assignableUsers}
                 projectIri={projectIri}
@@ -1292,75 +1390,98 @@ const SectionBlock = ({
                 onCustomFieldChange={onCustomFieldChange}
               />
             ))}
+            {tasks.length > 0 && visibleTasks.length === 0 && filtersActive && (
+              <tr>
+                <td
+                  colSpan={fullColSpan}
+                  className="px-3 py-3 text-sm text-muted-foreground"
+                >
+                  No tasks match the active filters.
+                </td>
+              </tr>
+            )}
             {addOpen && (
               <tr className="border-b bg-muted/20" data-testid="project-new-task-row">
                 <td className="px-3 py-2 align-middle">
                   <Plus className="h-4 w-4 text-muted-foreground" aria-hidden />
                 </td>
                 <td className="px-1 py-2" />
-                <td className="px-2 py-2">
-                  <Input
-                    ref={newTaskInputRef}
-                    value={newTaskTitle}
-                    onChange={(e) => onNewTaskTitle(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") {
-                        e.preventDefault();
-                        void onCreateTask();
-                      } else if (e.key === "Escape") {
-                        e.preventDefault();
-                        onCloseAddRow();
-                      }
-                    }}
-                    onBlur={(e) => {
-                      if (newTaskTitle.trim()) return;
-                      // Keep the row open while the user Tabs to a sibling field
-                      // (tags / due / assignees) before submitting; only close
-                      // when focus leaves the add row entirely.
-                      const next = e.relatedTarget as HTMLElement | null;
-                      if (next?.closest('[data-testid="project-new-task-row"]'))
-                        return;
-                      onCloseAddRow();
-                    }}
-                    placeholder="Task title, then Tab or Enter…"
-                    maxLength={255}
-                    disabled={isCreatingTask}
-                    className="h-8"
-                    data-testid="project-new-task-title"
-                  />
-                </td>
-                <td className="px-2 py-2 align-middle" data-testid="new-task-due">
-                  <DueDateCell
-                    value={newTaskDue}
-                    onChange={onNewTaskDue}
-                    ariaLabel="Due date for new task"
-                    testIdPrefix="project-new-task-due"
-                  />
-                </td>
-                <td
-                  className="px-2 py-2 align-middle"
-                  data-testid="new-task-assignees"
-                >
-                  <AssigneesCombobox
-                    value={newTaskAssignees}
-                    options={assignableUsers}
-                    onChange={onNewTaskAssignees}
-                    subjectLabel="new task"
-                  />
-                </td>
-                <td className="px-2 py-2 align-middle" data-testid="new-task-tags">
-                  <TagsCombobox
-                    value={newTaskTags}
-                    options={allTags}
-                    onChange={onNewTaskTags}
-                    subjectLabel="new task"
-                  />
-                </td>
-                {definitions.map((def) => (
-                  // Custom fields are set after the task exists; render an empty
-                  // cell so the inline fields stay aligned with the columns.
-                  <td key={def["@id"]} className="px-2 py-2 align-middle" />
-                ))}
+                {columns.map((column) => {
+                  if (column.key === "task") {
+                    return (
+                      <td key="task" className="px-2 py-2">
+                        <Input
+                          ref={newTaskInputRef}
+                          value={newTaskTitle}
+                          onChange={(e) => onNewTaskTitle(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter") {
+                              e.preventDefault();
+                              void onCreateTask();
+                            } else if (e.key === "Escape") {
+                              e.preventDefault();
+                              onCloseAddRow();
+                            }
+                          }}
+                          onBlur={(e) => {
+                            if (newTaskTitle.trim()) return;
+                            // Keep the row open while the user Tabs to a sibling
+                            // field before submitting; only close when focus
+                            // leaves the add row entirely.
+                            const next = e.relatedTarget as HTMLElement | null;
+                            if (next?.closest('[data-testid="project-new-task-row"]'))
+                              return;
+                            onCloseAddRow();
+                          }}
+                          placeholder="Task title, then Tab or Enter…"
+                          maxLength={255}
+                          disabled={isCreatingTask}
+                          className="h-8"
+                          data-testid="project-new-task-title"
+                        />
+                      </td>
+                    );
+                  }
+                  if (column.key === "due") {
+                    return (
+                      <td key="due" className="px-2 py-2 align-middle" data-testid="new-task-due">
+                        <DueDateCell
+                          value={newTaskDue}
+                          onChange={onNewTaskDue}
+                          ariaLabel="Due date for new task"
+                          testIdPrefix="project-new-task-due"
+                        />
+                      </td>
+                    );
+                  }
+                  if (column.key === "assignees") {
+                    return (
+                      <td key="assignees" className="px-2 py-2 align-middle" data-testid="new-task-assignees">
+                        <AssigneesCombobox
+                          value={newTaskAssignees}
+                          options={assignableUsers}
+                          onChange={onNewTaskAssignees}
+                          subjectLabel="new task"
+                        />
+                      </td>
+                    );
+                  }
+                  if (column.key === "tags") {
+                    return (
+                      <td key="tags" className="px-2 py-2 align-middle" data-testid="new-task-tags">
+                        <TagsCombobox
+                          value={newTaskTags}
+                          options={allTags}
+                          onChange={onNewTaskTags}
+                          subjectLabel="new task"
+                        />
+                      </td>
+                    );
+                  }
+                  // Custom fields are set after the task exists; an empty cell
+                  // keeps the inline fields aligned with the columns.
+                  return <td key={column.key} className="px-2 py-2 align-middle" />;
+                })}
                 <td className="px-2 py-2 align-middle" />
               </tr>
             )}
@@ -1383,13 +1504,14 @@ const SectionBlock = ({
             )}
           </tbody>
         </table>
+        </DndContext>
         {/* Per-section aggregates: a flush, column-aligned footer inside the
             same scroll container so it lines up with the columns above. */}
         <CustomFieldFooterRow
           projectId={projectId}
           filters={footerFilter}
           refreshKey={footerKey}
-          columns={definitions}
+          columns={columns}
           flush
         />
         </div>
@@ -1398,10 +1520,68 @@ const SectionBlock = ({
   );
 };
 
+/**
+ * One draggable list-view column header: a grip to reorder + the
+ * {@link ColumnHeaderMenu} for sort/filter. The grip carries the drag
+ * listeners so clicking the menu doesn't start a drag.
+ */
+const SortableHeaderCell = ({
+  column,
+  sort,
+  filter,
+  onSetSort,
+  onSetFilter,
+  assignableUsers,
+  allTags,
+}: {
+  column: ListColumn;
+  sort: SortState | null;
+  filter: FilterValue | undefined;
+  onSetSort: (sort: SortState | null) => void;
+  onSetFilter: (key: string, value: FilterValue | null) => void;
+  assignableUsers: AssigneeOption[];
+  allTags: TagOption[];
+}) => {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: column.key });
+  return (
+    <th
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={cn(
+        "px-2 py-2 text-left font-medium",
+        isDragging && "bg-accent opacity-60",
+      )}
+      data-testid={`column-th-${column.key}`}
+    >
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          className="shrink-0 cursor-grab touch-none text-muted-foreground/40 hover:text-foreground"
+          aria-label={`Reorder ${column.label} column`}
+          {...attributes}
+          {...listeners}
+        >
+          <GripVertical className="size-3.5" />
+        </button>
+        <ColumnHeaderMenu
+          column={column}
+          sort={sort}
+          filter={filter}
+          onSetSort={onSetSort}
+          onSetFilter={onSetFilter}
+          assignableUsers={assignableUsers}
+          allTags={allTags}
+        />
+      </div>
+    </th>
+  );
+};
+
 interface ProjectTaskRowProps {
   task: ProjectTask;
   index: number;
-  definitions: CustomFieldDefinition[];
+  columns: ListColumn[];
   allTags: TagOption[];
   assignableUsers: AssigneeOption[];
   projectIri: string;
@@ -1415,7 +1595,7 @@ interface ProjectTaskRowProps {
 const ProjectTaskRow = ({
   task,
   index,
-  definitions,
+  columns,
   allTags,
   assignableUsers,
   projectIri,
@@ -1425,6 +1605,75 @@ const ProjectTaskRow = ({
   patchTask,
   onCustomFieldChange,
 }: ProjectTaskRowProps) => {
+  const cellFor = (column: ListColumn) => {
+    switch (column.key) {
+      case "task":
+        return (
+          <button
+            type="button"
+            onClick={() => onOpen(task)}
+            className={cn(
+              "w-full cursor-pointer text-left font-medium hover:text-primary",
+              task.completedOn && "text-muted-foreground line-through",
+            )}
+            data-testid="project-task-title"
+          >
+            {task.title}
+          </button>
+        );
+      case "due":
+        return (
+          <DueDateCell
+            value={task.dueDate}
+            onChange={(next) => void patchTask(task, { dueDate: next })}
+            ariaLabel={`Due date for "${task.title}"`}
+            testIdPrefix="project-task-due-date"
+            recurrenceValue={task.recurrenceRule}
+            onRecurrenceChange={(next) =>
+              void patchTask(task, { recurrenceRule: next })
+            }
+            remindersValue={task.reminders}
+            onRemindersChange={(next) =>
+              void patchTask(task, { reminders: next })
+            }
+            status={dueDateStatus(task.dueDate, !!task.completedOn)}
+          />
+        );
+      case "assignees":
+        return (
+          <AssigneesCombobox
+            value={task.assignees}
+            options={assignableUsers}
+            onChange={(iris) => void patchTask(task, { assignees: iris })}
+            subjectLabel={task.title}
+          />
+        );
+      case "tags":
+        return (
+          <TagsCombobox
+            value={task.tags}
+            options={allTags}
+            onChange={(iris) => void patchTask(task, { tags: iris })}
+            subjectLabel={task.title}
+          />
+        );
+      default: {
+        const def = column.definition;
+        if (!def) return null;
+        return (
+          <ProjectCustomFieldCell
+            task={task}
+            definition={def}
+            projectIri={projectIri}
+            spaceIri={spaceIri}
+            users={assignableUsers}
+            onCustomFieldChange={onCustomFieldChange}
+          />
+        );
+      }
+    }
+  };
+
   return (
     <tr
       className="border-b last:border-0 hover:bg-accent/40"
@@ -1441,60 +1690,15 @@ const ProjectTaskRow = ({
       <td className="px-1 py-2 align-middle text-xs text-muted-foreground">
         T{index + 1}
       </td>
-      <td className="min-w-[12rem] px-2 py-2 align-middle">
-        <button
-          type="button"
-          onClick={() => onOpen(task)}
+      {columns.map((column) => (
+        <td
+          key={column.key}
           className={cn(
-            "w-full cursor-pointer text-left font-medium hover:text-primary",
-            task.completedOn && "text-muted-foreground line-through",
+            "px-2 py-2 align-middle",
+            column.key === "task" && "min-w-[12rem]",
           )}
-          data-testid="project-task-title"
         >
-          {task.title}
-        </button>
-      </td>
-      <td className="px-2 py-2 align-middle">
-        <DueDateCell
-          value={task.dueDate}
-          onChange={(next) => void patchTask(task, { dueDate: next })}
-          ariaLabel={`Due date for "${task.title}"`}
-          testIdPrefix="project-task-due-date"
-          recurrenceValue={task.recurrenceRule}
-          onRecurrenceChange={(next) =>
-            void patchTask(task, { recurrenceRule: next })
-          }
-          remindersValue={task.reminders}
-          onRemindersChange={(next) => void patchTask(task, { reminders: next })}
-          status={dueDateStatus(task.dueDate, !!task.completedOn)}
-        />
-      </td>
-      <td className="px-2 py-2 align-middle">
-        <AssigneesCombobox
-          value={task.assignees}
-          options={assignableUsers}
-          onChange={(iris) => void patchTask(task, { assignees: iris })}
-          subjectLabel={task.title}
-        />
-      </td>
-      <td className="px-2 py-2 align-middle">
-        <TagsCombobox
-          value={task.tags}
-          options={allTags}
-          onChange={(iris) => void patchTask(task, { tags: iris })}
-          subjectLabel={task.title}
-        />
-      </td>
-      {definitions.map((def) => (
-        <td key={def["@id"]} className="px-2 py-2 align-middle">
-          <ProjectCustomFieldCell
-            task={task}
-            definition={def}
-            projectIri={projectIri}
-            spaceIri={spaceIri}
-            users={assignableUsers}
-            onCustomFieldChange={onCustomFieldChange}
-          />
+          {cellFor(column)}
         </td>
       ))}
       <td className="px-2 py-2 align-middle">

--- a/pwa/pages/tasks.tsx
+++ b/pwa/pages/tasks.tsx
@@ -993,17 +993,34 @@ const Tasks = () => {
 
   const assignableForTask = useCallback(
     (task: Task): AssigneeOption[] => {
+      const self =
+        currentUserIri !== null
+          ? assignableUsers.find((u) => u["@id"] === currentUserIri)
+          : undefined;
+      // The current user is always a valid assignee for a task they own —
+      // mirrors the server's ValidAssignees rule (owner is always allowed),
+      // which matters on a personal / private board where the project lists
+      // no other members.
+      const ownsTask = task.owner["@id"] === currentUserIri;
+
       if (!task.project) {
-        // Personal task — only the owner can be assigned. The owner is
-        // always in the assignable-users set when it's the current user; for
-        // admin-viewed tasks owned by others, fall back to the task's
-        // current assignees (already known-valid).
-        const owner = task.assignees.find((a) => a["@id"] === currentUserIri);
-        return owner ? [owner] : task.assignees;
+        // Personal task — only the owner is assignable. For an admin viewing
+        // someone else's personal task, fall back to its current assignees
+        // (already known-valid).
+        if (self && ownsTask) return [self];
+        return task.assignees;
       }
+
       const memberIris = projectMembers.get(task.project);
-      if (!memberIris) return assignableUsers;
-      return assignableUsers.filter((u) => memberIris.has(u["@id"]));
+      const base = memberIris
+        ? assignableUsers.filter((u) => memberIris.has(u["@id"]))
+        : assignableUsers;
+      // Guarantee the owner is offered even if the project's member list
+      // hasn't caught up (e.g. a private space with no member projection).
+      if (self && ownsTask && !base.some((u) => u["@id"] === self["@id"])) {
+        return [self, ...base];
+      }
+      return base;
     },
     [assignableUsers, projectMembers, currentUserIri],
   );


### PR DESCRIPTION
﻿## Promote main -> production

Merging this triggers the production auto-deploy. **Use a merge commit** (not squash) to keep production fast-forwardable, per the branching policy.

### Included
- **security:** `/me/assignable-users` is now scoped to the caller's spaces — fixes a cross-space leak of user name/email/avatar across the deployment (#532).
- **feat(projects):** list-view columns are sortable, filterable, and drag-reorderable (per-project, persisted), with aligned footer totals (#533).
- **feat(custom-fields):** changing a field's type migrates existing task values where possible, with a delete-confirmation for the rest (#533).
- **fix(tasks):** self-assignment works on personal/private boards; new tasks in a personal space default to their creator (#533).

### Notes
- No new DB migrations in this batch.
- The deploy runs the usual maintenance-page -> backup -> swap -> health-check flow.
