### PR TITLE
feat(projects): single sticky-header list table with always-on add rows

### DIFF
--- a/pwa/components/custom-fields/CustomFieldFooterRow.tsx
+++ b/pwa/components/custom-fields/CustomFieldFooterRow.tsx
@@ -139,9 +139,8 @@ const CustomFieldFooterRow = ({
     const valueByDef = new Map(rows.map((row) => [row.definition, row]));
     const cells = (
       <>
-        {/* checkbox + # — fixed leading columns, mirroring the task table. */}
+        {/* checkbox — fixed leading column, mirroring the task table. */}
         <td className="px-3 py-2" />
-        <td className="px-1 py-2" />
         {columns.map((column) => {
           // Only custom-field columns can carry an aggregate; built-ins
           // (Task / Due / Assignees / Tags) render an empty spacer so the

--- a/pwa/components/custom-fields/CustomFieldFooterRow.tsx
+++ b/pwa/components/custom-fields/CustomFieldFooterRow.tsx
@@ -38,6 +38,10 @@ interface Props {
   /** Render as a bare table (no card wrapper) to sit inside a section table's
    *  scroll container as a flush, column-aligned footer. */
   flush?: boolean;
+  /** Render as a single `<tr>` (no table/colgroup wrapper) so the totals can
+   *  live inside a shared table body, e.g. one continuous list with section
+   *  rows. Requires `columns`; the parent owns the `<table>` + `<colgroup>`. */
+  asRow?: boolean;
 }
 
 const formatValue = (row: FooterRow): string => {
@@ -92,6 +96,7 @@ const CustomFieldFooterRow = ({
   columns,
   prominent,
   flush,
+  asRow,
 }: Props) => {
   const [rows, setRows] = useState<FooterRow[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -168,6 +173,22 @@ const CustomFieldFooterRow = ({
         <td className="px-2 py-2" />
       </>
     );
+
+    // As a single row inside a shared table body (the parent owns the table
+    // + colgroup), so per-section totals sit in one continuous list.
+    if (asRow) {
+      return (
+        <tr
+          className={cn(
+            "border-t",
+            prominent ? "bg-muted/60 font-semibold" : "bg-muted/20",
+          )}
+          data-testid="custom-field-footer-row"
+        >
+          {cells}
+        </tr>
+      );
+    }
 
     // Flush: a bare table that lives inside a section table's scroll container,
     // lining up with that table's columns and scrolling with it.

--- a/pwa/components/projects/TaskTableColumns.tsx
+++ b/pwa/components/projects/TaskTableColumns.tsx
@@ -5,7 +5,7 @@ import type { ListColumn } from "@/components/projects/listColumns";
  * tables and the grand-total bar line up column-for-column. Every table that
  * uses it must be `table-fixed`. Layout:
  *
- *   checkbox · # · [data columns, in the user's order] · actions
+ *   checkbox · [data columns, in the user's order] · actions
  *
  * The data columns (Task / Due / Assignees / Tags / custom fields) carry
  * their own width class; Task's is "" so `table-fixed` gives it the slack.
@@ -13,7 +13,6 @@ import type { ListColumn } from "@/components/projects/listColumns";
 const TaskTableColumns = ({ columns }: { columns: ListColumn[] }) => (
   <colgroup>
     <col className="w-8" />
-    <col className="w-10" />
     {columns.map((column) => (
       <col key={column.key} className={column.widthClass} />
     ))}

--- a/pwa/lib/useProjectListView.ts
+++ b/pwa/lib/useProjectListView.ts
@@ -16,6 +16,8 @@ export interface ProjectListView {
   filters: FilterMap;
   /** Saved column key order; [] = the natural/default order. */
   order: string[];
+  /** Saved section group-key order (incl. the default group); [] = natural. */
+  sectionOrder: string[];
 }
 
 interface UseProjectListView extends ProjectListView {
@@ -24,13 +26,19 @@ interface UseProjectListView extends ProjectListView {
   setFilter: (key: string, value: FilterValue | null) => void;
   clearAllFilters: () => void;
   setOrder: (order: string[]) => void;
+  setSectionOrder: (order: string[]) => void;
   activeFilterCount: number;
 }
 
 const storageKey = (projectId: string): string =>
   `madori.project.${projectId}.listview`;
 
-const empty: ProjectListView = { sort: null, filters: {}, order: [] };
+const empty: ProjectListView = {
+  sort: null,
+  filters: {},
+  order: [],
+  sectionOrder: [],
+};
 
 function load(projectId: string): ProjectListView {
   if (typeof window === "undefined") return empty;
@@ -42,6 +50,7 @@ function load(projectId: string): ProjectListView {
       sort: parsed.sort ?? null,
       filters: parsed.filters ?? {},
       order: Array.isArray(parsed.order) ? parsed.order : [],
+      sectionOrder: Array.isArray(parsed.sectionOrder) ? parsed.sectionOrder : [],
     };
   } catch {
     return empty;
@@ -98,14 +107,21 @@ export function useProjectListView(projectId: string | null): UseProjectListView
     [persist, view],
   );
 
+  const setSectionOrder = useCallback(
+    (sectionOrder: string[]) => persist({ ...view, sectionOrder }),
+    [persist, view],
+  );
+
   return {
     sort: view.sort,
     filters: view.filters,
     order: view.order,
+    sectionOrder: view.sectionOrder,
     setSort,
     setFilter,
     clearAllFilters,
     setOrder,
+    setSectionOrder,
     activeFilterCount: Object.keys(view.filters).length,
   };
 }

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -2,7 +2,7 @@ import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from "react";
-import { ChevronDown, Lock, MoreHorizontal, PanelRight, Plus, Rows3, Shield, Table2, Trash2, TriangleAlert } from "lucide-react";
+import { ChevronDown, ChevronRight, Lock, MoreHorizontal, PanelRight, Plus, Rows3, Shield, Table2, Trash2, TriangleAlert } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
 import { ENTRYPOINT } from "@/config/entrypoint";
@@ -405,7 +405,7 @@ const ProjectDetail = () => {
     [columns, listView],
   );
   // checkbox + # + each data column + trailing actions.
-  const fullColSpan = columns.length + 3;
+  const fullColSpan = columns.length + 2;
   const columnKeys = columns.map((c) => c.key);
   const listSensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
@@ -1026,7 +1026,6 @@ const ProjectDetail = () => {
                         <thead className="sticky top-0 z-20 bg-background">
                           <tr className="border-b text-xs uppercase tracking-wide text-muted-foreground">
                             <th className="w-8 px-3 py-2" />
-                            <th className="w-10 px-1 py-2 text-left font-medium">#</th>
                             <SortableContext
                               items={columnKeys}
                               strategy={horizontalListSortingStrategy}
@@ -1217,6 +1216,7 @@ const SectionRows = ({
   onDelete,
 }: SectionRowsProps) => {
   const sectionIri = section ? section["@id"] : null;
+  const [collapsed, setCollapsed] = useState(false);
   const visible = useMemo(
     () => applyView(tasks, columns, sort, filters),
     [tasks, columns, sort, filters],
@@ -1231,26 +1231,29 @@ const SectionRows = ({
       <SectionTitleRow
         section={section}
         colSpan={fullColSpan}
+        collapsed={collapsed}
+        count={tasks.length}
+        onToggleCollapsed={() => setCollapsed((c) => !c)}
         onRename={onRename}
         onDelete={onDelete}
       />
-      {visible.map((task, i) => (
-        <ProjectTaskRow
-          key={task["@id"]}
-          task={task}
-          index={i}
-          columns={columns}
-          allTags={allTags}
-          assignableUsers={assignableUsers}
-          projectIri={projectIri}
-          spaceIri={spaceIri}
-          onToggle={onToggle}
-          onOpen={onOpen}
-          patchTask={patchTask}
-          onCustomFieldChange={onCustomFieldChange}
-        />
-      ))}
-      {tasks.length > 0 && visible.length === 0 && filtersActive && (
+      {!collapsed &&
+        visible.map((task) => (
+          <ProjectTaskRow
+            key={task["@id"]}
+            task={task}
+            columns={columns}
+            allTags={allTags}
+            assignableUsers={assignableUsers}
+            projectIri={projectIri}
+            spaceIri={spaceIri}
+            onToggle={onToggle}
+            onOpen={onOpen}
+            patchTask={patchTask}
+            onCustomFieldChange={onCustomFieldChange}
+          />
+        ))}
+      {!collapsed && tasks.length > 0 && visible.length === 0 && filtersActive && (
         <tr>
           <td
             colSpan={fullColSpan}
@@ -1260,38 +1263,62 @@ const SectionRows = ({
           </td>
         </tr>
       )}
-      <AddTaskRow
-        columns={columns}
-        sectionIri={sectionIri}
-        onCreate={onCreate}
-        inputRef={newTaskInputRef}
-      />
-      <CustomFieldFooterRow
-        projectId={projectId}
-        filters={footerFilter}
-        refreshKey={footerKey}
-        columns={columns}
-        asRow
-      />
+      {!collapsed && (
+        <AddTaskRow
+          columns={columns}
+          sectionIri={sectionIri}
+          onCreate={onCreate}
+          inputRef={newTaskInputRef}
+        />
+      )}
+      {!collapsed && (
+        <CustomFieldFooterRow
+          projectId={projectId}
+          filters={footerFilter}
+          refreshKey={footerKey}
+          columns={columns}
+          asRow
+        />
+      )}
     </>
   );
 };
 
-/** Full-width section heading row (editable title + delete for user sections). */
+/** Full-width section heading row (collapse arrow + editable title + delete). */
 const SectionTitleRow = ({
   section,
   colSpan,
+  collapsed,
+  count,
+  onToggleCollapsed,
   onRename,
   onDelete,
 }: {
   section: TaskSection | null;
   colSpan: number;
+  collapsed: boolean;
+  count: number;
+  onToggleCollapsed: () => void;
   onRename: (section: TaskSection, title: string) => void | Promise<void>;
   onDelete: (section: TaskSection) => void | Promise<void>;
 }) => (
   <tr className="border-b bg-muted/40" data-testid="project-section">
     <td colSpan={colSpan} className="px-3 py-1.5">
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-1.5">
+        <button
+          type="button"
+          onClick={onToggleCollapsed}
+          aria-expanded={!collapsed}
+          aria-label={collapsed ? "Expand section" : "Collapse section"}
+          className="rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+          data-testid="section-collapse"
+        >
+          {collapsed ? (
+            <ChevronRight className="h-4 w-4" />
+          ) : (
+            <ChevronDown className="h-4 w-4" />
+          )}
+        </button>
         {section ? (
           <input
             defaultValue={section.title}
@@ -1308,6 +1335,7 @@ const SectionTitleRow = ({
             {DEFAULT_SECTION_LABEL}
           </span>
         )}
+        <span className="text-xs text-muted-foreground tabular-nums">{count}</span>
         {section && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
@@ -1368,7 +1396,6 @@ const AddTaskRow = ({
       <td className="px-3 py-2 align-middle">
         <Plus className="h-4 w-4 text-muted-foreground" aria-hidden />
       </td>
-      <td className="px-1 py-2" />
       {columns.map((column) =>
         column.key === "task" ? (
           <td key="task" className="px-2 py-2">
@@ -1458,7 +1485,6 @@ const SortableHeaderCell = ({
 
 interface ProjectTaskRowProps {
   task: ProjectTask;
-  index: number;
   columns: ListColumn[];
   allTags: TagOption[];
   assignableUsers: AssigneeOption[];
@@ -1472,7 +1498,6 @@ interface ProjectTaskRowProps {
 
 const ProjectTaskRow = ({
   task,
-  index,
   columns,
   allTags,
   assignableUsers,
@@ -1564,9 +1589,6 @@ const ProjectTaskRow = ({
           aria-label={`Mark "${task.title}" as ${task.completedOn ? "open" : "done"}`}
           className="size-[18px] cursor-pointer rounded-full border-muted-foreground/40 data-[state=checked]:border-emerald-600 data-[state=checked]:bg-emerald-600 data-[state=checked]:text-white"
         />
-      </td>
-      <td className="px-1 py-2 align-middle text-xs text-muted-foreground">
-        T{index + 1}
       </td>
       {columns.map((column) => (
         <td

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -1523,7 +1523,7 @@ const AddTaskRow = ({
             type="button"
             onClick={open}
             className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
-            data-testid="project-new-task"
+            data-testid="project-add-task"
           >
             <Plus className="h-4 w-4" /> Add task
           </button>

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -418,33 +418,6 @@ const ProjectDetail = () => {
     }
   };
 
-  // Drag-to-reorder user sections (the default group stays pinned first).
-  const sectionIds = useMemo(
-    () => [...sections].sort((a, b) => a.position - b.position).map((s) => s["@id"]),
-    [sections],
-  );
-  const onSectionDragEnd = (event: DragEndEvent) => {
-    const { active, over } = event;
-    if (!over || active.id === over.id) return;
-    const ordered = [...sections].sort((a, b) => a.position - b.position);
-    const from = ordered.findIndex((s) => s["@id"] === active.id);
-    const to = ordered.findIndex((s) => s["@id"] === over.id);
-    if (from === -1 || to === -1) return;
-    const next = arrayMove(ordered, from, to).map((s, i) => ({ ...s, position: i }));
-    setSections(next);
-    // Persist only the rows whose position actually changed.
-    next.forEach((s, i) => {
-      if (ordered[i]?.["@id"] !== s["@id"]) {
-        void fetch(`${ENTRYPOINT}${s["@id"]}`, {
-          method: "PATCH",
-          credentials: "include",
-          headers: { "Content-Type": "application/merge-patch+json" },
-          body: JSON.stringify({ position: i }),
-        });
-      }
-    });
-  };
-
   const toggleComplete = async (task: ProjectTask) => {
     const completedOn = task.completedOn ? null : new Date().toISOString();
     setError(null);
@@ -693,6 +666,36 @@ const ProjectDetail = () => {
     }
     return groups;
   }, [tasks, sections]);
+
+  // List-view section order is a personal preference (localStorage) so the
+  // default "In progress" group can be reordered too (it has no DB row to
+  // carry a position). Unknown/new groups fall to the end; the board keeps
+  // its own default-first order.
+  const orderedSectionGroups = useMemo(() => {
+    const order = listView.sectionOrder;
+    if (order.length === 0) return sectionGroups;
+    const byKey = new Map(sectionGroups.map((g) => [g.key, g]));
+    const seen = new Set<string>();
+    const out: typeof sectionGroups = [];
+    for (const key of order) {
+      const g = byKey.get(key);
+      if (g && !seen.has(key)) {
+        out.push(g);
+        seen.add(key);
+      }
+    }
+    for (const g of sectionGroups) if (!seen.has(g.key)) out.push(g);
+    return out;
+  }, [sectionGroups, listView.sectionOrder]);
+  const sectionIds = orderedSectionGroups.map((g) => g.key);
+  const onSectionDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const from = sectionIds.indexOf(String(active.id));
+    const to = sectionIds.indexOf(String(over.id));
+    if (from === -1 || to === -1) return;
+    listView.setSectionOrder(arrayMove(sectionIds, from, to));
+  };
 
   if (authLoading || !isAuthenticated) {
     return (
@@ -1088,9 +1091,10 @@ const ProjectDetail = () => {
                             items={sectionIds}
                             strategy={verticalListSortingStrategy}
                           >
-                            {sectionGroups.map((group) => (
+                            {orderedSectionGroups.map((group) => (
                               <SectionRows
                                 key={group.key}
+                                sortId={group.key}
                                 section={group.section}
                                 tasks={group.tasks}
                                 columns={columns}
@@ -1209,6 +1213,8 @@ const ProjectDetail = () => {
 
 interface SectionRowsProps {
   section: TaskSection | null;
+  /** Stable sortable id for the section's title row (the group key). */
+  sortId: string;
   tasks: ProjectTask[];
   columns: ListColumn[];
   fullColSpan: number;
@@ -1256,6 +1262,7 @@ const SectionRows = ({
   onCustomFieldChange,
   onRename,
   onDelete,
+  sortId,
 }: SectionRowsProps) => {
   const sectionIri = section ? section["@id"] : null;
   const [collapsed, setCollapsed] = useState(false);
@@ -1272,6 +1279,7 @@ const SectionRows = ({
     <>
       <SectionTitleRow
         section={section}
+        sortId={sortId}
         colSpan={fullColSpan}
         collapsed={collapsed}
         count={tasks.length}
@@ -1327,10 +1335,11 @@ const SectionRows = ({
 };
 
 /** Full-width section heading row: drag grip + collapse arrow + editable
- *  title + delete. User sections are drag-reorderable; the default group is
- *  pinned first (no grip). */
+ *  title + delete. Every section (including the default group) is
+ *  drag-reorderable in the list view. */
 const SectionTitleRow = ({
   section,
+  sortId,
   colSpan,
   collapsed,
   count,
@@ -1339,6 +1348,7 @@ const SectionTitleRow = ({
   onDelete,
 }: {
   section: TaskSection | null;
+  sortId: string;
   colSpan: number;
   collapsed: boolean;
   count: number;
@@ -1347,7 +1357,7 @@ const SectionTitleRow = ({
   onDelete: (section: TaskSection) => void | Promise<void>;
 }) => {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
-    useSortable({ id: section ? section["@id"] : "__default__", disabled: !section });
+    useSortable({ id: sortId });
   return (
     <tr
       ref={setNodeRef}
@@ -1360,18 +1370,16 @@ const SectionTitleRow = ({
     >
       <td colSpan={colSpan} className="px-3 py-1.5">
         <div className="flex items-center gap-1.5">
-          {section && (
-            <button
-              type="button"
-              className="cursor-grab touch-none rounded p-0.5 text-muted-foreground/40 hover:text-foreground"
-              aria-label={`Reorder section "${section.title}"`}
-              data-testid="section-drag"
-              {...attributes}
-              {...listeners}
-            >
-              <GripVertical className="h-3.5 w-3.5" />
-            </button>
-          )}
+          <button
+            type="button"
+            className="cursor-grab touch-none rounded p-0.5 text-muted-foreground/40 hover:text-foreground"
+            aria-label={`Reorder ${section ? `section "${section.title}"` : DEFAULT_SECTION_LABEL}`}
+            data-testid="section-drag"
+            {...attributes}
+            {...listeners}
+          >
+            <GripVertical className="h-3.5 w-3.5" />
+          </button>
           <button
             type="button"
             onClick={onToggleCollapsed}

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -172,21 +172,12 @@ const ProjectDetail = () => {
   const [confirmDeleteProjectOpen, setConfirmDeleteProjectOpen] =
     useState(false);
 
-  // Quick add-task. `addSection` is which group the inline add row is open in:
-  // undefined = closed, null = the default "In progress" group, a string = that
-  // section's IRI. So new tasks land in the section the user added them under.
-  const [addSection, setAddSection] = useState<string | null | undefined>(
-    undefined,
-  );
-  const [newTaskTitle, setNewTaskTitle] = useState("");
-  // Inline draft for the rest of the add row so the user can Tab from the title
-  // into tags / due / assignees before pressing Enter. Shared across sections
-  // since only one add row is open at a time.
-  const [newTaskTags, setNewTaskTags] = useState<TagOption[]>([]);
-  const [newTaskDue, setNewTaskDue] = useState<string | null>(null);
-  const [newTaskAssignees, setNewTaskAssignees] = useState<AssigneeOption[]>([]);
-  const [isCreatingTask, setIsCreatingTask] = useState(false);
+  // Every section carries a persistent quick-add row (managed locally by
+  // AddTaskRow). The top "New task" button just focuses the default group's
+  // add row via this ref.
   const newTaskInputRef = useRef<HTMLInputElement | null>(null);
+  const focusDefaultAddRow = () =>
+    requestAnimationFrame(() => newTaskInputRef.current?.focus());
   // Bumped whenever the task set changes so the aggregate footer re-fetches.
   const [footerKey, setFooterKey] = useState(0);
 
@@ -413,6 +404,18 @@ const ProjectDetail = () => {
     },
     [columns, listView],
   );
+  // checkbox + # + each data column + trailing actions.
+  const fullColSpan = columns.length + 3;
+  const columnKeys = columns.map((c) => c.key);
+  const listSensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  );
+  const onListDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (over && active.id !== over.id) {
+      handleColumnReorder(String(active.id), String(over.id));
+    }
+  };
 
   const toggleComplete = async (task: ProjectTask) => {
     const completedOn = task.completedOn ? null : new Date().toISOString();
@@ -432,81 +435,44 @@ const ProjectDetail = () => {
     }
   };
 
-  // Inline quick-add: create with just the title; everything else is edited in
-  // the row afterwards. Keeps the add row open + refocused for rapid entry.
-  const createTask = async () => {
-    const title = newTaskTitle.trim();
-    if (!project || !title) return;
-    setIsCreatingTask(true);
-    setError(null);
-    try {
-      const res = await fetch(`${ENTRYPOINT}/tasks`, {
-        method: "POST",
-        credentials: "include",
-        headers: { "Content-Type": "application/ld+json" },
-        body: JSON.stringify({
-          title,
-          project: project["@id"],
-          // `addSection` is the IRI of the group being added to; null = default.
-          ...(typeof addSection === "string" ? { section: addSection } : {}),
-          ...(newTaskTags.length
-            ? { tags: newTaskTags.map((t) => t["@id"]) }
-            : {}),
-          ...(newTaskDue ? { dueDate: newTaskDue } : {}),
-          ...(newTaskAssignees.length
-            ? { assignees: newTaskAssignees.map((u) => u["@id"]) }
-            : {}),
-        }),
-      });
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(
-          data.description ||
-            data.detail ||
-            data["hydra:description"] ||
-            "Failed to create task.",
-        );
+  // Inline quick-add from a section's persistent add row: create with just the
+  // title; everything else is edited in the row afterwards. Returns true on
+  // success so the add row can clear + refocus for rapid entry.
+  const createTaskInSection = useCallback(
+    async (sectionIri: string | null, rawTitle: string): Promise<boolean> => {
+      const title = rawTitle.trim();
+      if (!project || !title) return false;
+      setError(null);
+      try {
+        const res = await fetch(`${ENTRYPOINT}/tasks`, {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/ld+json" },
+          body: JSON.stringify({
+            title,
+            project: project["@id"],
+            ...(sectionIri ? { section: sectionIri } : {}),
+          }),
+        });
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          throw new Error(
+            data.description ||
+              data.detail ||
+              data["hydra:description"] ||
+              "Failed to create task.",
+          );
+        }
+        const created: ProjectTask = await res.json();
+        setTasks((prev) => [...prev, created]);
+        return true;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to create task.");
+        return false;
       }
-      const created: ProjectTask = await res.json();
-      setTasks((prev) => [...prev, created]);
-      resetNewTaskDraft();
-      requestAnimationFrame(() => newTaskInputRef.current?.focus());
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to create task.");
-    } finally {
-      setIsCreatingTask(false);
-    }
-  };
-
-  const resetNewTaskDraft = () => {
-    setNewTaskTitle("");
-    setNewTaskTags([]);
-    setNewTaskDue(null);
-    setNewTaskAssignees([]);
-  };
-  // The comboboxes report selection as a list of IRIs; resolve them back to the
-  // loaded options so the draft holds full objects for rendering chips.
-  const handleNewTaskTags = (iris: string[]) =>
-    setNewTaskTags(
-      iris
-        .map((iri) => allTags.find((t) => t["@id"] === iri))
-        .filter((t): t is TagOption => Boolean(t)),
-    );
-  const handleNewTaskAssignees = (iris: string[]) =>
-    setNewTaskAssignees(
-      iris
-        .map((iri) => assignableUsers.find((u) => u["@id"] === iri))
-        .filter((u): u is AssigneeOption => Boolean(u)),
-    );
-
-  const openAddRow = (section: string | null = null) => {
-    setAddSection(section);
-    requestAnimationFrame(() => newTaskInputRef.current?.focus());
-  };
-  const closeAddRow = () => {
-    setAddSection(undefined);
-    resetNewTaskDraft();
-  };
+    },
+    [project],
+  );
 
   const createSection = async () => {
     if (!project) return;
@@ -773,7 +739,7 @@ const ProjectDetail = () => {
                     <Button
                       size="sm"
                       className="rounded-r-none"
-                      onClick={() => openAddRow(null)}
+                      onClick={focusDefaultAddRow}
                       data-testid="project-new-task"
                     >
                       <Plus className="mr-1 h-3.5 w-3.5" /> New task
@@ -790,7 +756,7 @@ const ProjectDetail = () => {
                         </Button>
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="end">
-                        <DropdownMenuItem onClick={() => openAddRow(null)}>
+                        <DropdownMenuItem onClick={focusDefaultAddRow}>
                           <Plus className="mr-2 h-4 w-4" /> New task
                         </DropdownMenuItem>
                         <DropdownMenuItem
@@ -1042,74 +1008,87 @@ const ProjectDetail = () => {
                 </TabsContent>
 
                 <TabsContent value="list" className="mt-4">
-                  <div className="space-y-6" data-testid="project-task-list">
-                    {sectionGroups.map((group) => {
-                      const sectionIri = group.section
-                        ? group.section["@id"]
-                        : null;
-                      return (
-                        <SectionBlock
-                          key={group.key}
-                          section={group.section}
-                          title={
-                            group.section
-                              ? group.section.title
-                              : DEFAULT_SECTION_LABEL
-                          }
-                          tasks={group.tasks}
-                          columns={columns}
-                          projectId={project.id}
-                          projectIri={project["@id"]}
-                          spaceIri={projectSpaceIri(project)}
-                          allTags={allTags}
-                          assignableUsers={projectAssignableUsers}
-                          sort={listView.sort}
-                          filters={listView.filters}
-                          onSetSort={listView.setSort}
-                          onSetFilter={listView.setFilter}
-                          onReorder={handleColumnReorder}
-                          footerFilter={
-                            sectionIri
-                              ? `section=${encodeURIComponent(sectionIri)}`
-                              : "section=none"
-                          }
-                          footerKey={footerKey}
-                          addOpen={addSection === sectionIri}
-                          newTaskTitle={newTaskTitle}
-                          newTaskTags={newTaskTags}
-                          newTaskDue={newTaskDue}
-                          newTaskAssignees={newTaskAssignees}
-                          newTaskInputRef={newTaskInputRef}
-                          isCreatingTask={isCreatingTask}
-                          onNewTaskTitle={setNewTaskTitle}
-                          onNewTaskTags={handleNewTaskTags}
-                          onNewTaskDue={setNewTaskDue}
-                          onNewTaskAssignees={handleNewTaskAssignees}
-                          onCreateTask={createTask}
-                          onAddRow={() => openAddRow(sectionIri)}
-                          onCloseAddRow={closeAddRow}
-                          onToggle={toggleComplete}
-                          onOpen={openTaskDetail}
-                          patchTask={patchTask}
-                          onCustomFieldChange={handleCustomFieldChange}
-                          onRename={renameSection}
-                          onDelete={deleteSection}
-                        />
-                      );
-                    })}
-                  </div>
-
-                  {/* Grand totals across the whole board — only when
-                      there's more than one section to total across. */}
-                  {sectionGroups.length > 1 && (
-                    <CustomFieldFooterRow
-                      projectId={project.id}
-                      refreshKey={footerKey}
-                      columns={columns}
-                      prominent
-                      className="mt-6"
-                    />
-                  )}
+                  {/* One continuous table: a single sticky column header at the
+                      top, section titles as in-table rows, and a persistent
+                      add-task row at the foot of every section. The container
+                      scrolls internally so the header can stick. */}
+                  <DndContext
+                    sensors={listSensors}
+                    collisionDetection={closestCenter}
+                    onDragEnd={onListDragEnd}
+                  >
+                    <div
+                      className="max-h-[calc(100vh-13rem)] overflow-auto rounded-lg border"
+                      data-testid="project-task-list"
+                    >
+                      <table className="w-full table-fixed text-sm">
+                        <TaskTableColumns columns={columns} />
+                        <thead className="sticky top-0 z-20 bg-background">
+                          <tr className="border-b text-xs uppercase tracking-wide text-muted-foreground">
+                            <th className="w-8 px-3 py-2" />
+                            <th className="w-10 px-1 py-2 text-left font-medium">#</th>
+                            <SortableContext
+                              items={columnKeys}
+                              strategy={horizontalListSortingStrategy}
+                            >
+                              {columns.map((column) => (
+                                <SortableHeaderCell
+                                  key={column.key}
+                                  column={column}
+                                  sort={listView.sort}
+                                  filter={listView.filters[column.key]}
+                                  onSetSort={listView.setSort}
+                                  onSetFilter={listView.setFilter}
+                                  assignableUsers={projectAssignableUsers}
+                                  allTags={allTags}
+                                />
+                              ))}
+                            </SortableContext>
+                            <th className="w-10 px-2 py-2" />
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {sectionGroups.map((group) => (
+                            <SectionRows
+                              key={group.key}
+                              section={group.section}
+                              tasks={group.tasks}
+                              columns={columns}
+                              fullColSpan={fullColSpan}
+                              projectId={project.id}
+                              projectIri={project["@id"]}
+                              spaceIri={projectSpaceIri(project)}
+                              allTags={allTags}
+                              assignableUsers={projectAssignableUsers}
+                              sort={listView.sort}
+                              filters={listView.filters}
+                              footerKey={footerKey}
+                              newTaskInputRef={
+                                group.section ? undefined : newTaskInputRef
+                              }
+                              onCreate={createTaskInSection}
+                              onToggle={toggleComplete}
+                              onOpen={openTaskDetail}
+                              patchTask={patchTask}
+                              onCustomFieldChange={handleCustomFieldChange}
+                              onRename={renameSection}
+                              onDelete={deleteSection}
+                            />
+                          ))}
+                          {/* Grand total across the whole board. */}
+                          {sectionGroups.length > 1 && (
+                            <CustomFieldFooterRow
+                              projectId={project.id}
+                              refreshKey={footerKey}
+                              columns={columns}
+                              asRow
+                              prominent
+                            />
+                          )}
+                        </tbody>
+                      </table>
+                    </div>
+                  </DndContext>
                 </TabsContent>
 
                 <TabsContent value="board" className="mt-4">
@@ -1128,9 +1107,11 @@ const ProjectDetail = () => {
                       if (task) openTaskDetail(task);
                     }}
                     onMove={moveTaskToSection}
-                    onAddTask={(sectionIri) => {
+                    onAddTask={() => {
+                      // Every section has a persistent add row now; just jump
+                      // to the list and focus the default one.
                       setActiveTab("list");
-                      openAddRow(sectionIri);
+                      focusDefaultAddRow();
                     }}
                     onAddSection={() => void createSection()}
                     onDeleteSection={(sectionIri) => {
@@ -1185,11 +1166,11 @@ const ProjectDetail = () => {
   );
 };
 
-interface SectionBlockProps {
+interface SectionRowsProps {
   section: TaskSection | null;
-  title: string;
   tasks: ProjectTask[];
   columns: ListColumn[];
+  fullColSpan: number;
   projectId: string;
   projectIri: string;
   spaceIri: string;
@@ -1197,25 +1178,9 @@ interface SectionBlockProps {
   assignableUsers: AssigneeOption[];
   sort: SortState | null;
   filters: FilterMap;
-  onSetSort: (sort: SortState | null) => void;
-  onSetFilter: (key: string, value: FilterValue | null) => void;
-  onReorder: (activeKey: string, overKey: string) => void;
-  footerFilter: string;
   footerKey: number;
-  addOpen: boolean;
-  newTaskTitle: string;
-  newTaskTags: TagOption[];
-  newTaskDue: string | null;
-  newTaskAssignees: AssigneeOption[];
-  newTaskInputRef: RefObject<HTMLInputElement | null>;
-  isCreatingTask: boolean;
-  onNewTaskTitle: (value: string) => void;
-  onNewTaskTags: (iris: string[]) => void;
-  onNewTaskDue: (next: string | null) => void;
-  onNewTaskAssignees: (iris: string[]) => void;
-  onCreateTask: () => void | Promise<void>;
-  onAddRow: () => void;
-  onCloseAddRow: () => void;
+  newTaskInputRef?: RefObject<HTMLInputElement | null>;
+  onCreate: (sectionIri: string | null, title: string) => Promise<boolean>;
   onToggle: (task: ProjectTask) => void;
   onOpen: (task: ProjectTask) => void;
   patchTask: (task: ProjectTask, body: Record<string, unknown>) => Promise<void>;
@@ -1224,12 +1189,16 @@ interface SectionBlockProps {
   onDelete: (section: TaskSection) => void | Promise<void>;
 }
 
-/** One board section: editable title + its own task table + a footer. */
-const SectionBlock = ({
+/**
+ * One section rendered as a group of rows inside the shared list table: a
+ * full-width title row, its filtered/sorted task rows, a persistent
+ * add-task row, and the section's aggregate footer row.
+ */
+const SectionRows = ({
   section,
-  title,
   tasks,
   columns,
+  fullColSpan,
   projectId,
   projectIri,
   spaceIri,
@@ -1237,61 +1206,95 @@ const SectionBlock = ({
   assignableUsers,
   sort,
   filters,
-  onSetSort,
-  onSetFilter,
-  onReorder,
-  footerFilter,
   footerKey,
-  addOpen,
-  newTaskTitle,
-  newTaskTags,
-  newTaskDue,
-  newTaskAssignees,
   newTaskInputRef,
-  isCreatingTask,
-  onNewTaskTitle,
-  onNewTaskTags,
-  onNewTaskDue,
-  onNewTaskAssignees,
-  onCreateTask,
-  onAddRow,
-  onCloseAddRow,
+  onCreate,
   onToggle,
   onOpen,
   patchTask,
   onCustomFieldChange,
   onRename,
   onDelete,
-}: SectionBlockProps) => {
-  // checkbox + # + each data column + trailing actions.
-  const fullColSpan = columns.length + 3;
-  // Sort + filter the section's rows per the active column view. Falls back
-  // to the raw list when nothing is set (the common case).
-  const visibleTasks = useMemo(
+}: SectionRowsProps) => {
+  const sectionIri = section ? section["@id"] : null;
+  const visible = useMemo(
     () => applyView(tasks, columns, sort, filters),
     [tasks, columns, sort, filters],
   );
   const filtersActive = Object.keys(filters).length > 0;
-  const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
-  );
-  const columnKeys = columns.map((c) => c.key);
-  const onDragEnd = (event: DragEndEvent) => {
-    const { active, over } = event;
-    if (over && active.id !== over.id) {
-      onReorder(String(active.id), String(over.id));
-    }
-  };
+  const footerFilter = sectionIri
+    ? `section=${encodeURIComponent(sectionIri)}`
+    : "section=none";
 
   return (
-    <div data-testid="project-section">
-      {/* Every section shows a title above its table. User-created sections
-          get an editable title + Add task + delete menu; the default
-          "In progress" group shows a static title (add via "New task"). */}
-      <div className="mb-1.5 flex items-center gap-2">
+    <>
+      <SectionTitleRow
+        section={section}
+        colSpan={fullColSpan}
+        onRename={onRename}
+        onDelete={onDelete}
+      />
+      {visible.map((task, i) => (
+        <ProjectTaskRow
+          key={task["@id"]}
+          task={task}
+          index={i}
+          columns={columns}
+          allTags={allTags}
+          assignableUsers={assignableUsers}
+          projectIri={projectIri}
+          spaceIri={spaceIri}
+          onToggle={onToggle}
+          onOpen={onOpen}
+          patchTask={patchTask}
+          onCustomFieldChange={onCustomFieldChange}
+        />
+      ))}
+      {tasks.length > 0 && visible.length === 0 && filtersActive && (
+        <tr>
+          <td
+            colSpan={fullColSpan}
+            className="px-3 py-3 text-sm text-muted-foreground"
+          >
+            No tasks match the active filters.
+          </td>
+        </tr>
+      )}
+      <AddTaskRow
+        columns={columns}
+        sectionIri={sectionIri}
+        onCreate={onCreate}
+        inputRef={newTaskInputRef}
+      />
+      <CustomFieldFooterRow
+        projectId={projectId}
+        filters={footerFilter}
+        refreshKey={footerKey}
+        columns={columns}
+        asRow
+      />
+    </>
+  );
+};
+
+/** Full-width section heading row (editable title + delete for user sections). */
+const SectionTitleRow = ({
+  section,
+  colSpan,
+  onRename,
+  onDelete,
+}: {
+  section: TaskSection | null;
+  colSpan: number;
+  onRename: (section: TaskSection, title: string) => void | Promise<void>;
+  onDelete: (section: TaskSection) => void | Promise<void>;
+}) => (
+  <tr className="border-b bg-muted/40" data-testid="project-section">
+    <td colSpan={colSpan} className="px-3 py-1.5">
+      <div className="flex items-center gap-2">
         {section ? (
           <input
-            defaultValue={title}
+            defaultValue={section.title}
             onBlur={(e) => void onRename(section, e.target.value)}
             onKeyDown={(e) => {
               if (e.key === "Enter") (e.target as HTMLInputElement).blur();
@@ -1301,222 +1304,97 @@ const SectionBlock = ({
             data-testid="section-title-input"
           />
         ) : (
-          <span
-            className="px-1 text-sm font-semibold"
-            data-testid="section-title"
-          >
-            {title}
+          <span className="px-1 text-sm font-semibold" data-testid="section-title">
+            {DEFAULT_SECTION_LABEL}
           </span>
         )}
         {section && (
-          <>
-            <button
-              type="button"
-              onClick={onAddRow}
-              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
-              data-testid="section-add-task"
-            >
-              <Plus className="h-3.5 w-3.5" /> Add task
-            </button>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button
-                  type="button"
-                  className="ml-auto rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-                  aria-label="Section actions"
-                  data-testid="section-menu"
-                >
-                  <MoreHorizontal className="h-4 w-4" />
-                </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem
-                  onClick={() => void onDelete(section)}
-                  className="text-destructive"
-                  data-testid="section-delete"
-                >
-                  <Trash2 className="mr-2 h-4 w-4" /> Delete section
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                className="ml-auto rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                aria-label="Section actions"
+                data-testid="section-menu"
+              >
+                <MoreHorizontal className="h-4 w-4" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                onClick={() => void onDelete(section)}
+                className="text-destructive"
+                data-testid="section-delete"
+              >
+                <Trash2 className="mr-2 h-4 w-4" /> Delete section
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         )}
       </div>
+    </td>
+  </tr>
+);
 
-      <div className="overflow-hidden rounded-lg border">
-        <div className="overflow-x-auto">
-        <DndContext
-          sensors={sensors}
-          collisionDetection={closestCenter}
-          onDragEnd={onDragEnd}
-        >
-        <table className="w-full table-fixed text-sm">
-          <TaskTableColumns columns={columns} />
-          <thead>
-            <tr className="border-b text-xs uppercase tracking-wide text-muted-foreground">
-              <th className="w-8 px-3 py-2" />
-              <th className="w-10 px-1 py-2 text-left font-medium">#</th>
-              <SortableContext items={columnKeys} strategy={horizontalListSortingStrategy}>
-                {columns.map((column) => (
-                  <SortableHeaderCell
-                    key={column.key}
-                    column={column}
-                    sort={sort}
-                    filter={filters[column.key]}
-                    onSetSort={onSetSort}
-                    onSetFilter={onSetFilter}
-                    assignableUsers={assignableUsers}
-                    allTags={allTags}
-                  />
-                ))}
-              </SortableContext>
-              <th className="w-10 px-2 py-2" />
-            </tr>
-          </thead>
-          <tbody>
-            {visibleTasks.map((task, i) => (
-              <ProjectTaskRow
-                key={task["@id"]}
-                task={task}
-                index={i}
-                columns={columns}
-                allTags={allTags}
-                assignableUsers={assignableUsers}
-                projectIri={projectIri}
-                spaceIri={spaceIri}
-                onToggle={onToggle}
-                onOpen={onOpen}
-                patchTask={patchTask}
-                onCustomFieldChange={onCustomFieldChange}
-              />
-            ))}
-            {tasks.length > 0 && visibleTasks.length === 0 && filtersActive && (
-              <tr>
-                <td
-                  colSpan={fullColSpan}
-                  className="px-3 py-3 text-sm text-muted-foreground"
-                >
-                  No tasks match the active filters.
-                </td>
-              </tr>
-            )}
-            {addOpen && (
-              <tr className="border-b bg-muted/20" data-testid="project-new-task-row">
-                <td className="px-3 py-2 align-middle">
-                  <Plus className="h-4 w-4 text-muted-foreground" aria-hidden />
-                </td>
-                <td className="px-1 py-2" />
-                {columns.map((column) => {
-                  if (column.key === "task") {
-                    return (
-                      <td key="task" className="px-2 py-2">
-                        <Input
-                          ref={newTaskInputRef}
-                          value={newTaskTitle}
-                          onChange={(e) => onNewTaskTitle(e.target.value)}
-                          onKeyDown={(e) => {
-                            if (e.key === "Enter") {
-                              e.preventDefault();
-                              void onCreateTask();
-                            } else if (e.key === "Escape") {
-                              e.preventDefault();
-                              onCloseAddRow();
-                            }
-                          }}
-                          onBlur={(e) => {
-                            if (newTaskTitle.trim()) return;
-                            // Keep the row open while the user Tabs to a sibling
-                            // field before submitting; only close when focus
-                            // leaves the add row entirely.
-                            const next = e.relatedTarget as HTMLElement | null;
-                            if (next?.closest('[data-testid="project-new-task-row"]'))
-                              return;
-                            onCloseAddRow();
-                          }}
-                          placeholder="Task title, then Tab or Enter…"
-                          maxLength={255}
-                          disabled={isCreatingTask}
-                          className="h-8"
-                          data-testid="project-new-task-title"
-                        />
-                      </td>
-                    );
-                  }
-                  if (column.key === "due") {
-                    return (
-                      <td key="due" className="px-2 py-2 align-middle" data-testid="new-task-due">
-                        <DueDateCell
-                          value={newTaskDue}
-                          onChange={onNewTaskDue}
-                          ariaLabel="Due date for new task"
-                          testIdPrefix="project-new-task-due"
-                        />
-                      </td>
-                    );
-                  }
-                  if (column.key === "assignees") {
-                    return (
-                      <td key="assignees" className="px-2 py-2 align-middle" data-testid="new-task-assignees">
-                        <AssigneesCombobox
-                          value={newTaskAssignees}
-                          options={assignableUsers}
-                          onChange={onNewTaskAssignees}
-                          subjectLabel="new task"
-                        />
-                      </td>
-                    );
-                  }
-                  if (column.key === "tags") {
-                    return (
-                      <td key="tags" className="px-2 py-2 align-middle" data-testid="new-task-tags">
-                        <TagsCombobox
-                          value={newTaskTags}
-                          options={allTags}
-                          onChange={onNewTaskTags}
-                          subjectLabel="new task"
-                        />
-                      </td>
-                    );
-                  }
-                  // Custom fields are set after the task exists; an empty cell
-                  // keeps the inline fields aligned with the columns.
-                  return <td key={column.key} className="px-2 py-2 align-middle" />;
-                })}
-                <td className="px-2 py-2 align-middle" />
-              </tr>
-            )}
-            {tasks.length === 0 && !addOpen && (
-              <tr>
-                <td
-                  colSpan={fullColSpan}
-                  className="px-3 py-3 text-sm text-muted-foreground"
-                >
-                  No tasks here yet.{" "}
-                  <button
-                    type="button"
-                    onClick={onAddRow}
-                    className="text-foreground underline underline-offset-2 hover:no-underline"
-                  >
-                    Add one
-                  </button>
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
-        </DndContext>
-        {/* Per-section aggregates: a flush, column-aligned footer inside the
-            same scroll container so it lines up with the columns above. */}
-        <CustomFieldFooterRow
-          projectId={projectId}
-          filters={footerFilter}
-          refreshKey={footerKey}
-          columns={columns}
-          flush
-        />
-        </div>
-      </div>
-    </div>
+/**
+ * Persistent quick-add row at the foot of every section. Title-only: Enter
+ * creates the task in this section (other fields are edited on the row
+ * afterwards). Keeps its own draft so each section adds independently.
+ */
+const AddTaskRow = ({
+  columns,
+  sectionIri,
+  onCreate,
+  inputRef,
+}: {
+  columns: ListColumn[];
+  sectionIri: string | null;
+  onCreate: (sectionIri: string | null, title: string) => Promise<boolean>;
+  inputRef?: RefObject<HTMLInputElement | null>;
+}) => {
+  const [title, setTitle] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const submit = async () => {
+    if (!title.trim() || busy) return;
+    setBusy(true);
+    const ok = await onCreate(sectionIri, title);
+    setBusy(false);
+    if (ok) setTitle("");
+  };
+
+  return (
+    <tr className="border-b bg-muted/5" data-testid="project-new-task-row">
+      <td className="px-3 py-2 align-middle">
+        <Plus className="h-4 w-4 text-muted-foreground" aria-hidden />
+      </td>
+      <td className="px-1 py-2" />
+      {columns.map((column) =>
+        column.key === "task" ? (
+          <td key="task" className="px-2 py-2">
+            <Input
+              ref={inputRef}
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  void submit();
+                }
+              }}
+              placeholder="Add a task, then Enter…"
+              maxLength={255}
+              disabled={busy}
+              className="h-8 border-transparent bg-transparent hover:border-input focus-visible:border-input"
+              data-testid="project-new-task-title"
+            />
+          </td>
+        ) : (
+          <td key={column.key} className="px-2 py-2" />
+        ),
+      )}
+      <td className="px-2 py-2" />
+    </tr>
   );
 };
 

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -33,6 +33,7 @@ import {
   SortableContext,
   useSortable,
   horizontalListSortingStrategy,
+  verticalListSortingStrategy,
   arrayMove,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
@@ -404,17 +405,44 @@ const ProjectDetail = () => {
     },
     [columns, listView],
   );
-  // checkbox + # + each data column + trailing actions.
+  // checkbox + each data column + trailing actions.
   const fullColSpan = columns.length + 2;
   const columnKeys = columns.map((c) => c.key);
   const listSensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
   );
-  const onListDragEnd = (event: DragEndEvent) => {
+  const onColumnDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
     if (over && active.id !== over.id) {
       handleColumnReorder(String(active.id), String(over.id));
     }
+  };
+
+  // Drag-to-reorder user sections (the default group stays pinned first).
+  const sectionIds = useMemo(
+    () => [...sections].sort((a, b) => a.position - b.position).map((s) => s["@id"]),
+    [sections],
+  );
+  const onSectionDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const ordered = [...sections].sort((a, b) => a.position - b.position);
+    const from = ordered.findIndex((s) => s["@id"] === active.id);
+    const to = ordered.findIndex((s) => s["@id"] === over.id);
+    if (from === -1 || to === -1) return;
+    const next = arrayMove(ordered, from, to).map((s, i) => ({ ...s, position: i }));
+    setSections(next);
+    // Persist only the rows whose position actually changed.
+    next.forEach((s, i) => {
+      if (ordered[i]?.["@id"] !== s["@id"]) {
+        void fetch(`${ENTRYPOINT}${s["@id"]}`, {
+          method: "PATCH",
+          credentials: "include",
+          headers: { "Content-Type": "application/merge-patch+json" },
+          body: JSON.stringify({ position: i }),
+        });
+      }
+    });
   };
 
   const toggleComplete = async (task: ProjectTask) => {
@@ -1012,17 +1040,20 @@ const ProjectDetail = () => {
                       top, section titles as in-table rows, and a persistent
                       add-task row at the foot of every section. The container
                       scrolls internally so the header can stick. */}
-                  <DndContext
-                    sensors={listSensors}
-                    collisionDetection={closestCenter}
-                    onDragEnd={onListDragEnd}
+                  <div
+                    className="max-h-[calc(100vh-13rem)] overflow-auto rounded-lg border"
+                    data-testid="project-task-list"
                   >
-                    <div
-                      className="max-h-[calc(100vh-13rem)] overflow-auto rounded-lg border"
-                      data-testid="project-task-list"
-                    >
-                      <table className="w-full table-fixed text-sm">
-                        <TaskTableColumns columns={columns} />
+                    <table className="w-full table-fixed text-sm">
+                      <TaskTableColumns columns={columns} />
+                      {/* Column header reorder (horizontal) is its own DnD
+                          context, separate from section reorder (vertical) so
+                          the two never cross-target. */}
+                      <DndContext
+                        sensors={listSensors}
+                        collisionDetection={closestCenter}
+                        onDragEnd={onColumnDragEnd}
+                      >
                         <thead className="sticky top-0 z-20 bg-background">
                           <tr className="border-b text-xs uppercase tracking-wide text-muted-foreground">
                             <th className="w-8 px-3 py-2" />
@@ -1046,34 +1077,45 @@ const ProjectDetail = () => {
                             <th className="w-10 px-2 py-2" />
                           </tr>
                         </thead>
+                      </DndContext>
+                      <DndContext
+                        sensors={listSensors}
+                        collisionDetection={closestCenter}
+                        onDragEnd={onSectionDragEnd}
+                      >
                         <tbody>
-                          {sectionGroups.map((group) => (
-                            <SectionRows
-                              key={group.key}
-                              section={group.section}
-                              tasks={group.tasks}
-                              columns={columns}
-                              fullColSpan={fullColSpan}
-                              projectId={project.id}
-                              projectIri={project["@id"]}
-                              spaceIri={projectSpaceIri(project)}
-                              allTags={allTags}
-                              assignableUsers={projectAssignableUsers}
-                              sort={listView.sort}
-                              filters={listView.filters}
-                              footerKey={footerKey}
-                              newTaskInputRef={
-                                group.section ? undefined : newTaskInputRef
-                              }
-                              onCreate={createTaskInSection}
-                              onToggle={toggleComplete}
-                              onOpen={openTaskDetail}
-                              patchTask={patchTask}
-                              onCustomFieldChange={handleCustomFieldChange}
-                              onRename={renameSection}
-                              onDelete={deleteSection}
-                            />
-                          ))}
+                          <SortableContext
+                            items={sectionIds}
+                            strategy={verticalListSortingStrategy}
+                          >
+                            {sectionGroups.map((group) => (
+                              <SectionRows
+                                key={group.key}
+                                section={group.section}
+                                tasks={group.tasks}
+                                columns={columns}
+                                fullColSpan={fullColSpan}
+                                projectId={project.id}
+                                projectIri={project["@id"]}
+                                spaceIri={projectSpaceIri(project)}
+                                allTags={allTags}
+                                assignableUsers={projectAssignableUsers}
+                                sort={listView.sort}
+                                filters={listView.filters}
+                                footerKey={footerKey}
+                                newTaskInputRef={
+                                  group.section ? undefined : newTaskInputRef
+                                }
+                                onCreate={createTaskInSection}
+                                onToggle={toggleComplete}
+                                onOpen={openTaskDetail}
+                                patchTask={patchTask}
+                                onCustomFieldChange={handleCustomFieldChange}
+                                onRename={renameSection}
+                                onDelete={deleteSection}
+                              />
+                            ))}
+                          </SortableContext>
                           {/* Grand total across the whole board. */}
                           {sectionGroups.length > 1 && (
                             <CustomFieldFooterRow
@@ -1085,9 +1127,9 @@ const ProjectDetail = () => {
                             />
                           )}
                         </tbody>
-                      </table>
-                    </div>
-                  </DndContext>
+                      </DndContext>
+                    </table>
+                  </div>
                 </TabsContent>
 
                 <TabsContent value="board" className="mt-4">
@@ -1284,7 +1326,9 @@ const SectionRows = ({
   );
 };
 
-/** Full-width section heading row (collapse arrow + editable title + delete). */
+/** Full-width section heading row: drag grip + collapse arrow + editable
+ *  title + delete. User sections are drag-reorderable; the default group is
+ *  pinned first (no grip). */
 const SectionTitleRow = ({
   section,
   colSpan,
@@ -1301,18 +1345,41 @@ const SectionTitleRow = ({
   onToggleCollapsed: () => void;
   onRename: (section: TaskSection, title: string) => void | Promise<void>;
   onDelete: (section: TaskSection) => void | Promise<void>;
-}) => (
-  <tr className="border-b bg-muted/40" data-testid="project-section">
-    <td colSpan={colSpan} className="px-3 py-1.5">
-      <div className="flex items-center gap-1.5">
-        <button
-          type="button"
-          onClick={onToggleCollapsed}
-          aria-expanded={!collapsed}
-          aria-label={collapsed ? "Expand section" : "Collapse section"}
-          className="rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
-          data-testid="section-collapse"
-        >
+}) => {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: section ? section["@id"] : "__default__", disabled: !section });
+  return (
+    <tr
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={cn(
+        "border-b bg-muted/40",
+        isDragging && "relative z-10 opacity-70",
+      )}
+      data-testid="project-section"
+    >
+      <td colSpan={colSpan} className="px-3 py-1.5">
+        <div className="flex items-center gap-1.5">
+          {section && (
+            <button
+              type="button"
+              className="cursor-grab touch-none rounded p-0.5 text-muted-foreground/40 hover:text-foreground"
+              aria-label={`Reorder section "${section.title}"`}
+              data-testid="section-drag"
+              {...attributes}
+              {...listeners}
+            >
+              <GripVertical className="h-3.5 w-3.5" />
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={onToggleCollapsed}
+            aria-expanded={!collapsed}
+            aria-label={collapsed ? "Expand section" : "Collapse section"}
+            className="rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+            data-testid="section-collapse"
+          >
           {collapsed ? (
             <ChevronRight className="h-4 w-4" />
           ) : (
@@ -1359,10 +1426,11 @@ const SectionTitleRow = ({
             </DropdownMenuContent>
           </DropdownMenu>
         )}
-      </div>
-    </td>
-  </tr>
-);
+        </div>
+      </td>
+    </tr>
+  );
+};
 
 /**
  * Persistent quick-add row at the foot of every section. Title-only: Enter

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -145,6 +145,14 @@ const isEmptyFieldValue = (value: unknown): boolean =>
 const DEFAULT_SECTION_KEY = "__default__";
 const DEFAULT_SECTION_LABEL = "In progress";
 
+/** Draft payload for the inline add-task row (IRIs for the relations). */
+interface NewTaskDraft {
+  title: string;
+  dueDate: string | null;
+  assignees: string[];
+  tags: string[];
+}
+
 const ProjectDetail = () => {
   const { user, isAuthenticated, isLoading: authLoading } = useAuth();
   const { spaces } = useActiveSpace();
@@ -173,12 +181,12 @@ const ProjectDetail = () => {
   const [confirmDeleteProjectOpen, setConfirmDeleteProjectOpen] =
     useState(false);
 
-  // Every section carries a persistent quick-add row (managed locally by
-  // AddTaskRow). The top "New task" button just focuses the default group's
-  // add row via this ref.
-  const newTaskInputRef = useRef<HTMLInputElement | null>(null);
+  // Each section shows a collapsed "+ Add task" trigger that expands into a
+  // full draft row (managed locally by AddTaskRow). The top "New task" button
+  // clicks the default group's trigger to open + focus it.
+  const defaultAddTriggerRef = useRef<HTMLButtonElement | null>(null);
   const focusDefaultAddRow = () =>
-    requestAnimationFrame(() => newTaskInputRef.current?.focus());
+    requestAnimationFrame(() => defaultAddTriggerRef.current?.click());
   // Bumped whenever the task set changes so the aggregate footer re-fetches.
   const [footerKey, setFooterKey] = useState(0);
 
@@ -436,12 +444,12 @@ const ProjectDetail = () => {
     }
   };
 
-  // Inline quick-add from a section's persistent add row: create with just the
-  // title; everything else is edited in the row afterwards. Returns true on
-  // success so the add row can clear + refocus for rapid entry.
+  // Inline add from a section's expandable add row: create with the drafted
+  // title + due / assignees / tags. Returns true on success so the add row
+  // can clear + refocus for rapid entry.
   const createTaskInSection = useCallback(
-    async (sectionIri: string | null, rawTitle: string): Promise<boolean> => {
-      const title = rawTitle.trim();
+    async (sectionIri: string | null, draft: NewTaskDraft): Promise<boolean> => {
+      const title = draft.title.trim();
       if (!project || !title) return false;
       setError(null);
       try {
@@ -453,6 +461,9 @@ const ProjectDetail = () => {
             title,
             project: project["@id"],
             ...(sectionIri ? { section: sectionIri } : {}),
+            ...(draft.dueDate ? { dueDate: draft.dueDate } : {}),
+            ...(draft.assignees.length ? { assignees: draft.assignees } : {}),
+            ...(draft.tags.length ? { tags: draft.tags } : {}),
           }),
         });
         if (!res.ok) {
@@ -1107,8 +1118,8 @@ const ProjectDetail = () => {
                                 sort={listView.sort}
                                 filters={listView.filters}
                                 footerKey={footerKey}
-                                newTaskInputRef={
-                                  group.section ? undefined : newTaskInputRef
+                                addTriggerRef={
+                                  group.section ? undefined : defaultAddTriggerRef
                                 }
                                 onCreate={createTaskInSection}
                                 onToggle={toggleComplete}
@@ -1226,8 +1237,8 @@ interface SectionRowsProps {
   sort: SortState | null;
   filters: FilterMap;
   footerKey: number;
-  newTaskInputRef?: RefObject<HTMLInputElement | null>;
-  onCreate: (sectionIri: string | null, title: string) => Promise<boolean>;
+  addTriggerRef?: RefObject<HTMLButtonElement | null>;
+  onCreate: (sectionIri: string | null, draft: NewTaskDraft) => Promise<boolean>;
   onToggle: (task: ProjectTask) => void;
   onOpen: (task: ProjectTask) => void;
   patchTask: (task: ProjectTask, body: Record<string, unknown>) => Promise<void>;
@@ -1254,7 +1265,7 @@ const SectionRows = ({
   sort,
   filters,
   footerKey,
-  newTaskInputRef,
+  addTriggerRef,
   onCreate,
   onToggle,
   onOpen,
@@ -1317,8 +1328,10 @@ const SectionRows = ({
         <AddTaskRow
           columns={columns}
           sectionIri={sectionIri}
+          allTags={allTags}
+          assignableUsers={assignableUsers}
           onCreate={onCreate}
-          inputRef={newTaskInputRef}
+          triggerRef={addTriggerRef}
         />
       )}
       {!collapsed && (
@@ -1441,61 +1454,166 @@ const SectionTitleRow = ({
 };
 
 /**
- * Persistent quick-add row at the foot of every section. Title-only: Enter
- * creates the task in this section (other fields are edited on the row
- * afterwards). Keeps its own draft so each section adds independently.
+ * Foot-of-section add affordance. Collapsed it's just a "+ Add task" text
+ * trigger; clicking it expands into a full draft row (title + due +
+ * assignees + tags) that creates the task on Enter and stays open for rapid
+ * entry. Escape (or the top "New task" button via `triggerRef`) toggles it.
  */
 const AddTaskRow = ({
   columns,
   sectionIri,
+  allTags,
+  assignableUsers,
   onCreate,
-  inputRef,
+  triggerRef,
 }: {
   columns: ListColumn[];
   sectionIri: string | null;
-  onCreate: (sectionIri: string | null, title: string) => Promise<boolean>;
-  inputRef?: RefObject<HTMLInputElement | null>;
+  allTags: TagOption[];
+  assignableUsers: AssigneeOption[];
+  onCreate: (sectionIri: string | null, draft: NewTaskDraft) => Promise<boolean>;
+  triggerRef?: RefObject<HTMLButtonElement | null>;
 }) => {
-  const [title, setTitle] = useState("");
+  const [adding, setAdding] = useState(false);
   const [busy, setBusy] = useState(false);
+  const [title, setTitle] = useState("");
+  const [dueDate, setDueDate] = useState<string | null>(null);
+  const [tags, setTags] = useState<TagOption[]>([]);
+  const [assignees, setAssignees] = useState<AssigneeOption[]>([]);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const reset = () => {
+    setTitle("");
+    setDueDate(null);
+    setTags([]);
+    setAssignees([]);
+  };
+  const open = () => {
+    setAdding(true);
+    requestAnimationFrame(() => inputRef.current?.focus());
+  };
+  const close = () => {
+    setAdding(false);
+    reset();
+  };
 
   const submit = async () => {
     if (!title.trim() || busy) return;
     setBusy(true);
-    const ok = await onCreate(sectionIri, title);
+    const ok = await onCreate(sectionIri, {
+      title,
+      dueDate,
+      assignees: assignees.map((a) => a["@id"]),
+      tags: tags.map((t) => t["@id"]),
+    });
     setBusy(false);
-    if (ok) setTitle("");
+    if (ok) {
+      reset();
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
   };
 
+  if (!adding) {
+    return (
+      <tr className="border-b" data-testid="project-add-task-trigger">
+        <td className="px-3 py-2" />
+        <td colSpan={columns.length + 1} className="px-2 py-2">
+          <button
+            ref={triggerRef}
+            type="button"
+            onClick={open}
+            className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+            data-testid="project-new-task"
+          >
+            <Plus className="h-4 w-4" /> Add task
+          </button>
+        </td>
+      </tr>
+    );
+  }
+
   return (
-    <tr className="border-b bg-muted/5" data-testid="project-new-task-row">
+    <tr className="border-b bg-muted/10" data-testid="project-new-task-row">
       <td className="px-3 py-2 align-middle">
         <Plus className="h-4 w-4 text-muted-foreground" aria-hidden />
       </td>
-      {columns.map((column) =>
-        column.key === "task" ? (
-          <td key="task" className="px-2 py-2">
-            <Input
-              ref={inputRef}
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  e.preventDefault();
-                  void submit();
+      {columns.map((column) => {
+        if (column.key === "task") {
+          return (
+            <td key="task" className="px-2 py-2">
+              <Input
+                ref={inputRef}
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    void submit();
+                  } else if (e.key === "Escape") {
+                    e.preventDefault();
+                    close();
+                  }
+                }}
+                placeholder="Task name…"
+                maxLength={255}
+                disabled={busy}
+                className="h-8"
+                data-testid="project-new-task-title"
+              />
+            </td>
+          );
+        }
+        if (column.key === "due") {
+          return (
+            <td key="due" className="px-2 py-2 align-middle" data-testid="new-task-due">
+              <DueDateCell
+                value={dueDate}
+                onChange={setDueDate}
+                ariaLabel="Due date for new task"
+                testIdPrefix="project-new-task-due"
+              />
+            </td>
+          );
+        }
+        if (column.key === "assignees") {
+          return (
+            <td key="assignees" className="px-2 py-2 align-middle" data-testid="new-task-assignees">
+              <AssigneesCombobox
+                value={assignees}
+                options={assignableUsers}
+                onChange={(iris) =>
+                  setAssignees(
+                    iris
+                      .map((iri) => assignableUsers.find((u) => u["@id"] === iri))
+                      .filter((u): u is AssigneeOption => Boolean(u)),
+                  )
                 }
-              }}
-              placeholder="Add a task, then Enter…"
-              maxLength={255}
-              disabled={busy}
-              className="h-8 border-transparent bg-transparent hover:border-input focus-visible:border-input"
-              data-testid="project-new-task-title"
-            />
-          </td>
-        ) : (
-          <td key={column.key} className="px-2 py-2" />
-        ),
-      )}
+                subjectLabel="new task"
+              />
+            </td>
+          );
+        }
+        if (column.key === "tags") {
+          return (
+            <td key="tags" className="px-2 py-2 align-middle" data-testid="new-task-tags">
+              <TagsCombobox
+                value={tags}
+                options={allTags}
+                onChange={(iris) =>
+                  setTags(
+                    iris
+                      .map((iri) => allTags.find((t) => t["@id"] === iri))
+                      .filter((t): t is TagOption => Boolean(t)),
+                  )
+                }
+                subjectLabel="new task"
+              />
+            </td>
+          );
+        }
+        // Custom fields are set after the task exists.
+        return <td key={column.key} className="px-2 py-2 align-middle" />;
+      })}
       <td className="px-2 py-2" />
     </tr>
   );


### PR DESCRIPTION
﻿## Summary

Reworks the project **list view** into one continuous table (was one table per section):

- **Single sticky column header** — the column names sit once at the top and stay pinned while you scroll the task list (the table scrolls inside a max-height container so the header can stick). Sort/filter dropdowns and drag-to-reorder live in this one header.
- **Section titles are now rows in the table** (full-width), instead of separate headers above per-section tables.
- **Removed the per-section "Add task" button**; instead **every section has a persistent add-task row at its foot** — type a title, press Enter to create it in that section. The top "New task" button focuses the default section's add row; the split menu still adds sections.
- Per-section and grand-total **aggregate rows render inline**, so totals stay aligned under their (possibly reordered) columns.

## Notes
- Replaces the per-section `SectionBlock` with `SectionRows` (emits `<tr>`s into the shared table) + `SectionTitleRow` + `AddTaskRow`; `CustomFieldFooterRow` gains an `asRow` mode.
- Typecheck + lint clean; dev route compiles. **Big visual change — worth a look in the running app before merge.**
