### PR TITLE
fix(auth): persist sessions in Postgres (deploy-resilient logins)

### DIFF
--- a/api/config/packages/doctrine.yaml
+++ b/api/config/packages/doctrine.yaml
@@ -16,7 +16,10 @@ doctrine:
         # feedback_ticket_seq: a standalone Postgres sequence (created by a
         # migration, read via nextval in App\State\FeedbackOwnerProcessor)
         # that no entity's ID generator owns, so the ORM never tracks it.
-        schema_filter: ~^(?!messenger_messages|feedback_ticket_seq)~
+        # `sessions`: the PdoSessionHandler store (created by a migration) so
+        # logins survive a container swap / deploy — owned by Symfony's
+        # session handler, not the ORM.
+        schema_filter: ~^(?!messenger_messages|feedback_ticket_seq|sessions)~
 
         # doctrine/dbal 4 dropped the legacy `array` type. Gedmo's
         # AbstractLogEntry still declares its `data` column as

--- a/api/config/packages/framework.yaml
+++ b/api/config/packages/framework.yaml
@@ -16,6 +16,10 @@ framework:
         cookie_secure: auto
         cookie_httponly: true
         cookie_samesite: lax
+        # Persist sessions in Postgres (see services.yaml) instead of the
+        # container's filesystem, so a deploy / container swap doesn't log
+        # everyone out. The store survives because the database does.
+        handler_id: Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler
 
     # UUIDv7 is time-ordered, which keeps B-tree index locality good.
     # Configured globally so `doctrine.uuid_generator` emits v7.
@@ -81,4 +85,7 @@ when@test:
     framework:
         test: true
         session:
+            # The suite uses in-memory mock storage; null the DB handler so
+            # tests never touch the sessions table.
+            handler_id: null
             storage_factory_id: session.storage.factory.mock_file

--- a/api/config/services.yaml
+++ b/api/config/services.yaml
@@ -120,6 +120,21 @@ services:
         arguments:
             $converters: !tagged_iterator app.custom_field_converter
 
+    # Database-backed session storage (wired via framework.session.handler_id)
+    # so logins persist across container swaps / deploys. Uses a DEDICATED
+    # PDO (see SessionPdoFactory) — sharing Doctrine's connection makes the
+    # handler's row-lock transaction collide with the request's ORM
+    # transaction. The `sessions` table is provisioned by a migration and
+    # excluded from ORM schema management.
+    session.pdo:
+        class: PDO
+        factory: ['App\Session\SessionPdoFactory', 'create']
+        arguments: ['@doctrine.dbal.default_connection']
+
+    Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler:
+        arguments:
+            - '@session.pdo'
+
     # Replace stof's default actor provider with one that yields the
     # user's IRI (`/users/{uuid}`) instead of `getUserIdentifier()`
     # (= email). The IRI is stable across email changes and lets the

--- a/api/migrations/Version20260624090000.php
+++ b/api/migrations/Version20260624090000.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Session store for {@see \Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler}.
+ *
+ * Sessions move from the container filesystem into Postgres so a deploy /
+ * container swap no longer logs everyone out — the store lives in the
+ * database, which survives the swap. The schema matches PdoSessionHandler's
+ * Postgres defaults (`sessions` table, `sess_*` columns); the table is
+ * excluded from ORM schema management via `schema_filter` in doctrine.yaml.
+ */
+final class Version20260624090000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add the sessions table for database-backed (deploy-resilient) sessions.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE IF NOT EXISTS sessions (
+            sess_id VARCHAR(128) NOT NULL PRIMARY KEY,
+            sess_data BYTEA NOT NULL,
+            sess_lifetime INTEGER NOT NULL,
+            sess_time INTEGER NOT NULL
+        )');
+        $this->addSql('CREATE INDEX IF NOT EXISTS sessions_sess_lifetime_idx ON sessions (sess_lifetime)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE IF EXISTS sessions');
+    }
+}

--- a/api/src/Session/SessionPdoFactory.php
+++ b/api/src/Session/SessionPdoFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Session;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * Builds a dedicated PDO for {@see \Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler}.
+ *
+ * The session handler must NOT share Doctrine's connection: it opens its
+ * own transaction to lock the session row, which collides with whatever
+ * transaction the request's ORM work is in ("There is already an active
+ * transaction"). Symfony itself recommends a separate connection. We
+ * derive one from the app's existing DBAL credentials so there's nothing
+ * extra to configure — same database, independent connection.
+ */
+final class SessionPdoFactory
+{
+    public static function create(Connection $connection): \PDO
+    {
+        $params = $connection->getParams();
+
+        $host = is_string($params['host'] ?? null) ? $params['host'] : 'database';
+        $port = is_int($params['port'] ?? null) ? $params['port'] : 5432;
+        $dbname = is_string($params['dbname'] ?? null) ? $params['dbname'] : 'app';
+        $user = is_string($params['user'] ?? null) ? $params['user'] : null;
+        $password = is_string($params['password'] ?? null) ? $params['password'] : null;
+
+        $dsn = sprintf('pgsql:host=%s;port=%d;dbname=%s', $host, $port, $dbname);
+
+        return new \PDO($dsn, $user, $password, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+        ]);
+    }
+}


### PR DESCRIPTION
﻿## Summary

Persist sessions in Postgres so a deploy / container swap no longer logs everyone out.

### Problem
Sessions were stored on the container filesystem (`var/cache/<env>/sessions`), which is wiped on every container swap — so each deploy logged all users out. The next signed-out visit to a protected page then sat on a slow `/api/me` probe before redirecting to sign-in, which read as a "stuck on Loading" hang.

### Fix
- `framework.session.handler_id` -> `PdoSessionHandler`, storing sessions in Postgres (survives the swap because the DB does).
- A **dedicated** PDO via `SessionPdoFactory` — reusing Doctrine's connection makes the handler's row-lock transaction collide with the request's ORM transaction ("There is already an active transaction").
- New `sessions` table migration; excluded from ORM schema management via `schema_filter` (alongside messenger_messages / feedback_ticket_seq).
- Tests keep in-memory mock session storage (`handler_id: null` in `when@test`).

### On the redirect ("Loading" hang)
Verified the signed-out project page already redirects to `/signin?next=…` — the delay was purely the slow `/api/me` probe, which this change removes from normal use (no more deploy-logout). No redirect code change needed.

### Testing
Logged in locally, restarted the php container (simulating a deploy), and confirmed `/api/me` still returns the authenticated user. PHPStan + PHPCS clean; test container compiles.

> Note: this deploy logs everyone out one final time (file -> DB cutover); sessions persist across deploys after it.
