### PR TITLE
fix(spaces): gate billing UI off + stop settings reload on input

### DIFF
--- a/api/tests/Api/BillingTest.php
+++ b/api/tests/Api/BillingTest.php
@@ -8,6 +8,7 @@ use App\Entity\Space;
 use App\Entity\SpaceMembership;
 use App\Entity\Subscription;
 use App\Entity\User;
+use App\Entity\UserGroup;
 use App\Tests\Billing\InMemoryStripeGateway;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
@@ -258,6 +259,28 @@ class BillingTest extends ApiTestCase
         $client->request('GET', '/spaces/' . $space->getId() . '/billing');
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains(['plan' => 'free', 'active' => false]);
+    }
+
+    public function testStatusWithGroupInTheSpace(): void
+    {
+        // Repro for the prod billing 500: getEffectiveUsers() walks the space's
+        // groups (#groups-space), so a space that owns a group must still
+        // return a clean status.
+        $alice = $this->createUser('alice-grp@example.com');
+        $bob = $this->createUser('bob-grp@example.com');
+        $space = $this->createSpace($alice, 'Shared with a group');
+
+        $group = (new UserGroup())->setSpace($space)->setTitle('Crew')->setSlug('crew-billing');
+        $group->addMember($alice);
+        $group->addMember($bob);
+        $this->entityManager->persist($group);
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/spaces/' . $space->getId() . '/billing');
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertJsonContains(['limits' => ['memberCount' => 2]]);
     }
 
     public function testStatusReportsActiveWhenSubscribed(): void

--- a/pwa/.env.production
+++ b/pwa/.env.production
@@ -12,3 +12,8 @@ NEXT_PUBLIC_VAPID_PUBLIC_KEY=BI0zaJu3pluxfEaKoSa2r1lnpwv_mlU1y7GTKPwNKGlsl8LgjlX
 # canonical + OpenGraph URLs on the blog pages and the generated
 # /sitemap.xml. Set this to the production domain.
 NEXT_PUBLIC_SITE_URL=https://madori.app
+
+# Billing (Stripe) UI gate. Off until a real payment system is wired up —
+# while false the space plan/upgrade card isn't rendered or fetched. Set to
+# "true" (and configure the Stripe env on the API) to turn billing on.
+NEXT_PUBLIC_BILLING_ENABLED=false

--- a/pwa/pages/spaces/[id]/settings.tsx
+++ b/pwa/pages/spaces/[id]/settings.tsx
@@ -44,6 +44,11 @@ import DeleteSpaceDialog from "@/components/spaces/DeleteSpaceDialog";
 import ChangeVisibilityDialog from "@/components/spaces/ChangeVisibilityDialog";
 import UserAvatar, { type AvatarUser } from "@/components/user/UserAvatar";
 
+// Billing (Stripe) is off until a real payment system is wired up. Flip
+// NEXT_PUBLIC_BILLING_ENABLED=true (and configure the Stripe env) to surface
+// the plan/upgrade card again. Off = the card isn't mounted or fetched.
+const BILLING_ENABLED = process.env.NEXT_PUBLIC_BILLING_ENABLED === "true";
+
 type Role = "admin" | "member";
 
 interface PendingInvite {
@@ -110,7 +115,6 @@ const SpaceSettings = () => {
 
   const [space, setSpace] = useState<Space | null>(null);
   const [invites, setInvites] = useState<PendingInvite[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -148,7 +152,6 @@ const SpaceSettings = () => {
   const load = useCallback(async () => {
     if (!spaceId) return;
     setError(null);
-    setIsLoading(true);
     try {
       const res = await fetch(
         `${ENTRYPOINT}/spaces/${encodeURIComponent(spaceId)}`,
@@ -192,8 +195,6 @@ const SpaceSettings = () => {
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load space.");
-    } finally {
-      setIsLoading(false);
     }
   }, [spaceId, user]);
 
@@ -203,11 +204,14 @@ const SpaceSettings = () => {
     }
   }, [authLoading, isAuthenticated, router]);
 
+  // Load once per auth/space change — NOT on `load` identity, so an unstable
+  // callback ref can't re-fetch (and blank the page) on every render.
   useEffect(() => {
     if (isAuthenticated && spaceId) {
       void load();
     }
-  }, [isAuthenticated, spaceId, load]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isAuthenticated, spaceId]);
 
   const isAdmin =
     !!space &&
@@ -424,7 +428,7 @@ const SpaceSettings = () => {
     );
   }
 
-  if (isLoading || !space) {
+  if (!space) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-muted">
         <p className="text-muted-foreground">Loading…</p>
@@ -671,8 +675,11 @@ const SpaceSettings = () => {
           </>
         )}
 
-        {/* Plan & billing — personal spaces are never billable. */}
-        {!space.isPersonal && <SpaceBillingCard spaceId={space.id} />}
+        {/* Plan & billing — personal spaces are never billable, and the whole
+            surface is gated off until Stripe is wired up (BILLING_ENABLED). */}
+        {BILLING_ENABLED && !space.isPersonal && (
+          <SpaceBillingCard spaceId={space.id} />
+        )}
 
         {/* Export space data */}
         <Card className="mb-6">


### PR DESCRIPTION
Disables the billing/Stripe UI behind `NEXT_PUBLIC_BILLING_ENABLED` (default off) so the prod `GET /spaces/{id}/billing` 500 is no longer hit, and fixes the space settings page flashing to its Loading guard on every keystroke / tab-refocus. See commit body for details.