### PR TITLE
fix(date-popover): stable height + don't auto-close on first date pick

### DIFF
--- a/pwa/components/tasks/DueDateCell.tsx
+++ b/pwa/components/tasks/DueDateCell.tsx
@@ -57,9 +57,15 @@ const DueDateCell = ({
   const reminderCount = remindersValue?.length ?? 0;
 
   const handleSelect = (date: Date | undefined) => {
-    setOpen(false);
     const next = date ? localDateToIso(date) : null;
-    if (next === value) return;
+    if (next === value) {
+      setOpen(false);
+      return;
+    }
+    // Keep the popover open the first time a date is set so the user can go
+    // straight to recurrence / reminders (which only appear once a date
+    // exists). Re-picking an existing date closes as before.
+    if (value !== null) setOpen(false);
     void onChange(next);
   };
 
@@ -140,10 +146,11 @@ const DueDateCell = ({
       <PopoverContent
         // Cap the popover height and let it scroll internally — calendar +
         // recurrence picker + reminders + clear stack tall enough to spill
-        // off short viewports otherwise. Radix exposes its own
-        // `--radix-popover-content-available-height` so the cap also
-        // tracks the actual gap between trigger and viewport edge.
-        className="w-auto p-0 max-h-[min(560px,var(--radix-popover-content-available-height))] overflow-y-auto"
+        // off short viewports otherwise. Cap only to the actual gap between
+        // trigger and viewport edge (Radix's own variable) — no fixed px
+        // cap, so a normal-height screen fits the whole thing without a
+        // scrollbar; overflow scroll stays as a fallback for tiny viewports.
+        className="w-auto p-0 max-h-[var(--radix-popover-content-available-height)] overflow-y-auto"
         align="start"
         data-testid={`${testIdPrefix}-popover`}
       >

--- a/pwa/components/tasks/RecurrencePicker.tsx
+++ b/pwa/components/tasks/RecurrencePicker.tsx
@@ -189,47 +189,49 @@ const RecurrencePicker = ({
             </select>
           </div>
 
-          {/* Weekly: pick weekdays */}
-          {frequency === "weekly" && (
-            <div className="flex gap-1">
-              {WEEKDAYS.map((day) => (
-                <button
-                  key={day}
-                  type="button"
-                  onClick={() => toggleDay(day)}
-                  aria-pressed={byDay.includes(day)}
-                  aria-label={WEEKDAY_LABELS[day]}
-                  className={cn(
-                    "flex h-7 w-7 items-center justify-center rounded-full text-xs font-medium transition",
-                    byDay.includes(day)
-                      ? "bg-primary text-primary-foreground"
-                      : "border border-input text-muted-foreground hover:text-foreground",
-                  )}
-                  data-testid={`${testIdPrefix}-day-${day}`}
-                >
-                  {WEEKDAY_INITIALS[day]}
-                </button>
-              ))}
-            </div>
-          )}
+          {/* Frequency-specific control sits in a fixed-height slot so the
+              popover doesn't resize when switching daily/weekly/monthly/yearly. */}
+          <div className="flex min-h-8 items-center">
+            {frequency === "weekly" && (
+              <div className="flex gap-1">
+                {WEEKDAYS.map((day) => (
+                  <button
+                    key={day}
+                    type="button"
+                    onClick={() => toggleDay(day)}
+                    aria-pressed={byDay.includes(day)}
+                    aria-label={WEEKDAY_LABELS[day]}
+                    className={cn(
+                      "flex h-7 w-7 items-center justify-center rounded-full text-xs font-medium transition",
+                      byDay.includes(day)
+                        ? "bg-primary text-primary-foreground"
+                        : "border border-input text-muted-foreground hover:text-foreground",
+                    )}
+                    data-testid={`${testIdPrefix}-day-${day}`}
+                  >
+                    {WEEKDAY_INITIALS[day]}
+                  </button>
+                ))}
+              </div>
+            )}
 
-          {/* Monthly: on day N vs on the Nth weekday */}
-          {frequency === "monthly" && (
-            <select
-              value={monthlyMode}
-              onChange={(e) =>
-                emit({ monthlyMode: e.target.value as "day" | "weekday" })
-              }
-              className={cn(selectClass, "w-full")}
-              aria-label="Monthly pattern"
-              data-testid={`${testIdPrefix}-monthly`}
-            >
-              <option value="day">On day {dayOfMonth}</option>
-              <option value="weekday">
-                On the {ordinalLabel(nth)} {WEEKDAY_LABELS[dueWeekday]}
-              </option>
-            </select>
-          )}
+            {frequency === "monthly" && (
+              <select
+                value={monthlyMode}
+                onChange={(e) =>
+                  emit({ monthlyMode: e.target.value as "day" | "weekday" })
+                }
+                className={cn(selectClass, "w-full")}
+                aria-label="Monthly pattern"
+                data-testid={`${testIdPrefix}-monthly`}
+              >
+                <option value="day">On day {dayOfMonth}</option>
+                <option value="weekday">
+                  On the {ordinalLabel(nth)} {WEEKDAY_LABELS[dueWeekday]}
+                </option>
+              </select>
+            )}
+          </div>
 
           {/* Ends */}
           <div className="flex items-center gap-2 text-sm">


### PR DESCRIPTION
Reserve a fixed-height slot for the frequency control (no resize across daily/weekly/monthly/yearly), drop the fixed 560px height cap (no scrollbar on normal screens), and keep the popover open when a date is set for the first time.