### PR TITLE
fix(tags): random swatch color for inline-created tags

### DIFF
--- a/pwa/lib/avatarPalette.ts
+++ b/pwa/lib/avatarPalette.ts
@@ -41,6 +41,12 @@ export function deterministicPaletteColor(seed: string): string {
   return AVATAR_PALETTE[h];
 }
 
+/** A random color from the WCAG-AA palette — used when creating something
+ *  inline (e.g. a tag) without an explicit color, so it isn't always grey. */
+export function randomPaletteColor(): string {
+  return AVATAR_PALETTE[Math.floor(Math.random() * AVATAR_PALETTE.length)];
+}
+
 /**
  * Resolve the color to render for a Space's avatar tile, following the
  * spec: explicit `space.color` wins; otherwise inherit the creator's

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -15,6 +15,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
 import { ENTRYPOINT } from "@/config/entrypoint";
 import { signinHrefForCurrent } from "@/lib/authRedirect";
+import { randomPaletteColor } from "@/lib/avatarPalette";
 import ActivityPanel from "@/components/activity/ActivityPanel";
 import TaskBoard from "@/components/projects/TaskBoard";
 import TaskTableColumns from "@/components/projects/TaskTableColumns";
@@ -419,8 +420,13 @@ const ProjectDetail = () => {
           method: "POST",
           credentials: "include",
           headers: { "Content-Type": "application/ld+json" },
-          // Tags are space-scoped: create it in this project's space.
-          body: JSON.stringify({ title, space: projectSpaceIri(project) }),
+          // Tags are space-scoped: create it in this project's space. Give
+          // it a random palette color so inline-created tags aren't all grey.
+          body: JSON.stringify({
+            title,
+            space: projectSpaceIri(project),
+            color: randomPaletteColor(),
+          }),
         });
         if (!res.ok) return null;
         const created = (await res.json()) as TagOption;


### PR DESCRIPTION
Inline tag creation (project task add-row) now assigns a random palette color instead of defaulting to grey.