### PR TITLE
feat(projects): calendar tab (month + week views)

### DIFF
--- a/api/migrations/Version20260629043354.php
+++ b/api/migrations/Version20260629043354.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Widen project_field_visibility.visibility to hold a comma-joined surface SET
+ * (list/board/calendar) — adds the Calendar surface for custom fields. Legacy
+ * single values ('both'/'list'/'board') still parse, so no data conversion.
+ */
+final class Version20260629043354 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Widen project_field_visibility.visibility to VARCHAR(32) for the calendar surface.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE project_field_visibility ALTER visibility TYPE VARCHAR(32)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE project_field_visibility ALTER visibility TYPE VARCHAR(16)');
+    }
+}

--- a/api/src/Controller/CustomFieldVisibilityController.php
+++ b/api/src/Controller/CustomFieldVisibilityController.php
@@ -68,13 +68,17 @@ final class CustomFieldVisibilityController extends AbstractController
         }
 
         $payload = $request->toArray();
-        $visibility = $payload['visibility'] ?? null;
-        if (!is_string($visibility) || !in_array($visibility, CustomFieldDefinition::VISIBILITIES, true)) {
+        $raw = $payload['visibility'] ?? null;
+        // Accept a comma-joined SET of surfaces (list/board/calendar) or the
+        // legacy single value; normalise to a deduped, ordered surface string.
+        $surfaces = is_string($raw) ? CustomFieldDefinition::visibilitySurfaces($raw) : [];
+        if ([] === $surfaces) {
             return new JsonResponse(
-                ['error' => 'visibility must be one of: ' . implode(', ', CustomFieldDefinition::VISIBILITIES) . '.'],
+                ['error' => 'visibility must list one or more of: ' . implode(', ', CustomFieldDefinition::SURFACES) . '.'],
                 400,
             );
         }
+        $visibility = implode(',', array_values(array_unique($surfaces)));
 
         $row = $this->overrides->findOneFor($project, $definition);
         if (null === $row) {

--- a/api/src/Entity/CustomFieldDefinition.php
+++ b/api/src/Entity/CustomFieldDefinition.php
@@ -108,6 +108,8 @@ class CustomFieldDefinition
 
     public const VISIBILITY_LIST = 'list';
     public const VISIBILITY_BOARD = 'board';
+    public const VISIBILITY_CALENDAR = 'calendar';
+    /** Legacy single-value default meaning list + board (still accepted on read). */
     public const VISIBILITY_BOTH = 'both';
 
     /** @var list<string> */
@@ -116,6 +118,40 @@ class CustomFieldDefinition
         self::VISIBILITY_BOARD,
         self::VISIBILITY_BOTH,
     ];
+
+    /**
+     * The independent surfaces a field's value can show on. Per-project
+     * visibility (#custom-fields-project) is a comma-joined SET of these.
+     *
+     * @var list<string>
+     */
+    public const SURFACES = [
+        self::VISIBILITY_LIST,
+        self::VISIBILITY_BOARD,
+        self::VISIBILITY_CALENDAR,
+    ];
+
+    /**
+     * Parse a stored visibility value — legacy `both`, a single surface, or a
+     * comma-joined set — into the list of surfaces it shows on.
+     *
+     * @return list<string>
+     */
+    public static function visibilitySurfaces(string $visibility): array
+    {
+        if (self::VISIBILITY_BOTH === $visibility) {
+            return [self::VISIBILITY_LIST, self::VISIBILITY_BOARD];
+        }
+        $out = [];
+        foreach (explode(',', $visibility) as $surface) {
+            $surface = trim($surface);
+            if ('' !== $surface && in_array($surface, self::SURFACES, true)) {
+                $out[] = $surface;
+            }
+        }
+
+        return $out;
+    }
 
     #[ORM\Id]
     #[ORM\Column(type: 'uuid', unique: true)]

--- a/api/src/Entity/ProjectFieldVisibility.php
+++ b/api/src/Entity/ProjectFieldVisibility.php
@@ -7,7 +7,6 @@ namespace App\Entity;
 use App\Repository\ProjectFieldVisibilityRepository;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Uid\Uuid;
-use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * Per-project visibility override for a custom field (#custom-fields-project).
@@ -42,11 +41,9 @@ class ProjectFieldVisibility
     #[ORM\JoinColumn(name: 'definition_id', nullable: false, onDelete: 'CASCADE')]
     private ?CustomFieldDefinition $definition = null;
 
-    #[ORM\Column(length: 16, options: ['default' => CustomFieldDefinition::VISIBILITY_BOTH])]
-    #[Assert\Choice(
-        choices: CustomFieldDefinition::VISIBILITIES,
-        message: 'Visibility must be one of: {{ choices }}.',
-    )]
+    // A comma-joined SET of surfaces (list/board/calendar); 32 chars holds all
+    // three. Validated in the visibility controller, so no Assert\Choice here.
+    #[ORM\Column(length: 32, options: ['default' => CustomFieldDefinition::VISIBILITY_BOTH])]
     private string $visibility = CustomFieldDefinition::VISIBILITY_BOTH;
 
     public function getId(): ?Uuid

--- a/api/tests/Api/CustomFieldDefinitionTest.php
+++ b/api/tests/Api/CustomFieldDefinitionTest.php
@@ -153,6 +153,27 @@ class CustomFieldDefinitionTest extends ApiTestCase
         $this->assertJsonContains(['member' => [['name' => 'Severity', 'visibility' => 'board']]]);
     }
 
+    public function testProjectVisibilityAcceptsSurfaceSet(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $field = $this->seedField($project, 'Severity', 'text');
+        $projectIri = '/projects/' . $project->getId();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        // A comma-joined set including the calendar surface round-trips.
+        $client->request('PUT', $projectIri . '/custom_field_definitions/' . $field->getId() . '/visibility', [
+            'json' => ['visibility' => 'board,calendar'],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(200);
+
+        $client->request('GET', '/custom_field_definitions?projects=' . $projectIri);
+        $this->assertJsonContains(['member' => [['name' => 'Severity', 'visibility' => 'board,calendar']]]);
+    }
+
     public function testInvalidProjectVisibilityIsRejected(): void
     {
         $alice = $this->createUser('alice@example.com');

--- a/pwa/components/custom-fields/ProjectCustomFieldPicker.tsx
+++ b/pwa/components/custom-fields/ProjectCustomFieldPicker.tsx
@@ -5,7 +5,7 @@ import { ENTRYPOINT } from "@/config/entrypoint";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
-import type { CustomFieldDefinition } from "./types";
+import { visibilitySurfaces, type CustomFieldDefinition } from "./types";
 
 interface Collection<T> {
   member?: T[];
@@ -96,22 +96,30 @@ const ProjectCustomFieldPicker = ({
     if (!res.ok) throw new Error("Failed to update fields.");
   };
 
-  // The List + Board toggles drive both attachment and visibility: a field is
-  // on the project when either is on. Turning the last one off detaches it;
-  // turning one on (re)attaches and sets the per-project visibility.
-  const updateField = async (iri: string, nextList: boolean, nextBoard: boolean) => {
+  // The List / Board / Calendar toggles drive both attachment and visibility:
+  // a field is on the project when any is on. Turning the last one off detaches
+  // it; turning one on (re)attaches and sets the per-project surface set.
+  const updateField = async (
+    iri: string,
+    nextList: boolean,
+    nextBoard: boolean,
+    nextCalendar: boolean,
+  ) => {
     const wasAttached = attachedIris.includes(iri);
     const projectId = projectIri.split("/").pop();
     const defId = iri.split("/").pop();
     setBusy(iri);
     try {
-      if (!nextList && !nextBoard) {
+      if (!nextList && !nextBoard && !nextCalendar) {
         if (wasAttached) {
           await patchAttached(attachedIris.filter((i) => i !== iri));
         }
       } else {
-        const visibility =
-          nextList && nextBoard ? "both" : nextList ? "list" : "board";
+        const surfaces = [
+          nextList ? "list" : null,
+          nextBoard ? "board" : null,
+          nextCalendar ? "calendar" : null,
+        ].filter(Boolean);
         if (!wasAttached) {
           await patchAttached([...attachedIris, iri]);
         }
@@ -121,7 +129,7 @@ const ProjectCustomFieldPicker = ({
             method: "PUT",
             credentials: "include",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ visibility }),
+            body: JSON.stringify({ visibility: surfaces.join(",") }),
           },
         );
         if (!res.ok) throw new Error("Failed to update visibility.");
@@ -141,8 +149,8 @@ const ProjectCustomFieldPicker = ({
           <h3 className="text-sm font-medium">Custom fields</h3>
           <p className="text-xs text-muted-foreground">
             Toggle where each of the space&apos;s fields shows on this
-            project — the task list, the board, or both (off both = not on this
-            project). Define and order fields in{" "}
+            project — the task list, the board, and/or the calendar (all off =
+            not on this project). Define and order fields in{" "}
             <Link href="/custom-fields" className="text-cyan-700 hover:underline dark:text-cyan-400">
               space settings
             </Link>
@@ -173,9 +181,12 @@ const ProjectCustomFieldPicker = ({
         <ul className="divide-y rounded-md border">
           {spaceFields.map((def) => {
             const checked = attachedIris.includes(def["@id"]);
-            const vis = checked ? projectVisibility[def["@id"]] ?? "both" : null;
-            const showList = vis === "both" || vis === "list";
-            const showBoard = vis === "both" || vis === "board";
+            const surfaces = checked
+              ? visibilitySurfaces(projectVisibility[def["@id"]] ?? "both")
+              : [];
+            const showList = surfaces.includes("list");
+            const showBoard = surfaces.includes("board");
+            const showCalendar = surfaces.includes("calendar");
             const isBusy = busy === def["@id"];
             return (
               <li
@@ -193,7 +204,7 @@ const ProjectCustomFieldPicker = ({
                     checked={showList}
                     disabled={isBusy}
                     onCheckedChange={(v) =>
-                      void updateField(def["@id"], v, showBoard)
+                      void updateField(def["@id"], v, showBoard, showCalendar)
                     }
                     aria-label={`Show ${def.name} on the task list`}
                   />
@@ -204,11 +215,22 @@ const ProjectCustomFieldPicker = ({
                     checked={showBoard}
                     disabled={isBusy}
                     onCheckedChange={(v) =>
-                      void updateField(def["@id"], showList, v)
+                      void updateField(def["@id"], showList, v, showCalendar)
                     }
                     aria-label={`Show ${def.name} on the board`}
                   />
                   Board
+                </label>
+                <label className="flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground">
+                  <Switch
+                    checked={showCalendar}
+                    disabled={isBusy}
+                    onCheckedChange={(v) =>
+                      void updateField(def["@id"], showList, showBoard, v)
+                    }
+                    aria-label={`Show ${def.name} on the calendar`}
+                  />
+                  Calendar
                 </label>
                 {isSpaceAdmin && (
                   <button

--- a/pwa/components/custom-fields/types.ts
+++ b/pwa/components/custom-fields/types.ts
@@ -70,8 +70,34 @@ export interface FooterDescriptor {
   label?: string;
 }
 
-/** Where a field's value is surfaced to readers (the task drawer always shows all). */
-export type CustomFieldVisibility = "list" | "board" | "both";
+/** The independent surfaces a field's value can show on (task drawer always shows all). */
+export type CustomFieldSurface = "list" | "board" | "calendar";
+export const CUSTOM_FIELD_SURFACES: CustomFieldSurface[] = ["list", "board", "calendar"];
+
+/**
+ * Stored visibility is a comma-joined SET of surfaces, with legacy single
+ * values still accepted ("both" = list + board). Kept as a string on the wire.
+ */
+export type CustomFieldVisibility = string;
+
+/** Parse a stored visibility value into its surfaces (handles legacy "both"). */
+export const visibilitySurfaces = (
+  visibility: string | null | undefined,
+): CustomFieldSurface[] => {
+  if (!visibility || visibility === "both") return ["list", "board"];
+  return visibility
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s): s is CustomFieldSurface =>
+      (CUSTOM_FIELD_SURFACES as string[]).includes(s),
+    );
+};
+
+/** Whether a stored visibility includes a given surface. */
+export const showsOnSurface = (
+  visibility: string | null | undefined,
+  surface: CustomFieldSurface,
+): boolean => visibilitySurfaces(visibility).includes(surface);
 
 export interface CustomFieldDefinition {
   "@id": string;

--- a/pwa/components/projects/TaskCalendar.tsx
+++ b/pwa/components/projects/TaskCalendar.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import UserAvatar, { type AvatarUser } from "@/components/user/UserAvatar";
+import AssignMenu, { type AssignableUser } from "@/components/tasks/AssignMenu";
 import { isoToLocalDate } from "@/components/tasks/taskHelpers";
 import { cn } from "@/lib/utils";
 
@@ -12,12 +12,15 @@ export interface CalendarTask {
   title: string;
   dueDate: string | null;
   completedOn: string | null;
-  assignees: AvatarUser[];
+  assignees: AssignableUser[];
 }
 
 interface TaskCalendarProps {
   tasks: CalendarTask[];
+  /** Everyone assignable on this project, for the per-task assign menu. */
+  assignableUsers: AssignableUser[];
   onOpen: (taskIri: string) => void;
+  onAssign: (taskIri: string, userIris: string[]) => void | Promise<void>;
 }
 
 type View = "month" | "week";
@@ -37,34 +40,31 @@ const addDays = (d: Date, n: number): Date => {
 /** Sunday that starts the week containing `d`. */
 const startOfWeek = (d: Date): Date => addDays(d, -d.getDay());
 
-const AssigneeStack = ({ users }: { users: AvatarUser[] }) => {
-  if (users.length === 0) return null;
-  return (
-    <span className="flex -space-x-1">
-      {users.slice(0, 3).map((u, i) => (
-        <UserAvatar key={i} user={u} size="sm" className="h-4 w-4 ring-1 ring-card" />
-      ))}
-      {users.length > 3 && (
-        <span className="flex h-4 items-center rounded-full bg-muted px-1 text-xs text-muted-foreground">
-          +{users.length - 3}
-        </span>
-      )}
-    </span>
-  );
-};
-
 const TaskChip = ({
   task,
+  assignableUsers,
   onOpen,
+  onAssign,
 }: {
   task: CalendarTask;
+  assignableUsers: AssignableUser[];
   onOpen: (iri: string) => void;
+  onAssign: (taskIri: string, userIris: string[]) => void | Promise<void>;
 }) => (
-  <button
-    type="button"
+  // A div (not a button) so the nested assign menu's button is valid markup
+  // and its clicks don't bubble up to open the drawer.
+  <div
+    role="button"
+    tabIndex={0}
     onClick={() => onOpen(task["@id"])}
+    onKeyDown={(e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        onOpen(task["@id"]);
+      }
+    }}
     className={cn(
-      "flex w-full items-center gap-1 rounded border bg-card px-1.5 py-0.5 text-left text-xs hover:border-foreground/30",
+      "flex w-full cursor-pointer items-center gap-2 rounded-md border bg-card px-2 py-1.5 text-left text-xs hover:border-foreground/30",
       task.completedOn && "opacity-60",
     )}
     title={task.title}
@@ -73,8 +73,12 @@ const TaskChip = ({
     <span className={cn("min-w-0 flex-1 truncate", task.completedOn && "line-through")}>
       {task.title}
     </span>
-    <AssigneeStack users={task.assignees} />
-  </button>
+    <AssignMenu
+      assignees={task.assignees}
+      assignableUsers={assignableUsers}
+      onAssign={(iris) => onAssign(task["@id"], iris)}
+    />
+  </div>
 );
 
 /**
@@ -82,7 +86,12 @@ const TaskChip = ({
  * assignee avatars. Clicking a task opens the detail drawer. Tasks with no
  * due date are surfaced in a small footer so they aren't lost.
  */
-const TaskCalendar = ({ tasks, onOpen }: TaskCalendarProps) => {
+const TaskCalendar = ({
+  tasks,
+  assignableUsers,
+  onOpen,
+  onAssign,
+}: TaskCalendarProps) => {
   const [view, setView] = useState<View>("month");
   // Anchor day — drives which month/week is shown. Local "today" at mount.
   const [anchorKey, setAnchorKey] = useState<string>(() => dayKey(new Date()));
@@ -229,7 +238,13 @@ const TaskCalendar = ({ tasks, onOpen }: TaskCalendarProps) => {
               </div>
               <div className="space-y-1">
                 {visible.map((task) => (
-                  <TaskChip key={task["@id"]} task={task} onOpen={onOpen} />
+                  <TaskChip
+                    key={task["@id"]}
+                    task={task}
+                    assignableUsers={assignableUsers}
+                    onOpen={onOpen}
+                    onAssign={onAssign}
+                  />
                 ))}
                 {view === "month" && dayTasks.length > visible.length && (
                   <span className="px-0.5 text-xs text-muted-foreground">
@@ -250,7 +265,12 @@ const TaskCalendar = ({ tasks, onOpen }: TaskCalendarProps) => {
           <div className="flex flex-wrap gap-1">
             {undated.map((task) => (
               <div key={task["@id"]} className="max-w-56">
-                <TaskChip task={task} onOpen={onOpen} />
+                <TaskChip
+                  task={task}
+                  assignableUsers={assignableUsers}
+                  onOpen={onOpen}
+                  onAssign={onAssign}
+                />
               </div>
             ))}
           </div>

--- a/pwa/components/projects/TaskCalendar.tsx
+++ b/pwa/components/projects/TaskCalendar.tsx
@@ -2,6 +2,9 @@ import { useMemo, useState } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import AssignMenu, { type AssignableUser } from "@/components/tasks/AssignMenu";
+import CustomFieldValueCell from "@/components/custom-fields/CustomFieldValueCell";
+import type { CustomFieldDefinition } from "@/components/custom-fields/types";
+import type { CustomFieldValuePair } from "@/components/tasks/CustomFieldValueList";
 import { isoToLocalDate } from "@/components/tasks/taskHelpers";
 import { cn } from "@/lib/utils";
 
@@ -13,15 +16,24 @@ export interface CalendarTask {
   dueDate: string | null;
   completedOn: string | null;
   assignees: AssignableUser[];
+  customFieldValues: CustomFieldValuePair[];
 }
 
 interface TaskCalendarProps {
   tasks: CalendarTask[];
+  /** Custom fields to surface on calendar chips (filtered to calendar visibility). */
+  definitions: CustomFieldDefinition[];
   /** Everyone assignable on this project, for the per-task assign menu. */
   assignableUsers: AssignableUser[];
   onOpen: (taskIri: string) => void;
   onAssign: (taskIri: string, userIris: string[]) => void | Promise<void>;
 }
+
+const isEmptyValue = (v: unknown): boolean =>
+  v === null ||
+  v === undefined ||
+  v === "" ||
+  (Array.isArray(v) && v.length === 0);
 
 type View = "month" | "week";
 
@@ -42,44 +54,74 @@ const startOfWeek = (d: Date): Date => addDays(d, -d.getDay());
 
 const TaskChip = ({
   task,
+  definitions,
   assignableUsers,
   onOpen,
   onAssign,
 }: {
   task: CalendarTask;
+  definitions: CustomFieldDefinition[];
   assignableUsers: AssignableUser[];
   onOpen: (iri: string) => void;
   onAssign: (taskIri: string, userIris: string[]) => void | Promise<void>;
-}) => (
-  // A div (not a button) so the nested assign menu's button is valid markup
-  // and its clicks don't bubble up to open the drawer.
-  <div
-    role="button"
-    tabIndex={0}
-    onClick={() => onOpen(task["@id"])}
-    onKeyDown={(e) => {
-      if (e.key === "Enter" || e.key === " ") {
-        e.preventDefault();
-        onOpen(task["@id"]);
-      }
-    }}
-    className={cn(
-      "flex w-full cursor-pointer items-center gap-2 rounded-md border bg-card px-2 py-1.5 text-left text-xs hover:border-foreground/30",
-      task.completedOn && "opacity-60",
-    )}
-    title={task.title}
-    data-testid="calendar-task"
-  >
-    <span className={cn("min-w-0 flex-1 truncate", task.completedOn && "line-through")}>
-      {task.title}
-    </span>
-    <AssignMenu
-      assignees={task.assignees}
-      assignableUsers={assignableUsers}
-      onAssign={(iris) => onAssign(task["@id"], iris)}
-    />
-  </div>
-);
+}) => {
+  const fields = definitions
+    .map((def) => ({
+      def,
+      value: task.customFieldValues.find((v) => v.definition === def["@id"])
+        ?.value,
+    }))
+    .filter(({ value }) => !isEmptyValue(value));
+  return (
+    // A div (not a button) so the nested assign menu's button is valid markup
+    // and its clicks don't bubble up to open the drawer.
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => onOpen(task["@id"])}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onOpen(task["@id"]);
+        }
+      }}
+      className={cn(
+        "w-full cursor-pointer space-y-1 rounded-md border bg-card px-2 py-1.5 text-left text-xs hover:border-foreground/30",
+        task.completedOn && "opacity-60",
+      )}
+      title={task.title}
+      data-testid="calendar-task"
+    >
+      <div className="flex items-center gap-2">
+        <span className={cn("min-w-0 flex-1 truncate", task.completedOn && "line-through")}>
+          {task.title}
+        </span>
+        <AssignMenu
+          assignees={task.assignees}
+          assignableUsers={assignableUsers}
+          onAssign={(iris) => onAssign(task["@id"], iris)}
+        />
+      </div>
+      {fields.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {fields.map(({ def, value }) => (
+            <span
+              key={def["@id"]}
+              className="inline-flex items-center gap-1 rounded border bg-muted/40 px-1 py-0.5 text-xs"
+            >
+              <span className="text-muted-foreground">{def.name}</span>
+              <CustomFieldValueCell
+                definition={def}
+                value={value}
+                className="font-medium"
+              />
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
 
 /**
  * Month / week calendar of a project's tasks, bucketed by due date with
@@ -88,6 +130,7 @@ const TaskChip = ({
  */
 const TaskCalendar = ({
   tasks,
+  definitions,
   assignableUsers,
   onOpen,
   onAssign,
@@ -241,6 +284,7 @@ const TaskCalendar = ({
                   <TaskChip
                     key={task["@id"]}
                     task={task}
+                    definitions={definitions}
                     assignableUsers={assignableUsers}
                     onOpen={onOpen}
                     onAssign={onAssign}
@@ -267,6 +311,7 @@ const TaskCalendar = ({
               <div key={task["@id"]} className="max-w-56">
                 <TaskChip
                   task={task}
+                  definitions={definitions}
                   assignableUsers={assignableUsers}
                   onOpen={onOpen}
                   onAssign={onAssign}

--- a/pwa/components/projects/TaskCalendar.tsx
+++ b/pwa/components/projects/TaskCalendar.tsx
@@ -1,0 +1,263 @@
+import { useMemo, useState } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import UserAvatar, { type AvatarUser } from "@/components/user/UserAvatar";
+import { isoToLocalDate } from "@/components/tasks/taskHelpers";
+import { cn } from "@/lib/utils";
+
+/** Minimal task shape the calendar needs. */
+export interface CalendarTask {
+  "@id": string;
+  id: string;
+  title: string;
+  dueDate: string | null;
+  completedOn: string | null;
+  assignees: AvatarUser[];
+}
+
+interface TaskCalendarProps {
+  tasks: CalendarTask[];
+  onOpen: (taskIri: string) => void;
+}
+
+type View = "month" | "week";
+
+const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+/** Local YYYY-MM-DD key for a date (used to bucket tasks per day). */
+const dayKey = (d: Date): string =>
+  `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+
+const addDays = (d: Date, n: number): Date => {
+  const next = new Date(d);
+  next.setDate(next.getDate() + n);
+  return next;
+};
+
+/** Sunday that starts the week containing `d`. */
+const startOfWeek = (d: Date): Date => addDays(d, -d.getDay());
+
+const AssigneeStack = ({ users }: { users: AvatarUser[] }) => {
+  if (users.length === 0) return null;
+  return (
+    <span className="flex -space-x-1">
+      {users.slice(0, 3).map((u, i) => (
+        <UserAvatar key={i} user={u} size="sm" className="h-4 w-4 ring-1 ring-card" />
+      ))}
+      {users.length > 3 && (
+        <span className="flex h-4 items-center rounded-full bg-muted px-1 text-xs text-muted-foreground">
+          +{users.length - 3}
+        </span>
+      )}
+    </span>
+  );
+};
+
+const TaskChip = ({
+  task,
+  onOpen,
+}: {
+  task: CalendarTask;
+  onOpen: (iri: string) => void;
+}) => (
+  <button
+    type="button"
+    onClick={() => onOpen(task["@id"])}
+    className={cn(
+      "flex w-full items-center gap-1 rounded border bg-card px-1.5 py-0.5 text-left text-xs hover:border-foreground/30",
+      task.completedOn && "opacity-60",
+    )}
+    title={task.title}
+    data-testid="calendar-task"
+  >
+    <span className={cn("min-w-0 flex-1 truncate", task.completedOn && "line-through")}>
+      {task.title}
+    </span>
+    <AssigneeStack users={task.assignees} />
+  </button>
+);
+
+/**
+ * Month / week calendar of a project's tasks, bucketed by due date with
+ * assignee avatars. Clicking a task opens the detail drawer. Tasks with no
+ * due date are surfaced in a small footer so they aren't lost.
+ */
+const TaskCalendar = ({ tasks, onOpen }: TaskCalendarProps) => {
+  const [view, setView] = useState<View>("month");
+  // Anchor day — drives which month/week is shown. Local "today" at mount.
+  const [anchorKey, setAnchorKey] = useState<string>(() => dayKey(new Date()));
+  const anchor = useMemo(() => {
+    const [y, m, d] = anchorKey.split("-").map(Number);
+    return new Date(y, m - 1, d);
+  }, [anchorKey]);
+
+  const todayKey = dayKey(new Date());
+
+  const { byDay, undated } = useMemo(() => {
+    const map = new Map<string, CalendarTask[]>();
+    const noDate: CalendarTask[] = [];
+    for (const task of tasks) {
+      const date = isoToLocalDate(task.dueDate);
+      if (!date) {
+        noDate.push(task);
+        continue;
+      }
+      const key = dayKey(date);
+      const list = map.get(key) ?? [];
+      list.push(task);
+      map.set(key, list);
+    }
+    return { byDay: map, undated: noDate };
+  }, [tasks]);
+
+  // The grid of days to render: 6 weeks for month, 1 week for week view.
+  const days = useMemo(() => {
+    if (view === "week") {
+      const start = startOfWeek(anchor);
+      return Array.from({ length: 7 }, (_, i) => addDays(start, i));
+    }
+    const firstOfMonth = new Date(anchor.getFullYear(), anchor.getMonth(), 1);
+    const gridStart = startOfWeek(firstOfMonth);
+    return Array.from({ length: 42 }, (_, i) => addDays(gridStart, i));
+  }, [view, anchor]);
+
+  const label = useMemo(() => {
+    if (view === "week") {
+      const start = startOfWeek(anchor);
+      const end = addDays(start, 6);
+      const sameMonth = start.getMonth() === end.getMonth();
+      const fmt = (d: Date, withMonth: boolean) =>
+        d.toLocaleDateString(undefined, {
+          month: withMonth ? "short" : undefined,
+          day: "numeric",
+        });
+      return `${fmt(start, true)} – ${fmt(end, !sameMonth)}, ${end.getFullYear()}`;
+    }
+    return anchor.toLocaleDateString(undefined, { month: "long", year: "numeric" });
+  }, [view, anchor]);
+
+  const shift = (dir: -1 | 1) => {
+    setAnchorKey(dayKey(addDays(anchor, dir * (view === "week" ? 7 : 30))));
+  };
+
+  return (
+    <div data-testid="task-calendar">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-1">
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            className="h-8 w-8"
+            onClick={() => shift(-1)}
+            aria-label="Previous"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setAnchorKey(todayKey)}
+          >
+            Today
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            className="h-8 w-8"
+            onClick={() => shift(1)}
+            aria-label="Next"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+          <span className="ml-2 text-sm font-semibold">{label}</span>
+        </div>
+        <div className="inline-flex overflow-hidden rounded-md border">
+          {(["month", "week"] as const).map((v) => (
+            <button
+              key={v}
+              type="button"
+              onClick={() => setView(v)}
+              className={cn(
+                "px-3 py-1 text-sm capitalize",
+                view === v
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:bg-accent",
+              )}
+            >
+              {v}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-7 border-l border-t">
+        {WEEKDAYS.map((d) => (
+          <div
+            key={d}
+            className="border-b border-r bg-muted/40 px-2 py-1 text-xs font-medium text-muted-foreground"
+          >
+            {d}
+          </div>
+        ))}
+        {days.map((day) => {
+          const key = dayKey(day);
+          const dayTasks = byDay.get(key) ?? [];
+          const inMonth = view === "week" || day.getMonth() === anchor.getMonth();
+          const isToday = key === todayKey;
+          const visible = view === "week" ? dayTasks : dayTasks.slice(0, 4);
+          return (
+            <div
+              key={key}
+              className={cn(
+                "border-b border-r p-1 align-top",
+                view === "week" ? "min-h-48" : "min-h-24",
+                !inMonth && "bg-muted/20 text-muted-foreground",
+              )}
+            >
+              <div className="mb-1 flex items-center justify-between px-0.5">
+                <span
+                  className={cn(
+                    "inline-flex h-5 min-w-5 items-center justify-center rounded-full px-1 text-xs",
+                    isToday && "bg-primary font-semibold text-primary-foreground",
+                  )}
+                >
+                  {day.getDate()}
+                </span>
+              </div>
+              <div className="space-y-1">
+                {visible.map((task) => (
+                  <TaskChip key={task["@id"]} task={task} onOpen={onOpen} />
+                ))}
+                {view === "month" && dayTasks.length > visible.length && (
+                  <span className="px-0.5 text-xs text-muted-foreground">
+                    +{dayTasks.length - visible.length} more
+                  </span>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {undated.length > 0 && (
+        <div className="mt-3 rounded-md border p-2">
+          <p className="mb-1 text-xs font-medium text-muted-foreground">
+            No due date ({undated.length})
+          </p>
+          <div className="flex flex-wrap gap-1">
+            {undated.map((task) => (
+              <div key={task["@id"]} className="max-w-56">
+                <TaskChip task={task} onOpen={onOpen} />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TaskCalendar;

--- a/pwa/components/tasks/AssignMenu.tsx
+++ b/pwa/components/tasks/AssignMenu.tsx
@@ -1,0 +1,97 @@
+import { Check } from "lucide-react";
+import UserAvatar, { type AvatarUser } from "@/components/user/UserAvatar";
+import AssigneePlaceholder from "@/components/user/AssigneePlaceholder";
+import { displayName } from "@/lib/userDisplay";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+/** A user carrying its IRI, so the menu can toggle membership + emit IRIs. */
+export type AssignableUser = AvatarUser & { "@id": string };
+
+/**
+ * Assignee cluster + picker (#space-roles board/calendar): shows the assignees'
+ * avatars, or an anonymous {@see AssigneePlaceholder} when no one is assigned;
+ * either opens a dropdown to toggle who's assigned. Stops pointer/click
+ * propagation so it neither starts a drag nor opens the parent (card/chip).
+ * Place it inside a non-button container (a `<div role="button">`).
+ */
+const AssignMenu = ({
+  assignees,
+  assignableUsers,
+  onAssign,
+  align = "end",
+}: {
+  assignees: AssignableUser[];
+  assignableUsers: AssignableUser[];
+  onAssign: (userIris: string[]) => void | Promise<void>;
+  align?: "start" | "end";
+}) => {
+  const assignedIris = new Set(assignees.map((a) => a["@id"]));
+  const toggle = (iri: string) => {
+    const next = assignedIris.has(iri)
+      ? assignees.map((a) => a["@id"]).filter((i) => i !== iri)
+      : [...assignees.map((a) => a["@id"]), iri];
+    void onAssign(next);
+  };
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          onClick={(e) => e.stopPropagation()}
+          onPointerDown={(e) => e.stopPropagation()}
+          className="flex items-center rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label={assignees.length > 0 ? "Change assignees" : "Assign someone"}
+          data-testid="assign-menu"
+        >
+          {assignees.length > 0 ? (
+            <span className="flex -space-x-1.5">
+              {assignees.slice(0, 3).map((a) => (
+                <UserAvatar
+                  key={a["@id"]}
+                  user={a}
+                  size="sm"
+                  className="ring-2 ring-card"
+                />
+              ))}
+            </span>
+          ) : (
+            <AssigneePlaceholder className="hover:border-foreground/40 hover:text-foreground" />
+          )}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align={align}
+        className="max-h-64 overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {assignableUsers.length === 0 ? (
+          <DropdownMenuItem disabled>No one to assign</DropdownMenuItem>
+        ) : (
+          assignableUsers.map((u) => (
+            <DropdownMenuItem
+              key={u["@id"]}
+              onSelect={(e) => {
+                e.preventDefault();
+                toggle(u["@id"]);
+              }}
+              className="gap-2"
+            >
+              <UserAvatar user={u} size="sm" />
+              <span className="min-w-0 flex-1 truncate">{displayName(u)}</span>
+              {assignedIris.has(u["@id"]) && (
+                <Check className="h-3.5 w-3.5 shrink-0" />
+              )}
+            </DropdownMenuItem>
+          ))
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+export default AssignMenu;

--- a/pwa/components/tasks/AssigneesCombobox.tsx
+++ b/pwa/components/tasks/AssigneesCombobox.tsx
@@ -95,7 +95,7 @@ const AssigneesCombobox = ({
           }
         >
           {value.length === 0 && (
-            <AssigneePlaceholder className="group-hover/field:border-foreground/40 group-hover/field:text-foreground" />
+            <AssigneePlaceholder size="xs" className="group-hover/field:border-foreground/40 group-hover/field:text-foreground" />
           )}
           <ComboboxValue>
             {value.map((u) => (

--- a/pwa/components/user/AssigneePlaceholder.tsx
+++ b/pwa/components/user/AssigneePlaceholder.tsx
@@ -1,20 +1,35 @@
 import { UserPlus } from "lucide-react";
 import { cn } from "@/lib/utils";
 
+type Size = "xs" | "sm";
+
+/** Box sizes mirror the assignee avatars they sit beside: `sm` = UserAvatar
+ *  size="sm" (32px) on board/calendar cards; `xs` = the 16px list chips. */
+const BOX: Record<Size, string> = { xs: "h-4 w-4", sm: "h-8 w-8" };
+const ICON: Record<Size, string> = { xs: "h-3 w-3", sm: "h-4 w-4" };
+
 /**
  * Anonymous "no one assigned" placeholder avatar — a dashed square with a
- * UserPlus glyph. Shared by the board cards and the list assignee field so the
- * empty-assignee affordance looks the same everywhere.
+ * UserPlus glyph, sized to match an actual assignee avatar. Shared by the board
+ * cards, calendar chips, and the list assignee field so the empty-assignee
+ * affordance looks the same everywhere.
  */
-const AssigneePlaceholder = ({ className }: { className?: string }) => (
+const AssigneePlaceholder = ({
+  size = "sm",
+  className,
+}: {
+  size?: Size;
+  className?: string;
+}) => (
   <span
     className={cn(
-      "flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-dashed border-muted-foreground/40 text-muted-foreground transition",
+      "flex shrink-0 items-center justify-center rounded-md border border-dashed border-muted-foreground/40 text-muted-foreground transition",
+      BOX[size],
       className,
     )}
     aria-hidden="true"
   >
-    <UserPlus className="h-3.5 w-3.5" />
+    <UserPlus className={ICON[size]} />
   </span>
 );
 

--- a/pwa/pages/dev/components/assignee-placeholder.tsx
+++ b/pwa/pages/dev/components/assignee-placeholder.tsx
@@ -4,13 +4,18 @@ import ComponentDoc from "@/components/dev/ComponentDoc";
 const AssigneePlaceholderPage = () => (
   <ComponentDoc
     name="AssigneePlaceholder"
-    description="Anonymous 'no one assigned' placeholder avatar — a dashed square with a UserPlus glyph. Shared by the board cards and the list assignee field so the empty-assignee affordance looks the same everywhere. Presentation only; the caller wires the click (open an assign menu) and any hover styling via `className`."
+    description="Anonymous 'no one assigned' placeholder avatar — a dashed square with a UserPlus glyph, sized to match an actual assignee avatar (`sm` = 32px board/calendar cards, `xs` = 16px list chips). Shared by the board cards, calendar chips, and the list assignee field so the empty-assignee affordance looks the same everywhere. Presentation only; the caller wires the click (open an assign menu) and any hover styling via `className`."
     importPath={`import AssigneePlaceholder from "@/components/user/AssigneePlaceholder";`}
     examples={[
       {
-        title: "Default",
+        title: "Default (sm — matches a 32px assignee avatar)",
         code: `<AssigneePlaceholder />`,
         preview: <AssigneePlaceholder />,
+      },
+      {
+        title: "xs (matches a 16px list chip)",
+        code: `<AssigneePlaceholder size="xs" />`,
+        preview: <AssigneePlaceholder size="xs" />,
       },
       {
         title: "With hover affordance",

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -1471,9 +1471,14 @@ const ProjectDetail = () => {
                 <TabsContent value="calendar" className="mt-4">
                   <TaskCalendar
                     tasks={tasks}
+                    assignableUsers={projectAssignableUsers}
                     onOpen={(taskIri) => {
                       const task = tasks.find((t) => t["@id"] === taskIri);
                       if (task) openTaskDetail(task);
+                    }}
+                    onAssign={(taskIri, iris) => {
+                      const task = tasks.find((t) => t["@id"] === taskIri);
+                      if (task) void patchTask(task, { assignees: iris });
                     }}
                   />
                 </TabsContent>

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -68,6 +68,10 @@ import type {
   CustomFieldSubtype,
 } from "@/components/custom-fields/types";
 import {
+  showsOnSurface,
+  visibilitySurfaces,
+} from "@/components/custom-fields/types";
+import {
   dueDateStatus,
   type Reminder,
   type RecurrenceRule,
@@ -386,29 +390,37 @@ const ProjectDetail = () => {
     [project, definitions],
   );
 
-  // Fields that exist on the project but are hidden from the list view
-  // (visibility "board") — offered in the add-column menu to re-show.
+  // Fields on the project but hidden from the list view — offered in the
+  // add-column menu to re-show.
   const hiddenListFields = useMemo(
-    () => definitions.filter((d) => (d.visibility ?? "both") === "board"),
+    () => definitions.filter((d) => !showsOnSurface(d.visibility, "list")),
     [definitions],
   );
 
-  // Reveal a hidden field in the list view by widening its visibility.
+  // Reveal a hidden field in the list view by adding `list` to its per-project
+  // surface set.
   const enableListField = useCallback(
     async (def: CustomFieldDefinition) => {
+      if (!projectId) return;
+      const surfaces = [
+        ...new Set([...visibilitySurfaces(def.visibility), "list"]),
+      ].join(",");
       try {
-        const res = await fetch(`${ENTRYPOINT}${def["@id"]}`, {
-          method: "PATCH",
-          credentials: "include",
-          headers: { "Content-Type": "application/merge-patch+json" },
-          body: JSON.stringify({ visibility: "both" }),
-        });
+        const res = await fetch(
+          `${ENTRYPOINT}/projects/${projectId}/custom_field_definitions/${def.id}/visibility`,
+          {
+            method: "PUT",
+            credentials: "include",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ visibility: surfaces }),
+          },
+        );
         if (res.ok) void reloadDefinitions();
       } catch {
         /* transient — leave the field hidden */
       }
     },
-    [reloadDefinitions],
+    [projectId, reloadDefinitions],
   );
 
   // Create a tag from free text typed into a tags field (Enter / comma).
@@ -496,14 +508,18 @@ const ProjectDetail = () => {
     [definitions, patchTask],
   );
 
-  // Definitions surfaced per view. The drawer always shows every field; the
-  // list and board honour each field's `visibility` setting (default "both").
+  // Definitions surfaced per view. The drawer always shows every field; list /
+  // board / calendar each honour the field's visibility surface set.
   const listDefinitions = useMemo(
-    () => definitions.filter((d) => (d.visibility ?? "both") !== "board"),
+    () => definitions.filter((d) => showsOnSurface(d.visibility, "list")),
     [definitions],
   );
   const boardDefinitions = useMemo(
-    () => definitions.filter((d) => (d.visibility ?? "both") !== "list"),
+    () => definitions.filter((d) => showsOnSurface(d.visibility, "board")),
+    [definitions],
+  );
+  const calendarDefinitions = useMemo(
+    () => definitions.filter((d) => showsOnSurface(d.visibility, "calendar")),
     [definitions],
   );
 
@@ -1471,6 +1487,7 @@ const ProjectDetail = () => {
                 <TabsContent value="calendar" className="mt-4">
                   <TaskCalendar
                     tasks={tasks}
+                    definitions={calendarDefinitions}
                     assignableUsers={projectAssignableUsers}
                     onOpen={(taskIri) => {
                       const task = tasks.find((t) => t["@id"] === taskIri);

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -18,6 +18,7 @@ import { signinHrefForCurrent } from "@/lib/authRedirect";
 import { randomPaletteColor } from "@/lib/avatarPalette";
 import ActivityPanel from "@/components/activity/ActivityPanel";
 import TaskBoard from "@/components/projects/TaskBoard";
+import TaskCalendar from "@/components/projects/TaskCalendar";
 import TaskTableColumns from "@/components/projects/TaskTableColumns";
 import ColumnHeaderMenu from "@/components/projects/ColumnHeaderMenu";
 import {
@@ -1102,6 +1103,7 @@ const ProjectDetail = () => {
                   <TabsList variant="line">
                     <TabsTrigger value="list">List</TabsTrigger>
                     <TabsTrigger value="board">Board</TabsTrigger>
+                    <TabsTrigger value="calendar">Calendar</TabsTrigger>
                     <TabsTrigger value="activity">Activity</TabsTrigger>
                     <TabsTrigger value="settings" data-testid="project-settings-tab">
                       Settings
@@ -1462,6 +1464,16 @@ const ProjectDetail = () => {
                         (s) => s["@id"] === sectionIri,
                       );
                       if (section) void deleteSection(section);
+                    }}
+                  />
+                </TabsContent>
+
+                <TabsContent value="calendar" className="mt-4">
+                  <TaskCalendar
+                    tasks={tasks}
+                    onOpen={(taskIri) => {
+                      const task = tasks.find((t) => t["@id"] === taskIri);
+                      if (task) openTaskDetail(task);
                     }}
                   />
                 </TabsContent>


### PR DESCRIPTION
A **Calendar** tab on the project detail page (between Board and Activity).

- **Month** + **Week** views with prev/next/**Today** navigation; current period labeled.
- Tasks bucketed onto their **due date** as clickable chips (title + assignee avatar stack) → opens the task drawer.
- Today highlighted; completed tasks dimmed + struck; month days cap at 4 with "+N more"; out-of-month days muted.
- Tasks with no due date listed in a footer.
- Pure client-side — tasks already carry `dueDate` + `assignees`.

Rebased onto current `main` (post the big batch merge). Typecheck + lint clean.