### PR TITLE
fix(security): encode visibility-URL path segments (CodeQL SSRF #15)

### DIFF
--- a/pwa/components/custom-fields/ProjectCustomFieldPicker.tsx
+++ b/pwa/components/custom-fields/ProjectCustomFieldPicker.tsx
@@ -124,7 +124,7 @@ const ProjectCustomFieldPicker = ({
           await patchAttached([...attachedIris, iri]);
         }
         const res = await fetch(
-          `${ENTRYPOINT}/projects/${projectId}/custom_field_definitions/${defId}/visibility`,
+          `${ENTRYPOINT}/projects/${encodeURIComponent(projectId ?? "")}/custom_field_definitions/${encodeURIComponent(defId ?? "")}/visibility`,
           {
             method: "PUT",
             credentials: "include",

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -407,7 +407,7 @@ const ProjectDetail = () => {
       ].join(",");
       try {
         const res = await fetch(
-          `${ENTRYPOINT}/projects/${projectId}/custom_field_definitions/${def.id}/visibility`,
+          `${ENTRYPOINT}/projects/${encodeURIComponent(projectId)}/custom_field_definitions/${encodeURIComponent(def.id)}/visibility`,
           {
             method: "PUT",
             credentials: "include",


### PR DESCRIPTION
Fixes code-scanning alert #15 (js/request-forgery, critical). The per-project custom-field visibility PUT interpolated `projectId`/`def.id` raw into the fetch URL; wrap both segments in `encodeURIComponent`. Same fix applied to ProjectCustomFieldPicker's visibility call. Typecheck clean.