### PR TITLE
fix(assignees): match list placeholder size to the assignee avatars

### DIFF
--- a/pwa/components/tasks/AssigneesCombobox.tsx
+++ b/pwa/components/tasks/AssigneesCombobox.tsx
@@ -95,7 +95,7 @@ const AssigneesCombobox = ({
           }
         >
           {value.length === 0 && (
-            <AssigneePlaceholder size="xs" className="group-hover/field:border-foreground/40 group-hover/field:text-foreground" />
+            <AssigneePlaceholder className="group-hover/field:border-foreground/40 group-hover/field:text-foreground" />
           )}
           <ComboboxValue>
             {value.map((u) => (

--- a/pwa/components/user/AssigneePlaceholder.tsx
+++ b/pwa/components/user/AssigneePlaceholder.tsx
@@ -3,9 +3,12 @@ import { cn } from "@/lib/utils";
 
 type Size = "xs" | "sm";
 
-/** Box sizes mirror the assignee avatars they sit beside: `sm` = UserAvatar
- *  size="sm" (32px) on board/calendar cards; `xs` = the 16px list chips. */
-const BOX: Record<Size, string> = { xs: "h-4 w-4", sm: "h-8 w-8" };
+/** Box sizes mirror the assignee avatars they sit beside, and use the SAME
+ *  inline width/height mechanism as {@see UserAvatar} (which sizes via a px
+ *  style, not a Tailwind class) so the dashed square is pixel-identical to a
+ *  real avatar regardless of any surrounding flex/grid constraints. `sm` =
+ *  UserAvatar size="sm" (32px); `xs` = the 16px list chips. */
+const BOX_PX: Record<Size, number> = { xs: 16, sm: 32 };
 const ICON: Record<Size, string> = { xs: "h-3 w-3", sm: "h-4 w-4" };
 
 /**
@@ -20,17 +23,20 @@ const AssigneePlaceholder = ({
 }: {
   size?: Size;
   className?: string;
-}) => (
-  <span
-    className={cn(
-      "flex shrink-0 items-center justify-center rounded-md border border-dashed border-muted-foreground/40 text-muted-foreground transition",
-      BOX[size],
-      className,
-    )}
-    aria-hidden="true"
-  >
-    <UserPlus className={ICON[size]} />
-  </span>
-);
+}) => {
+  const px = BOX_PX[size];
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center justify-center rounded-md border border-dashed border-muted-foreground/40 text-muted-foreground transition",
+        className,
+      )}
+      style={{ width: px, height: px }}
+      aria-hidden="true"
+    >
+      <UserPlus className={ICON[size]} />
+    </span>
+  );
+};
 
 export default AssigneePlaceholder;


### PR DESCRIPTION
On the project list view, the empty assignee placeholder rendered at 16px (xs) while the actual assignee avatars render at 32px (UserAvatar's inline width/height overrides the chip's h-4 className). Drop the xs so the placeholder matches the real avatars' size/shape. Typecheck clean.