### PR TITLE
feat: global custom fields (instance-wide, admin-managed)

### DIFF
--- a/api/config/packages/security.yaml
+++ b/api/config/packages/security.yaml
@@ -114,6 +114,11 @@ security:
         # User segments (A/B tests, beta gating, rollouts) — platform admins
         # only. Covers the ApiResource CRUD and the member/preview controller.
         - { path: ^/segments, roles: ROLE_ADMIN }
+        # Global custom fields (#global-custom-fields) — instance-wide,
+        # admin-managed. Only create/edit/delete is platform-admin; reads stay
+        # open to any authenticated user (ROLE_USER, enforced on the entity) so
+        # global fields render in the per-project field picker and on task values.
+        - { path: ^/global_custom_field_definitions, methods: [POST, PUT, PATCH, DELETE], roles: ROLE_ADMIN }
         - { path: ^/media-objects, methods: [POST], roles: ROLE_USER }
         - { path: ^/projects/[^/]+/members$, methods: [POST], roles: ROLE_USER }
         - { path: ^/api-tokens, roles: ROLE_USER }

--- a/api/migrations/Version20260701203037.php
+++ b/api/migrations/Version20260701203037.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Global custom fields (instance-wide, admin-managed).
+ *
+ * Adds `global_custom_field_definition` — the sibling of
+ * `custom_field_definition` that belongs to no space and is available to
+ * every project. Same (kind, subtype, config, footer, nullable) shape, so it
+ * reuses the whole custom-field type-strategy system. Names are unique across
+ * the instance. Per-project opt-in + polymorphic task values land in later
+ * migrations.
+ */
+final class Version20260701203037 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add global_custom_field_definition (instance-wide, admin-managed custom fields).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE global_custom_field_definition (id UUID NOT NULL, name VARCHAR(80) NOT NULL, kind VARCHAR(16) NOT NULL, subtype VARCHAR(24) NOT NULL, config JSON DEFAULT \'{}\' NOT NULL, footer JSON DEFAULT NULL, nullable BOOLEAN DEFAULT true NOT NULL, position INT DEFAULT 0 NOT NULL, visibility VARCHAR(16) DEFAULT \'both\' NOT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY (id))');
+        $this->addSql('CREATE UNIQUE INDEX uniq_gcfd_name ON global_custom_field_definition (name)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE global_custom_field_definition');
+    }
+}

--- a/api/migrations/Version20260701203735.php
+++ b/api/migrations/Version20260701203735.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Polymorphic custom-field values: a task value can now point at EITHER a
+ * space-owned `custom_field_definition` OR the instance-wide
+ * `global_custom_field_definition`.
+ *
+ * Adds a nullable `global_definition_id` FK alongside the (now nullable)
+ * `definition_id`, with a CHECK enforcing exactly one is set (mirrors the
+ * `Comment` polymorphic-parent pattern). The global uniqueness constraint is
+ * DEFERRABLE INITIALLY DEFERRED like its space sibling so PATCH's
+ * delete-then-insert of the whole value set collapses cleanly in one flush.
+ * Both partial cases coexist because NULLs are distinct in a unique
+ * constraint by default — a global-value row has `definition_id = NULL`
+ * (many allowed) and vice-versa.
+ */
+final class Version20260701203735 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add polymorphic global_definition_id to custom_field_value (XOR with definition_id).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE custom_field_value ADD global_definition_id UUID DEFAULT NULL');
+        $this->addSql('ALTER TABLE custom_field_value ALTER definition_id DROP NOT NULL');
+        $this->addSql('ALTER TABLE custom_field_value ADD CONSTRAINT FK_EC7B05C3AA8C40 FOREIGN KEY (global_definition_id) REFERENCES global_custom_field_definition (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('CREATE INDEX idx_cfv_global_definition ON custom_field_value (global_definition_id)');
+        // Deferrable so a PATCH that rebuilds the value set (delete-then-insert)
+        // doesn't trip uniqueness mid-transaction — same shape as the existing
+        // uniq_cfv_task_definition constraint.
+        $this->addSql('ALTER TABLE custom_field_value ADD CONSTRAINT uniq_cfv_task_global_definition UNIQUE (task_id, global_definition_id) DEFERRABLE INITIALLY DEFERRED');
+        // Exactly one definition source per value.
+        $this->addSql(<<<'SQL'
+            ALTER TABLE custom_field_value
+            ADD CONSTRAINT chk_cfv_definition_exactly_one
+            CHECK (
+                (definition_id IS NOT NULL AND global_definition_id IS NULL)
+                OR (definition_id IS NULL AND global_definition_id IS NOT NULL)
+            )
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE custom_field_value DROP CONSTRAINT chk_cfv_definition_exactly_one');
+        $this->addSql('ALTER TABLE custom_field_value DROP CONSTRAINT uniq_cfv_task_global_definition');
+        $this->addSql('ALTER TABLE custom_field_value DROP CONSTRAINT FK_EC7B05C3AA8C40');
+        $this->addSql('DROP INDEX idx_cfv_global_definition');
+        $this->addSql('ALTER TABLE custom_field_value ALTER definition_id SET NOT NULL');
+        $this->addSql('ALTER TABLE custom_field_value DROP global_definition_id');
+    }
+}

--- a/api/migrations/Version20260701204741.php
+++ b/api/migrations/Version20260701204741.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Per-project opt-in for global custom fields.
+ *
+ * Adds `project_global_custom_field_definition` — the join table by which a
+ * project opts into instance-wide global fields (the global twin of
+ * `project_custom_field_definition`). Also makes `project_field_visibility`
+ * polymorphic: a nullable `global_definition_id` alongside the now-nullable
+ * `definition_id`, with a CHECK enforcing exactly one, so a project can
+ * override where a global field shows just like a space field.
+ */
+final class Version20260701204741 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add per-project opt-in + visibility overrides for global custom fields.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE project_global_custom_field_definition (project_id UUID NOT NULL, global_custom_field_definition_id UUID NOT NULL, PRIMARY KEY (project_id, global_custom_field_definition_id))');
+        $this->addSql('CREATE INDEX IDX_9A4C797C166D1F9C ON project_global_custom_field_definition (project_id)');
+        $this->addSql('CREATE INDEX IDX_9A4C797C117A7288 ON project_global_custom_field_definition (global_custom_field_definition_id)');
+        $this->addSql('ALTER TABLE project_global_custom_field_definition ADD CONSTRAINT FK_9A4C797C166D1F9C FOREIGN KEY (project_id) REFERENCES project (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE project_global_custom_field_definition ADD CONSTRAINT FK_9A4C797C117A7288 FOREIGN KEY (global_custom_field_definition_id) REFERENCES global_custom_field_definition (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE project_field_visibility ADD global_definition_id UUID DEFAULT NULL');
+        $this->addSql('ALTER TABLE project_field_visibility ALTER definition_id DROP NOT NULL');
+        $this->addSql('ALTER TABLE project_field_visibility ADD CONSTRAINT FK_E183E9D1C3AA8C40 FOREIGN KEY (global_definition_id) REFERENCES global_custom_field_definition (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('CREATE INDEX idx_pfv_global_definition ON project_field_visibility (global_definition_id)');
+        $this->addSql('CREATE UNIQUE INDEX uniq_pfv_project_global_definition ON project_field_visibility (project_id, global_definition_id)');
+        // Exactly one field source per override row.
+        $this->addSql(<<<'SQL'
+            ALTER TABLE project_field_visibility
+            ADD CONSTRAINT chk_pfv_definition_exactly_one
+            CHECK (
+                (definition_id IS NOT NULL AND global_definition_id IS NULL)
+                OR (definition_id IS NULL AND global_definition_id IS NOT NULL)
+            )
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE project_field_visibility DROP CONSTRAINT chk_pfv_definition_exactly_one');
+        $this->addSql('ALTER TABLE project_global_custom_field_definition DROP CONSTRAINT FK_9A4C797C166D1F9C');
+        $this->addSql('ALTER TABLE project_global_custom_field_definition DROP CONSTRAINT FK_9A4C797C117A7288');
+        $this->addSql('DROP TABLE project_global_custom_field_definition');
+        $this->addSql('ALTER TABLE project_field_visibility DROP CONSTRAINT FK_E183E9D1C3AA8C40');
+        $this->addSql('DROP INDEX idx_pfv_global_definition');
+        $this->addSql('DROP INDEX uniq_pfv_project_global_definition');
+        $this->addSql('ALTER TABLE project_field_visibility DROP global_definition_id');
+        $this->addSql('ALTER TABLE project_field_visibility ALTER definition_id SET NOT NULL');
+    }
+}

--- a/api/migrations/Version20260701210000.php
+++ b/api/migrations/Version20260701210000.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Seed the four out-of-the-box global custom fields (#global-custom-fields):
+ *
+ *   - Effort — numeric.int
+ *   - Cost   — numeric.money (USD)
+ *   - Time   — numeric.float (hours)
+ *   - Status — select.single (Backlog / To do / In progress / Review / Ready / Done)
+ *
+ * These land unattached — every project can opt into them via its field
+ * picker. They stay fully admin-editable / removable afterwards; this only
+ * provides sensible defaults on a fresh instance. Idempotent-ish: skips a name
+ * that already exists so a re-run (or a manual pre-seed) doesn't collide with
+ * the unique-name constraint.
+ */
+final class Version20260701210000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Seed the four default global custom fields (Effort, Cost, Time, Status).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $statusOptions = [
+            ['key' => 'backlog', 'label' => 'Backlog'],
+            ['key' => 'to_do', 'label' => 'To do'],
+            ['key' => 'in_progress', 'label' => 'In progress'],
+            ['key' => 'review', 'label' => 'Review'],
+            ['key' => 'ready', 'label' => 'Ready'],
+            ['key' => 'done', 'label' => 'Done'],
+        ];
+
+        $fields = [
+            ['name' => 'Effort', 'kind' => 'numeric', 'subtype' => 'int', 'config' => []],
+            ['name' => 'Cost', 'kind' => 'numeric', 'subtype' => 'money', 'config' => ['currency' => 'USD']],
+            ['name' => 'Time', 'kind' => 'numeric', 'subtype' => 'float', 'config' => []],
+            ['name' => 'Status', 'kind' => 'select', 'subtype' => 'single', 'config' => ['multi' => false, 'options' => $statusOptions]],
+        ];
+
+        $position = 0;
+        foreach ($fields as $field) {
+            $config = json_encode($field['config'], JSON_THROW_ON_ERROR);
+            $this->addSql(
+                <<<'SQL'
+                    INSERT INTO global_custom_field_definition
+                        (id, name, kind, subtype, config, footer, nullable, position, visibility, created_at)
+                    SELECT gen_random_uuid(), :name, :kind, :subtype, CAST(:config AS JSON), NULL, true, :position, 'both', now()
+                    WHERE NOT EXISTS (
+                        SELECT 1 FROM global_custom_field_definition WHERE name = :name
+                    )
+                    SQL,
+                [
+                    'name' => $field['name'],
+                    'kind' => $field['kind'],
+                    'subtype' => $field['subtype'],
+                    'config' => $config,
+                    'position' => $position,
+                ],
+            );
+            ++$position;
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(
+            "DELETE FROM global_custom_field_definition WHERE name IN ('Effort', 'Cost', 'Time', 'Status')",
+        );
+    }
+}

--- a/api/migrations/Version20260701210000.php
+++ b/api/migrations/Version20260701210000.php
@@ -10,10 +10,11 @@ use Doctrine\Migrations\AbstractMigration;
 /**
  * Seed the four out-of-the-box global custom fields (#global-custom-fields):
  *
- *   - Effort — numeric.int
- *   - Cost   — numeric.money (USD)
- *   - Time   — numeric.float (hours)
- *   - Status — select.single (Backlog / To do / In progress / Review / Ready / Done)
+ *   - Effort — numeric.int             · footer SUM
+ *   - Cost   — numeric.money (USD)      · footer SUM
+ *   - Time   — numeric.float (hours)    · footer SUM
+ *   - Status — select.single (Backlog / To do / In progress / Review / Ready /
+ *              Done) · footer BREAKDOWN (per-option counts)
  *
  * These land unattached — every project can opt into them via its field
  * picker. They stay fully admin-editable / removable afterwards; this only
@@ -39,21 +40,25 @@ final class Version20260701210000 extends AbstractMigration
             ['key' => 'done', 'label' => 'Done'],
         ];
 
+        $sum = ['kind' => 'sum'];
+        $breakdown = ['kind' => 'breakdown'];
+
         $fields = [
-            ['name' => 'Effort', 'kind' => 'numeric', 'subtype' => 'int', 'config' => []],
-            ['name' => 'Cost', 'kind' => 'numeric', 'subtype' => 'money', 'config' => ['currency' => 'USD']],
-            ['name' => 'Time', 'kind' => 'numeric', 'subtype' => 'float', 'config' => []],
-            ['name' => 'Status', 'kind' => 'select', 'subtype' => 'single', 'config' => ['multi' => false, 'options' => $statusOptions]],
+            ['name' => 'Effort', 'kind' => 'numeric', 'subtype' => 'int', 'config' => [], 'footer' => $sum],
+            ['name' => 'Cost', 'kind' => 'numeric', 'subtype' => 'money', 'config' => ['currency' => 'USD'], 'footer' => $sum],
+            ['name' => 'Time', 'kind' => 'numeric', 'subtype' => 'float', 'config' => [], 'footer' => $sum],
+            ['name' => 'Status', 'kind' => 'select', 'subtype' => 'single', 'config' => ['multi' => false, 'options' => $statusOptions], 'footer' => $breakdown],
         ];
 
         $position = 0;
         foreach ($fields as $field) {
             $config = json_encode($field['config'], JSON_THROW_ON_ERROR);
+            $footer = json_encode($field['footer'], JSON_THROW_ON_ERROR);
             $this->addSql(
                 <<<'SQL'
                     INSERT INTO global_custom_field_definition
                         (id, name, kind, subtype, config, footer, nullable, position, visibility, created_at)
-                    SELECT gen_random_uuid(), :name, :kind, :subtype, CAST(:config AS JSON), NULL, true, :position, 'both', now()
+                    SELECT gen_random_uuid(), :name, :kind, :subtype, CAST(:config AS JSON), CAST(:footer AS JSON), true, :position, 'both', now()
                     WHERE NOT EXISTS (
                         SELECT 1 FROM global_custom_field_definition WHERE name = :name
                     )
@@ -63,6 +68,7 @@ final class Version20260701210000 extends AbstractMigration
                     'kind' => $field['kind'],
                     'subtype' => $field['subtype'],
                     'config' => $config,
+                    'footer' => $footer,
                     'position' => $position,
                 ],
             );

--- a/api/src/Controller/CustomFieldFooterController.php
+++ b/api/src/Controller/CustomFieldFooterController.php
@@ -6,7 +6,8 @@ namespace App\Controller;
 
 use App\CustomField\Footer\FooterAggregator;
 use App\Doctrine\SpaceMembershipDql;
-use App\Entity\CustomFieldDefinition;
+use App\Entity\CustomFieldDefinitionInterface;
+use App\Entity\GlobalCustomFieldDefinition;
 use App\Entity\Project;
 use App\Entity\Task;
 use App\Entity\User;
@@ -71,16 +72,20 @@ class CustomFieldFooterController extends AbstractController
             return new JsonResponse(['error' => 'Not found.'], 404);
         }
 
-        // The fields this project has opted into, in space order.
-        $definitions = $project->getCustomFieldDefinitions()->toArray();
+        // The fields this project has opted into — space + global — in
+        // position order (a project's effective field set is the union).
+        $definitions = array_merge(
+            $project->getCustomFieldDefinitions()->toArray(),
+            $project->getGlobalCustomFieldDefinitions()->toArray(),
+        );
         usort(
             $definitions,
-            static fn (CustomFieldDefinition $a, CustomFieldDefinition $b): int
+            static fn (CustomFieldDefinitionInterface $a, CustomFieldDefinitionInterface $b): int
                 => $a->getPosition() <=> $b->getPosition(),
         );
         $haveFooters = array_filter(
             $definitions,
-            static fn (CustomFieldDefinition $d) => null !== $d->getFooter(),
+            static fn (CustomFieldDefinitionInterface $d) => null !== $d->getFooter(),
         );
 
         // Cheap exit when no field has a footer configured — saves the
@@ -94,10 +99,13 @@ class CustomFieldFooterController extends AbstractController
 
         return new JsonResponse([
             'footers' => array_map(static function (array $row): array {
-                /** @var CustomFieldDefinition $def */
+                /** @var CustomFieldDefinitionInterface $def */
                 $def = $row['definition'];
+                $iriBase = $def instanceof GlobalCustomFieldDefinition
+                    ? '/global_custom_field_definitions/'
+                    : '/custom_field_definitions/';
                 return [
-                    'definition' => '/custom_field_definitions/' . $def->getId(),
+                    'definition' => $iriBase . $def->getId(),
                     'name' => $def->getName(),
                     'kind' => $row['kind'],
                     'label' => $row['label'],

--- a/api/src/Controller/CustomFieldStatsController.php
+++ b/api/src/Controller/CustomFieldStatsController.php
@@ -6,7 +6,9 @@ namespace App\Controller;
 
 use App\CustomField\CustomFieldKind;
 use App\Entity\CustomFieldDefinition;
+use App\Entity\CustomFieldDefinitionInterface;
 use App\Entity\CustomFieldValue;
+use App\Entity\GlobalCustomFieldDefinition;
 use App\Entity\Project;
 use App\Entity\Space;
 use App\Entity\Task;
@@ -67,39 +69,33 @@ class CustomFieldStatsController extends AbstractController
             ->getSingleScalarResult();
 
         // At most one value row per (task, definition) thanks to the unique
-        // constraint, so a plain COUNT over non-null values is the number
-        // of tasks that have filled the field.
-        /** @var list<array{did: Uuid|string, filled: int|string}> $rows */
-        $rows = $this->em->createQueryBuilder()
-            ->select('IDENTITY(cfv.definition) AS did', 'COUNT(cfv.id) AS filled')
-            ->from(CustomFieldValue::class, 'cfv')
-            ->join('cfv.task', 't')
-            ->where('t.project = :project')
-            ->andWhere('cfv.value IS NOT NULL')
-            ->setParameter('project', $project)
-            ->groupBy('cfv.definition')
-            ->getQuery()
-            ->getArrayResult();
+        // constraints, so a plain COUNT over non-null values is the number
+        // of tasks that have filled the field. Values point at either a
+        // space definition or a global one — count both, keyed by def UUID
+        // (space and global UUIDs never collide).
+        $filledByDef = array_merge(
+            $this->filledCounts($project, 'definition'),
+            $this->filledCounts($project, 'globalDefinition'),
+        );
 
-        $filledByDef = [];
-        foreach ($rows as $row) {
-            $did = $row['did'];
-            $key = $did instanceof Uuid ? $did->toRfc4122() : $did;
-            $filledByDef[$key] = (int) $row['filled'];
-        }
-
-        // The fields this project has opted into, in space order.
-        $definitions = $project->getCustomFieldDefinitions()->toArray();
+        // The fields this project has opted into — space + global — in order.
+        $definitions = array_merge(
+            $project->getCustomFieldDefinitions()->toArray(),
+            $project->getGlobalCustomFieldDefinitions()->toArray(),
+        );
         usort(
             $definitions,
-            static fn (CustomFieldDefinition $a, CustomFieldDefinition $b): int
+            static fn (CustomFieldDefinitionInterface $a, CustomFieldDefinitionInterface $b): int
                 => $a->getPosition() <=> $b->getPosition(),
         );
 
-        $stats = array_map(function (CustomFieldDefinition $def) use ($filledByDef): array {
+        $stats = array_map(function (CustomFieldDefinitionInterface $def) use ($filledByDef): array {
             $key = (string) $def->getId();
+            $iriBase = $def instanceof GlobalCustomFieldDefinition
+                ? '/global_custom_field_definitions/'
+                : '/custom_field_definitions/';
             return [
-                'definition' => '/custom_field_definitions/' . $def->getId(),
+                'definition' => $iriBase . $def->getId(),
                 'filled' => $filledByDef[$key] ?? 0,
             ];
         }, $definitions);
@@ -127,14 +123,90 @@ class CustomFieldStatsController extends AbstractController
             return new JsonResponse(['error' => 'Not found.'], 404);
         }
 
+        return new JsonResponse(['options' => $this->computeOptionStats($definition, 'definition')]);
+    }
+
+    /**
+     * Per-option usage for a GLOBAL select field, across every task that
+     * carries it. Admin-only (mirrors the definition's write gate) since a
+     * global field has no space to scope reads by.
+     */
+    #[Route(
+        '/global_custom_field_definitions/{id}/option_stats',
+        name: 'global_custom_field_definition_option_stats',
+        methods: ['GET'],
+    )]
+    public function globalOptionStats(string $id, #[CurrentUser] ?User $user): Response
+    {
+        if (null === $user) {
+            return new JsonResponse(['error' => 'Not authenticated.'], 401);
+        }
+        if (!$this->isGranted('ROLE_ADMIN')) {
+            return new JsonResponse(['error' => 'Forbidden.'], 403);
+        }
+        if (!Uuid::isValid($id)) {
+            return new JsonResponse(['error' => 'Not found.'], 404);
+        }
+
+        $definition = $this->em->getRepository(GlobalCustomFieldDefinition::class)->find($id);
+        if (null === $definition) {
+            return new JsonResponse(['error' => 'Not found.'], 404);
+        }
+
+        return new JsonResponse(['options' => $this->computeOptionStats($definition, 'globalDefinition')]);
+    }
+
+    /**
+     * Filled (non-null) value counts for a project's fields, keyed by the
+     * definition UUID string. `$association` is the CustomFieldValue side to
+     * group on — `definition` (space) or `globalDefinition`.
+     *
+     * @return array<string, int>
+     */
+    private function filledCounts(Project $project, string $association): array
+    {
+        /** @var list<array{did: Uuid|string|null, filled: int|string}> $rows */
+        $rows = $this->em->createQueryBuilder()
+            ->select(sprintf('IDENTITY(cfv.%s) AS did', $association), 'COUNT(cfv.id) AS filled')
+            ->from(CustomFieldValue::class, 'cfv')
+            ->join('cfv.task', 't')
+            ->where('t.project = :project')
+            ->andWhere('cfv.value IS NOT NULL')
+            ->andWhere(sprintf('cfv.%s IS NOT NULL', $association))
+            ->setParameter('project', $project)
+            ->groupBy(sprintf('cfv.%s', $association))
+            ->getQuery()
+            ->getArrayResult();
+
+        $out = [];
+        foreach ($rows as $row) {
+            $did = $row['did'];
+            if (null === $did) {
+                continue;
+            }
+            $key = $did instanceof Uuid ? $did->toRfc4122() : $did;
+            $out[$key] = (int) $row['filled'];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Per-option usage counts for a select definition, whichever source it
+     * comes from. `$association` selects the CustomFieldValue FK to filter on.
+     *
+     * @return list<array{key: string, label: string, count: int}>
+     */
+    private function computeOptionStats(CustomFieldDefinitionInterface $definition, string $association): array
+    {
         if (CustomFieldKind::SELECT->value !== $definition->getKind()) {
-            return new JsonResponse(['options' => []]);
+            return [];
         }
 
         $counts = [];
         /** @var list<CustomFieldValue> $values */
         $values = $this->em->getRepository(CustomFieldValue::class)
-            ->findBy(['definition' => $definition]);
+            ->findBy([$association => $definition]);
         foreach ($values as $cfv) {
             foreach ($this->keysOf($cfv->getValue()) as $key) {
                 $counts[$key] = ($counts[$key] ?? 0) + 1;
@@ -154,7 +226,7 @@ class CustomFieldStatsController extends AbstractController
             $result[] = ['key' => $key, 'label' => $label, 'count' => $counts[$key] ?? 0];
         }
 
-        return new JsonResponse(['options' => $result]);
+        return $result;
     }
 
     /**

--- a/api/src/Controller/CustomFieldVisibilityController.php
+++ b/api/src/Controller/CustomFieldVisibilityController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use App\Entity\CustomFieldDefinition;
+use App\Entity\GlobalCustomFieldDefinition;
 use App\Entity\Project;
 use App\Entity\ProjectFieldVisibility;
 use App\Entity\User;
@@ -67,18 +68,15 @@ final class CustomFieldVisibilityController extends AbstractController
             return new JsonResponse(['error' => 'Not found.'], 404);
         }
 
-        $payload = $request->toArray();
-        $raw = $payload['visibility'] ?? null;
         // Accept a comma-joined SET of surfaces (list/board/calendar) or the
         // legacy single value; normalise to a deduped, ordered surface string.
-        $surfaces = is_string($raw) ? CustomFieldDefinition::visibilitySurfaces($raw) : [];
-        if ([] === $surfaces) {
+        $visibility = $this->parseVisibility($request);
+        if (null === $visibility) {
             return new JsonResponse(
                 ['error' => 'visibility must list one or more of: ' . implode(', ', CustomFieldDefinition::SURFACES) . '.'],
                 400,
             );
         }
-        $visibility = implode(',', array_values(array_unique($surfaces)));
 
         $row = $this->overrides->findOneFor($project, $definition);
         if (null === $row) {
@@ -91,6 +89,76 @@ final class CustomFieldVisibilityController extends AbstractController
         $this->em->flush();
 
         return new JsonResponse(['visibility' => $visibility], 200);
+    }
+
+    /**
+     * The global-field twin of {@see __invoke()}: sets where an instance-wide
+     * global field shows WITHIN this project. Same access + body contract; the
+     * override targets the polymorphic global arm of {@see ProjectFieldVisibility}.
+     */
+    #[Route(
+        '/projects/{id}/global_custom_field_definitions/{defId}/visibility',
+        name: 'project_global_custom_field_definition_visibility',
+        methods: ['PUT'],
+    )]
+    public function globalVisibility(
+        string $id,
+        string $defId,
+        Request $request,
+        #[CurrentUser] ?User $user,
+    ): Response {
+        if (null === $user) {
+            return new JsonResponse(['error' => 'Not authenticated.'], 401);
+        }
+        if (!Uuid::isValid($id) || !Uuid::isValid($defId)) {
+            return new JsonResponse(['error' => 'Not found.'], 404);
+        }
+
+        $project = $this->em->getRepository(Project::class)->find($id);
+        if (null === $project || !$this->canManage($project, $user)) {
+            return new JsonResponse(['error' => 'Not found.'], 404);
+        }
+
+        $definition = $this->em->getRepository(GlobalCustomFieldDefinition::class)->find($defId);
+        if (null === $definition || !$project->getGlobalCustomFieldDefinitions()->contains($definition)) {
+            return new JsonResponse(['error' => 'Not found.'], 404);
+        }
+
+        $visibility = $this->parseVisibility($request);
+        if (null === $visibility) {
+            return new JsonResponse(
+                ['error' => 'visibility must list one or more of: ' . implode(', ', CustomFieldDefinition::SURFACES) . '.'],
+                400,
+            );
+        }
+
+        $row = $this->overrides->findOneForGlobal($project, $definition);
+        if (null === $row) {
+            $row = (new ProjectFieldVisibility())
+                ->setProject($project)
+                ->setGlobalDefinition($definition);
+            $this->em->persist($row);
+        }
+        $row->setVisibility($visibility);
+        $this->em->flush();
+
+        return new JsonResponse(['visibility' => $visibility], 200);
+    }
+
+    /**
+     * Parse + normalise the `{visibility}` body into a deduped, ordered
+     * comma-joined surface string, or null when it names no valid surface.
+     */
+    private function parseVisibility(Request $request): ?string
+    {
+        $payload = $request->toArray();
+        $raw = $payload['visibility'] ?? null;
+        $surfaces = is_string($raw) ? CustomFieldDefinition::visibilitySurfaces($raw) : [];
+        if ([] === $surfaces) {
+            return null;
+        }
+
+        return implode(',', array_values(array_unique($surfaces)));
     }
 
     private function canManage(Project $project, User $user): bool

--- a/api/src/Controller/ProjectCopyController.php
+++ b/api/src/Controller/ProjectCopyController.php
@@ -150,6 +150,20 @@ class ProjectCopyController extends AbstractController
             $this->copyFieldVisibility($copy, $clone, $effective);
         }
 
+        // Global fields (#global-custom-fields) are instance-wide — a copy in
+        // any space opts into the same definitions (nothing to clone), keeping
+        // each field's per-project visibility override.
+        foreach ($source->getGlobalCustomFieldDefinitions() as $sourceGlobal) {
+            $effective = $sourceVisibility[(string) $sourceGlobal->getId()]
+                ?? $sourceGlobal->getVisibility();
+            $copy->addGlobalCustomFieldDefinition($sourceGlobal);
+            $row = (new ProjectFieldVisibility())
+                ->setProject($copy)
+                ->setGlobalDefinition($sourceGlobal)
+                ->setVisibility($effective);
+            $this->em->persist($row);
+        }
+
         // Optional task clone (#182 deep-copy). Opt-in via
         // `includeTasks: true` so the default copy stays metadata +
         // schema only. The clone carries forward the structural

--- a/api/src/CustomField/EventSubscriber/CustomFieldValueSearchSubscriber.php
+++ b/api/src/CustomField/EventSubscriber/CustomFieldValueSearchSubscriber.php
@@ -62,7 +62,7 @@ final class CustomFieldValueSearchSubscriber
 
     private function refresh(CustomFieldValue $cfv): void
     {
-        $definition = $cfv->getDefinition();
+        $definition = $cfv->getEffectiveDefinition();
         if (null === $definition) {
             $cfv->setValueSearch(null);
             return;

--- a/api/src/CustomField/Footer/FooterAggregator.php
+++ b/api/src/CustomField/Footer/FooterAggregator.php
@@ -96,6 +96,12 @@ final class FooterAggregator
      */
     private function compute(CustomFieldDefinitionInterface $definition, string $aggKind, array $taskIds): mixed
     {
+        // Per-option breakdown (select only). Handled first so it also renders
+        // a complete zero-filled list when no tasks are in scope.
+        if (FooterKind::BREAKDOWN->value === $aggKind) {
+            return $this->aggregateBreakdown($definition, $taskIds);
+        }
+
         // No tasks in scope — every aggregate is either null or 0.
         if ([] === $taskIds) {
             return FooterKind::COUNT->value === $aggKind ? 0 : null;
@@ -259,6 +265,67 @@ final class FooterAggregator
             array_merge([$definitionId], $params),
         )->fetchOne();
         return is_string($raw) && '' !== $raw ? $raw : null;
+    }
+
+    /**
+     * Per-option counts for a select field: one `{key, label, count}` row per
+     * configured option, in option order, including zero-count options so the
+     * breakdown is stable. Counts occurrences across the scoped tasks —
+     * single-select stores the bare key, multi-select a JSON array of keys
+     * (unrolled here). No DB round-trip when the scope is empty.
+     *
+     * @param list<string> $taskIds
+     * @return list<array{key: string, label: string, count: int}>
+     */
+    private function aggregateBreakdown(CustomFieldDefinitionInterface $definition, array $taskIds): array
+    {
+        $config = $definition->getConfig();
+        $rawOptions = $config['options'] ?? null;
+        $options = is_array($rawOptions) ? $rawOptions : [];
+
+        $counts = [];
+        $definitionId = $definition->getId()?->toRfc4122();
+        if ([] !== $taskIds && null !== $definitionId) {
+            $isMulti = true === ($config['multi'] ?? false);
+            // Single-select stores the bare key (`value #>> '{}'`); multi-select
+            // stores a JSON array — unroll each element to a text key.
+            $keyExpr = $isMulti
+                ? 'jsonb_array_elements_text(value::jsonb)'
+                : "value #>> '{}'";
+            [$placeholders, $params] = $this->bindUuids($taskIds);
+            $sql = sprintf(
+                'SELECT k, COUNT(*) AS c
+                 FROM (
+                     SELECT %s AS k
+                     FROM custom_field_value
+                     WHERE %s = ?
+                       AND task_id IN (%s)
+                       AND value IS NOT NULL
+                 ) keys
+                 GROUP BY k',
+                $keyExpr,
+                $this->definitionColumn($definition),
+                $placeholders,
+            );
+            /** @var list<array{k: mixed, c: mixed}> $rows */
+            $rows = $this->connection->executeQuery($sql, array_merge([$definitionId], $params))->fetchAllAssociative();
+            foreach ($rows as $row) {
+                if (is_string($row['k'])) {
+                    $counts[$row['k']] = is_numeric($row['c']) ? (int) $row['c'] : 0;
+                }
+            }
+        }
+
+        $result = [];
+        foreach ($options as $option) {
+            if (!is_array($option) || !is_string($key = $option['key'] ?? null)) {
+                continue;
+            }
+            $label = is_string($option['label'] ?? null) ? $option['label'] : $key;
+            $result[] = ['key' => $key, 'label' => $label, 'count' => $counts[$key] ?? 0];
+        }
+
+        return $result;
     }
 
     /**

--- a/api/src/CustomField/Footer/FooterAggregator.php
+++ b/api/src/CustomField/Footer/FooterAggregator.php
@@ -6,7 +6,8 @@ namespace App\CustomField\Footer;
 
 use App\CustomField\CustomFieldKind;
 use App\CustomField\CustomFieldTypeRegistry;
-use App\Entity\CustomFieldDefinition;
+use App\Entity\CustomFieldDefinitionInterface;
+use App\Entity\GlobalCustomFieldDefinition;
 use Doctrine\DBAL\Connection;
 
 /**
@@ -41,11 +42,11 @@ final class FooterAggregator
     }
 
     /**
-     * @param iterable<CustomFieldDefinition> $definitions
-     * @param list<string>                    $taskIds       UUIDs (string) of tasks in scope.
+     * @param iterable<CustomFieldDefinitionInterface> $definitions
+     * @param list<string>                             $taskIds       UUIDs (string) of tasks in scope.
      *
      * @return list<array{
-     *     definition: CustomFieldDefinition,
+     *     definition: CustomFieldDefinitionInterface,
      *     kind: string,
      *     label: ?string,
      *     value: mixed,
@@ -82,9 +83,18 @@ final class FooterAggregator
     }
 
     /**
+     * The FK column a value stores this definition in — space-owned fields
+     * live in `definition_id`, global fields in `global_definition_id`.
+     */
+    private function definitionColumn(CustomFieldDefinitionInterface $definition): string
+    {
+        return $definition instanceof GlobalCustomFieldDefinition ? 'global_definition_id' : 'definition_id';
+    }
+
+    /**
      * @param list<string> $taskIds
      */
-    private function compute(CustomFieldDefinition $definition, string $aggKind, array $taskIds): mixed
+    private function compute(CustomFieldDefinitionInterface $definition, string $aggKind, array $taskIds): mixed
     {
         // No tasks in scope — every aggregate is either null or 0.
         if ([] === $taskIds) {
@@ -92,7 +102,7 @@ final class FooterAggregator
         }
 
         if (FooterKind::COUNT->value === $aggKind) {
-            return $this->countNonNull($definition->getId()?->toRfc4122(), $taskIds);
+            return $this->countNonNull($this->definitionColumn($definition), $definition->getId()?->toRfc4122(), $taskIds);
         }
 
         $kind = $definition->getKind();
@@ -121,7 +131,7 @@ final class FooterAggregator
     /**
      * @param list<string> $taskIds
      */
-    private function countNonNull(?string $definitionId, array $taskIds): int
+    private function countNonNull(string $column, ?string $definitionId, array $taskIds): int
     {
         if (null === $definitionId) {
             return 0;
@@ -130,9 +140,10 @@ final class FooterAggregator
         $sql = sprintf(
             'SELECT COUNT(*)
              FROM custom_field_value
-             WHERE definition_id = ?
+             WHERE %s = ?
                AND task_id IN (%s)
                AND value IS NOT NULL',
+            $column,
             $placeholders,
         );
         $stmt = $this->connection->executeQuery(
@@ -149,12 +160,13 @@ final class FooterAggregator
     /**
      * @param list<string> $taskIds
      */
-    private function aggregateNumeric(CustomFieldDefinition $definition, string $aggKind, array $taskIds): mixed
+    private function aggregateNumeric(CustomFieldDefinitionInterface $definition, string $aggKind, array $taskIds): mixed
     {
         $definitionId = $definition->getId()?->toRfc4122();
         if (null === $definitionId) {
             return null;
         }
+        $column = $this->definitionColumn($definition);
         [$placeholders, $params] = $this->bindUuids($taskIds);
 
         $isMoney = 'money' === $definition->getSubtype();
@@ -180,11 +192,12 @@ final class FooterAggregator
         $sql = sprintf(
             "SELECT %s(%s)
              FROM custom_field_value
-             WHERE definition_id = ?
+             WHERE %s = ?
                AND task_id IN (%s)
                AND value IS NOT NULL",
             $aggSql,
             $valueExpr,
+            $column,
             $placeholders,
         );
         $raw = $this->connection->executeQuery(
@@ -215,7 +228,7 @@ final class FooterAggregator
     /**
      * @param list<string> $taskIds
      */
-    private function aggregateDate(CustomFieldDefinition $definition, string $aggKind, array $taskIds): mixed
+    private function aggregateDate(CustomFieldDefinitionInterface $definition, string $aggKind, array $taskIds): mixed
     {
         $definitionId = $definition->getId()?->toRfc4122();
         if (null === $definitionId) {
@@ -224,6 +237,7 @@ final class FooterAggregator
         if (!in_array($aggKind, [FooterKind::MIN->value, FooterKind::MAX->value], true)) {
             return null;
         }
+        $column = $this->definitionColumn($definition);
         [$placeholders, $params] = $this->bindUuids($taskIds);
 
         $aggSql = FooterKind::MIN->value === $aggKind ? 'MIN' : 'MAX';
@@ -233,10 +247,11 @@ final class FooterAggregator
         $sql = sprintf(
             "SELECT %s(value #>> '{}')
              FROM custom_field_value
-             WHERE definition_id = ?
+             WHERE %s = ?
                AND task_id IN (%s)
                AND value IS NOT NULL",
             $aggSql,
+            $column,
             $placeholders,
         );
         $raw = $this->connection->executeQuery(

--- a/api/src/CustomField/Footer/FooterKind.php
+++ b/api/src/CustomField/Footer/FooterKind.php
@@ -16,6 +16,11 @@ enum FooterKind: string
     case MIN = 'min';
     case MAX = 'max';
     case COUNT = 'count';
+    /**
+     * Per-option counts for a select field — a `{key, label, count}` list
+     * (one entry per configured option). Only select strategies advertise it.
+     */
+    case BREAKDOWN = 'breakdown';
 
     /**
      * @return list<string>

--- a/api/src/CustomField/Type/Boolean/BooleanStrategy.php
+++ b/api/src/CustomField/Type/Boolean/BooleanStrategy.php
@@ -7,7 +7,7 @@ namespace App\CustomField\Type\Boolean;
 use App\CustomField\CustomFieldKind;
 use App\CustomField\Type\AbstractTypeStrategy;
 use App\CustomField\Type\TypeViolation;
-use App\Entity\CustomFieldDefinition;
+use App\Entity\CustomFieldDefinitionInterface;
 
 /**
  * `boolean.boolean` — single-value checkbox. The only subtype under
@@ -32,7 +32,7 @@ final class BooleanStrategy extends AbstractTypeStrategy
         return 'boolean';
     }
 
-    public function validateValue(mixed $value, array $config, CustomFieldDefinition $definition): array
+    public function validateValue(mixed $value, array $config, CustomFieldDefinitionInterface $definition): array
     {
         if (is_bool($value)) {
             return [];

--- a/api/src/CustomField/Type/CustomFieldTypeInterface.php
+++ b/api/src/CustomField/Type/CustomFieldTypeInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\CustomField\Type;
 
-use App\Entity\CustomFieldDefinition;
+use App\Entity\CustomFieldDefinitionInterface;
 
 /**
  * Strategy for a single (kind, subtype) custom-field type. Each concrete
@@ -58,7 +58,7 @@ interface CustomFieldTypeInterface
      * @param array<string, mixed> $config
      * @return list<TypeViolation>
      */
-    public function validateValue(mixed $value, array $config, CustomFieldDefinition $definition): array;
+    public function validateValue(mixed $value, array $config, CustomFieldDefinitionInterface $definition): array;
 
     /**
      * Canonical storage form — applied on persist so different inputs

--- a/api/src/CustomField/Type/Date/AbstractDateStrategy.php
+++ b/api/src/CustomField/Type/Date/AbstractDateStrategy.php
@@ -9,7 +9,7 @@ use App\CustomField\Footer\FooterKind;
 use App\CustomField\Type\AbstractTypeStrategy;
 use App\CustomField\Type\MultiValueHelper;
 use App\CustomField\Type\TypeViolation;
-use App\Entity\CustomFieldDefinition;
+use App\Entity\CustomFieldDefinitionInterface;
 
 /**
  * Shared validation + normalization for date-flavoured kinds. Each
@@ -89,7 +89,7 @@ abstract class AbstractDateStrategy extends AbstractTypeStrategy
         return $violations;
     }
 
-    public function validateValue(mixed $value, array $config, CustomFieldDefinition $definition): array
+    public function validateValue(mixed $value, array $config, CustomFieldDefinitionInterface $definition): array
     {
         $multi = $this->isMulti($config);
         $shape = $this->ensureMultiShape($value, $multi);

--- a/api/src/CustomField/Type/Numeric/AbstractNumericStrategy.php
+++ b/api/src/CustomField/Type/Numeric/AbstractNumericStrategy.php
@@ -9,7 +9,7 @@ use App\CustomField\Footer\FooterKind;
 use App\CustomField\Type\AbstractTypeStrategy;
 use App\CustomField\Type\MultiValueHelper;
 use App\CustomField\Type\TypeViolation;
-use App\Entity\CustomFieldDefinition;
+use App\Entity\CustomFieldDefinitionInterface;
 
 /**
  * Shared validation + normalization for numeric kinds (int, float).
@@ -75,7 +75,7 @@ abstract class AbstractNumericStrategy extends AbstractTypeStrategy
         return $violations;
     }
 
-    public function validateValue(mixed $value, array $config, CustomFieldDefinition $definition): array
+    public function validateValue(mixed $value, array $config, CustomFieldDefinitionInterface $definition): array
     {
         $multi = $this->isMulti($config);
         $shape = $this->ensureMultiShape($value, $multi);

--- a/api/src/CustomField/Type/Numeric/MoneyStrategy.php
+++ b/api/src/CustomField/Type/Numeric/MoneyStrategy.php
@@ -8,7 +8,7 @@ use App\CustomField\CustomFieldKind;
 use App\CustomField\Footer\FooterKind;
 use App\CustomField\Type\AbstractTypeStrategy;
 use App\CustomField\Type\TypeViolation;
-use App\Entity\CustomFieldDefinition;
+use App\Entity\CustomFieldDefinitionInterface;
 use Symfony\Component\Intl\Currencies;
 
 /**
@@ -96,7 +96,7 @@ final class MoneyStrategy extends AbstractTypeStrategy
         return $violations;
     }
 
-    public function validateValue(mixed $value, array $config, CustomFieldDefinition $definition): array
+    public function validateValue(mixed $value, array $config, CustomFieldDefinitionInterface $definition): array
     {
         if (!is_array($value)) {
             return [new TypeViolation('', 'Expected an object with amount and currency.')];

--- a/api/src/CustomField/Type/Reference/AbstractReferenceStrategy.php
+++ b/api/src/CustomField/Type/Reference/AbstractReferenceStrategy.php
@@ -8,7 +8,7 @@ use App\CustomField\CustomFieldKind;
 use App\CustomField\Type\AbstractTypeStrategy;
 use App\CustomField\Type\MultiValueHelper;
 use App\CustomField\Type\TypeViolation;
-use App\Entity\CustomFieldDefinition;
+use App\Entity\CustomFieldDefinitionInterface;
 use App\Entity\Space;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Uid\Uuid;
@@ -80,7 +80,7 @@ abstract class AbstractReferenceStrategy extends AbstractTypeStrategy
      */
     abstract protected function isInScope(object $target, Space $space): bool;
 
-    public function validateValue(mixed $value, array $config, CustomFieldDefinition $definition): array
+    public function validateValue(mixed $value, array $config, CustomFieldDefinitionInterface $definition): array
     {
         $multi = $this->isMulti($config);
         $shape = $this->ensureMultiShape($value, $multi);

--- a/api/src/CustomField/Type/Select/AbstractSelectStrategy.php
+++ b/api/src/CustomField/Type/Select/AbstractSelectStrategy.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\CustomField\Type\Select;
 
 use App\CustomField\CustomFieldKind;
+use App\CustomField\Footer\FooterKind;
 use App\CustomField\Type\AbstractTypeStrategy;
 use App\CustomField\Type\TypeViolation;
 use App\Entity\CustomFieldDefinitionInterface;
@@ -21,14 +22,22 @@ use App\Entity\CustomFieldDefinitionInterface;
  * stable identifier is `key`, the user-facing string is `label`,
  * and `color` is optional UI styling.
  *
- * Footer: `count` only — sum/avg/min/max aren't meaningful on
- * categorical choices.
+ * Footer: `count` (filled rows) + `breakdown` (per-option counts) —
+ * sum/avg/min/max aren't meaningful on categorical choices.
  */
 abstract class AbstractSelectStrategy extends AbstractTypeStrategy
 {
     public function kind(): string
     {
         return CustomFieldKind::SELECT->value;
+    }
+
+    /**
+     * @return list<value-of<FooterKind>>
+     */
+    public function supportedAggregations(): array
+    {
+        return [FooterKind::COUNT->value, FooterKind::BREAKDOWN->value];
     }
 
     public function validateConfig(array $config): array

--- a/api/src/CustomField/Type/Select/AbstractSelectStrategy.php
+++ b/api/src/CustomField/Type/Select/AbstractSelectStrategy.php
@@ -7,7 +7,7 @@ namespace App\CustomField\Type\Select;
 use App\CustomField\CustomFieldKind;
 use App\CustomField\Type\AbstractTypeStrategy;
 use App\CustomField\Type\TypeViolation;
-use App\Entity\CustomFieldDefinition;
+use App\Entity\CustomFieldDefinitionInterface;
 
 /**
  * Shared validation + normalization for select kinds. The (single,
@@ -75,7 +75,7 @@ abstract class AbstractSelectStrategy extends AbstractTypeStrategy
         return $violations;
     }
 
-    public function validateValue(mixed $value, array $config, CustomFieldDefinition $definition): array
+    public function validateValue(mixed $value, array $config, CustomFieldDefinitionInterface $definition): array
     {
         return $this->validateValueAgainstKeys($value, $this->keysFromConfig($config), $config);
     }

--- a/api/src/CustomField/Type/Text/AbstractTextStrategy.php
+++ b/api/src/CustomField/Type/Text/AbstractTextStrategy.php
@@ -8,7 +8,7 @@ use App\CustomField\CustomFieldKind;
 use App\CustomField\Type\AbstractTypeStrategy;
 use App\CustomField\Type\MultiValueHelper;
 use App\CustomField\Type\TypeViolation;
-use App\Entity\CustomFieldDefinition;
+use App\Entity\CustomFieldDefinitionInterface;
 
 /**
  * Shared validation + normalization for every text-flavoured kind
@@ -77,7 +77,7 @@ abstract class AbstractTextStrategy extends AbstractTypeStrategy
         return $violations;
     }
 
-    public function validateValue(mixed $value, array $config, CustomFieldDefinition $definition): array
+    public function validateValue(mixed $value, array $config, CustomFieldDefinitionInterface $definition): array
     {
         $multi = $this->isMulti($config);
         $shape = $this->ensureMultiShape($value, $multi);

--- a/api/src/Entity/CustomFieldDefinition.php
+++ b/api/src/Entity/CustomFieldDefinition.php
@@ -89,7 +89,7 @@ use Symfony\Component\Validator\Constraints as Assert;
     message: 'A field with this name already exists in this space.',
 )]
 #[ValidCustomFieldDefinition]
-class CustomFieldDefinition
+class CustomFieldDefinition implements CustomFieldDefinitionInterface
 {
     /**
      * Legacy flat-type constants from the pre-#227 enum. The columns

--- a/api/src/Entity/CustomFieldDefinitionInterface.php
+++ b/api/src/Entity/CustomFieldDefinitionInterface.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Shared contract for the two custom-field definition sources: the
+ * space-owned {@see CustomFieldDefinition} (#custom-fields-space) and the
+ * instance-wide, admin-managed {@see GlobalCustomFieldDefinition}.
+ *
+ * Both speak the same (kind, subtype, config, footer, nullable) shape and
+ * resolve to the same {@see App\CustomField\Type\CustomFieldTypeInterface}
+ * strategy through the registry, so validation, normalization, FTS
+ * projection, and footer aggregation are written once against this
+ * interface and reused for either source. A {@see CustomFieldValue} can
+ * therefore point at either definition (a nullable second FK + XOR) and
+ * every consumer reaches its live definition through
+ * {@see CustomFieldValue::getEffectiveDefinition()}.
+ *
+ * `getSpace()` returns null for global definitions — they are not scoped
+ * to any space. The only strategy that reads it is the reference family,
+ * which is why global fields disallow the `reference` kind in v1.
+ */
+interface CustomFieldDefinitionInterface
+{
+    public function getId(): ?Uuid;
+
+    public function getName(): string;
+
+    /** Top-level family — one of {@see App\CustomField\CustomFieldKind}'s values. */
+    public function getKind(): string;
+
+    /** Specialisation within the kind (e.g. `money` under `numeric`). */
+    public function getSubtype(): string;
+
+    /** Composite `<kind>.<subtype>` registry lookup key. */
+    public function getTypeKey(): string;
+
+    /** @return array<string, mixed> */
+    public function getConfig(): array;
+
+    /** @return array{kind: string, label?: string}|null */
+    public function getFooter(): ?array;
+
+    public function isNullable(): bool;
+
+    /** The owning space, or null for instance-wide global definitions. */
+    public function getSpace(): ?Space;
+
+    /** Default surface visibility (`list` / `board` / `both` / comma-joined set). */
+    public function getVisibility(): string;
+}

--- a/api/src/Entity/CustomFieldDefinitionInterface.php
+++ b/api/src/Entity/CustomFieldDefinitionInterface.php
@@ -47,6 +47,9 @@ interface CustomFieldDefinitionInterface
 
     public function isNullable(): bool;
 
+    /** Sort position within its manager's list. */
+    public function getPosition(): int;
+
     /** The owning space, or null for instance-wide global definitions. */
     public function getSpace(): ?Space;
 

--- a/api/src/Entity/CustomFieldValue.php
+++ b/api/src/Entity/CustomFieldValue.php
@@ -7,7 +7,6 @@ use App\Repository\CustomFieldValueRepository;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Uid\Uuid;
-use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * Per-task value for a {@see CustomFieldDefinition} (#84). Embedded as a
@@ -26,8 +25,10 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ORM\Table(name: 'custom_field_value')]
 #[ORM\Index(columns: ['task_id'], name: 'idx_cfv_task')]
 #[ORM\Index(columns: ['definition_id'], name: 'idx_cfv_definition')]
+#[ORM\Index(columns: ['global_definition_id'], name: 'idx_cfv_global_definition')]
 #[ORM\Index(columns: ['search_vector'], name: 'idx_cfv_search_vector', flags: ['gin'])]
 #[ORM\UniqueConstraint(name: 'uniq_cfv_task_definition', columns: ['task_id', 'definition_id'])]
+#[ORM\UniqueConstraint(name: 'uniq_cfv_task_global_definition', columns: ['task_id', 'global_definition_id'])]
 class CustomFieldValue
 {
     #[ORM\Id]
@@ -46,16 +47,32 @@ class CustomFieldValue
     private ?Task $task = null;
 
     /**
-     * Bare IRI on read — embedding the full definition would balloon
-     * every task payload by N fields. Clients already fetched the
-     * definitions when rendering the project's field schema.
+     * The space-owned definition this value is for, OR null when the value
+     * points at a {@see $globalDefinition} instead. Exactly one of the two
+     * is non-null — the XOR is enforced by {@see ValidCustomFieldValues} and
+     * a DB CHECK (`chk_cfv_definition_exactly_one`). Reach the live
+     * definition regardless of source through {@see getEffectiveDefinition()}.
+     *
+     * Bare IRI on read — embedding the full definition would balloon every
+     * task payload by N fields. Clients already fetched the definitions when
+     * rendering the project's field schema.
      */
     #[ApiProperty(readableLink: false)]
     #[ORM\ManyToOne(targetEntity: CustomFieldDefinition::class)]
-    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
-    #[Assert\NotNull(message: 'Custom field definition is required.')]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'CASCADE')]
     #[Groups(['task:read', 'task:write'])]
     private ?CustomFieldDefinition $definition = null;
+
+    /**
+     * The instance-wide global definition this value is for, OR null when
+     * the value points at a space-owned {@see $definition}. The global
+     * sibling in the polymorphic pair — see the note on {@see $definition}.
+     */
+    #[ApiProperty(readableLink: false)]
+    #[ORM\ManyToOne(targetEntity: GlobalCustomFieldDefinition::class)]
+    #[ORM\JoinColumn(name: 'global_definition_id', nullable: true, onDelete: 'CASCADE')]
+    #[Groups(['task:read', 'task:write'])]
+    private ?GlobalCustomFieldDefinition $globalDefinition = null;
 
     /**
      * Type-erased scalar (or list). Stored as JSON so a single column
@@ -121,6 +138,29 @@ class CustomFieldValue
     {
         $this->definition = $definition;
         return $this;
+    }
+
+    public function getGlobalDefinition(): ?GlobalCustomFieldDefinition
+    {
+        return $this->globalDefinition;
+    }
+
+    public function setGlobalDefinition(?GlobalCustomFieldDefinition $globalDefinition): static
+    {
+        $this->globalDefinition = $globalDefinition;
+        return $this;
+    }
+
+    /**
+     * The live definition this value belongs to, whichever source it points
+     * at. Every custom-field consumer (validator, FTS subscriber, footer
+     * aggregator, serializers) reads through this so it never has to care
+     * whether the field is space-owned or global. Null only in the
+     * transient invalid state where neither FK is set.
+     */
+    public function getEffectiveDefinition(): ?CustomFieldDefinitionInterface
+    {
+        return $this->definition ?? $this->globalDefinition;
     }
 
     public function getValue(): mixed

--- a/api/src/Entity/GlobalCustomFieldDefinition.php
+++ b/api/src/Entity/GlobalCustomFieldDefinition.php
@@ -3,7 +3,9 @@
 namespace App\Entity;
 
 use ApiPlatform\Doctrine\Orm\Filter\OrderFilter;
+use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Get;
@@ -12,7 +14,10 @@ use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
 use App\CustomField\CustomFieldKind;
 use App\Repository\GlobalCustomFieldDefinitionRepository;
+use App\State\GlobalCustomFieldVisibilityProvider;
 use App\Validator\ValidCustomFieldDefinition;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Serializer\Attribute\Groups;
@@ -43,6 +48,7 @@ use Symfony\Component\Validator\Constraints as Assert;
     operations: [
         new GetCollection(
             security: "is_granted('ROLE_USER')",
+            provider: GlobalCustomFieldVisibilityProvider::class,
         ),
         new Post(
             security: "is_granted('ROLE_ADMIN')",
@@ -61,6 +67,7 @@ use Symfony\Component\Validator\Constraints as Assert;
     denormalizationContext: ['groups' => ['global_custom_field_definition:write']],
     order: ['position' => 'ASC', 'createdAt' => 'ASC'],
 )]
+#[ApiFilter(SearchFilter::class, properties: ['projects' => 'exact'])]
 #[ApiFilter(OrderFilter::class, properties: ['position'], arguments: ['orderParameterName' => 'order'])]
 #[ORM\Entity(repositoryClass: GlobalCustomFieldDefinitionRepository::class)]
 #[ORM\Table(name: 'global_custom_field_definition')]
@@ -166,9 +173,30 @@ class GlobalCustomFieldDefinition implements CustomFieldDefinitionInterface
     #[Groups(['global_custom_field_definition:read'])]
     private \DateTimeImmutable $createdAt;
 
+    /**
+     * Projects that have opted this global field into their task view.
+     * Inverse side — the join table is owned by
+     * {@see Project::$globalCustomFieldDefinitions}. Backs the `?projects=`
+     * filter the PWA uses to fetch a project's effective global field set.
+     *
+     * @var Collection<int, Project>
+     */
+    #[ApiProperty(readableLink: false)]
+    #[ORM\ManyToMany(targetEntity: Project::class, mappedBy: 'globalCustomFieldDefinitions')]
+    private Collection $projects;
+
     public function __construct()
     {
         $this->createdAt = new \DateTimeImmutable();
+        $this->projects = new ArrayCollection();
+    }
+
+    /**
+     * @return Collection<int, Project>
+     */
+    public function getProjects(): Collection
+    {
+        return $this->projects;
     }
 
     public function getId(): ?Uuid

--- a/api/src/Entity/GlobalCustomFieldDefinition.php
+++ b/api/src/Entity/GlobalCustomFieldDefinition.php
@@ -1,0 +1,302 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Doctrine\Orm\Filter\OrderFilter;
+use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use App\CustomField\CustomFieldKind;
+use App\Repository\GlobalCustomFieldDefinitionRepository;
+use App\Validator\ValidCustomFieldDefinition;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Instance-wide, admin-managed custom field definition. The sibling of the
+ * space-owned {@see CustomFieldDefinition}: it carries the exact same
+ * (kind, subtype, config, footer, nullable) shape and resolves to the same
+ * {@see App\CustomField\Type\CustomFieldTypeInterface} strategy registry, so
+ * validation, value editors, footers, and search behave identically — the
+ * only difference is scope. A global field lives in its own table, belongs
+ * to no space, and is available to every project in every space.
+ *
+ * Only platform admins (`ROLE_ADMIN`) create / edit / delete definitions;
+ * any authenticated user may read them (so they render in the project field
+ * picker) and toggle them on/off per project via
+ * {@see Project::$globalCustomFieldDefinitions}. A project's effective field
+ * set is the union of its space fields + its opted-in global fields.
+ *
+ * The `reference` kind is disallowed for global fields in v1 — a reference
+ * value scopes its target IRIs against the field's space, and a global field
+ * has none. This is enforced in {@see App\Validator\ValidCustomFieldDefinition}.
+ */
+#[ApiResource(
+    shortName: 'GlobalCustomFieldDefinition',
+    operations: [
+        new GetCollection(
+            security: "is_granted('ROLE_USER')",
+        ),
+        new Post(
+            security: "is_granted('ROLE_ADMIN')",
+        ),
+        new Get(
+            security: "is_granted('ROLE_USER')",
+        ),
+        new Patch(
+            security: "is_granted('ROLE_ADMIN')",
+        ),
+        new Delete(
+            security: "is_granted('ROLE_ADMIN')",
+        ),
+    ],
+    normalizationContext: ['groups' => ['global_custom_field_definition:read']],
+    denormalizationContext: ['groups' => ['global_custom_field_definition:write']],
+    order: ['position' => 'ASC', 'createdAt' => 'ASC'],
+)]
+#[ApiFilter(OrderFilter::class, properties: ['position'], arguments: ['orderParameterName' => 'order'])]
+#[ORM\Entity(repositoryClass: GlobalCustomFieldDefinitionRepository::class)]
+#[ORM\Table(name: 'global_custom_field_definition')]
+#[ORM\UniqueConstraint(name: 'uniq_gcfd_name', columns: ['name'])]
+#[ORM\HasLifecycleCallbacks]
+#[UniqueEntity(
+    fields: ['name'],
+    message: 'A global field with this name already exists.',
+)]
+#[ValidCustomFieldDefinition]
+class GlobalCustomFieldDefinition implements CustomFieldDefinitionInterface
+{
+    public const MAX_NAME_LENGTH = 80;
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
+    #[Groups(['global_custom_field_definition:read'])]
+    private ?Uuid $id = null;
+
+    #[ORM\Column(length: self::MAX_NAME_LENGTH)]
+    #[Assert\NotBlank(message: 'Field name is required.')]
+    #[Assert\Length(
+        max: self::MAX_NAME_LENGTH,
+        maxMessage: 'Field name cannot be longer than {{ limit }} characters.',
+    )]
+    #[Groups(['global_custom_field_definition:read', 'global_custom_field_definition:write'])]
+    private string $name = '';
+
+    /**
+     * Top-level family — one of {@see CustomFieldKind}'s values.
+     */
+    #[ORM\Column(length: 16)]
+    #[Assert\Choice(
+        callback: [CustomFieldKind::class, 'values'],
+        message: 'Kind must be one of: {{ choices }}.',
+    )]
+    #[Groups(['global_custom_field_definition:read', 'global_custom_field_definition:write'])]
+    private string $kind = CustomFieldKind::TEXT->value;
+
+    /**
+     * Specialisation within the kind. The (kind, subtype) pair is the
+     * registry lookup key for the concrete strategy.
+     */
+    #[ORM\Column(length: 24)]
+    #[Assert\NotBlank(message: 'Subtype is required.')]
+    #[Assert\Length(max: 24)]
+    #[Groups(['global_custom_field_definition:read', 'global_custom_field_definition:write'])]
+    private string $subtype = 'text';
+
+    /**
+     * Per-kind configuration payload. Shape is owned by the strategy for
+     * the (kind, subtype) pair — see CustomFieldTypeInterface docblock.
+     *
+     * @var array<string, mixed>
+     */
+    #[ORM\Column(type: 'json', options: ['default' => '{}'])]
+    #[Groups(['global_custom_field_definition:read', 'global_custom_field_definition:write'])]
+    private array $config = [];
+
+    /**
+     * Optional footer aggregation descriptor `{kind, label?}`. Null means
+     * no footer row; the kind, when present, must be one supported by the
+     * strategy (enforced in {@see ValidCustomFieldDefinition}).
+     *
+     * @var array{kind: string, label?: string}|null
+     */
+    #[ORM\Column(type: 'json', nullable: true)]
+    #[Groups(['global_custom_field_definition:read', 'global_custom_field_definition:write'])]
+    private ?array $footer = null;
+
+    /**
+     * Whether a missing or null value is acceptable for this field.
+     * `false` means the task validator enforces presence at save time.
+     */
+    #[ORM\Column(type: 'boolean', options: ['default' => true])]
+    #[Groups(['global_custom_field_definition:read', 'global_custom_field_definition:write'])]
+    private bool $nullable = true;
+
+    #[ORM\Column(type: 'integer', options: ['default' => 0])]
+    #[Assert\PositiveOrZero(message: 'Position cannot be negative.')]
+    #[Groups(['global_custom_field_definition:read', 'global_custom_field_definition:write'])]
+    private int $position = 0;
+
+    /**
+     * Default surface visibility — where the field shows: the task list
+     * (`list`), the Kanban board (`board`), or both. Like the space-owned
+     * field, this is the per-project fallback: a {@see ProjectFieldVisibility}
+     * override row wins in a project context (#custom-fields-project). Unlike
+     * the space field, admins set this default directly (it is writable) since
+     * there is no per-space manager to own it.
+     */
+    #[ORM\Column(length: 16, options: ['default' => CustomFieldDefinition::VISIBILITY_BOTH])]
+    #[Assert\Choice(
+        choices: CustomFieldDefinition::VISIBILITIES,
+        message: 'Visibility must be one of: {{ choices }}.',
+    )]
+    #[Groups(['global_custom_field_definition:read', 'global_custom_field_definition:write'])]
+    private string $visibility = CustomFieldDefinition::VISIBILITY_BOTH;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    #[Groups(['global_custom_field_definition:read'])]
+    private \DateTimeImmutable $createdAt;
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?Uuid
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): static
+    {
+        $this->name = trim($name);
+        return $this;
+    }
+
+    public function getKind(): string
+    {
+        return $this->kind;
+    }
+
+    public function setKind(string $kind): static
+    {
+        $this->kind = $kind;
+        return $this;
+    }
+
+    public function getSubtype(): string
+    {
+        return $this->subtype;
+    }
+
+    public function setSubtype(string $subtype): static
+    {
+        $this->subtype = $subtype;
+        return $this;
+    }
+
+    /**
+     * Composite `<kind>.<subtype>` lookup key — what the strategy registry
+     * resolves against.
+     */
+    public function getTypeKey(): string
+    {
+        return $this->kind . '.' . $this->subtype;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getConfig(): array
+    {
+        return $this->config;
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function setConfig(array $config): static
+    {
+        $this->config = $config;
+        return $this;
+    }
+
+    /**
+     * @return array{kind: string, label?: string}|null
+     */
+    public function getFooter(): ?array
+    {
+        return $this->footer;
+    }
+
+    /**
+     * @param array{kind: string, label?: string}|null $footer
+     */
+    public function setFooter(?array $footer): static
+    {
+        $this->footer = $footer;
+        return $this;
+    }
+
+    public function isNullable(): bool
+    {
+        return $this->nullable;
+    }
+
+    public function setNullable(bool $nullable): static
+    {
+        $this->nullable = $nullable;
+        return $this;
+    }
+
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function setPosition(int $position): static
+    {
+        $this->position = $position;
+        return $this;
+    }
+
+    public function getVisibility(): string
+    {
+        return $this->visibility;
+    }
+
+    public function setVisibility(string $visibility): static
+    {
+        $this->visibility = $visibility;
+        return $this;
+    }
+
+    /**
+     * Global fields belong to no space. Part of the shared
+     * {@see CustomFieldDefinitionInterface} contract — the reference
+     * strategy reads it, which is why global fields disallow references.
+     */
+    public function getSpace(): ?Space
+    {
+        return null;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+}

--- a/api/src/Entity/Project.php
+++ b/api/src/Entity/Project.php
@@ -156,11 +156,29 @@ class Project
     #[Groups(['project:read', 'project:write'])]
     private Collection $customFieldDefinitions;
 
+    /**
+     * Instance-wide global custom-field definitions this project opts into
+     * (#global-custom-fields). Same per-project chooser as the space fields
+     * above, but a separate join table — a project's effective field set is
+     * the union of the two. Global definitions are admin-managed; a project
+     * member can only toggle them on/off here (write) — never edit them.
+     *
+     * @var Collection<int, GlobalCustomFieldDefinition>
+     */
+    #[ApiProperty(readableLink: false)]
+    #[ORM\ManyToMany(targetEntity: GlobalCustomFieldDefinition::class, inversedBy: 'projects')]
+    #[ORM\JoinTable(name: 'project_global_custom_field_definition')]
+    #[ORM\JoinColumn(name: 'project_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
+    #[ORM\InverseJoinColumn(name: 'global_custom_field_definition_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
+    #[Groups(['project:read', 'project:write'])]
+    private Collection $globalCustomFieldDefinitions;
+
     public function __construct()
     {
         $this->createdOn = new \DateTimeImmutable();
         $this->tasks = new ArrayCollection();
         $this->customFieldDefinitions = new ArrayCollection();
+        $this->globalCustomFieldDefinitions = new ArrayCollection();
     }
 
     public function getId(): ?Uuid
@@ -244,6 +262,28 @@ class Project
     public function removeCustomFieldDefinition(CustomFieldDefinition $definition): static
     {
         $this->customFieldDefinitions->removeElement($definition);
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, GlobalCustomFieldDefinition>
+     */
+    public function getGlobalCustomFieldDefinitions(): Collection
+    {
+        return $this->globalCustomFieldDefinitions;
+    }
+
+    public function addGlobalCustomFieldDefinition(GlobalCustomFieldDefinition $definition): static
+    {
+        if (!$this->globalCustomFieldDefinitions->contains($definition)) {
+            $this->globalCustomFieldDefinitions->add($definition);
+        }
+        return $this;
+    }
+
+    public function removeGlobalCustomFieldDefinition(GlobalCustomFieldDefinition $definition): static
+    {
+        $this->globalCustomFieldDefinitions->removeElement($definition);
         return $this;
     }
 

--- a/api/src/Entity/ProjectFieldVisibility.php
+++ b/api/src/Entity/ProjectFieldVisibility.php
@@ -11,12 +11,16 @@ use Symfony\Component\Uid\Uuid;
 /**
  * Per-project visibility override for a custom field (#custom-fields-project).
  *
- * Custom field definitions are space-owned and shared across the projects that
- * attach them, but where a field is shown — the task list, the Kanban board, or
- * both — is a per-project choice. One row per (project, definition) pair holds
- * that choice; when no row exists the definition's own {@see
- * CustomFieldDefinition::$visibility} acts as the default. Server-managed only
- * (not an API resource): written through the per-project visibility endpoint.
+ * Custom field definitions are shared across the projects that attach them,
+ * but where a field is shown — the task list, the Kanban board, or both — is a
+ * per-project choice. One row per (project, field) pair holds that choice; when
+ * no row exists the definition's own `visibility` acts as the default.
+ * Server-managed only (not an API resource): written through the per-project
+ * visibility endpoints.
+ *
+ * The field is polymorphic like {@see CustomFieldValue}: exactly one of
+ * {@see $definition} (space-owned) / {@see $globalDefinition} (instance-wide)
+ * is set, so a project can override the visibility of either field source.
  */
 #[ORM\Entity(repositoryClass: ProjectFieldVisibilityRepository::class)]
 #[ORM\Table(name: 'project_field_visibility')]
@@ -24,7 +28,12 @@ use Symfony\Component\Uid\Uuid;
     name: 'uniq_pfv_project_definition',
     columns: ['project_id', 'definition_id'],
 )]
+#[ORM\UniqueConstraint(
+    name: 'uniq_pfv_project_global_definition',
+    columns: ['project_id', 'global_definition_id'],
+)]
 #[ORM\Index(columns: ['definition_id'], name: 'idx_pfv_definition')]
+#[ORM\Index(columns: ['global_definition_id'], name: 'idx_pfv_global_definition')]
 class ProjectFieldVisibility
 {
     #[ORM\Id]
@@ -38,8 +47,12 @@ class ProjectFieldVisibility
     private ?Project $project = null;
 
     #[ORM\ManyToOne(targetEntity: CustomFieldDefinition::class)]
-    #[ORM\JoinColumn(name: 'definition_id', nullable: false, onDelete: 'CASCADE')]
+    #[ORM\JoinColumn(name: 'definition_id', nullable: true, onDelete: 'CASCADE')]
     private ?CustomFieldDefinition $definition = null;
+
+    #[ORM\ManyToOne(targetEntity: GlobalCustomFieldDefinition::class)]
+    #[ORM\JoinColumn(name: 'global_definition_id', nullable: true, onDelete: 'CASCADE')]
+    private ?GlobalCustomFieldDefinition $globalDefinition = null;
 
     // A comma-joined SET of surfaces (list/board/calendar); 32 chars holds all
     // three. Validated in the visibility controller, so no Assert\Choice here.
@@ -73,6 +86,26 @@ class ProjectFieldVisibility
         $this->definition = $definition;
 
         return $this;
+    }
+
+    public function getGlobalDefinition(): ?GlobalCustomFieldDefinition
+    {
+        return $this->globalDefinition;
+    }
+
+    public function setGlobalDefinition(GlobalCustomFieldDefinition $globalDefinition): static
+    {
+        $this->globalDefinition = $globalDefinition;
+
+        return $this;
+    }
+
+    /**
+     * The field this override targets, whichever source it points at.
+     */
+    public function getEffectiveDefinition(): ?CustomFieldDefinitionInterface
+    {
+        return $this->definition ?? $this->globalDefinition;
     }
 
     public function getVisibility(): string

--- a/api/src/Mcp/McpEntitySerializer.php
+++ b/api/src/Mcp/McpEntitySerializer.php
@@ -56,7 +56,8 @@ final class McpEntitySerializer
             'customFieldValues' => array_map(
                 fn (CustomFieldValue $v) => [
                     'definitionId' => null === $v->getDefinition() ? null : (string) $v->getDefinition()->getId(),
-                    'name' => $v->getDefinition()?->getName(),
+                    'globalDefinitionId' => null === $v->getGlobalDefinition() ? null : (string) $v->getGlobalDefinition()->getId(),
+                    'name' => $v->getEffectiveDefinition()?->getName(),
                     'value' => $v->getValue(),
                 ],
                 $task->getCustomFieldValues()->toArray(),

--- a/api/src/Mcp/Tool/UpdateTaskTool.php
+++ b/api/src/Mcp/Tool/UpdateTaskTool.php
@@ -3,6 +3,7 @@
 namespace App\Mcp\Tool;
 
 use App\Entity\CustomFieldDefinition;
+use App\Entity\GlobalCustomFieldDefinition;
 use App\Entity\CustomFieldValue;
 use App\Entity\Project;
 use App\Entity\Task;
@@ -66,10 +67,11 @@ final class UpdateTaskTool implements McpToolInterface
                     'items' => [
                         'type' => 'object',
                         'properties' => [
-                            'definitionId' => ['type' => 'string', 'description' => 'UUID of a CustomFieldDefinition on the task\'s project.'],
+                            'definitionId' => ['type' => 'string', 'description' => 'UUID of a CustomFieldDefinition on the task\'s project. Provide this OR globalDefinitionId, not both.'],
+                            'globalDefinitionId' => ['type' => 'string', 'description' => 'UUID of a GlobalCustomFieldDefinition (instance-wide) opted into by the task\'s project. Provide this OR definitionId, not both.'],
                             'value' => ['description' => 'The value, shaped to the field\'s kind/subtype (string, number, bool, ISO date, {amount,currency} for money, an IRI for references, or an array when the field is multi).'],
                         ],
-                        'required' => ['definitionId', 'value'],
+                        'required' => ['value'],
                         'additionalProperties' => false,
                     ],
                 ],
@@ -172,16 +174,31 @@ final class UpdateTaskTool implements McpToolInterface
             if (!is_array($entry)) {
                 throw McpException::invalidInput('Each customFieldValues entry must be an object.');
             }
-            $definitionId = $this->input->requireUuid(
-                'customFieldValues[].definitionId',
-                $entry['definitionId'] ?? null,
-            );
-            $definition = $this->em->getRepository(CustomFieldDefinition::class)->find($definitionId);
-            if (null === $definition) {
-                throw McpException::notFound(sprintf('Custom field %s', $definitionId));
-            }
             $value = new CustomFieldValue();
-            $value->setDefinition($definition);
+            // A value targets exactly one definition source — a space-owned
+            // field (definitionId) or an instance-wide global field
+            // (globalDefinitionId). The XOR is policed by ValidCustomFieldValues.
+            if (array_key_exists('globalDefinitionId', $entry) && null !== $entry['globalDefinitionId']) {
+                $globalId = $this->input->requireUuid(
+                    'customFieldValues[].globalDefinitionId',
+                    $entry['globalDefinitionId'],
+                );
+                $global = $this->em->getRepository(GlobalCustomFieldDefinition::class)->find($globalId);
+                if (null === $global) {
+                    throw McpException::notFound(sprintf('Global custom field %s', $globalId));
+                }
+                $value->setGlobalDefinition($global);
+            } else {
+                $definitionId = $this->input->requireUuid(
+                    'customFieldValues[].definitionId',
+                    $entry['definitionId'] ?? null,
+                );
+                $definition = $this->em->getRepository(CustomFieldDefinition::class)->find($definitionId);
+                if (null === $definition) {
+                    throw McpException::notFound(sprintf('Custom field %s', $definitionId));
+                }
+                $value->setDefinition($definition);
+            }
             $value->setValue($entry['value'] ?? null);
             $task->addCustomFieldValue($value);
         }

--- a/api/src/Repository/GlobalCustomFieldDefinitionRepository.php
+++ b/api/src/Repository/GlobalCustomFieldDefinitionRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\GlobalCustomFieldDefinition;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<GlobalCustomFieldDefinition>
+ */
+class GlobalCustomFieldDefinitionRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, GlobalCustomFieldDefinition::class);
+    }
+}

--- a/api/src/Repository/ProjectFieldVisibilityRepository.php
+++ b/api/src/Repository/ProjectFieldVisibilityRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\CustomFieldDefinition;
+use App\Entity\GlobalCustomFieldDefinition;
 use App\Entity\Project;
 use App\Entity\ProjectFieldVisibility;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
@@ -22,6 +23,9 @@ class ProjectFieldVisibilityRepository extends ServiceEntityRepository
 
     /**
      * Visibility overrides for a project, keyed by definition UUID string.
+     * Covers both field sources — space and global override rows land in the
+     * same map (their UUIDs never collide) so the collection providers can
+     * look up either without caring which source they hold.
      *
      * @return array<string, string> definitionId => visibility
      */
@@ -29,7 +33,7 @@ class ProjectFieldVisibilityRepository extends ServiceEntityRepository
     {
         $map = [];
         foreach ($this->findBy(['project' => $project]) as $row) {
-            $defId = $row->getDefinition()?->getId();
+            $defId = $row->getEffectiveDefinition()?->getId();
             if (null !== $defId) {
                 $map[(string) $defId] = $row->getVisibility();
             }
@@ -43,5 +47,12 @@ class ProjectFieldVisibilityRepository extends ServiceEntityRepository
         CustomFieldDefinition $definition,
     ): ?ProjectFieldVisibility {
         return $this->findOneBy(['project' => $project, 'definition' => $definition]);
+    }
+
+    public function findOneForGlobal(
+        Project $project,
+        GlobalCustomFieldDefinition $definition,
+    ): ?ProjectFieldVisibility {
+        return $this->findOneBy(['project' => $project, 'globalDefinition' => $definition]);
     }
 }

--- a/api/src/Service/SpaceExportBuilder.php
+++ b/api/src/Service/SpaceExportBuilder.php
@@ -224,7 +224,8 @@ final class SpaceExportBuilder
             'tags' => array_map(static fn (Tag $t): string => $t->getTitle(), $task->getTags()->toArray()),
             'customFieldValues' => array_map(static fn (CustomFieldValue $v): array => [
                 'definitionId' => null !== $v->getDefinition() ? (string) $v->getDefinition()->getId() : null,
-                'name' => $v->getDefinition()?->getName(),
+                'globalDefinitionId' => null !== $v->getGlobalDefinition() ? (string) $v->getGlobalDefinition()->getId() : null,
+                'name' => $v->getEffectiveDefinition()?->getName(),
                 'value' => $v->getValue(),
             ], $task->getCustomFieldValues()->toArray()),
             'attachments' => array_map(fn (MediaObject $m): array => [

--- a/api/src/State/GlobalCustomFieldVisibilityProvider.php
+++ b/api/src/State/GlobalCustomFieldVisibilityProvider.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\Entity\GlobalCustomFieldDefinition;
+use App\Entity\Project;
+use App\Repository\ProjectFieldVisibilityRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * The global-field sibling of {@see CustomFieldVisibilityProvider}: decorates
+ * the GlobalCustomFieldDefinition collection provider to inject each field's
+ * PER-PROJECT visibility (#custom-fields-project / #global-custom-fields) when
+ * the collection is fetched in a project context (`?projects={iri}`).
+ *
+ * Global definitions are admin-managed and their own `visibility` column is
+ * only the cross-project default; a {@see \App\Entity\ProjectFieldVisibility}
+ * row (its polymorphic global arm) lets a project member place the field on
+ * the list / board without touching the shared definition.
+ *
+ * @implements ProviderInterface<GlobalCustomFieldDefinition>
+ */
+final class GlobalCustomFieldVisibilityProvider implements ProviderInterface
+{
+    /**
+     * @param ProviderInterface<GlobalCustomFieldDefinition> $inner
+     */
+    public function __construct(
+        #[Autowire(service: 'api_platform.doctrine.orm.state.collection_provider')]
+        private readonly ProviderInterface $inner,
+        private readonly EntityManagerInterface $em,
+        private readonly ProjectFieldVisibilityRepository $overrides,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $uriVariables
+     * @param array<string, mixed> $context
+     */
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
+    {
+        $result = $this->inner->provide($operation, $uriVariables, $context);
+
+        $project = $this->resolveProject($context);
+        if (null !== $project && is_iterable($result)) {
+            $map = $this->overrides->visibilityMapForProject($project);
+            foreach ($result as $definition) {
+                $override = $map[(string) $definition->getId()] ?? null;
+                if (null !== $override) {
+                    $definition->setVisibility($override);
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Resolve a single-project context from the `?projects={iri}` filter.
+     *
+     * @param array<string, mixed> $context
+     */
+    private function resolveProject(array $context): ?Project
+    {
+        $filters = $context['filters'] ?? null;
+        $raw = is_array($filters) ? ($filters['projects'] ?? null) : null;
+        if (!is_string($raw) || '' === $raw) {
+            return null;
+        }
+
+        $segment = substr($raw, (int) strrpos($raw, '/') + 1);
+        if (!Uuid::isValid($segment)) {
+            return null;
+        }
+
+        return $this->em->getRepository(Project::class)->find($segment);
+    }
+}

--- a/api/src/Validator/ValidCustomFieldDefinition.php
+++ b/api/src/Validator/ValidCustomFieldDefinition.php
@@ -7,10 +7,12 @@ namespace App\Validator;
 use Symfony\Component\Validator\Constraint;
 
 /**
- * Class-level constraint on {@see App\Entity\CustomFieldDefinition} that
- * delegates per-kind config validation to the matching strategy in the
- * registry. Replaces the hand-rolled `validateOptions` / `validateFooter`
- * Callbacks the entity used to host.
+ * Class-level constraint on both custom-field definition sources — the
+ * space-owned {@see App\Entity\CustomFieldDefinition} and the instance-wide
+ * {@see App\Entity\GlobalCustomFieldDefinition} — that delegates per-kind
+ * config validation to the matching strategy in the registry. Replaces the
+ * hand-rolled `validateOptions` / `validateFooter` Callbacks the entity used
+ * to host.
  *
  * The strategy owns its own config schema (`numeric.money` knows about
  * `currency`, `select.*` knows about `options`, etc.), so this
@@ -23,6 +25,7 @@ final class ValidCustomFieldDefinition extends Constraint
 {
     public string $messageUnknownType = 'Unknown custom-field type "{{ key }}".';
     public string $messageUnsupportedFooter = 'Footer kind "{{ kind }}" is not supported by {{ type }}.';
+    public string $messageGlobalNoReference = 'Global custom fields cannot be reference fields.';
 
     public function getTargets(): string
     {

--- a/api/src/Validator/ValidCustomFieldDefinitionValidator.php
+++ b/api/src/Validator/ValidCustomFieldDefinitionValidator.php
@@ -4,13 +4,22 @@ declare(strict_types=1);
 
 namespace App\Validator;
 
+use App\CustomField\CustomFieldKind;
 use App\CustomField\CustomFieldTypeRegistry;
-use App\Entity\CustomFieldDefinition;
+use App\Entity\CustomFieldDefinitionInterface;
+use App\Entity\GlobalCustomFieldDefinition;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Exception\UnexpectedValueException;
 
+/**
+ * Config + footer well-formedness for a custom-field definition. Runs for
+ * BOTH definition sources — the space-owned {@see App\Entity\CustomFieldDefinition}
+ * and the instance-wide {@see GlobalCustomFieldDefinition} — since both
+ * implement {@see CustomFieldDefinitionInterface} and dispatch through the
+ * same strategy registry.
+ */
 final class ValidCustomFieldDefinitionValidator extends ConstraintValidator
 {
     public function __construct(private readonly CustomFieldTypeRegistry $registry)
@@ -25,8 +34,18 @@ final class ValidCustomFieldDefinitionValidator extends ConstraintValidator
         if (null === $value) {
             return;
         }
-        if (!$value instanceof CustomFieldDefinition) {
-            throw new UnexpectedValueException($value, CustomFieldDefinition::class);
+        if (!$value instanceof CustomFieldDefinitionInterface) {
+            throw new UnexpectedValueException($value, CustomFieldDefinitionInterface::class);
+        }
+
+        // Global fields have no space, so a reference value has nothing to
+        // scope its target IRIs against — disallow the whole `reference`
+        // family for global definitions in v1.
+        if ($value instanceof GlobalCustomFieldDefinition && CustomFieldKind::REFERENCE->value === $value->getKind()) {
+            $this->context->buildViolation($constraint->messageGlobalNoReference)
+                ->atPath('kind')
+                ->addViolation();
+            return;
         }
 
         $key = $value->getTypeKey();

--- a/api/src/Validator/ValidCustomFieldValues.php
+++ b/api/src/Validator/ValidCustomFieldValues.php
@@ -29,6 +29,7 @@ use Symfony\Component\Validator\Constraint;
 final class ValidCustomFieldValues extends Constraint
 {
     public string $messageNoProject = 'Custom fields require the task to belong to a project.';
+    public string $messageDefinitionSource = 'A custom field value must reference exactly one definition (space or global).';
     public string $messageWrongProject = 'Custom field "{{ name }}" does not belong to this task\'s project.';
     public string $messageDuplicate = 'Custom field "{{ name }}" is set more than once.';
     public string $messageRequired = 'Custom field "{{ name }}" is required.';

--- a/api/src/Validator/ValidCustomFieldValuesValidator.php
+++ b/api/src/Validator/ValidCustomFieldValuesValidator.php
@@ -4,6 +4,7 @@ namespace App\Validator;
 
 use App\CustomField\CustomFieldTypeRegistry;
 use App\Entity\CustomFieldDefinition;
+use App\Entity\CustomFieldDefinitionInterface;
 use App\Entity\CustomFieldValue;
 use App\Entity\Project;
 use App\Entity\Task;
@@ -59,29 +60,43 @@ final class ValidCustomFieldValuesValidator extends ConstraintValidator
         $providedDefinitionIds = [];
 
         foreach ($values as $index => $cfv) {
-            $definition = $cfv->getDefinition();
-            if (null === $definition) {
-                // NotNull constraint on the property surfaces the
-                // missing definition separately.
-                continue;
-            }
-            // A value is only legal for a definition the task's project has
-            // opted into (the space-owned field is attached to this project).
-            $attached = false;
-            if (null !== $project) {
-                foreach ($definition->getProjects() as $defProject) {
-                    if ((string) $defProject->getId() === (string) $project->getId()) {
-                        $attached = true;
-                        break;
-                    }
-                }
-            }
-            if (!$attached) {
-                $this->context->buildViolation($constraint->messageWrongProject)
-                    ->setParameter('{{ name }}', $definition->getName())
+            $spaceDefinition = $cfv->getDefinition();
+            $globalDefinition = $cfv->getGlobalDefinition();
+
+            // XOR: a value points at exactly one definition source. Neither
+            // or both is the transient invalid state the DB CHECK also guards.
+            if ((null === $spaceDefinition) === (null === $globalDefinition)) {
+                $this->context->buildViolation($constraint->messageDefinitionSource)
                     ->atPath(sprintf('customFieldValues[%d].definition', $index))
                     ->addViolation();
                 continue;
+            }
+
+            $definition = $spaceDefinition ?? $globalDefinition;
+            if (null === $definition) {
+                continue;
+            }
+
+            // A space-owned value is only legal for a definition the task's
+            // project has opted into. Global fields are instance-wide; their
+            // per-project opt-in check lands with the join table (commit 3).
+            if (null !== $spaceDefinition) {
+                $attached = false;
+                if (null !== $project) {
+                    foreach ($spaceDefinition->getProjects() as $defProject) {
+                        if ((string) $defProject->getId() === (string) $project->getId()) {
+                            $attached = true;
+                            break;
+                        }
+                    }
+                }
+                if (!$attached) {
+                    $this->context->buildViolation($constraint->messageWrongProject)
+                        ->setParameter('{{ name }}', $spaceDefinition->getName())
+                        ->atPath(sprintf('customFieldValues[%d].definition', $index))
+                        ->addViolation();
+                    continue;
+                }
             }
 
             $defId = (string) $definition->getId();
@@ -105,7 +120,7 @@ final class ValidCustomFieldValuesValidator extends ConstraintValidator
 
     private function dispatchToStrategy(
         CustomFieldValue $cfv,
-        CustomFieldDefinition $definition,
+        CustomFieldDefinitionInterface $definition,
         ValidCustomFieldValues $constraint,
         int $index,
     ): void {

--- a/api/src/Validator/ValidCustomFieldValuesValidator.php
+++ b/api/src/Validator/ValidCustomFieldValuesValidator.php
@@ -3,7 +3,6 @@
 namespace App\Validator;
 
 use App\CustomField\CustomFieldTypeRegistry;
-use App\Entity\CustomFieldDefinition;
 use App\Entity\CustomFieldDefinitionInterface;
 use App\Entity\CustomFieldValue;
 use App\Entity\Project;
@@ -77,26 +76,20 @@ final class ValidCustomFieldValuesValidator extends ConstraintValidator
                 continue;
             }
 
-            // A space-owned value is only legal for a definition the task's
-            // project has opted into. Global fields are instance-wide; their
-            // per-project opt-in check lands with the join table (commit 3).
-            if (null !== $spaceDefinition) {
-                $attached = false;
-                if (null !== $project) {
-                    foreach ($spaceDefinition->getProjects() as $defProject) {
-                        if ((string) $defProject->getId() === (string) $project->getId()) {
-                            $attached = true;
-                            break;
-                        }
-                    }
-                }
-                if (!$attached) {
-                    $this->context->buildViolation($constraint->messageWrongProject)
-                        ->setParameter('{{ name }}', $spaceDefinition->getName())
-                        ->atPath(sprintf('customFieldValues[%d].definition', $index))
-                        ->addViolation();
-                    continue;
-                }
+            // A value is only legal for a definition the task's project has
+            // opted into — a space-owned field via the project.customFieldDefinitions
+            // M2M, a global field via project.globalCustomFieldDefinitions.
+            $attached = null !== $project && (
+                null !== $spaceDefinition
+                    ? $this->projectHasDefinition($project->getCustomFieldDefinitions(), $spaceDefinition)
+                    : $this->projectHasDefinition($project->getGlobalCustomFieldDefinitions(), $definition)
+            );
+            if (!$attached) {
+                $this->context->buildViolation($constraint->messageWrongProject)
+                    ->setParameter('{{ name }}', $definition->getName())
+                    ->atPath(sprintf('customFieldValues[%d].definition', $index))
+                    ->addViolation();
+                continue;
             }
 
             $defId = (string) $definition->getId();
@@ -158,6 +151,21 @@ final class ValidCustomFieldValuesValidator extends ConstraintValidator
     }
 
     /**
+     * @param iterable<CustomFieldDefinitionInterface> $collection
+     */
+    private function projectHasDefinition(iterable $collection, CustomFieldDefinitionInterface $definition): bool
+    {
+        $target = (string) $definition->getId();
+        foreach ($collection as $candidate) {
+            if ((string) $candidate->getId() === $target) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * @param array<string, CustomFieldValue> $providedDefinitionIds
      */
     private function enforceRequired(
@@ -165,13 +173,17 @@ final class ValidCustomFieldValuesValidator extends ConstraintValidator
         array $providedDefinitionIds,
         ValidCustomFieldValues $constraint,
     ): void {
-        // Required = the project's opted-in fields that aren't nullable.
-        $definitions = array_filter(
+        // Required = the project's opted-in fields (space + global) that
+        // aren't nullable. Both sources share the value-set keyed by def id.
+        $definitions = array_merge(
             $project->getCustomFieldDefinitions()->toArray(),
-            static fn (CustomFieldDefinition $d): bool => !$d->isNullable(),
+            $project->getGlobalCustomFieldDefinitions()->toArray(),
         );
 
         foreach ($definitions as $definition) {
+            if ($definition->isNullable()) {
+                continue;
+            }
             $defId = (string) $definition->getId();
             $cfv = $providedDefinitionIds[$defId] ?? null;
             if (null === $cfv || $this->isEmpty($cfv->getValue())) {

--- a/api/tests/Api/CustomFieldFooterTest.php
+++ b/api/tests/Api/CustomFieldFooterTest.php
@@ -166,6 +166,41 @@ class CustomFieldFooterTest extends ApiTestCase
         $this->assertEqualsCanonicalizing(7, $first['value']);
     }
 
+    public function testSelectBreakdownCountsPerOption(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $status = $this->seedSelectField($project, 'Status', [
+            ['key' => 'backlog', 'label' => 'Backlog'],
+            ['key' => 'in_progress', 'label' => 'In progress'],
+            ['key' => 'done', 'label' => 'Done'],
+        ], footerKind: 'breakdown');
+
+        $this->seedTaskWithValue($alice, $project, $status, 'backlog');
+        $this->seedTaskWithValue($alice, $project, $status, 'done');
+        $this->seedTaskWithValue($alice, $project, $status, 'done');
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/projects/' . $project->getId() . '/custom_field_footers');
+        $this->assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+        $footers = $body['footers'] ?? null;
+        $this->assertIsArray($footers);
+        $first = $footers[0] ?? null;
+        $this->assertIsArray($first);
+        $this->assertSame('breakdown', $first['kind']);
+        // One row per configured option, in order, zero-filled where unused.
+        $this->assertSame([
+            ['key' => 'backlog', 'label' => 'Backlog', 'count' => 1],
+            ['key' => 'in_progress', 'label' => 'In progress', 'count' => 0],
+            ['key' => 'done', 'label' => 'Done', 'count' => 2],
+        ], $first['value']);
+    }
+
     public function testMoneyFooterEmitsAmountCurrencyShape(): void
     {
         $alice = $this->createUser('alice@example.com');
@@ -256,6 +291,25 @@ class CustomFieldFooterTest extends ApiTestCase
             ->setKind(CustomFieldKind::NUMERIC->value)
             ->setSubtype('money')
             ->setConfig(['currency' => $currency]);
+        if (null !== $footerKind) {
+            $field->setFooter(['kind' => $footerKind]);
+        }
+        $this->entityManager->persist($field);
+        $this->entityManager->flush();
+        return $field;
+    }
+
+    /**
+     * @param list<array{key: string, label: string}> $options
+     */
+    private function seedSelectField(Project $project, string $name, array $options, ?string $footerKind): CustomFieldDefinition
+    {
+        $field = new CustomFieldDefinition();
+        $field->setProject($project)
+            ->setName($name)
+            ->setKind(CustomFieldKind::SELECT->value)
+            ->setSubtype('single')
+            ->setConfig(['multi' => false, 'options' => $options]);
         if (null !== $footerKind) {
             $field->setFooter(['kind' => $footerKind]);
         }

--- a/api/tests/Api/CustomFieldFooterTest.php
+++ b/api/tests/Api/CustomFieldFooterTest.php
@@ -201,6 +201,38 @@ class CustomFieldFooterTest extends ApiTestCase
         ], $first['value']);
     }
 
+    public function testMultiSelectBreakdownUnrollsEachValue(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $labels = $this->seedMultiSelectField($project, 'Labels', [
+            ['key' => 'bug', 'label' => 'Bug'],
+            ['key' => 'chore', 'label' => 'Chore'],
+        ], footerKind: 'breakdown');
+
+        // One task tagged both, one tagged just bug → bug=2, chore=1.
+        $this->seedTaskWithValue($alice, $project, $labels, ['bug', 'chore']);
+        $this->seedTaskWithValue($alice, $project, $labels, ['bug']);
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/projects/' . $project->getId() . '/custom_field_footers');
+        $this->assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = $response->toArray();
+        $footers = $body['footers'] ?? null;
+        $this->assertIsArray($footers);
+        $first = $footers[0] ?? null;
+        $this->assertIsArray($first);
+        $this->assertSame('breakdown', $first['kind']);
+        $this->assertSame([
+            ['key' => 'bug', 'label' => 'Bug', 'count' => 2],
+            ['key' => 'chore', 'label' => 'Chore', 'count' => 1],
+        ], $first['value']);
+    }
+
     public function testMoneyFooterEmitsAmountCurrencyShape(): void
     {
         $alice = $this->createUser('alice@example.com');
@@ -310,6 +342,25 @@ class CustomFieldFooterTest extends ApiTestCase
             ->setKind(CustomFieldKind::SELECT->value)
             ->setSubtype('single')
             ->setConfig(['multi' => false, 'options' => $options]);
+        if (null !== $footerKind) {
+            $field->setFooter(['kind' => $footerKind]);
+        }
+        $this->entityManager->persist($field);
+        $this->entityManager->flush();
+        return $field;
+    }
+
+    /**
+     * @param list<array{key: string, label: string}> $options
+     */
+    private function seedMultiSelectField(Project $project, string $name, array $options, ?string $footerKind): CustomFieldDefinition
+    {
+        $field = new CustomFieldDefinition();
+        $field->setProject($project)
+            ->setName($name)
+            ->setKind(CustomFieldKind::SELECT->value)
+            ->setSubtype('multi')
+            ->setConfig(['multi' => true, 'options' => $options]);
         if (null !== $footerKind) {
             $field->setFooter(['kind' => $footerKind]);
         }

--- a/api/tests/Api/GlobalCustomFieldDefinitionTest.php
+++ b/api/tests/Api/GlobalCustomFieldDefinitionTest.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\GlobalCustomFieldDefinition;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Instance-wide, admin-managed global custom fields (#global-custom-fields).
+ * Writes are ROLE_ADMIN; reads are open to any authenticated user so the
+ * fields render in the per-project picker.
+ */
+class GlobalCustomFieldDefinitionTest extends ApiTestCase
+{
+    use JsonBodyAssertions;
+
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->em = $em;
+
+        $this->em->createQuery('DELETE FROM App\Entity\CustomFieldValue')->execute();
+        $this->em->createQuery('DELETE FROM App\Entity\GlobalCustomFieldDefinition')->execute();
+        $this->em->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testNonAdminCannotCreate(): void
+    {
+        $user = $this->makeUser('plain@example.com');
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        $client->request('POST', '/global_custom_field_definitions', [
+            'json' => ['name' => 'Effort', 'kind' => 'numeric', 'subtype' => 'int', 'config' => []],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testAnyAuthenticatedUserCanList(): void
+    {
+        $this->seedGlobal('Effort', 'numeric', 'int');
+        $user = $this->makeUser('plain@example.com');
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        $client->request('GET', '/global_custom_field_definitions', [
+            'headers' => ['Accept' => 'application/ld+json'],
+        ]);
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testAdminCreatesAndSerializes(): void
+    {
+        $admin = $this->makeUser('admin@example.com', ['ROLE_ADMIN']);
+        $client = static::createClient();
+        $client->loginUser($admin);
+
+        $client->request('POST', '/global_custom_field_definitions', [
+            'json' => [
+                'name' => 'Cost',
+                'kind' => 'numeric',
+                'subtype' => 'money',
+                'config' => ['currency' => 'USD'],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+
+        $body = $this->body($client);
+        $this->assertSame('Cost', $this->stringField($body, 'name'));
+        $this->assertSame('numeric', $this->stringField($body, 'kind'));
+        $this->assertSame('money', $this->stringField($body, 'subtype'));
+    }
+
+    public function testReferenceKindRejected(): void
+    {
+        $admin = $this->makeUser('admin@example.com', ['ROLE_ADMIN']);
+        $client = static::createClient();
+        $client->loginUser($admin);
+
+        $client->request('POST', '/global_custom_field_definitions', [
+            'json' => [
+                'name' => 'Owner',
+                'kind' => 'reference',
+                'subtype' => 'user',
+                'config' => [],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        // Global fields have no space to scope reference targets against.
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testDuplicateNameRejected(): void
+    {
+        $this->seedGlobal('Effort', 'numeric', 'int');
+        $admin = $this->makeUser('admin@example.com', ['ROLE_ADMIN']);
+        $client = static::createClient();
+        $client->loginUser($admin);
+
+        $client->request('POST', '/global_custom_field_definitions', [
+            'json' => ['name' => 'Effort', 'kind' => 'numeric', 'subtype' => 'int', 'config' => []],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testAdminCanPatchAndNonAdminCannot(): void
+    {
+        $field = $this->seedGlobal('Effort', 'numeric', 'int');
+        $iri = '/global_custom_field_definitions/' . $field->getId();
+
+        $client = static::createClient();
+        $client->loginUser($this->makeUser('plain@example.com'));
+        $client->request('PATCH', $iri, [
+            'json' => ['name' => 'Renamed'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(403);
+
+        $client->loginUser($this->makeUser('admin@example.com', ['ROLE_ADMIN']));
+        $client->request('PATCH', $iri, [
+            'json' => ['name' => 'Renamed'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testAdminCanDelete(): void
+    {
+        $field = $this->seedGlobal('Effort', 'numeric', 'int');
+        $client = static::createClient();
+        $client->loginUser($this->makeUser('admin@example.com', ['ROLE_ADMIN']));
+        $client->request('DELETE', '/global_custom_field_definitions/' . $field->getId());
+        $this->assertResponseStatusCodeSame(204);
+    }
+
+    /**
+     * @return array<int|string, mixed>
+     */
+    private function body(\ApiPlatform\Symfony\Bundle\Test\Client $client): array
+    {
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        return $response->toArray(false);
+    }
+
+    private function seedGlobal(string $name, string $kind, string $subtype): GlobalCustomFieldDefinition
+    {
+        $field = new GlobalCustomFieldDefinition();
+        $field->setName($name);
+        $field->setKind($kind);
+        $field->setSubtype($subtype);
+        $this->em->persist($field);
+        $this->em->flush();
+        return $field;
+    }
+
+    /**
+     * @param string[] $roles
+     */
+    private function makeUser(string $email, array $roles = ['ROLE_USER']): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles($roles);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $this->em->persist($user);
+        $this->em->flush();
+        return $user;
+    }
+}

--- a/api/tests/Api/GlobalCustomFieldDefinitionTest.php
+++ b/api/tests/Api/GlobalCustomFieldDefinitionTest.php
@@ -99,6 +99,43 @@ class GlobalCustomFieldDefinitionTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(422);
     }
 
+    public function testSelectAcceptsBreakdownFooterButNumericRejectsIt(): void
+    {
+        $admin = $this->makeUser('admin@example.com', ['ROLE_ADMIN']);
+        $client = static::createClient();
+        $client->loginUser($admin);
+
+        // A select field may declare the per-option `breakdown` footer.
+        $client->request('POST', '/global_custom_field_definitions', [
+            'json' => [
+                'name' => 'Status',
+                'kind' => 'select',
+                'subtype' => 'single',
+                'config' => ['multi' => false, 'options' => [
+                    ['key' => 'backlog', 'label' => 'Backlog'],
+                    ['key' => 'done', 'label' => 'Done'],
+                ]],
+                'footer' => ['kind' => 'breakdown'],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+
+        // Breakdown is meaningless on a numeric field — the strategy doesn't
+        // advertise it, so the footer validator rejects it.
+        $client->request('POST', '/global_custom_field_definitions', [
+            'json' => [
+                'name' => 'Effort',
+                'kind' => 'numeric',
+                'subtype' => 'int',
+                'config' => [],
+                'footer' => ['kind' => 'breakdown'],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+    }
+
     public function testDuplicateNameRejected(): void
     {
         $this->seedGlobal('Effort', 'numeric', 'int');

--- a/api/tests/Api/GlobalCustomFieldValueTest.php
+++ b/api/tests/Api/GlobalCustomFieldValueTest.php
@@ -205,6 +205,113 @@ class GlobalCustomFieldValueTest extends ApiTestCase
         $this->assertSame(8, $row['value'] ?? null);
     }
 
+    public function testGlobalFieldAppearsInProjectStats(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $effort = $this->seedGlobal('Effort', 'numeric', 'int');
+        $this->attachGlobal($project, $effort);
+        $task = $this->createTask($alice, $project, 'A');
+        $this->seedGlobalValue($task, $effort, 4);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/projects/' . $project->getId() . '/custom_field_stats');
+        $this->assertResponseIsSuccessful();
+
+        $body = $this->body($client);
+        $stats = $this->arrayField($body, 'stats');
+        $iri = '/global_custom_field_definitions/' . $effort->getId();
+        $filled = null;
+        foreach ($stats as $stat) {
+            if (is_array($stat) && ($stat['definition'] ?? null) === $iri) {
+                $filled = $stat['filled'] ?? null;
+            }
+        }
+        $this->assertSame(1, $filled);
+    }
+
+    public function testGlobalOptionStatsForAdmin(): void
+    {
+        $admin = $this->createUser('admin@example.com', ['ROLE_ADMIN']);
+        $project = $this->createProject($admin, 'Backend');
+        $status = $this->seedGlobal('Status', 'select', 'single');
+        $status->setConfig(['multi' => false, 'options' => [
+            ['key' => 'a', 'label' => 'Alpha'],
+            ['key' => 'b', 'label' => 'Beta'],
+        ]]);
+        $this->entityManager->flush();
+        $this->attachGlobal($project, $status);
+        $task = $this->createTask($admin, $project, 'T');
+        $this->seedGlobalValue($task, $status, 'a');
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $client->request('GET', '/global_custom_field_definitions/' . $status->getId() . '/option_stats');
+        $this->assertResponseIsSuccessful();
+
+        $body = $this->body($client);
+        $options = $this->arrayField($body, 'options');
+        $counts = [];
+        foreach ($options as $option) {
+            if (is_array($option) && is_string($option['key'] ?? null)) {
+                $counts[$option['key']] = $option['count'] ?? null;
+            }
+        }
+        $this->assertSame(1, $counts['a'] ?? null);
+        $this->assertSame(0, $counts['b'] ?? null);
+    }
+
+    public function testGlobalOptionStatsForbiddenForNonAdmin(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $status = $this->seedGlobal('Status', 'select', 'single');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/global_custom_field_definitions/' . $status->getId() . '/option_stats');
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testPerProjectVisibilityOverrideForGlobalField(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $effort = $this->seedGlobal('Effort', 'numeric', 'int');
+        $this->attachGlobal($project, $effort);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request(
+            'PUT',
+            '/projects/' . $project->getId() . '/global_custom_field_definitions/' . $effort->getId() . '/visibility',
+            [
+                'json' => ['visibility' => 'board'],
+                'headers' => ['Content-Type' => 'application/json'],
+            ],
+        );
+        $this->assertResponseIsSuccessful();
+
+        // A project-scoped read injects the per-project visibility override.
+        $client->request(
+            'GET',
+            '/global_custom_field_definitions?projects=' . urlencode('/projects/' . $project->getId()),
+            ['headers' => ['Accept' => 'application/ld+json']],
+        );
+        $this->assertResponseIsSuccessful();
+
+        $body = $this->body($client);
+        $members = $body['member'] ?? $body['hydra:member'] ?? null;
+        $this->assertIsArray($members);
+        $visibility = null;
+        foreach ($members as $member) {
+            if (is_array($member) && ($member['id'] ?? null) === (string) $effort->getId()) {
+                $visibility = $member['visibility'] ?? null;
+            }
+        }
+        $this->assertSame('board', $visibility);
+    }
+
     private function attachGlobal(Project $project, GlobalCustomFieldDefinition $global): void
     {
         $project->addGlobalCustomFieldDefinition($global);

--- a/api/tests/Api/GlobalCustomFieldValueTest.php
+++ b/api/tests/Api/GlobalCustomFieldValueTest.php
@@ -1,0 +1,296 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\CustomFieldDefinition;
+use App\Entity\CustomFieldValue;
+use App\Entity\GlobalCustomFieldDefinition;
+use App\Entity\Project;
+use App\Entity\Task;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Task values pointing at an instance-wide global custom field
+ * (#global-custom-fields) — the polymorphic `CustomFieldValue.globalDefinition`
+ * arm and its per-project opt-in enforcement.
+ */
+class GlobalCustomFieldValueTest extends ApiTestCase
+{
+    use SpaceMembershipFixture;
+    use JsonBodyAssertions;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\CustomFieldValue')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\ProjectFieldVisibility')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\CustomFieldDefinition')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Notification')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Comment')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\GlobalCustomFieldDefinition')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testSetGlobalValueOnAttachedProject(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $effort = $this->seedGlobal('Effort', 'numeric', 'int');
+        $this->attachGlobal($project, $effort);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks', [
+            'json' => [
+                'title' => 'Estimate',
+                'project' => '/projects/' . $project->getId(),
+                'customFieldValues' => [
+                    ['globalDefinition' => '/global_custom_field_definitions/' . $effort->getId(), 'value' => 5],
+                ],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+
+        $body = $this->body($client);
+        $cfvs = $this->arrayField($body, 'customFieldValues');
+        $this->assertCount(1, $cfvs);
+        $first = $cfvs[0];
+        $this->assertIsArray($first);
+        $this->assertSame(
+            '/global_custom_field_definitions/' . $effort->getId(),
+            $first['globalDefinition'] ?? null,
+        );
+        $this->assertNull($first['definition'] ?? null);
+        $this->assertSame(5, $first['value'] ?? null);
+    }
+
+    public function testGlobalValueRejectedWhenNotAttached(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        // Global exists but the project has NOT opted into it.
+        $effort = $this->seedGlobal('Effort', 'numeric', 'int');
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks', [
+            'json' => [
+                'title' => 'Estimate',
+                'project' => '/projects/' . $project->getId(),
+                'customFieldValues' => [
+                    ['globalDefinition' => '/global_custom_field_definitions/' . $effort->getId(), 'value' => 5],
+                ],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testBothSourcesOnOneValueRejected(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $spaceField = $this->seedSpaceField($project, 'Severity');
+        $effort = $this->seedGlobal('Effort', 'numeric', 'int');
+        $this->attachGlobal($project, $effort);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks', [
+            'json' => [
+                'title' => 'Confused',
+                'project' => '/projects/' . $project->getId(),
+                'customFieldValues' => [
+                    [
+                        'definition' => '/custom_field_definitions/' . $spaceField->getId(),
+                        'globalDefinition' => '/global_custom_field_definitions/' . $effort->getId(),
+                        'value' => 'x',
+                    ],
+                ],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testRequiredGlobalEnforcedOnCreate(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $effort = $this->seedGlobal('Effort', 'numeric', 'int');
+        $effort->setNullable(false);
+        $this->entityManager->flush();
+        $this->attachGlobal($project, $effort);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('POST', '/tasks', [
+            'json' => [
+                'title' => 'No effort',
+                'project' => '/projects/' . $project->getId(),
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testPatchReplacesGlobalValue(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $effort = $this->seedGlobal('Effort', 'numeric', 'int');
+        $this->attachGlobal($project, $effort);
+        $task = $this->createTask($alice, $project, 'Estimate');
+        $this->seedGlobalValue($task, $effort, 3);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('PATCH', '/tasks/' . $task->getId(), [
+            'json' => [
+                'customFieldValues' => [
+                    ['globalDefinition' => '/global_custom_field_definitions/' . $effort->getId(), 'value' => 8],
+                ],
+            ],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $this->entityManager->clear();
+        $reloaded = $this->entityManager->getRepository(Task::class)->find($task->getId());
+        $this->assertNotNull($reloaded);
+        $values = $reloaded->getCustomFieldValues()->toArray();
+        $this->assertCount(1, $values);
+        $this->assertSame(8, $values[0]->getValue());
+        $this->assertSame((string) $effort->getId(), (string) $values[0]->getGlobalDefinition()?->getId());
+    }
+
+    public function testFooterAggregatesGlobalField(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $effort = $this->seedGlobal('Effort', 'numeric', 'int');
+        $effort->setFooter(['kind' => 'sum']);
+        $this->entityManager->flush();
+        $this->attachGlobal($project, $effort);
+
+        $t1 = $this->createTask($alice, $project, 'A');
+        $t2 = $this->createTask($alice, $project, 'B');
+        $this->seedGlobalValue($t1, $effort, 3);
+        $this->seedGlobalValue($t2, $effort, 5);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $client->request('GET', '/projects/' . $project->getId() . '/custom_field_footers');
+        $this->assertResponseIsSuccessful();
+
+        $body = $this->body($client);
+        $footers = $this->arrayField($body, 'footers');
+        $this->assertCount(1, $footers);
+        $row = $footers[0];
+        $this->assertIsArray($row);
+        $this->assertSame('/global_custom_field_definitions/' . $effort->getId(), $row['definition'] ?? null);
+        $this->assertSame('sum', $row['kind'] ?? null);
+        $this->assertSame(8, $row['value'] ?? null);
+    }
+
+    private function attachGlobal(Project $project, GlobalCustomFieldDefinition $global): void
+    {
+        $project->addGlobalCustomFieldDefinition($global);
+        $this->entityManager->flush();
+    }
+
+    private function seedGlobal(string $name, string $kind, string $subtype): GlobalCustomFieldDefinition
+    {
+        $field = new GlobalCustomFieldDefinition();
+        $field->setName($name);
+        $field->setKind($kind);
+        $field->setSubtype($subtype);
+        $this->entityManager->persist($field);
+        $this->entityManager->flush();
+        return $field;
+    }
+
+    private function seedSpaceField(Project $project, string $name): CustomFieldDefinition
+    {
+        $field = new CustomFieldDefinition();
+        $field->setProject($project);
+        $field->setName($name);
+        $field->setType(CustomFieldDefinition::TYPE_TEXT);
+        $this->entityManager->persist($field);
+        $this->entityManager->flush();
+        return $field;
+    }
+
+    private function seedGlobalValue(Task $task, GlobalCustomFieldDefinition $definition, mixed $value): CustomFieldValue
+    {
+        $cfv = new CustomFieldValue();
+        $cfv->setTask($task);
+        $cfv->setGlobalDefinition($definition);
+        $cfv->setValue($value);
+        $this->entityManager->persist($cfv);
+        $this->entityManager->flush();
+        return $cfv;
+    }
+
+    private function createProject(User $owner, string $title): Project
+    {
+        $project = new Project();
+        $project->setOwner($owner);
+        $project->setTitle($title);
+        $this->addProjectMember($project, $owner);
+        $this->entityManager->persist($project);
+        $this->entityManager->flush();
+        return $project;
+    }
+
+    private function createTask(User $owner, Project $project, string $title): Task
+    {
+        $task = new Task();
+        $task->setOwner($owner);
+        $task->setProject($project);
+        $task->setTitle($title);
+        $this->entityManager->persist($task);
+        $this->entityManager->flush();
+        return $task;
+    }
+
+    /**
+     * @param string[] $roles
+     */
+    private function createUser(string $email, array $roles = ['ROLE_USER']): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles($roles);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+        return $user;
+    }
+
+    /**
+     * @return array<int|string, mixed>
+     */
+    private function body(\ApiPlatform\Symfony\Bundle\Test\Client $client): array
+    {
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        return $response->toArray(false);
+    }
+}

--- a/api/tests/CustomField/FooterAggregatorTest.php
+++ b/api/tests/CustomField/FooterAggregatorTest.php
@@ -10,6 +10,7 @@ use App\CustomField\Type\Date\DateStrategy;
 use App\CustomField\Type\Numeric\FloatStrategy;
 use App\CustomField\Type\Numeric\IntStrategy;
 use App\CustomField\Type\Numeric\MoneyStrategy;
+use App\CustomField\Type\Select\SingleSelectStrategy;
 use App\Entity\CustomFieldDefinition;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
@@ -38,6 +39,7 @@ final class FooterAggregatorTest extends TestCase
             new FloatStrategy(),
             new MoneyStrategy(),
             new DateStrategy(),
+            new SingleSelectStrategy(),
         ]);
     }
 
@@ -149,6 +151,34 @@ final class FooterAggregatorTest extends TestCase
         foreach ($rows as $row) {
             $this->assertNull($row['value']);
         }
+    }
+
+    public function testSelectBreakdownEmptyTaskSetReturnsZeroFilledOptions(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        // Breakdown short-circuits to zero counts without querying when the
+        // task scope is empty.
+        $connection->expects($this->never())->method('executeQuery');
+
+        $def = $this->definition('select', 'single', ['kind' => FooterKind::BREAKDOWN->value]);
+        $def->setConfig([
+            'options' => [
+                ['key' => 'backlog', 'label' => 'Backlog'],
+                ['key' => 'done', 'label' => 'Done'],
+            ],
+        ]);
+
+        $rows = $this->aggregator($connection)->aggregate([$def], []);
+
+        $this->assertCount(1, $rows);
+        $this->assertSame(FooterKind::BREAKDOWN->value, $rows[0]['kind']);
+        $this->assertSame(
+            [
+                ['key' => 'backlog', 'label' => 'Backlog', 'count' => 0],
+                ['key' => 'done', 'label' => 'Done', 'count' => 0],
+            ],
+            $rows[0]['value'],
+        );
     }
 
     public function testMissingLabelIsNull(): void

--- a/pwa/components/common/SidebarNav.tsx
+++ b/pwa/components/common/SidebarNav.tsx
@@ -290,6 +290,11 @@ const AdminSection = ({ wrap }: { wrap: (children: ReactNode) => ReactNode }) =>
     { href: "/admin/users", label: "Users", match: "/admin/users" },
     { href: "/admin/waitlist", label: "Waitlist", match: "/admin/waitlist" },
     { href: "/admin/segments", label: "Segments", match: "/admin/segments" },
+    {
+      href: "/admin/global-custom-fields",
+      label: "Global custom fields",
+      match: "/admin/global-custom-fields",
+    },
     { href: "/feedback", label: "Feedback", match: "/feedback" },
     ...ADMIN_EXTERNAL_LINKS.map((l) => ({ ...l, match: l.href, external: true })),
   ];

--- a/pwa/components/custom-fields/CustomFieldFooterRow.tsx
+++ b/pwa/components/custom-fields/CustomFieldFooterRow.tsx
@@ -4,7 +4,11 @@ import { Card, CardContent } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import TaskTableColumns from "@/components/projects/TaskTableColumns";
 import type { ListColumn } from "@/components/projects/listColumns";
-import type { FooterResponse, FooterRow } from "./types";
+import type {
+  FooterBreakdownEntry,
+  FooterResponse,
+  FooterRow,
+} from "./types";
 
 /**
  * Renders the aggregated footer row for a project's task list. Fetches
@@ -86,6 +90,43 @@ const formatNumber = (v: number): string => {
     : v.toLocaleString(undefined, { maximumFractionDigits: 2 });
 };
 
+const isBreakdown = (v: unknown): v is FooterBreakdownEntry[] =>
+  Array.isArray(v) &&
+  v.every(
+    (e) =>
+      e !== null &&
+      typeof e === "object" &&
+      "count" in e &&
+      "label" in e,
+  );
+
+/**
+ * Renders a footer value. Scalar aggregations (sum/avg/min/max/count, money)
+ * go through {@link formatValue}; a select `breakdown` renders as a small
+ * stacked per-option "label count" list.
+ */
+const FooterValue = ({ row }: { row: FooterRow }) => {
+  if (row.kind === "breakdown" && isBreakdown(row.value)) {
+    if (row.value.length === 0) return <>—</>;
+    return (
+      <span className="flex flex-col gap-0.5">
+        {row.value.map((entry) => (
+          <span
+            key={entry.key}
+            className="flex items-baseline justify-between gap-3 whitespace-nowrap"
+          >
+            <span className="font-normal text-muted-foreground">
+              {entry.label}
+            </span>
+            <span className="tabular-nums">{entry.count}</span>
+          </span>
+        ))}
+      </span>
+    );
+  }
+  return <>{formatValue(row)}</>;
+};
+
 const CustomFieldFooterRow = ({
   projectId,
   filters,
@@ -161,8 +202,8 @@ const CustomFieldFooterRow = ({
                   <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
                     {row.label ?? row.kind}
                   </span>
-                  <span className="truncate tabular-nums font-semibold">
-                    {formatValue(row)}
+                  <span className="tabular-nums font-semibold">
+                    <FooterValue row={row} />
                   </span>
                 </div>
               )}
@@ -253,7 +294,9 @@ const CustomFieldFooterRow = ({
             <span className="text-muted-foreground">
               {row.label ?? `${row.name} (${row.kind})`}
             </span>
-            <span className="font-medium tabular-nums">{formatValue(row)}</span>
+            <span className="font-medium tabular-nums">
+              <FooterValue row={row} />
+            </span>
           </div>
         ))}
       </CardContent>

--- a/pwa/components/custom-fields/CustomFieldSheet.tsx
+++ b/pwa/components/custom-fields/CustomFieldSheet.tsx
@@ -59,8 +59,13 @@ import type {
 interface Props {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  /** Space that owns the field (#custom-fields-space) — set on create. */
-  spaceIri: string;
+  /** Space that owns the field (#custom-fields-space) — set on create. Omitted
+   *  for the instance-wide global manager (#global-custom-fields). */
+  spaceIri?: string;
+  /** Collection endpoint for create (POST). Defaults to the space
+   *  `/custom_field_definitions`; the global admin manager passes
+   *  `/global_custom_field_definitions`. */
+  collectionPath?: string;
   /** Optional project context, used to scope reference-field option lists. */
   projectIri?: string;
   spaceName?: string;
@@ -139,6 +144,7 @@ const CustomFieldSheet = ({
   open,
   onOpenChange,
   spaceIri,
+  collectionPath = "/custom_field_definitions",
   projectIri,
   spaceName,
   initial,
@@ -314,11 +320,15 @@ const CustomFieldSheet = ({
         body: JSON.stringify(body),
       });
     }
-    return fetch(`${ENTRYPOINT}/custom_field_definitions`, {
+    return fetch(`${ENTRYPOINT}${collectionPath}`, {
       method: "POST",
       credentials: "include",
       headers: { "Content-Type": "application/ld+json" },
-      body: JSON.stringify({ ...body, space: spaceIri, position: initialPosition }),
+      body: JSON.stringify({
+        ...body,
+        ...(spaceIri ? { space: spaceIri } : {}),
+        position: initialPosition,
+      }),
     });
   };
 

--- a/pwa/components/custom-fields/CustomFieldSheet.tsx
+++ b/pwa/components/custom-fields/CustomFieldSheet.tsx
@@ -91,6 +91,7 @@ const FOOTER_LABELS: Record<FooterKind, string> = {
   avg: "Avg",
   min: "Min",
   max: "Max",
+  breakdown: "Breakdown",
 };
 
 

--- a/pwa/components/custom-fields/CustomFieldsManager.tsx
+++ b/pwa/components/custom-fields/CustomFieldsManager.tsx
@@ -47,8 +47,9 @@ interface Collection<T> {
 }
 
 interface Props {
-  /** Space that owns the fields (#custom-fields-space). Drives load + create. */
-  spaceIri: string;
+  /** Space that owns the fields (#custom-fields-space). Drives load + create.
+   *  Omitted for the instance-wide global manager (#global-custom-fields). */
+  spaceIri?: string;
   /** Header `slug · N fields` badge label (space or project title). */
   projectTitle: string;
   /** When mounted in a project's Settings tab, enables drag-reorder (via the
@@ -57,6 +58,10 @@ interface Props {
   /** Active space name, surfaced in the admin notice + reference scope note. */
   spaceName?: string;
   isSpaceAdmin: boolean;
+  /** Collection endpoint for the definitions — the space `/custom_field_definitions`
+   *  by default, or `/global_custom_field_definitions` for the admin global
+   *  manager. `def["@id"]` already carries the right base for item routes. */
+  collectionPath?: string;
   /** Fired after any definition mutation (create/edit/delete/reorder) so a
    *  host that also renders the definitions (e.g. task columns) can re-sync. */
   onDefinitionsChanged?: () => void;
@@ -87,6 +92,7 @@ const CustomFieldsManager = ({
   projectIri,
   spaceName,
   isSpaceAdmin,
+  collectionPath = "/custom_field_definitions",
   onDefinitionsChanged,
 }: Props) => {
   const projectId = projectIri ? projectIdFromIri(projectIri) : null;
@@ -113,7 +119,10 @@ const CustomFieldsManager = ({
     setIsLoading(true);
     setLoadError(null);
     try {
-      const url = `${ENTRYPOINT}/custom_field_definitions?space=${encodeURIComponent(spaceIri)}`;
+      const query = spaceIri
+        ? `?space=${encodeURIComponent(spaceIri)}`
+        : "";
+      const url = `${ENTRYPOINT}${collectionPath}${query}`;
       const res = await fetch(url, {
         credentials: "include",
         headers: { Accept: "application/ld+json" },
@@ -128,7 +137,7 @@ const CustomFieldsManager = ({
     } finally {
       setIsLoading(false);
     }
-  }, [spaceIri]);
+  }, [spaceIri, collectionPath]);
 
   const loadStats = useCallback(async () => {
     if (null === projectId) return;
@@ -202,7 +211,7 @@ const CustomFieldsManager = ({
     async (def: CustomFieldDefinition) => {
       setLoadError(null);
       try {
-        const res = await fetch(`${ENTRYPOINT}/custom_field_definitions`, {
+        const res = await fetch(`${ENTRYPOINT}${collectionPath}`, {
           method: "POST",
           credentials: "include",
           headers: { "Content-Type": "application/ld+json" },
@@ -214,7 +223,7 @@ const CustomFieldsManager = ({
             nullable: def.nullable,
             footer: def.footer,
             visibility: def.visibility,
-            space: spaceIri,
+            ...(spaceIri ? { space: spaceIri } : {}),
             position: nextPosition,
           }),
         });
@@ -227,7 +236,7 @@ const CustomFieldsManager = ({
         );
       }
     },
-    [spaceIri, nextPosition],
+    [spaceIri, nextPosition, collectionPath],
   );
 
   const persistOrder = useCallback(
@@ -386,6 +395,7 @@ const CustomFieldsManager = ({
         open={sheetOpen}
         onOpenChange={setSheetOpen}
         spaceIri={spaceIri}
+        collectionPath={collectionPath}
         projectIri={projectIri}
         spaceName={spaceName}
         initial={editing ?? undefined}

--- a/pwa/components/custom-fields/ProjectCustomFieldPicker.tsx
+++ b/pwa/components/custom-fields/ProjectCustomFieldPicker.tsx
@@ -4,7 +4,11 @@ import { Settings2 } from "lucide-react";
 import { ENTRYPOINT } from "@/config/entrypoint";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
-import { visibilitySurfaces, type CustomFieldDefinition } from "./types";
+import {
+  isGlobalDefinition,
+  visibilitySurfaces,
+  type CustomFieldDefinition,
+} from "./types";
 
 interface Collection<T> {
   member?: T[];
@@ -12,17 +16,19 @@ interface Collection<T> {
 }
 
 interface Props {
-  /** Space that owns the fields (#custom-fields-space). */
+  /** Space that owns the space fields (#custom-fields-space). */
   spaceIri: string;
   /** This project's IRI (`/projects/{id}`) — the PATCH target. */
   projectIri: string;
-  /** IRIs of the fields currently shown on this project. */
+  /** IRIs of the SPACE fields currently shown on this project. */
   attachedIris: string[];
-  /** Per-project visibility ('list'|'board'|'both') for attached fields, keyed by definition IRI. */
+  /** IRIs of the GLOBAL fields currently shown on this project. */
+  attachedGlobalIris: string[];
+  /** Per-project visibility for attached fields, keyed by definition IRI. */
   projectVisibility: Record<string, string>;
-  /** Space admins can edit definitions inline (creation lives in space settings). */
+  /** Space admins can edit space definitions inline (creation lives in space settings). */
   isSpaceAdmin: boolean;
-  /** Open the field editor for an existing definition. */
+  /** Open the field editor for an existing SPACE definition. */
   onEdit: (def: CustomFieldDefinition) => void;
   /** Re-sync after attach/detach so the task columns update. */
   onChanged: () => void;
@@ -37,22 +43,35 @@ const KIND_LABEL: Record<string, string> = {
   reference: "Reference",
 };
 
+/** Endpoint segment for a field source's per-project routes. */
+const routeBaseFor = (global: boolean): string =>
+  global ? "global_custom_field_definitions" : "custom_field_definitions";
+
+/** The project M2M key for a field source. */
+const attachKeyFor = (global: boolean): string =>
+  global ? "globalCustomFieldDefinitions" : "customFieldDefinitions";
+
 /**
- * Per-project field selector (#custom-fields-space): fields are defined at the
- * space level; each project ticks the ones it shows on its tasks. Toggling
- * PATCHes the project's `customFieldDefinitions` M2M. Defining / editing the
- * fields themselves lives in the space-level manager (/custom-fields).
+ * Per-project field selector: fields are defined at the space level
+ * (#custom-fields-space) or instance-wide by admins (#global-custom-fields);
+ * each project ticks the ones it shows on its tasks. Toggling PATCHes the
+ * project's matching M2M (`customFieldDefinitions` / `globalCustomFieldDefinitions`)
+ * — a project's effective field set is the union. Space fields can be edited
+ * inline by space admins; global fields are managed by platform admins on the
+ * admin page, so they're shown read-only here.
  */
 const ProjectCustomFieldPicker = ({
   spaceIri,
   projectIri,
   attachedIris,
+  attachedGlobalIris,
   projectVisibility,
   isSpaceAdmin,
   onEdit,
   onChanged,
 }: Props) => {
   const [spaceFields, setSpaceFields] = useState<CustomFieldDefinition[]>([]);
+  const [globalFields, setGlobalFields] = useState<CustomFieldDefinition[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
@@ -60,17 +79,30 @@ const ProjectCustomFieldPicker = ({
   const load = useCallback(async () => {
     setIsLoading(true);
     setError(null);
+    const sortFields = (list: CustomFieldDefinition[]): CustomFieldDefinition[] =>
+      [...list].sort(
+        (a, b) => a.position - b.position || a.name.localeCompare(b.name),
+      );
     try {
-      const res = await fetch(
-        `${ENTRYPOINT}/custom_field_definitions?space=${encodeURIComponent(spaceIri)}`,
-        { credentials: "include", headers: { Accept: "application/ld+json" } },
-      );
-      if (!res.ok) throw new Error("Failed to load fields.");
-      const data: Collection<CustomFieldDefinition> = await res.json();
-      const list = data.member ?? data["hydra:member"] ?? [];
-      setSpaceFields(
-        [...list].sort((a, b) => a.position - b.position || a.name.localeCompare(b.name)),
-      );
+      const [spaceRes, globalRes] = await Promise.all([
+        fetch(
+          `${ENTRYPOINT}/custom_field_definitions?space=${encodeURIComponent(spaceIri)}`,
+          { credentials: "include", headers: { Accept: "application/ld+json" } },
+        ),
+        fetch(`${ENTRYPOINT}/global_custom_field_definitions`, {
+          credentials: "include",
+          headers: { Accept: "application/ld+json" },
+        }),
+      ]);
+      if (!spaceRes.ok) throw new Error("Failed to load fields.");
+      const spaceData: Collection<CustomFieldDefinition> = await spaceRes.json();
+      setSpaceFields(sortFields(spaceData.member ?? spaceData["hydra:member"] ?? []));
+      if (globalRes.ok) {
+        const globalData: Collection<CustomFieldDefinition> = await globalRes.json();
+        setGlobalFields(
+          sortFields(globalData.member ?? globalData["hydra:member"] ?? []),
+        );
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load fields.");
     } finally {
@@ -82,12 +114,12 @@ const ProjectCustomFieldPicker = ({
     void load();
   }, [load]);
 
-  const patchAttached = async (iris: string[]): Promise<void> => {
+  const patchAttached = async (global: boolean, iris: string[]): Promise<void> => {
     const res = await fetch(`${ENTRYPOINT}${projectIri}`, {
       method: "PATCH",
       credentials: "include",
       headers: { "Content-Type": "application/merge-patch+json" },
-      body: JSON.stringify({ customFieldDefinitions: iris }),
+      body: JSON.stringify({ [attachKeyFor(global)]: iris }),
     });
     if (!res.ok) throw new Error("Failed to update fields.");
   };
@@ -97,18 +129,20 @@ const ProjectCustomFieldPicker = ({
   // it; turning one on (re)attaches and sets the per-project surface set.
   const updateField = async (
     iri: string,
+    global: boolean,
     nextList: boolean,
     nextBoard: boolean,
     nextCalendar: boolean,
   ) => {
-    const wasAttached = attachedIris.includes(iri);
+    const attached = global ? attachedGlobalIris : attachedIris;
+    const wasAttached = attached.includes(iri);
     const projectId = projectIri.split("/").pop();
     const defId = iri.split("/").pop();
     setBusy(iri);
     try {
       if (!nextList && !nextBoard && !nextCalendar) {
         if (wasAttached) {
-          await patchAttached(attachedIris.filter((i) => i !== iri));
+          await patchAttached(global, attached.filter((i) => i !== iri));
         }
       } else {
         const surfaces = [
@@ -117,10 +151,10 @@ const ProjectCustomFieldPicker = ({
           nextCalendar ? "calendar" : null,
         ].filter(Boolean);
         if (!wasAttached) {
-          await patchAttached([...attachedIris, iri]);
+          await patchAttached(global, [...attached, iri]);
         }
         const res = await fetch(
-          `${ENTRYPOINT}/projects/${encodeURIComponent(projectId ?? "")}/custom_field_definitions/${encodeURIComponent(defId ?? "")}/visibility`,
+          `${ENTRYPOINT}/projects/${encodeURIComponent(projectId ?? "")}/${routeBaseFor(global)}/${encodeURIComponent(defId ?? "")}/visibility`,
           {
             method: "PUT",
             credentials: "include",
@@ -138,19 +172,86 @@ const ProjectCustomFieldPicker = ({
     }
   };
 
+  const renderRow = (def: CustomFieldDefinition) => {
+    const global = isGlobalDefinition(def);
+    const attached = global ? attachedGlobalIris : attachedIris;
+    const checked = attached.includes(def["@id"]);
+    const surfaces = checked
+      ? visibilitySurfaces(projectVisibility[def["@id"]] ?? "both")
+      : [];
+    const showList = surfaces.includes("list");
+    const showBoard = surfaces.includes("board");
+    const showCalendar = surfaces.includes("calendar");
+    const isBusy = busy === def["@id"];
+    return (
+      <li key={def["@id"]} className="flex items-center gap-3 px-3 py-2 text-sm">
+        <span className={cn("min-w-0 flex-1 truncate", !checked && "text-muted-foreground")}>
+          {def.name}
+        </span>
+        <span className="shrink-0 text-xs text-muted-foreground">
+          {KIND_LABEL[def.kind] ?? def.kind}
+        </span>
+        <label className="flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground">
+          <Switch
+            checked={showList}
+            disabled={isBusy}
+            onCheckedChange={(v) =>
+              void updateField(def["@id"], global, v, showBoard, showCalendar)
+            }
+            aria-label={`Show ${def.name} on the task list`}
+          />
+          List
+        </label>
+        <label className="flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground">
+          <Switch
+            checked={showBoard}
+            disabled={isBusy}
+            onCheckedChange={(v) =>
+              void updateField(def["@id"], global, showList, v, showCalendar)
+            }
+            aria-label={`Show ${def.name} on the board`}
+          />
+          Board
+        </label>
+        <label className="flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground">
+          <Switch
+            checked={showCalendar}
+            disabled={isBusy}
+            onCheckedChange={(v) =>
+              void updateField(def["@id"], global, showList, showBoard, v)
+            }
+            aria-label={`Show ${def.name} on the calendar`}
+          />
+          Calendar
+        </label>
+        {isSpaceAdmin && !global ? (
+          <button
+            type="button"
+            onClick={() => onEdit(def)}
+            aria-label={`Edit ${def.name}`}
+            className="shrink-0 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            <Settings2 className="h-3.5 w-3.5" />
+          </button>
+        ) : (
+          <span className="w-[1.625rem] shrink-0" />
+        )}
+      </li>
+    );
+  };
+
   return (
     <div className="space-y-4" data-testid="project-custom-field-picker">
       <div className="space-y-1">
         <h3 className="text-sm font-medium">Custom fields</h3>
         <p className="text-xs text-muted-foreground">
-          Toggle where each of the space&apos;s fields shows on this
-          project — the task list, the board, and/or the calendar (all off =
-          not on this project). Custom fields are defined and ordered at the
-          space level in{" "}
+          Toggle where each field shows on this project — the task list, the
+          board, and/or the calendar (all off = not on this project). Space
+          fields are defined in{" "}
           <Link href="/custom-fields" className="text-cyan-700 hover:underline dark:text-cyan-400">
             space settings
           </Link>
-          .
+          ; global fields are managed by admins.
         </p>
       </div>
 
@@ -158,83 +259,38 @@ const ProjectCustomFieldPicker = ({
 
       {isLoading ? (
         <p className="text-sm text-muted-foreground">Loading fields…</p>
-      ) : spaceFields.length === 0 ? (
-        <p className="text-sm text-muted-foreground">
-          This space has no custom fields yet. Define them in{" "}
-          <Link href="/custom-fields" className="text-cyan-700 hover:underline dark:text-cyan-400">
-            space settings
-          </Link>
-          .
-        </p>
       ) : (
-        <ul className="divide-y rounded-md border">
-          {spaceFields.map((def) => {
-            const checked = attachedIris.includes(def["@id"]);
-            const surfaces = checked
-              ? visibilitySurfaces(projectVisibility[def["@id"]] ?? "both")
-              : [];
-            const showList = surfaces.includes("list");
-            const showBoard = surfaces.includes("board");
-            const showCalendar = surfaces.includes("calendar");
-            const isBusy = busy === def["@id"];
-            return (
-              <li
-                key={def["@id"]}
-                className="flex items-center gap-3 px-3 py-2 text-sm"
-              >
-                <span className={cn("min-w-0 flex-1 truncate", !checked && "text-muted-foreground")}>
-                  {def.name}
-                </span>
-                <span className="shrink-0 text-xs text-muted-foreground">
-                  {KIND_LABEL[def.kind] ?? def.kind}
-                </span>
-                <label className="flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground">
-                  <Switch
-                    checked={showList}
-                    disabled={isBusy}
-                    onCheckedChange={(v) =>
-                      void updateField(def["@id"], v, showBoard, showCalendar)
-                    }
-                    aria-label={`Show ${def.name} on the task list`}
-                  />
-                  List
-                </label>
-                <label className="flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground">
-                  <Switch
-                    checked={showBoard}
-                    disabled={isBusy}
-                    onCheckedChange={(v) =>
-                      void updateField(def["@id"], showList, v, showCalendar)
-                    }
-                    aria-label={`Show ${def.name} on the board`}
-                  />
-                  Board
-                </label>
-                <label className="flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground">
-                  <Switch
-                    checked={showCalendar}
-                    disabled={isBusy}
-                    onCheckedChange={(v) =>
-                      void updateField(def["@id"], showList, showBoard, v)
-                    }
-                    aria-label={`Show ${def.name} on the calendar`}
-                  />
-                  Calendar
-                </label>
-                {isSpaceAdmin && (
-                  <button
-                    type="button"
-                    onClick={() => onEdit(def)}
-                    aria-label={`Edit ${def.name}`}
-                    className="shrink-0 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-                  >
-                    <Settings2 className="h-3.5 w-3.5" />
-                  </button>
-                )}
-              </li>
-            );
-          })}
-        </ul>
+        <div className="space-y-4">
+          <section className="space-y-1.5">
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Space fields
+            </h4>
+            {spaceFields.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                This space has no custom fields yet. Define them in{" "}
+                <Link href="/custom-fields" className="text-cyan-700 hover:underline dark:text-cyan-400">
+                  space settings
+                </Link>
+                .
+              </p>
+            ) : (
+              <ul className="divide-y rounded-md border">
+                {spaceFields.map(renderRow)}
+              </ul>
+            )}
+          </section>
+
+          {globalFields.length > 0 && (
+            <section className="space-y-1.5">
+              <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Global fields
+              </h4>
+              <ul className="divide-y rounded-md border">
+                {globalFields.map(renderRow)}
+              </ul>
+            </section>
+          )}
+        </div>
       )}
     </div>
   );

--- a/pwa/components/custom-fields/kind-editors.tsx
+++ b/pwa/components/custom-fields/kind-editors.tsx
@@ -113,7 +113,7 @@ export const KIND_DESCRIPTORS: Record<CustomFieldKind, KindDescriptor> = {
       { value: "multi", label: "Multi-select" },
     ],
     supportsMulti: false,
-    footerKinds: ["count"],
+    footerKinds: ["count", "breakdown"],
   },
   reference: {
     label: "Reference",

--- a/pwa/components/custom-fields/types.ts
+++ b/pwa/components/custom-fields/types.ts
@@ -112,6 +112,20 @@ export interface CustomFieldDefinition {
   visibility: CustomFieldVisibility;
 }
 
+/**
+ * Whether a definition (or bare IRI) is an instance-wide GLOBAL field rather
+ * than a space-owned one (#global-custom-fields). Global fields live at
+ * `/global_custom_field_definitions/...`; a task value keys them on
+ * `globalDefinition` instead of `definition`, and per-project attach /
+ * visibility use the parallel `global_custom_field_definitions` routes.
+ */
+export const isGlobalDefinition = (
+  defOrIri: string | { "@id": string },
+): boolean => {
+  const iri = typeof defOrIri === "string" ? defOrIri : defOrIri["@id"];
+  return iri.includes("/global_custom_field_definitions/");
+};
+
 export interface FooterRow {
   definition: string;
   name: string;

--- a/pwa/components/custom-fields/types.ts
+++ b/pwa/components/custom-fields/types.ts
@@ -37,7 +37,14 @@ export type CustomFieldSubtype =
   | "page"
   | "discussion";
 
-export type FooterKind = "sum" | "avg" | "min" | "max" | "count";
+export type FooterKind = "sum" | "avg" | "min" | "max" | "count" | "breakdown";
+
+/** One entry of a select field's per-option `breakdown` footer value. */
+export interface FooterBreakdownEntry {
+  key: string;
+  label: string;
+  count: number;
+}
 
 export interface SelectOption {
   key: string;

--- a/pwa/components/projects/TaskBoard.tsx
+++ b/pwa/components/projects/TaskBoard.tsx
@@ -125,8 +125,9 @@ const CardCustomFields = ({
   const chips = definitions
     .map((def) => ({
       def,
-      value: task.customFieldValues.find((v) => v.definition === def["@id"])
-        ?.value,
+      value: task.customFieldValues.find(
+        (v) => (v.definition ?? v.globalDefinition) === def["@id"],
+      )?.value,
     }))
     .filter(({ value }) => !isEmptyValue(value));
   if (chips.length === 0) return null;

--- a/pwa/components/projects/columnWidths.ts
+++ b/pwa/components/projects/columnWidths.ts
@@ -23,7 +23,11 @@ export interface WidthTask {
   dueDate: string | null;
   assignees: unknown[];
   tags: { title: string }[];
-  customFieldValues: { definition: string; value: unknown }[];
+  customFieldValues: {
+    definition?: string | null;
+    globalDefinition?: string | null;
+    value: unknown;
+  }[];
 }
 
 // Rough metrics for the text-sm table cells (px). Heuristic, not exact — the
@@ -102,7 +106,9 @@ const contentChars = (col: ListColumn, task: WidthTask): number => {
       return task.tags.map((t) => t.title).join(", ").length;
     default: {
       const iri = col.definition?.["@id"];
-      const value = task.customFieldValues.find((v) => v.definition === iri)?.value;
+      const value = task.customFieldValues.find(
+        (v) => (v.definition ?? v.globalDefinition) === iri,
+      )?.value;
       return cfText(col.definition, value).length;
     }
   }

--- a/pwa/components/projects/listColumns.ts
+++ b/pwa/components/projects/listColumns.ts
@@ -26,7 +26,11 @@ export interface ColumnTask {
     email: string;
   }>;
   tags: Array<{ "@id": string; title: string }>;
-  customFieldValues: Array<{ definition: string; value: unknown }>;
+  customFieldValues: Array<{
+    definition?: string | null;
+    globalDefinition?: string | null;
+    value: unknown;
+  }>;
 }
 
 /** How a column's header dropdown renders its filter, and how rows match it. */
@@ -158,7 +162,9 @@ export const orderColumns = (
 };
 
 const cfValue = (task: ColumnTask, def: CustomFieldDefinition): unknown =>
-  task.customFieldValues.find((v) => v.definition === def["@id"])?.value ?? null;
+  task.customFieldValues.find(
+    (v) => (v.definition ?? v.globalDefinition) === def["@id"],
+  )?.value ?? null;
 
 const optionLabel = (def: CustomFieldDefinition, key: string): string => {
   const opt = def.config.options?.find((o) => o.key === key);

--- a/pwa/components/tasks/CustomFieldValueList.tsx
+++ b/pwa/components/tasks/CustomFieldValueList.tsx
@@ -2,14 +2,35 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import type { AvatarUser } from "@/components/user/UserAvatar";
 import { type ViolationMap } from "@/lib/violations";
-import type { CustomFieldDefinition } from "@/components/custom-fields/types";
+import {
+  isGlobalDefinition,
+  type CustomFieldDefinition,
+} from "@/components/custom-fields/types";
 import CustomFieldValueFields from "./CustomFieldValueFields";
 
-/** One `{definition, value}` pair as carried on `Task.customFieldValues`. */
+/**
+ * One value pair as carried on `Task.customFieldValues`. Polymorphic like the
+ * server entity: a value targets EITHER a space-owned field (`definition`) or
+ * an instance-wide global field (`globalDefinition`) — exactly one is set.
+ */
 export interface CustomFieldValuePair {
-  definition: string;
+  definition?: string | null;
+  globalDefinition?: string | null;
   value: unknown;
 }
+
+/** The definition IRI a value pair belongs to, whichever source it points at. */
+export const valuePairDefinitionIri = (pair: CustomFieldValuePair): string =>
+  pair.definition ?? pair.globalDefinition ?? "";
+
+/** Build a write pair, keying the right FK by the definition's source. */
+export const makeValuePair = (
+  def: CustomFieldDefinition,
+  value: unknown,
+): CustomFieldValuePair =>
+  isGlobalDefinition(def["@id"])
+    ? { globalDefinition: def["@id"], value }
+    : { definition: def["@id"], value };
 
 interface Props {
   definitions: CustomFieldDefinition[];
@@ -50,7 +71,7 @@ const CustomFieldValueList = ({
   // Working copy keyed by definition IRI.
   const initial = useMemo(() => {
     const map: Record<string, unknown> = {};
-    for (const v of values) map[v.definition] = v.value;
+    for (const v of values) map[valuePairDefinitionIri(v)] = v.value;
     return map;
   }, [values]);
 
@@ -80,7 +101,7 @@ const CustomFieldValueList = ({
       const value = working[def["@id"]];
       if (isEmpty(value)) continue;
       indexToDef.push(def["@id"]);
-      payload.push({ definition: def["@id"], value });
+      payload.push(makeValuePair(def, value));
     }
 
     setSaving(true);

--- a/pwa/components/tasks/TaskDetailDrawer.tsx
+++ b/pwa/components/tasks/TaskDetailDrawer.tsx
@@ -175,9 +175,13 @@ const TaskDetailDrawer = ({
     let cancelled = false;
     void (async () => {
       try {
-        const [defsRes, projRes] = await Promise.all([
+        const [defsRes, globalDefsRes, projRes] = await Promise.all([
           fetch(
             `${ENTRYPOINT}/custom_field_definitions?project=${encodeURIComponent(projectIri)}`,
+            { credentials: "include", headers: { Accept: "application/ld+json" } },
+          ),
+          fetch(
+            `${ENTRYPOINT}/global_custom_field_definitions?projects=${encodeURIComponent(projectIri)}`,
             { credentials: "include", headers: { Accept: "application/ld+json" } },
           ),
           fetch(`${ENTRYPOINT}${projectIri}`, {
@@ -185,10 +189,17 @@ const TaskDetailDrawer = ({
             headers: { Accept: "application/ld+json" },
           }),
         ]);
-        if (defsRes.ok && !cancelled) {
-          const data: Collection<CustomFieldDefinition> = await defsRes.json();
+        if (!cancelled && (defsRes.ok || globalDefsRes.ok)) {
+          // Effective field set = the project's space fields ∪ its opted-in
+          // global fields (#global-custom-fields).
+          const spaceDefs: CustomFieldDefinition[] = defsRes.ok
+            ? membersOf(await defsRes.json())
+            : [];
+          const globalDefs: CustomFieldDefinition[] = globalDefsRes.ok
+            ? membersOf(await globalDefsRes.json())
+            : [];
           setDefinitions(
-            membersOf(data).sort((a, b) => a.position - b.position),
+            [...spaceDefs, ...globalDefs].sort((a, b) => a.position - b.position),
           );
         }
         if (projRes.ok && !cancelled) {

--- a/pwa/pages/admin/global-custom-fields.tsx
+++ b/pwa/pages/admin/global-custom-fields.tsx
@@ -1,0 +1,90 @@
+import type { NextPage } from "next";
+import Head from "next/head";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+import { Globe } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { signinHrefForCurrent } from "@/lib/authRedirect";
+import CustomFieldsManager from "@/components/custom-fields/CustomFieldsManager";
+import PageHeader from "@/components/common/PageHeader";
+
+/**
+ * Admin-only manager for instance-wide GLOBAL custom fields
+ * (#global-custom-fields). Reuses the space {@link CustomFieldsManager} UX
+ * (kind/subtype editors, create/edit/delete drawer) but points it at
+ * `/global_custom_field_definitions` and drops the space/project context —
+ * global fields belong to no space and any project can opt into them.
+ * ROLE_ADMIN gated (matching the segments / waitlist admin pages).
+ */
+const AdminGlobalCustomFields: NextPage = () => {
+  const { user, isAuthenticated, isLoading } = useAuth();
+  const router = useRouter();
+  const isAdmin = user?.roles?.includes("ROLE_ADMIN");
+
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated) {
+      router.replace(signinHrefForCurrent(router.asPath));
+    }
+  }, [isLoading, isAuthenticated, router]);
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-muted">
+        <p className="text-muted-foreground">Loading…</p>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) return null;
+
+  if (!isAdmin) {
+    return (
+      <>
+        <Head>
+          <title>Access Denied - Madori</title>
+        </Head>
+        <div className="min-h-screen flex items-center justify-center bg-muted px-4">
+          <div className="text-center">
+            <h1 className="text-2xl font-bold text-foreground mb-2">
+              Access Denied
+            </h1>
+            <p className="text-muted-foreground">
+              You need administrator privileges to view this page.
+            </p>
+          </div>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Global custom fields - Madori</title>
+      </Head>
+      <div className="min-h-screen bg-background px-4 py-8">
+        <div className="mx-auto w-full max-w-4xl">
+          <PageHeader
+            title="Global custom fields"
+            icon={<Globe className="h-6 w-6 text-cyan-600 dark:text-cyan-400" />}
+            subtitle={
+              <>
+                Reusable task fields available to every project in every space.
+                Admins define them here; project members can only toggle them
+                on or off per project.
+              </>
+            }
+          />
+
+          <CustomFieldsManager
+            projectTitle="Global"
+            collectionPath="/global_custom_field_definitions"
+            isSpaceAdmin
+          />
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default AdminGlobalCustomFields;

--- a/pwa/pages/projects/[id].tsx
+++ b/pwa/pages/projects/[id].tsx
@@ -72,9 +72,15 @@ import type {
   CustomFieldSubtype,
 } from "@/components/custom-fields/types";
 import {
+  isGlobalDefinition,
   showsOnSurface,
   visibilitySurfaces,
 } from "@/components/custom-fields/types";
+import {
+  makeValuePair,
+  valuePairDefinitionIri,
+  type CustomFieldValuePair,
+} from "@/components/tasks/CustomFieldValueList";
 import {
   dueDateStatus,
   type Reminder,
@@ -119,11 +125,6 @@ interface Project {
   owner: Member;
   members: Member[];
   space: string | SpaceRef;
-}
-
-interface CustomFieldValuePair {
-  definition: string;
-  value: unknown;
 }
 
 interface ProjectTask {
@@ -344,31 +345,40 @@ const ProjectDetail = () => {
       setProject(projectData);
 
       const projectIri = projectData["@id"];
-      const [tasksRes, defsRes, sectionsRes, usersRes, tagsRes] = await Promise.all([
-        fetch(`${ENTRYPOINT}/tasks?project=${encodeURIComponent(projectIri)}`, init),
-        fetch(
-          `${ENTRYPOINT}/custom_field_definitions?projects=${encodeURIComponent(projectIri)}`,
-          init,
-        ),
-        fetch(
-          `${ENTRYPOINT}/task_sections?project=${encodeURIComponent(projectIri)}`,
-          init,
-        ),
-        fetch(`${ENTRYPOINT}/me/assignable-users`, init),
-        fetch(
-          `${ENTRYPOINT}/tags?space=${encodeURIComponent(projectSpaceIri(projectData))}`,
-          init,
-        ),
-      ]);
+      const [tasksRes, defsRes, globalDefsRes, sectionsRes, usersRes, tagsRes] =
+        await Promise.all([
+          fetch(`${ENTRYPOINT}/tasks?project=${encodeURIComponent(projectIri)}`, init),
+          fetch(
+            `${ENTRYPOINT}/custom_field_definitions?projects=${encodeURIComponent(projectIri)}`,
+            init,
+          ),
+          fetch(
+            `${ENTRYPOINT}/global_custom_field_definitions?projects=${encodeURIComponent(projectIri)}`,
+            init,
+          ),
+          fetch(
+            `${ENTRYPOINT}/task_sections?project=${encodeURIComponent(projectIri)}`,
+            init,
+          ),
+          fetch(`${ENTRYPOINT}/me/assignable-users`, init),
+          fetch(
+            `${ENTRYPOINT}/tags?space=${encodeURIComponent(projectSpaceIri(projectData))}`,
+            init,
+          ),
+        ]);
       if (!tasksRes.ok) throw new Error("Failed to load tasks.");
       setTasks(membersOf<ProjectTask>(await tasksRes.json()));
-      if (defsRes.ok) {
-        setDefinitions(
-          membersOf<CustomFieldDefinition>(await defsRes.json()).sort(
-            (a, b) => a.position - b.position,
-          ),
-        );
-      }
+      // A project's effective field set is the union of its space fields and
+      // the instance-wide global fields it opts into (#global-custom-fields).
+      const spaceDefs = defsRes.ok
+        ? membersOf<CustomFieldDefinition>(await defsRes.json())
+        : [];
+      const globalDefs = globalDefsRes.ok
+        ? membersOf<CustomFieldDefinition>(await globalDefsRes.json())
+        : [];
+      setDefinitions(
+        [...spaceDefs, ...globalDefs].sort((a, b) => a.position - b.position),
+      );
       if (sectionsRes.ok) {
         setSections(
           membersOf<TaskSection>(await sectionsRes.json()).sort(
@@ -400,15 +410,24 @@ const ProjectDetail = () => {
   const reloadDefinitions = useCallback(async () => {
     if (!project) return;
     try {
-      const res = await fetch(
-        `${ENTRYPOINT}/custom_field_definitions?projects=${encodeURIComponent(project["@id"])}`,
-        { credentials: "include" },
-      );
-      if (res.ok) {
+      const iri = encodeURIComponent(project["@id"]);
+      const [spaceRes, globalRes] = await Promise.all([
+        fetch(`${ENTRYPOINT}/custom_field_definitions?projects=${iri}`, {
+          credentials: "include",
+        }),
+        fetch(`${ENTRYPOINT}/global_custom_field_definitions?projects=${iri}`, {
+          credentials: "include",
+        }),
+      ]);
+      const spaceDefs = spaceRes.ok
+        ? membersOf<CustomFieldDefinition>(await spaceRes.json())
+        : [];
+      const globalDefs = globalRes.ok
+        ? membersOf<CustomFieldDefinition>(await globalRes.json())
+        : [];
+      if (spaceRes.ok || globalRes.ok) {
         setDefinitions(
-          membersOf<CustomFieldDefinition>(await res.json()).sort(
-            (a, b) => a.position - b.position,
-          ),
+          [...spaceDefs, ...globalDefs].sort((a, b) => a.position - b.position),
         );
       }
     } catch {
@@ -416,18 +435,26 @@ const ProjectDetail = () => {
     }
   }, [project]);
 
-  // Attach a space-owned field to this project (per-project selection M2M).
+  // Attach a field to this project (per-project selection M2M). Space and
+  // global fields live in separate join tables, so PATCH the matching key
+  // with the full current set of that source plus the new IRI.
   const attachFieldToProject = useCallback(
     async (defIri: string) => {
       if (!project) return;
-      const current = definitions.map((d) => d["@id"]);
-      if (current.includes(defIri)) return;
+      if (definitions.some((d) => d["@id"] === defIri)) return;
+      const global = isGlobalDefinition(defIri);
+      const currentOfSource = definitions
+        .filter((d) => isGlobalDefinition(d) === global)
+        .map((d) => d["@id"]);
+      const key = global
+        ? "globalCustomFieldDefinitions"
+        : "customFieldDefinitions";
       try {
         await fetch(`${ENTRYPOINT}${project["@id"]}`, {
           method: "PATCH",
           credentials: "include",
           headers: { "Content-Type": "application/merge-patch+json" },
-          body: JSON.stringify({ customFieldDefinitions: [...current, defIri] }),
+          body: JSON.stringify({ [key]: [...currentOfSource, defIri] }),
         });
       } catch {
         /* transient — the field just won't show until retried */
@@ -451,9 +478,12 @@ const ProjectDetail = () => {
       const surfaces = [
         ...new Set([...visibilitySurfaces(def.visibility), "list"]),
       ].join(",");
+      const base = isGlobalDefinition(def)
+        ? "global_custom_field_definitions"
+        : "custom_field_definitions";
       try {
         const res = await fetch(
-          `${ENTRYPOINT}/projects/${encodeURIComponent(projectId)}/custom_field_definitions/${encodeURIComponent(def.id)}/visibility`,
+          `${ENTRYPOINT}/projects/${encodeURIComponent(projectId)}/${base}/${encodeURIComponent(def.id)}/visibility`,
           {
             method: "PUT",
             credentials: "include",
@@ -541,12 +571,12 @@ const ProjectDetail = () => {
       const next = definitions
         .map((def) => {
           const existing = task.customFieldValues.find(
-            (v) => v.definition === def["@id"],
+            (v) => valuePairDefinitionIri(v) === def["@id"],
           );
-          return {
-            definition: def["@id"],
-            value: def["@id"] === defIri ? value : existing?.value,
-          };
+          return makeValuePair(
+            def,
+            def["@id"] === defIri ? value : existing?.value,
+          );
         })
         .filter((p) => !isEmptyFieldValue(p.value));
       void patchTask(task, { customFieldValues: next });
@@ -1433,7 +1463,12 @@ const ProjectDetail = () => {
                     <ProjectCustomFieldPicker
                       spaceIri={projectSpaceIri(project)}
                       projectIri={project["@id"]}
-                      attachedIris={definitions.map((d) => d["@id"])}
+                      attachedIris={definitions
+                        .filter((d) => !isGlobalDefinition(d))
+                        .map((d) => d["@id"])}
+                      attachedGlobalIris={definitions
+                        .filter((d) => isGlobalDefinition(d))
+                        .map((d) => d["@id"])}
                       projectVisibility={Object.fromEntries(
                         definitions.map((d) => [d["@id"], d.visibility ?? "both"]),
                       )}
@@ -2556,8 +2591,9 @@ const ProjectCustomFieldCell = ({
   ) => void;
 }) => {
   const serverValue =
-    task.customFieldValues.find((v) => v.definition === definition["@id"])
-      ?.value ?? null;
+    task.customFieldValues.find(
+      (v) => valuePairDefinitionIri(v) === definition["@id"],
+    )?.value ?? null;
   const serverKey = JSON.stringify(serverValue);
   const [value, setValue] = useState<unknown>(() => JSON.parse(serverKey));
   const dirty = useRef(false);


### PR DESCRIPTION
@
## Summary

Adds **global custom fields** — reusable, instance-wide custom fields that admins define once and any project (in any space) can toggle on, alongside the existing space-scoped custom fields. They reuse the entire custom-field type system (kind/subtype/config/footer/nullable, the strategy registry, validation, value editors, footers, FTS) — the only difference is scope.

## How a task value points at either source (the crux)

A shared `App\Entity\CustomFieldDefinitionInterface` is implemented by both `CustomFieldDefinition` (space) and the new `GlobalCustomFieldDefinition`, so strategies/validators/serializers are reused unchanged. `CustomFieldValue` gained a nullable `globalDefinition` FK beside `definition`, with a DB `CHECK` + validator **XOR** enforcing exactly one; `getEffectiveDefinition()` is the single accessor every consumer reads through. Uniqueness is a **parallel deferrable constraint** so PATCHs delete-then-insert value rebuild still collapses cleanly.

## Whats included

- **Entity + interface + migration** — `GlobalCustomFieldDefinition`, admin-gated `/global_custom_field_definitions` CRUD; reads open to any authenticated user so fields render in the picker.
- **Polymorphic `CustomFieldValue`** — dual FK, XOR, deferrable uniqueness; value validator, FTS subscriber, MCP + space-export serializers, and MCP `update_task` all updated.
- **Per-project opt-in** — `project_global_custom_field_definition` join; a projects effective field set is the union of space ∪ global. Footers/stats union both sources; `ProjectFieldVisibility` made polymorphic so a project can place a global field on List/Board/Calendar; project-copy carries global attachments.
- **Security** — writes `ROLE_ADMIN` (belt-and-suspenders `access_control` + entity expressions), reads `ROLE_USER`.
- **PWA** — admin `/admin/global-custom-fields` page (reuses `CustomFieldsManager`) + sidebar link; `ProjectCustomFieldPicker` lists space **and** global fields in independent sections; `globalDefinition` threaded through columns/board/drawer/inline editors.
- **Seed migration** — ships four defaults: **Effort** (numeric.int, SUM footer), **Cost** (numeric.money USD, SUM), **Time** (numeric.float hours, SUM), **Status** (select: Backlog/To do/In progress/Review/Ready/Done, per-option **breakdown** footer). Unattached + fully admin-editable/removable.
- **Select `breakdown` footer** — new `FooterKind` advertised only by select strategies; `FooterAggregator` computes one `{key,label,count}` row per option (single/multi aware, zero-filled, DB-free on empty scope). PWA renders it as a stacked per-option list.

## v1 scope notes

- Global fields disallow the `reference` kind (no space to scope target IRIs).
- Editing a global fields type doesnt auto-convert existing values (space fields keep that behavior).
- MCP accepts `globalDefinitionId` in the task value payload; no new global-management MCP tools.

## Tests

`GlobalCustomFieldDefinitionTest` (admin CRUD, open reads, reference/breakdown/duplicate gating), `GlobalCustomFieldValueTest` (polymorphic values, XOR, attach + required enforcement, deferrable PATCH, footer over global), plus footer aggregator unit + endpoint breakdown coverage.

Local gates all green: PHPUnit (1005 tests), PHPStan L10 + strict, PHPCS, PWA typecheck + lint, Doctrine schema:validate.
@