### PR TITLE
feat: one-way calendar sync (read-only iCal feed)

### DIFF
--- a/api/config/packages/security.yaml
+++ b/api/config/packages/security.yaml
@@ -98,6 +98,11 @@ security:
         - { path: ^/api/me$, roles: IS_AUTHENTICATED_FULLY }
         - { path: ^/me/2fa, roles: ROLE_USER }
         - { path: ^/me/sessions, roles: ROLE_USER }
+        # Self-service calendar-feed management (reveal/regenerate/revoke).
+        # The feed itself (/calendar/feed/{token}.ics) is token-authenticated
+        # and stays PUBLIC_ACCESS via the catch-all — calendar clients can't
+        # present a session cookie.
+        - { path: ^/me/calendar-feed, roles: ROLE_USER }
         # Account lifecycle (GDPR/CCPA): any fully-authenticated account —
         # including a waitlisted ROLE_WAITLISTED one, which holds no ROLE_USER
         # — must be able to deactivate, export, and delete itself. The

--- a/api/migrations/Version20260702090000.php
+++ b/api/migrations/Version20260702090000.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Per-user calendar-feed token (#calendar-sync): the sha256-hashed secret that
+ * authorises a user's read-only iCal feed at `GET /calendar/feed/{token}.ics`.
+ * One row per user (unique user_id); only the hash is stored.
+ */
+final class Version20260702090000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create calendar_feed_token (per-user iCal feed secret).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(
+            'CREATE TABLE calendar_feed_token ('
+            . 'id UUID NOT NULL, '
+            . 'user_id UUID NOT NULL, '
+            . 'token_hash VARCHAR(64) NOT NULL, '
+            . 'created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, '
+            . 'last_accessed_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL, '
+            . 'PRIMARY KEY (id))',
+        );
+        $this->addSql('CREATE UNIQUE INDEX uniq_calendar_feed_token_hash ON calendar_feed_token (token_hash)');
+        $this->addSql('CREATE UNIQUE INDEX uniq_calendar_feed_token_user ON calendar_feed_token (user_id)');
+        $this->addSql(
+            'ALTER TABLE calendar_feed_token ADD CONSTRAINT FK_calendar_feed_token_user '
+            . 'FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE',
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE calendar_feed_token DROP CONSTRAINT FK_calendar_feed_token_user');
+        $this->addSql('DROP TABLE calendar_feed_token');
+    }
+}

--- a/api/src/Controller/CalendarFeedController.php
+++ b/api/src/Controller/CalendarFeedController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Controller;
+
+use App\Ical\CalendarFeedBuilder;
+use App\Service\CalendarFeedTokenManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * The public, token-authenticated read-only iCal feed (#calendar-sync). A
+ * calendar client (Google / Outlook / Apple) subscribes to
+ * `GET /calendar/feed/{token}.ics`; there is no session — the unguessable
+ * token in the URL is the sole credential, resolved sha256-hashed like the
+ * password-reset / export tokens.
+ *
+ * An unknown or malformed token returns 404 (never distinguishing "no such
+ * token" from "revoked"), so the endpoint can't be used to probe which feeds
+ * exist. A valid token yields a `text/calendar` document of the owner's
+ * due-dated tasks.
+ */
+class CalendarFeedController extends AbstractController
+{
+    public function __construct(
+        private readonly CalendarFeedTokenManager $tokens,
+        private readonly CalendarFeedBuilder $builder,
+        private readonly EntityManagerInterface $em,
+    ) {
+    }
+
+    #[Route(
+        '/calendar/feed/{token}.ics',
+        name: 'calendar_feed',
+        requirements: ['token' => '[A-Za-z0-9]+'],
+        methods: ['GET'],
+    )]
+    public function __invoke(string $token, Request $request): Response
+    {
+        $record = $this->tokens->resolve($token);
+        if (null === $record) {
+            return new Response('Not found.', Response::HTTP_NOT_FOUND, ['Content-Type' => 'text/plain']);
+        }
+
+        $ical = $this->builder->build($record->getUser(), $request->getSchemeAndHttpHost());
+
+        // Best-effort "last synced" stamp; never let it break serving the feed.
+        $record->markAccessed();
+        $this->em->flush();
+
+        $response = new Response($ical);
+        $response->headers->set('Content-Type', 'text/calendar; charset=utf-8');
+        $response->headers->set('Content-Disposition', 'inline; filename="madori.ics"');
+        $response->headers->set('Cache-Control', 'private, no-cache, must-revalidate');
+
+        return $response;
+    }
+}

--- a/api/src/Controller/CalendarFeedSettingsController.php
+++ b/api/src/Controller/CalendarFeedSettingsController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\User;
+use App\Service\CalendarFeedTokenManager;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+
+/**
+ * Self-service management of the current user's read-only iCal calendar feed
+ * (#calendar-sync). The feed itself is served token-authenticated from
+ * {@see CalendarFeedController}; these routes are session-gated (ROLE_USER) so
+ * only the signed-in owner can reveal status, (re)generate, or revoke it.
+ *
+ * Because the token is stored hashed, the plaintext subscribe URL is returned
+ * exactly once — from the regenerate endpoint — and never again. `GET` reports
+ * only metadata (enabled / created / last-synced); the PWA keeps the one-shot
+ * URL in view after generation and otherwise offers "regenerate" to mint a new
+ * one.
+ */
+class CalendarFeedSettingsController extends AbstractController
+{
+    public function __construct(
+        private readonly CalendarFeedTokenManager $tokens,
+    ) {
+    }
+
+    #[Route('/me/calendar-feed', name: 'me_calendar_feed_get', methods: ['GET'])]
+    public function status(#[CurrentUser] ?User $user): JsonResponse
+    {
+        if (null === $user) {
+            return $this->json(['error' => 'Not authenticated.'], 401);
+        }
+
+        $token = $this->tokens->findForUser($user);
+
+        return $this->json([
+            'enabled' => null !== $token,
+            'createdAt' => $token?->getCreatedAt()->format(\DateTimeInterface::ATOM),
+            'lastAccessedAt' => $token?->getLastAccessedAt()?->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+
+    #[Route('/me/calendar-feed/regenerate', name: 'me_calendar_feed_regenerate', methods: ['POST'])]
+    public function regenerate(Request $request, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if (null === $user) {
+            return $this->json(['error' => 'Not authenticated.'], 401);
+        }
+
+        $plaintext = $this->tokens->regenerate($user);
+        $feedUrl = $this->tokens->buildFeedUrl($request->getSchemeAndHttpHost(), $plaintext);
+
+        return $this->json(['feedUrl' => $feedUrl], 201);
+    }
+
+    #[Route('/me/calendar-feed', name: 'me_calendar_feed_delete', methods: ['DELETE'])]
+    public function revoke(#[CurrentUser] ?User $user): JsonResponse
+    {
+        if (null === $user) {
+            return $this->json(['error' => 'Not authenticated.'], 401);
+        }
+
+        $this->tokens->revoke($user);
+
+        return new JsonResponse(null, 204);
+    }
+}

--- a/api/src/Entity/CalendarFeedToken.php
+++ b/api/src/Entity/CalendarFeedToken.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\CalendarFeedTokenRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * The private, unguessable token that authorises one user's read-only iCal
+ * calendar feed (`GET /calendar/feed/{token}.ics`). Calendar clients (Google /
+ * Outlook / Apple) can't log in, so the feed authenticates purely on this
+ * bearer-in-the-URL secret.
+ *
+ * There is at most one token per user (unique FK). It follows the
+ * PasswordResetToken / export-token model: only the sha256 hash is persisted,
+ * and the plaintext exists solely in the subscribe URL handed back once at
+ * generation time. Regenerating rotates the hash, so the old URL stops
+ * resolving; revoking deletes the row. Neither the API nor the DB can ever
+ * re-derive the plaintext, so a leaked database yields no working feed URLs.
+ */
+#[ORM\Entity(repositoryClass: CalendarFeedTokenRepository::class)]
+#[ORM\Table(name: 'calendar_feed_token')]
+#[ORM\UniqueConstraint(name: 'uniq_calendar_feed_token_hash', columns: ['token_hash'])]
+#[ORM\UniqueConstraint(name: 'uniq_calendar_feed_token_user', columns: ['user_id'])]
+class CalendarFeedToken
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
+    private ?Uuid $id = null;
+
+    #[ORM\OneToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private User $user;
+
+    /** sha256 of the plaintext feed token. */
+    #[ORM\Column(length: 64)]
+    private string $tokenHash;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $createdAt;
+
+    /** Stamped each time the feed is fetched, for the "last synced" hint. */
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?\DateTimeImmutable $lastAccessedAt = null;
+
+    public function __construct(User $user, string $tokenHash)
+    {
+        $this->user = $user;
+        $this->tokenHash = $tokenHash;
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?Uuid
+    {
+        return $this->id;
+    }
+
+    public function getUser(): User
+    {
+        return $this->user;
+    }
+
+    public function getTokenHash(): string
+    {
+        return $this->tokenHash;
+    }
+
+    /** Rotate to a new hash and reset the creation timestamp (regenerate). */
+    public function rotate(string $tokenHash): void
+    {
+        $this->tokenHash = $tokenHash;
+        $this->createdAt = new \DateTimeImmutable();
+        $this->lastAccessedAt = null;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getLastAccessedAt(): ?\DateTimeImmutable
+    {
+        return $this->lastAccessedAt;
+    }
+
+    public function markAccessed(): void
+    {
+        $this->lastAccessedAt = new \DateTimeImmutable();
+    }
+}

--- a/api/src/Ical/CalendarFeedBuilder.php
+++ b/api/src/Ical/CalendarFeedBuilder.php
@@ -5,6 +5,7 @@ namespace App\Ical;
 use App\Entity\Task;
 use App\Entity\User;
 use App\Service\RecurrenceCalculator;
+use App\Service\ReminderScheduler;
 use Doctrine\ORM\EntityManagerInterface;
 
 /**
@@ -33,6 +34,7 @@ final class CalendarFeedBuilder
         private readonly VTimezoneBuilder $vtimezone,
         private readonly RecurrenceCalculator $recurrence,
         private readonly RecurrenceRuleToRrule $rrule,
+        private readonly ReminderScheduler $reminders,
     ) {
     }
 
@@ -170,9 +172,95 @@ final class CalendarFeedBuilder
             }
         }
 
+        $lines = array_merge($lines, $this->valarms($task));
+
         $lines[] = 'END:VEVENT';
 
         return $lines;
+    }
+
+    /**
+     * VALARM sub-components for a task's reminders. Relative reminders map to
+     * a DTSTART-relative TRIGGER (`-PT15M`), which iCal applies to each
+     * recurrence; absolute reminders map to a fixed UTC DATE-TIME trigger.
+     * "Repeat daily until done" is an Aura-server concept with no iCal
+     * equivalent, so only the base trigger is emitted.
+     *
+     * @return list<string>
+     */
+    private function valarms(Task $task): array
+    {
+        $reminders = $task->getReminders();
+        if (null === $reminders) {
+            return [];
+        }
+
+        $lines = [];
+        foreach ($reminders as $reminder) {
+            if (!is_array($reminder) || !$this->reminders->isValidShape($reminder)) {
+                continue;
+            }
+            $trigger = $this->triggerLine($reminder);
+            if (null === $trigger) {
+                continue;
+            }
+            $lines[] = 'BEGIN:VALARM';
+            $lines[] = 'ACTION:DISPLAY';
+            $lines[] = $this->writer->line('DESCRIPTION', $this->writer->escapeText($task->getTitle()));
+            $lines[] = $trigger;
+            $lines[] = 'END:VALARM';
+        }
+
+        return $lines;
+    }
+
+    /**
+     * The TRIGGER content line for one reminder, or null when it can't be
+     * expressed (e.g. an unparseable absolute time).
+     *
+     * @param array<array-key, mixed> $reminder
+     */
+    private function triggerLine(array $reminder): ?string
+    {
+        $type = $reminder['type'] ?? null;
+
+        if ('relative' === $type) {
+            $value = is_int($reminder['value'] ?? null) ? $reminder['value'] : 0;
+            $unit = is_string($reminder['unit'] ?? null) ? $reminder['unit'] : 'minutes';
+
+            return $this->writer->line('TRIGGER', $this->relativeDuration($value, $unit));
+        }
+
+        if ('absolute' === $type) {
+            $at = is_string($reminder['at'] ?? null) ? $reminder['at'] : '';
+            try {
+                $when = new \DateTimeImmutable($at);
+            } catch (\Exception) {
+                return null;
+            }
+
+            return $this->writer->line(
+                'TRIGGER',
+                $this->writer->formatUtc($when),
+                ['VALUE' => 'DATE-TIME'],
+            );
+        }
+
+        return null;
+    }
+
+    /** A negative ISO-8601 duration relative to the event start ("before due"). */
+    private function relativeDuration(int $value, string $unit): string
+    {
+        if (0 === $value) {
+            return '-PT0M';
+        }
+
+        return match ($unit) {
+            'hours' => '-PT' . $value . 'H',
+            'days' => '-P' . $value . 'D',
+            default => '-PT' . $value . 'M',
+        };
     }
 
     /**

--- a/api/src/Ical/CalendarFeedBuilder.php
+++ b/api/src/Ical/CalendarFeedBuilder.php
@@ -1,0 +1,290 @@
+<?php
+
+namespace App\Ical;
+
+use App\Entity\Task;
+use App\Entity\User;
+use App\Service\RecurrenceCalculator;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Renders a user's due-dated tasks as an RFC 5545 iCalendar document for the
+ * read-only calendar feed (#calendar-sync). Scope is the tasks the user owns
+ * OR is assigned to and that carry a due date.
+ *
+ * Times are rendered in the user's timezone preference (a single VTIMEZONE is
+ * emitted; UTC users get plain `Z` times). Each non-recurring task — and each
+ * completed recurring task, whose live successor carries the rest of the
+ * series — is one VEVENT on its due date. A *live* recurring task (a rule with
+ * no completion) is emitted as a single VEVENT carrying an RRULE when its rule
+ * maps cleanly, otherwise expanded into individual dated VEVENTs over a bounded
+ * upcoming window.
+ */
+final class CalendarFeedBuilder
+{
+    /** Bounded expansion window for rules that don't map to a single RRULE. */
+    private const EXPANSION_BACK_DAYS = 30;
+    private const EXPANSION_FORWARD_DAYS = 400;
+    private const MAX_OCCURRENCES = 200;
+
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly IcalWriter $writer,
+        private readonly VTimezoneBuilder $vtimezone,
+        private readonly RecurrenceCalculator $recurrence,
+        private readonly RecurrenceRuleToRrule $rrule,
+    ) {
+    }
+
+    public function build(User $user, string $baseUrl): string
+    {
+        $tz = $this->resolveTimezone($user);
+        $now = new \DateTimeImmutable('now');
+        $domain = $this->domainFor($baseUrl);
+
+        $lines = [
+            'BEGIN:VCALENDAR',
+            'VERSION:2.0',
+            $this->writer->line('PRODID', '-//Madori//Calendar Feed//EN'),
+            'CALSCALE:GREGORIAN',
+            'METHOD:PUBLISH',
+            $this->writer->line('X-WR-CALNAME', $this->writer->escapeText($this->calendarName($user))),
+            $this->writer->line('X-WR-TIMEZONE', $tz->getName()),
+        ];
+
+        $vtz = $this->vtimezone->build(
+            $tz,
+            $now->modify('-1 year'),
+            $now->modify('+5 years'),
+        );
+        if (null !== $vtz) {
+            $lines = array_merge($lines, $vtz);
+        }
+
+        foreach ($this->fetchTasks($user) as $task) {
+            $lines = array_merge($lines, $this->veventsForTask($task, $tz, $now, $baseUrl, $domain));
+        }
+
+        $lines[] = 'END:VCALENDAR';
+
+        return $this->writer->document($lines);
+    }
+
+    /**
+     * The VEVENT(s) for one task.
+     *
+     * @return list<string>
+     */
+    private function veventsForTask(
+        Task $task,
+        \DateTimeZone $tz,
+        \DateTimeImmutable $now,
+        string $baseUrl,
+        string $domain,
+    ): array {
+        $due = $task->getDueDate();
+        if (null === $due) {
+            return [];
+        }
+
+        $rule = $task->getRecurrenceRule();
+        $isLiveSeries = null !== $rule && null === $task->getCompletedOn();
+
+        if (!$isLiveSeries) {
+            return $this->vevent($task, $due, $tz, $now, $baseUrl, $domain, null);
+        }
+
+        // Live recurring series ($rule is non-null here): prefer a single
+        // VEVENT + RRULE.
+        $rruleLine = $this->rrule->map($due, $rule, $tz);
+        if (null !== $rruleLine) {
+            return $this->vevent($task, $due, $tz, $now, $baseUrl, $domain, $rruleLine);
+        }
+
+        // Fall back to expanding a bounded upcoming window as dated VEVENTs.
+        $rangeStart = $now->modify('-' . self::EXPANSION_BACK_DAYS . ' days');
+        $rangeEnd = $now->modify('+' . self::EXPANSION_FORWARD_DAYS . ' days');
+        $occurrences = $this->recurrence->occurrencesInRange(
+            $due,
+            $rule,
+            $rangeStart,
+            $rangeEnd,
+            $task->getRecurrenceExceptions(),
+        );
+
+        $lines = [];
+        $count = 0;
+        foreach ($occurrences as $occurrence) {
+            if ($count >= self::MAX_OCCURRENCES) {
+                break;
+            }
+            $lines = array_merge(
+                $lines,
+                $this->vevent($task, $occurrence, $tz, $now, $baseUrl, $domain, null, $occurrence),
+            );
+            ++$count;
+        }
+
+        return $lines;
+    }
+
+    /**
+     * A single VEVENT. `$rrule`, when present, is the RRULE line for a
+     * recurring series; `$occurrenceKey`, when present, disambiguates the UID
+     * of one expanded occurrence of a series.
+     *
+     * @return list<string>
+     */
+    private function vevent(
+        Task $task,
+        \DateTimeInterface $start,
+        \DateTimeZone $tz,
+        \DateTimeImmutable $now,
+        string $baseUrl,
+        string $domain,
+        ?string $rrule,
+        ?\DateTimeInterface $occurrenceKey = null,
+    ): array {
+        $lines = ['BEGIN:VEVENT'];
+        $lines[] = $this->writer->line('UID', $this->uid($task, $domain, $occurrenceKey));
+        $lines[] = $this->writer->line('DTSTAMP', $this->writer->formatUtc($now));
+        $lines[] = $this->dateTimeLine('DTSTART', $start, $tz);
+        $lines[] = $this->writer->line('SUMMARY', $this->writer->escapeText($task->getTitle()));
+        $lines[] = $this->writer->line(
+            'DESCRIPTION',
+            $this->writer->escapeText($this->descriptionFor($task, $baseUrl)),
+        );
+        $lines[] = $this->writer->line('URL', $this->deepLink($task, $baseUrl));
+
+        if (null !== $task->getCompletedOn()) {
+            $lines[] = 'STATUS:COMPLETED';
+        }
+
+        if (null !== $rrule) {
+            $lines[] = $rrule;
+            foreach ($task->getRecurrenceExceptions() as $exception) {
+                $exdate = $this->exdateLine($exception, $start, $tz);
+                if (null !== $exdate) {
+                    $lines[] = $exdate;
+                }
+            }
+        }
+
+        $lines[] = 'END:VEVENT';
+
+        return $lines;
+    }
+
+    /**
+     * Emit a DATE-TIME property in the user's zone (TZID + floating local
+     * time), or as UTC (`Z`) when the zone is UTC.
+     */
+    private function dateTimeLine(string $name, \DateTimeInterface $when, \DateTimeZone $tz): string
+    {
+        if ('UTC' === $tz->getName()) {
+            return $this->writer->line($name, $this->writer->formatUtc($when));
+        }
+
+        return $this->writer->line(
+            $name,
+            $this->writer->formatLocal($when, $tz),
+            ['TZID' => $tz->getName()],
+        );
+    }
+
+    /**
+     * An EXDATE for one `Y-m-d` exception, timed at the series' clock time in
+     * the user's zone. Returns null when the exception can't be parsed.
+     */
+    private function exdateLine(string $exception, \DateTimeInterface $start, \DateTimeZone $tz): ?string
+    {
+        $clock = \DateTimeImmutable::createFromInterface($start)->setTimezone($tz);
+        $local = \DateTimeImmutable::createFromFormat(
+            '!Y-m-d H:i:s',
+            $exception . ' ' . $clock->format('H:i:s'),
+            $tz,
+        );
+        if (false === $local) {
+            return null;
+        }
+
+        return $this->dateTimeLine('EXDATE', $local, $tz);
+    }
+
+    private function uid(Task $task, string $domain, ?\DateTimeInterface $occurrenceKey): string
+    {
+        $base = 'task-' . $task->getId();
+        if (null !== $occurrenceKey) {
+            $base .= '-' . $occurrenceKey->format('Ymd');
+        }
+
+        return $base . '@' . $domain;
+    }
+
+    private function descriptionFor(Task $task, string $baseUrl): string
+    {
+        $parts = [];
+        $body = $task->getDescription();
+        if (null !== $body && '' !== trim($body)) {
+            $parts[] = trim($body);
+        }
+        // Also surface the deep link in the body, for clients that don't
+        // present the URL property prominently.
+        $parts[] = 'Open in Madori: ' . $this->deepLink($task, $baseUrl);
+
+        return implode("\n\n", $parts);
+    }
+
+    private function deepLink(Task $task, string $baseUrl): string
+    {
+        return rtrim($baseUrl, '/') . '/tasks?task=' . $task->getId();
+    }
+
+    /**
+     * Due-dated tasks the user owns or is assigned to.
+     *
+     * @return list<Task>
+     */
+    private function fetchTasks(User $user): array
+    {
+        // MEMBER OF (rather than a JOIN + DISTINCT) avoids SELECT DISTINCT over
+        // the task's json columns, which Postgres can't compare for equality.
+        /** @var list<Task> $tasks */
+        $tasks = $this->em->getRepository(Task::class)->createQueryBuilder('t')
+            ->andWhere('t.dueDate IS NOT NULL')
+            ->andWhere('t.owner = :user OR :user MEMBER OF t.assignees')
+            ->setParameter('user', $user)
+            ->getQuery()
+            ->getResult();
+
+        return $tasks;
+    }
+
+    private function resolveTimezone(User $user): \DateTimeZone
+    {
+        $tz = $user->getPreferences()['timezone'] ?? 'UTC';
+        if (!is_string($tz)) {
+            return new \DateTimeZone('UTC');
+        }
+        try {
+            return new \DateTimeZone($tz);
+        } catch (\Exception) {
+            return new \DateTimeZone('UTC');
+        }
+    }
+
+    private function calendarName(User $user): string
+    {
+        $name = trim($user->getGivenName() . ' ' . $user->getFamilyName());
+
+        return '' !== $name ? $name . ' — Madori tasks' : 'Madori tasks';
+    }
+
+    /** Host portion of the app origin, for globally-unique UIDs. */
+    private function domainFor(string $baseUrl): string
+    {
+        $host = parse_url($baseUrl, PHP_URL_HOST);
+
+        return is_string($host) && '' !== $host ? $host : 'madori';
+    }
+}

--- a/api/src/Ical/IcalWriter.php
+++ b/api/src/Ical/IcalWriter.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Ical;
+
+/**
+ * Minimal RFC 5545 (iCalendar) serialization helper. Hand-rolled rather than
+ * pulling a dependency: the feed only needs VCALENDAR / VEVENT / VALARM /
+ * VTIMEZONE with correct escaping, CRLF line endings, and 75-octet line
+ * folding, which is a small, well-specified surface.
+ *
+ * A "content line" is built as `NAME[;PARAMS]:VALUE`; text values are escaped
+ * per §3.3.11 and every emitted line is folded per §3.1.
+ */
+final class IcalWriter
+{
+    /** RFC 5545 mandates CRLF line breaks between content lines. */
+    public const CRLF = "\r\n";
+
+    /**
+     * Escape a TEXT value: backslash, semicolon and comma are escaped, and
+     * newlines become the literal `\n` sequence (§3.3.11).
+     */
+    public function escapeText(string $value): string
+    {
+        $value = str_replace('\\', '\\\\', $value);
+        $value = str_replace(["\r\n", "\r", "\n"], '\\n', $value);
+        $value = str_replace(';', '\\;', $value);
+
+        return str_replace(',', '\\,', $value);
+    }
+
+    /**
+     * Fold a single already-assembled content line to <=75 octets per line,
+     * continuation lines beginning with a single space (§3.1). Folding is
+     * octet-based, but we avoid splitting a multibyte UTF-8 sequence by only
+     * breaking before a byte that is not a UTF-8 continuation byte.
+     */
+    public function fold(string $line): string
+    {
+        if (\strlen($line) <= 75) {
+            return $line;
+        }
+
+        $out = '';
+        $current = '';
+        $length = \strlen($line);
+        for ($i = 0; $i < $length; ++$i) {
+            $byte = $line[$i];
+            // A continuation byte is 10xxxxxx; never break just before one.
+            $isContinuation = (\ord($byte) & 0xC0) === 0x80;
+            if (\strlen($current) >= 74 && !$isContinuation) {
+                $out .= $current . self::CRLF . ' ';
+                $current = '';
+            }
+            $current .= $byte;
+        }
+
+        return $out . $current;
+    }
+
+    /**
+     * Assemble and fold a content line from a property name, an optional set
+     * of parameters, and an already-formatted (and, for TEXT, pre-escaped)
+     * value.
+     *
+     * @param array<string, string> $params
+     */
+    public function line(string $name, string $value, array $params = []): string
+    {
+        $prefix = $name;
+        foreach ($params as $key => $paramValue) {
+            $prefix .= ';' . $key . '=' . $paramValue;
+        }
+
+        return $this->fold($prefix . ':' . $value);
+    }
+
+    /**
+     * Join content lines into a CRLF-terminated document (trailing CRLF
+     * included, as clients expect).
+     *
+     * @param list<string> $lines
+     */
+    public function document(array $lines): string
+    {
+        return implode(self::CRLF, $lines) . self::CRLF;
+    }
+
+    /** Format an instant as a UTC DATE-TIME (`20260701T090000Z`). */
+    public function formatUtc(\DateTimeInterface $when): string
+    {
+        return (clone \DateTime::createFromInterface($when))
+            ->setTimezone(new \DateTimeZone('UTC'))
+            ->format('Ymd\THis\Z');
+    }
+
+    /**
+     * Format an instant as a floating local DATE-TIME (`20260701T090000`) in
+     * the given zone — pair with a `TZID` parameter and a matching VTIMEZONE.
+     */
+    public function formatLocal(\DateTimeInterface $when, \DateTimeZone $tz): string
+    {
+        return \DateTimeImmutable::createFromInterface($when)
+            ->setTimezone($tz)
+            ->format('Ymd\THis');
+    }
+}

--- a/api/src/Ical/RecurrenceRuleToRrule.php
+++ b/api/src/Ical/RecurrenceRuleToRrule.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace App\Ical;
+
+/**
+ * Maps Aura's recurrenceRule JSON (see {@see \App\Service\RecurrenceCalculator})
+ * to a single RFC 5545 RRULE line, or null when the rule can't be expressed as
+ * one RRULE and the feed should instead expand occurrences individually.
+ *
+ * Cleanly-mappable rules:
+ *   - daily / weekly / monthly / yearly with an interval
+ *   - weekly BYDAY (which weekdays fire)
+ *   - monthly "day" mode when the anchor day is <= 28 (see below)
+ *   - monthly "weekday" mode -> BYDAY=<setpos><day> (e.g. 2TH, -1FR)
+ *   - ends: UNTIL (UTC) / COUNT
+ *
+ * The one deliberate mismatch is monthly "day" mode on days 29–31: Aura clamps
+ * the day into short months (Jan 31 -> Feb 28) whereas RRULE BYMONTHDAY simply
+ * skips months without that day. Those return null so the feed expands the real
+ * (clamped) dates instead.
+ */
+final class RecurrenceRuleToRrule
+{
+    /** ISO weekday number (1=Mon…7=Sun) -> RRULE day token. */
+    private const DAY_TOKENS = [
+        1 => 'MO', 2 => 'TU', 3 => 'WE', 4 => 'TH', 5 => 'FR', 6 => 'SA', 7 => 'SU',
+    ];
+
+    private const VALID_TOKENS = ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU'];
+
+    /**
+     * @param array<array-key, mixed> $rule
+     */
+    public function map(\DateTimeInterface $anchor, array $rule, \DateTimeZone $tz): ?string
+    {
+        $frequency = is_string($rule['frequency'] ?? null) ? $rule['frequency'] : '';
+        $interval = max(1, is_int($rule['interval'] ?? null) ? $rule['interval'] : 1);
+
+        $parts = match ($frequency) {
+            'daily' => ['FREQ=DAILY'],
+            'weekly' => $this->weeklyParts($rule),
+            'monthly' => $this->monthlyParts($anchor, $rule),
+            'yearly' => ['FREQ=YEARLY'],
+            default => null,
+        };
+        if (null === $parts) {
+            return null;
+        }
+
+        if ($interval > 1) {
+            $parts[] = 'INTERVAL=' . $interval;
+        }
+
+        $ends = $this->endsPart($rule, $tz);
+        if (false === $ends) {
+            return null;
+        }
+        if (null !== $ends) {
+            $parts[] = $ends;
+        }
+
+        return 'RRULE:' . implode(';', $parts);
+    }
+
+    /**
+     * @param array<array-key, mixed> $rule
+     *
+     * @return list<string>
+     */
+    private function weeklyParts(array $rule): array
+    {
+        $parts = ['FREQ=WEEKLY'];
+        $tokens = $this->byDayTokens($rule);
+        if ([] !== $tokens) {
+            $parts[] = 'BYDAY=' . implode(',', $tokens);
+        }
+
+        return $parts;
+    }
+
+    /**
+     * @param array<array-key, mixed> $rule
+     *
+     * @return list<string>|null null when the day-mode anchor can't be a clean RRULE
+     */
+    private function monthlyParts(\DateTimeInterface $anchor, array $rule): ?array
+    {
+        $mode = ($rule['monthlyMode'] ?? 'day') === 'weekday' ? 'weekday' : 'day';
+
+        if ('day' === $mode) {
+            $day = (int) $anchor->format('j');
+            // Days 29–31 clamp differently than RRULE BYMONTHDAY — expand.
+            if ($day > 28) {
+                return null;
+            }
+
+            return ['FREQ=MONTHLY', 'BYMONTHDAY=' . $day];
+        }
+
+        $tokens = $this->byDayTokens($rule);
+        // format('N') is always 1..7, so the lookup always resolves.
+        $token = $tokens[0] ?? self::DAY_TOKENS[(int) $anchor->format('N')];
+        $setPos = is_int($rule['bySetPos'] ?? null) ? $rule['bySetPos'] : 1;
+        if (-1 !== $setPos && ($setPos < 1 || $setPos > 5)) {
+            return null;
+        }
+
+        return ['FREQ=MONTHLY', 'BYDAY=' . $setPos . $token];
+    }
+
+    /**
+     * The ends clause: a string (`UNTIL=…`/`COUNT=…`), null for "never ends",
+     * or false when an `until` is present but unparseable (map fails).
+     *
+     * @param array<array-key, mixed> $rule
+     */
+    private function endsPart(array $rule, \DateTimeZone $tz): string|false|null
+    {
+        $ends = $rule['ends'] ?? null;
+        if (!is_array($ends)) {
+            return null;
+        }
+        $type = $ends['type'] ?? null;
+
+        if ('count' === $type) {
+            $count = $ends['count'] ?? null;
+
+            return is_int($count) && $count >= 1 ? 'COUNT=' . $count : null;
+        }
+
+        if ('until' === $type) {
+            $until = $ends['until'] ?? null;
+            if (!is_string($until) || '' === $until) {
+                return false;
+            }
+            // Inclusive end-of-day in the user's zone, expressed in UTC — RRULE
+            // UNTIL must be UTC when DTSTART is a local (TZID) time.
+            $parsed = \DateTimeImmutable::createFromFormat('!Y-m-d', $until, $tz);
+            if (false === $parsed) {
+                return false;
+            }
+            $utc = $parsed->setTime(23, 59, 59)->setTimezone(new \DateTimeZone('UTC'));
+
+            return 'UNTIL=' . $utc->format('Ymd\THis\Z');
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<array-key, mixed> $rule
+     *
+     * @return list<string>
+     */
+    private function byDayTokens(array $rule): array
+    {
+        $byDay = $rule['byDay'] ?? null;
+        if (!is_array($byDay)) {
+            return [];
+        }
+        $out = [];
+        foreach ($byDay as $token) {
+            if (is_string($token) && in_array($token, self::VALID_TOKENS, true) && !in_array($token, $out, true)) {
+                $out[] = $token;
+            }
+        }
+
+        return $out;
+    }
+}

--- a/api/src/Ical/VTimezoneBuilder.php
+++ b/api/src/Ical/VTimezoneBuilder.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Ical;
+
+/**
+ * Builds a valid RFC 5545 VTIMEZONE component for an IANA zone by emitting its
+ * explicit UTC-offset transitions over a bounded window (rather than deriving
+ * recurring RRULE-based transition rules, which is fragile). Every DTSTART /
+ * DTEND that carries a `TZID` in the feed must have a matching VTIMEZONE, so
+ * the feed builder emits exactly one of these for the user's zone.
+ *
+ * UTC needs no VTIMEZONE (events are emitted with a `Z` suffix instead), so
+ * {@see build} returns null for it.
+ */
+final class VTimezoneBuilder
+{
+    public function __construct(private readonly IcalWriter $writer)
+    {
+    }
+
+    /**
+     * @return list<string>|null the VTIMEZONE content lines, or null for UTC
+     */
+    public function build(\DateTimeZone $tz, \DateTimeImmutable $from, \DateTimeImmutable $to): ?array
+    {
+        if ('UTC' === $tz->getName()) {
+            return null;
+        }
+
+        $transitions = $tz->getTransitions($from->getTimestamp(), $to->getTimestamp());
+        if ([] === $transitions) {
+            return null;
+        }
+
+        $lines = [
+            'BEGIN:VTIMEZONE',
+            $this->writer->line('TZID', $tz->getName()),
+        ];
+
+        $previousOffset = $transitions[0]['offset'];
+        foreach ($transitions as $index => $transition) {
+            // First entry is the state at the window start, not a real
+            // transition — anchor its "from" offset to itself so the initial
+            // STANDARD/DAYLIGHT component is self-consistent.
+            $offsetFrom = 0 === $index ? $transition['offset'] : $previousOffset;
+            $lines = array_merge($lines, $this->component($transition, $offsetFrom));
+            $previousOffset = $transition['offset'];
+        }
+
+        $lines[] = 'END:VTIMEZONE';
+
+        return $lines;
+    }
+
+    /**
+     * @param array{ts: int, offset: int, isdst: bool, abbr: string} $transition
+     *
+     * @return list<string>
+     */
+    private function component(array $transition, int $offsetFrom): array
+    {
+        $type = $transition['isdst'] ? 'DAYLIGHT' : 'STANDARD';
+        // The transition's local wall-clock start is the UTC instant shifted
+        // by the offset that takes effect at the transition.
+        $localStart = (new \DateTimeImmutable('@' . $transition['ts']))
+            ->modify(sprintf('%+d seconds', $transition['offset']))
+            ->format('Ymd\THis');
+
+        return [
+            'BEGIN:' . $type,
+            $this->writer->line('DTSTART', $localStart),
+            $this->writer->line('TZOFFSETFROM', $this->formatOffset($offsetFrom)),
+            $this->writer->line('TZOFFSETTO', $this->formatOffset($transition['offset'])),
+            $this->writer->line('TZNAME', $this->writer->escapeText($transition['abbr'])),
+            'END:' . $type,
+        ];
+    }
+
+    /** Format seconds-of-offset as an iCal UTC offset (`+0100`, `-0430`). */
+    private function formatOffset(int $seconds): string
+    {
+        $sign = $seconds < 0 ? '-' : '+';
+        $abs = abs($seconds);
+        $hours = intdiv($abs, 3600);
+        $minutes = intdiv($abs % 3600, 60);
+
+        return sprintf('%s%02d%02d', $sign, $hours, $minutes);
+    }
+}

--- a/api/src/Repository/CalendarFeedTokenRepository.php
+++ b/api/src/Repository/CalendarFeedTokenRepository.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\CalendarFeedToken;
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<CalendarFeedToken>
+ */
+class CalendarFeedTokenRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, CalendarFeedToken::class);
+    }
+
+    public function findByTokenHash(string $tokenHash): ?CalendarFeedToken
+    {
+        return $this->findOneBy(['tokenHash' => $tokenHash]);
+    }
+
+    public function findForUser(User $user): ?CalendarFeedToken
+    {
+        return $this->findOneBy(['user' => $user]);
+    }
+}

--- a/api/src/Service/CalendarFeedTokenManager.php
+++ b/api/src/Service/CalendarFeedTokenManager.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\CalendarFeedToken;
+use App\Entity\User;
+use App\Repository\CalendarFeedTokenRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Owns the lifecycle of a user's calendar-feed token: reveal (metadata),
+ * (re)generate, revoke, and resolve-by-plaintext. The plaintext secret is
+ * generated here and returned exactly once; only its sha256 hash is persisted,
+ * so nothing downstream — not the DB, not the API — can reproduce a live feed
+ * URL after the fact (mirrors the password-reset / export-token model).
+ */
+final class CalendarFeedTokenManager
+{
+    /** The route path a plaintext token slots into: /calendar/feed/{token}.ics */
+    public const FEED_PATH_PREFIX = '/calendar/feed/';
+    public const FEED_PATH_SUFFIX = '.ics';
+
+    public function __construct(
+        private readonly CalendarFeedTokenRepository $repository,
+        private readonly EntityManagerInterface $em,
+    ) {
+    }
+
+    public function findForUser(User $user): ?CalendarFeedToken
+    {
+        return $this->repository->findForUser($user);
+    }
+
+    /**
+     * Resolve a plaintext token to its (owning) record, or null when unknown.
+     * Constant-length guard keeps the hash lookup cheap and avoids feeding an
+     * absurd string into the hasher.
+     */
+    public function resolve(string $plaintext): ?CalendarFeedToken
+    {
+        if ('' === $plaintext || \strlen($plaintext) > 128) {
+            return null;
+        }
+
+        return $this->repository->findByTokenHash(hash('sha256', $plaintext));
+    }
+
+    /**
+     * Create the user's feed token, or rotate it if one already exists, and
+     * return the fresh plaintext. The old URL stops resolving immediately.
+     */
+    public function regenerate(User $user): string
+    {
+        $plaintext = bin2hex(random_bytes(32));
+        $hash = hash('sha256', $plaintext);
+
+        $token = $this->repository->findForUser($user);
+        if (null === $token) {
+            $token = new CalendarFeedToken($user, $hash);
+            $this->em->persist($token);
+        } else {
+            $token->rotate($hash);
+        }
+        $this->em->flush();
+
+        return $plaintext;
+    }
+
+    /** Delete the user's feed token so the subscribe URL dies. */
+    public function revoke(User $user): void
+    {
+        $token = $this->repository->findForUser($user);
+        if (null !== $token) {
+            $this->em->remove($token);
+            $this->em->flush();
+        }
+    }
+
+    /**
+     * The absolute subscribe URL for a freshly-minted plaintext token, built
+     * off the app's own origin (the feed is served from the same host).
+     */
+    public function buildFeedUrl(string $baseUrl, string $plaintext): string
+    {
+        return rtrim($baseUrl, '/') . self::FEED_PATH_PREFIX . $plaintext . self::FEED_PATH_SUFFIX;
+    }
+}

--- a/api/tests/Api/CalendarFeedTest.php
+++ b/api/tests/Api/CalendarFeedTest.php
@@ -1,0 +1,289 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\Task;
+use App\Entity\User;
+use App\Ical\IcalWriter;
+use App\Service\CalendarFeedTokenManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Covers the read-only iCal calendar feed (#calendar-sync): token auth
+ * (valid/invalid/rotated), feed contents (VEVENT/RRULE/VALARM), timezone
+ * rendering, recurrence mapping vs expansion, and the self-service
+ * /me/calendar-feed lifecycle endpoints.
+ */
+class CalendarFeedTest extends ApiTestCase
+{
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->em = $em;
+
+        $this->em->createQuery('DELETE FROM App\Entity\CalendarFeedToken')->execute();
+        $this->em->createQuery('DELETE FROM App\Entity\Task')->execute();
+        $this->em->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testUnknownTokenReturns404(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/calendar/feed/deadbeefdeadbeef.ics');
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testValidTokenServesTextCalendar(): void
+    {
+        $user = $this->createUser('feed@example.com');
+        $this->createTask($user, 'Ship it', '2026-07-06T13:00:00+00:00');
+        $token = $this->mintToken($user);
+
+        $client = static::createClient();
+        $response = $client->request('GET', $this->feedPath($token));
+
+        $this->assertResponseIsSuccessful();
+        $this->assertResponseHeaderSame('Content-Type', 'text/calendar; charset=utf-8');
+
+        $body = $this->unfold($response->getContent());
+        $this->assertStringContainsString('BEGIN:VCALENDAR', $body);
+        $this->assertStringContainsString('SUMMARY:Ship it', $body);
+        $this->assertStringContainsString('UID:task-', $body);
+    }
+
+    public function testFeedIncludesOwnedAndAssignedButNotForeignOrUndated(): void
+    {
+        $user = $this->createUser('me@example.com');
+        $other = $this->createUser('other@example.com');
+
+        $this->createTask($user, 'Owned due', '2026-07-06T13:00:00+00:00');
+        $this->createTask($user, 'Owned no due', null);
+
+        $assigned = $this->createTask($other, 'Assigned to me', '2026-07-07T13:00:00+00:00');
+        $assigned->addAssignee($user);
+        $this->createTask($other, 'Not mine', '2026-07-08T13:00:00+00:00');
+        $this->em->flush();
+
+        $body = $this->fetchFeed($user);
+
+        $this->assertStringContainsString('SUMMARY:Owned due', $body);
+        $this->assertStringContainsString('SUMMARY:Assigned to me', $body);
+        $this->assertStringNotContainsString('Owned no due', $body);
+        $this->assertStringNotContainsString('Not mine', $body);
+    }
+
+    public function testTimezoneRenderingUsesUserPreference(): void
+    {
+        $user = $this->createUser('ny@example.com', ['timezone' => 'America/New_York']);
+        $this->createTask($user, 'Standup', '2026-07-06T13:00:00+00:00');
+
+        $body = $this->fetchFeed($user);
+
+        // 13:00 UTC in July = 09:00 EDT, emitted as local time with a TZID.
+        $this->assertStringContainsString('BEGIN:VTIMEZONE', $body);
+        $this->assertStringContainsString('TZID:America/New_York', $body);
+        $this->assertStringContainsString('DTSTART;TZID=America/New_York:20260706T090000', $body);
+    }
+
+    public function testUtcUserGetsZuluTimesAndNoVtimezone(): void
+    {
+        $user = $this->createUser('utc@example.com', ['timezone' => 'UTC']);
+        $this->createTask($user, 'Zulu', '2026-07-06T13:00:00+00:00');
+
+        $body = $this->fetchFeed($user);
+
+        $this->assertStringNotContainsString('BEGIN:VTIMEZONE', $body);
+        $this->assertStringContainsString('DTSTART:20260706T130000Z', $body);
+    }
+
+    public function testWeeklyRecurringMapsToSingleRrule(): void
+    {
+        $user = $this->createUser('weekly@example.com', ['timezone' => 'UTC']);
+        $task = $this->createTask($user, 'Weekly review', '2026-07-06T13:00:00+00:00');
+        $task->setRecurrenceRule([
+            'frequency' => 'weekly',
+            'interval' => 1,
+            'byDay' => ['MO'],
+        ]);
+        $this->em->flush();
+
+        $body = $this->fetchFeed($user);
+
+        $this->assertStringContainsString('RRULE:FREQ=WEEKLY;BYDAY=MO', $body);
+        $this->assertSame(1, substr_count($body, 'BEGIN:VEVENT'));
+    }
+
+    public function testMonthlyDay31ExpandsIntoMultipleEvents(): void
+    {
+        $user = $this->createUser('monthly@example.com', ['timezone' => 'UTC']);
+        $task = $this->createTask($user, 'Rent', '2026-07-31T13:00:00+00:00');
+        $task->setRecurrenceRule(['frequency' => 'monthly', 'interval' => 1]);
+        $this->em->flush();
+
+        $body = $this->fetchFeed($user);
+
+        // Day-31 monthly can't be a single RRULE (clamp semantics), so it is
+        // expanded into individual dated VEVENTs.
+        $this->assertStringNotContainsString('RRULE:', $body);
+        $this->assertGreaterThan(1, substr_count($body, 'BEGIN:VEVENT'));
+    }
+
+    public function testRelativeReminderBecomesValarm(): void
+    {
+        $user = $this->createUser('reminder@example.com', ['timezone' => 'UTC']);
+        $task = $this->createTask($user, 'Call client', '2026-07-06T13:00:00+00:00');
+        $task->setReminders([
+            ['type' => 'relative', 'value' => 15, 'unit' => 'minutes', 'repeat' => false],
+        ]);
+        $this->em->flush();
+
+        $body = $this->fetchFeed($user);
+
+        $this->assertStringContainsString('BEGIN:VALARM', $body);
+        $this->assertStringContainsString('ACTION:DISPLAY', $body);
+        $this->assertStringContainsString('TRIGGER:-PT15M', $body);
+    }
+
+    public function testAbsoluteReminderBecomesUtcValarm(): void
+    {
+        $user = $this->createUser('abs@example.com', ['timezone' => 'UTC']);
+        $task = $this->createTask($user, 'Launch', '2026-07-06T13:00:00+00:00');
+        $task->setReminders([
+            ['type' => 'absolute', 'at' => '2026-07-06T08:00:00+00:00', 'repeat' => false],
+        ]);
+        $this->em->flush();
+
+        $body = $this->fetchFeed($user);
+
+        $this->assertStringContainsString('TRIGGER;VALUE=DATE-TIME:20260706T080000Z', $body);
+    }
+
+    public function testRotatingTokenInvalidatesOldUrl(): void
+    {
+        $user = $this->createUser('rotate@example.com');
+        $this->createTask($user, 'Task', '2026-07-06T13:00:00+00:00');
+
+        $manager = $this->tokenManager();
+        $first = $manager->regenerate($user);
+        $second = $manager->regenerate($user);
+        $this->assertNotSame($first, $second);
+
+        $client = static::createClient();
+        $client->request('GET', $this->feedPath($first));
+        $this->assertResponseStatusCodeSame(404);
+
+        $client->request('GET', $this->feedPath($second));
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testSelfServiceLifecycle(): void
+    {
+        $user = $this->createUser('lifecycle@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        // Initially disabled.
+        $response = $client->request('GET', '/me/calendar-feed');
+        $this->assertResponseIsSuccessful();
+        $this->assertFalse($response->toArray()['enabled']);
+
+        // Regenerate returns a one-shot URL that actually resolves.
+        $response = $client->request('POST', '/me/calendar-feed/regenerate');
+        $this->assertResponseStatusCodeSame(201);
+        $feedUrl = $response->toArray()['feedUrl'];
+        $this->assertIsString($feedUrl);
+        $this->assertStringContainsString('/calendar/feed/', $feedUrl);
+
+        $response = $client->request('GET', '/me/calendar-feed');
+        $this->assertTrue($response->toArray()['enabled']);
+
+        // Revoke.
+        $client->request('DELETE', '/me/calendar-feed');
+        $this->assertResponseStatusCodeSame(204);
+
+        $response = $client->request('GET', '/me/calendar-feed');
+        $this->assertFalse($response->toArray()['enabled']);
+    }
+
+    public function testSelfServiceRequiresAuth(): void
+    {
+        static::createClient()->request('GET', '/me/calendar-feed');
+        $this->assertResponseStatusCodeSame(401);
+    }
+
+    // --- helpers ---------------------------------------------------------
+
+    private function fetchFeed(User $user): string
+    {
+        $token = $this->mintToken($user);
+        $client = static::createClient();
+        $response = $client->request('GET', $this->feedPath($token));
+        $this->assertResponseIsSuccessful();
+
+        return $this->unfold($response->getContent());
+    }
+
+    /** Rejoin folded continuation lines so property assertions are simple. */
+    private function unfold(string $content): string
+    {
+        return str_replace(IcalWriter::CRLF . ' ', '', $content);
+    }
+
+    private function feedPath(string $token): string
+    {
+        return '/calendar/feed/' . $token . '.ics';
+    }
+
+    private function mintToken(User $user): string
+    {
+        return $this->tokenManager()->regenerate($user);
+    }
+
+    private function tokenManager(): CalendarFeedTokenManager
+    {
+        return static::getContainer()->get(CalendarFeedTokenManager::class);
+    }
+
+    /**
+     * @param array<string, mixed> $preferences
+     */
+    private function createUser(string $email, array $preferences = []): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        if ([] !== $preferences) {
+            $user->setPreferences($preferences);
+        }
+        $this->em->persist($user);
+        $this->em->flush();
+
+        return $user;
+    }
+
+    private function createTask(User $owner, string $title, ?string $dueDate): Task
+    {
+        $task = new Task();
+        $task->setOwner($owner);
+        $task->setTitle($title);
+        if (null !== $dueDate) {
+            $task->setDueDate(new \DateTimeImmutable($dueDate));
+        }
+        $this->em->persist($task);
+        $this->em->flush();
+
+        return $task;
+    }
+}

--- a/api/tests/Ical/IcalWriterTest.php
+++ b/api/tests/Ical/IcalWriterTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Tests\Ical;
+
+use App\Ical\IcalWriter;
+use PHPUnit\Framework\TestCase;
+
+class IcalWriterTest extends TestCase
+{
+    private IcalWriter $writer;
+
+    protected function setUp(): void
+    {
+        $this->writer = new IcalWriter();
+    }
+
+    public function testEscapeText(): void
+    {
+        $this->assertSame(
+            'a\\,b\\; c\\nd \\\\e',
+            $this->writer->escapeText("a,b; c\nd \\e"),
+        );
+    }
+
+    public function testFoldBreaksLongLinesWithLeadingSpace(): void
+    {
+        $line = 'DESCRIPTION:' . str_repeat('x', 200);
+        $folded = $this->writer->fold($line);
+
+        foreach (explode(IcalWriter::CRLF, $folded) as $i => $physical) {
+            // First physical line <=75; continuations start with a space.
+            $this->assertLessThanOrEqual(75, \strlen($physical));
+            if ($i > 0) {
+                $this->assertStringStartsWith(' ', $physical);
+            }
+        }
+        // Unfolding restores the original.
+        $this->assertSame($line, str_replace(IcalWriter::CRLF . ' ', '', $folded));
+    }
+
+    public function testFormatUtc(): void
+    {
+        $this->assertSame(
+            '20260706T130000Z',
+            $this->writer->formatUtc(new \DateTimeImmutable('2026-07-06T09:00:00-04:00')),
+        );
+    }
+
+    public function testFormatLocal(): void
+    {
+        $this->assertSame(
+            '20260706T090000',
+            $this->writer->formatLocal(
+                new \DateTimeImmutable('2026-07-06T13:00:00+00:00'),
+                new \DateTimeZone('America/New_York'),
+            ),
+        );
+    }
+}

--- a/api/tests/Ical/RecurrenceRuleToRruleTest.php
+++ b/api/tests/Ical/RecurrenceRuleToRruleTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace App\Tests\Ical;
+
+use App\Ical\RecurrenceRuleToRrule;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit coverage for the recurrenceRule -> RRULE mapping, including the cases
+ * that deliberately return null so the feed falls back to expansion.
+ */
+class RecurrenceRuleToRruleTest extends TestCase
+{
+    private RecurrenceRuleToRrule $mapper;
+    private \DateTimeImmutable $anchor;
+
+    protected function setUp(): void
+    {
+        $this->mapper = new RecurrenceRuleToRrule();
+        // A Wednesday.
+        $this->anchor = new \DateTimeImmutable('2026-07-15T09:00:00+00:00');
+    }
+
+    /**
+     * @param array<array-key, mixed> $rule
+     */
+    private function map(array $rule, string $tz = 'UTC'): ?string
+    {
+        return $this->mapper->map($this->anchor, $rule, new \DateTimeZone($tz));
+    }
+
+    public function testDailyWithInterval(): void
+    {
+        $this->assertSame(
+            'RRULE:FREQ=DAILY;INTERVAL=2',
+            $this->map(['frequency' => 'daily', 'interval' => 2]),
+        );
+    }
+
+    public function testDailyIntervalOneOmitsInterval(): void
+    {
+        $this->assertSame(
+            'RRULE:FREQ=DAILY',
+            $this->map(['frequency' => 'daily', 'interval' => 1]),
+        );
+    }
+
+    public function testWeeklyByDay(): void
+    {
+        $this->assertSame(
+            'RRULE:FREQ=WEEKLY;BYDAY=MO,WE',
+            $this->map(['frequency' => 'weekly', 'interval' => 1, 'byDay' => ['MO', 'WE']]),
+        );
+    }
+
+    public function testWeeklyWithCount(): void
+    {
+        $this->assertSame(
+            'RRULE:FREQ=WEEKLY;COUNT=5',
+            $this->map([
+                'frequency' => 'weekly',
+                'interval' => 1,
+                'ends' => ['type' => 'count', 'count' => 5],
+            ]),
+        );
+    }
+
+    public function testMonthlyDayModeUnder29(): void
+    {
+        $anchor = new \DateTimeImmutable('2026-07-15T09:00:00+00:00');
+        $this->assertSame(
+            'RRULE:FREQ=MONTHLY;BYMONTHDAY=15',
+            $this->mapper->map($anchor, ['frequency' => 'monthly', 'interval' => 1], new \DateTimeZone('UTC')),
+        );
+    }
+
+    public function testMonthlyDayMode31DoesNotMap(): void
+    {
+        // Aura clamps day 31 into short months; RRULE BYMONTHDAY would skip
+        // them. So this must return null and let the feed expand instead.
+        $anchor = new \DateTimeImmutable('2026-07-31T09:00:00+00:00');
+        $this->assertNull(
+            $this->mapper->map($anchor, ['frequency' => 'monthly', 'interval' => 1], new \DateTimeZone('UTC')),
+        );
+    }
+
+    public function testMonthlyWeekdayNth(): void
+    {
+        $this->assertSame(
+            'RRULE:FREQ=MONTHLY;BYDAY=2TH',
+            $this->map([
+                'frequency' => 'monthly',
+                'interval' => 1,
+                'monthlyMode' => 'weekday',
+                'byDay' => ['TH'],
+                'bySetPos' => 2,
+            ]),
+        );
+    }
+
+    public function testMonthlyWeekdayLast(): void
+    {
+        $this->assertSame(
+            'RRULE:FREQ=MONTHLY;BYDAY=-1FR',
+            $this->map([
+                'frequency' => 'monthly',
+                'interval' => 1,
+                'monthlyMode' => 'weekday',
+                'byDay' => ['FR'],
+                'bySetPos' => -1,
+            ]),
+        );
+    }
+
+    public function testYearly(): void
+    {
+        $this->assertSame(
+            'RRULE:FREQ=YEARLY',
+            $this->map(['frequency' => 'yearly', 'interval' => 1]),
+        );
+    }
+
+    public function testUntilIsConvertedToUtc(): void
+    {
+        // 2026-12-31 23:59:59 in America/New_York (EST, -05:00) is
+        // 2027-01-01 04:59:59 UTC.
+        $result = $this->map([
+            'frequency' => 'daily',
+            'interval' => 1,
+            'ends' => ['type' => 'until', 'until' => '2026-12-31'],
+        ], 'America/New_York');
+
+        $this->assertSame('RRULE:FREQ=DAILY;UNTIL=20270101T045959Z', $result);
+    }
+
+    public function testUnknownFrequencyDoesNotMap(): void
+    {
+        $this->assertNull($this->map(['frequency' => 'fortnightly', 'interval' => 1]));
+    }
+}

--- a/pwa/components/settings/CalendarSyncCard.tsx
+++ b/pwa/components/settings/CalendarSyncCard.tsx
@@ -1,0 +1,228 @@
+import { useCallback, useEffect, useState } from "react";
+import { Calendar, Check, Copy, RefreshCw, Trash2 } from "lucide-react";
+import {
+  fetchCalendarFeedStatus,
+  regenerateCalendarFeed,
+  revokeCalendarFeed,
+  type CalendarFeedStatus,
+} from "@/lib/calendarFeed";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+const formatDate = (iso: string | null): string =>
+  iso ? new Date(iso).toLocaleString() : "—";
+
+/**
+ * Settings → Calendar sync card. Reveals, (re)generates, and revokes the
+ * private read-only iCal subscribe URL. Because the token is stored hashed,
+ * the plaintext URL is shown exactly once (right after generation); on a later
+ * visit we can only report that a feed is active and offer Regenerate/Revoke.
+ */
+const CalendarSyncCard = () => {
+  const [status, setStatus] = useState<CalendarFeedStatus | null>(null);
+  const [feedUrl, setFeedUrl] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isBusy, setIsBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      setStatus(await fetchCalendarFeedStatus());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load status.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const regenerate = async () => {
+    setIsBusy(true);
+    setError(null);
+    try {
+      const url = await regenerateCalendarFeed();
+      setFeedUrl(url);
+      setCopied(false);
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to generate URL.");
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const revoke = async () => {
+    if (
+      !window.confirm(
+        "Revoke the calendar feed? Any calendar subscribed to it will stop updating.",
+      )
+    ) {
+      return;
+    }
+    setIsBusy(true);
+    setError(null);
+    try {
+      await revokeCalendarFeed();
+      setFeedUrl(null);
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to revoke feed.");
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const copy = async () => {
+    if (!feedUrl) return;
+    try {
+      await navigator.clipboard.writeText(feedUrl);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setError("Couldn't copy to clipboard — select and copy the URL manually.");
+    }
+  };
+
+  const enabled = status?.enabled ?? false;
+
+  return (
+    <div className="space-y-4" data-testid="calendar-sync">
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5 rounded-md bg-muted p-2 text-muted-foreground">
+          <Calendar className="h-5 w-5" />
+        </div>
+        <div className="space-y-1">
+          <p className="text-sm text-muted-foreground">
+            Subscribe to a private, read-only feed of your tasks (those with a
+            due date, that you own or are assigned) in Google, Outlook, or Apple
+            Calendar. The feed is one-way — edits in your calendar app don&apos;t
+            change your tasks.
+          </p>
+        </div>
+      </div>
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : (
+        <div className="space-y-4">
+          {feedUrl ? (
+            <div className="space-y-2 rounded-md border border-cyan-700/30 bg-cyan-700/5 p-4">
+              <p className="text-sm font-medium">Your subscribe URL</p>
+              <div className="flex gap-2">
+                <Input
+                  readOnly
+                  value={feedUrl}
+                  onFocus={(e) => e.currentTarget.select()}
+                  className="font-mono text-xs"
+                  data-testid="calendar-feed-url"
+                  aria-label="Calendar subscribe URL"
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => void copy()}
+                  data-testid="calendar-feed-copy"
+                >
+                  {copied ? (
+                    <>
+                      <Check className="h-4 w-4" /> Copied
+                    </>
+                  ) : (
+                    <>
+                      <Copy className="h-4 w-4" /> Copy
+                    </>
+                  )}
+                </Button>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Copy this now — for your security it won&apos;t be shown again.
+                Anyone with this link can view your task schedule, so keep it
+                private. Lost it? Just regenerate.
+              </p>
+            </div>
+          ) : enabled ? (
+            <Alert>
+              <AlertDescription>
+                A calendar feed is active (created {formatDate(status?.createdAt ?? null)}
+                {status?.lastAccessedAt
+                  ? `, last synced ${formatDate(status.lastAccessedAt)}`
+                  : ""}
+                ). The subscribe URL is only shown once — regenerate to get a new
+                link (which replaces the old one).
+              </AlertDescription>
+            </Alert>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              No calendar feed yet. Generate a private subscribe URL to get
+              started.
+            </p>
+          )}
+
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="button"
+              onClick={() => void regenerate()}
+              disabled={isBusy}
+              data-testid="calendar-feed-regenerate"
+            >
+              <RefreshCw className="h-4 w-4" />
+              {enabled ? "Regenerate URL" : "Generate URL"}
+            </Button>
+            {enabled && (
+              <Button
+                type="button"
+                variant="ghost"
+                className="text-destructive hover:text-destructive"
+                onClick={() => void revoke()}
+                disabled={isBusy}
+                data-testid="calendar-feed-revoke"
+              >
+                <Trash2 className="h-4 w-4" /> Revoke
+              </Button>
+            )}
+          </div>
+
+          <div className="rounded-md border bg-muted/30 p-4 text-sm">
+            <p className="font-medium">How to subscribe</p>
+            <ul className="mt-2 space-y-1.5 text-muted-foreground">
+              <li>
+                <span className="font-medium text-foreground">Google Calendar:</span>{" "}
+                Other calendars → <span className="italic">From URL</span> → paste
+                the link.
+              </li>
+              <li>
+                <span className="font-medium text-foreground">Outlook:</span> Add
+                calendar → <span className="italic">Subscribe from web</span> →
+                paste the link.
+              </li>
+              <li>
+                <span className="font-medium text-foreground">Apple Calendar:</span>{" "}
+                File → <span className="italic">New Calendar Subscription</span> →
+                paste the link.
+              </li>
+            </ul>
+            <p className="mt-2 text-xs text-muted-foreground">
+              Calendar apps refresh subscriptions on their own schedule (often
+              every few hours), so new tasks may take a little while to appear.
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CalendarSyncCard;

--- a/pwa/components/settings/SettingsNav.tsx
+++ b/pwa/components/settings/SettingsNav.tsx
@@ -1,11 +1,19 @@
 import Link from "next/link";
-import { Bell, KeyRound, Shield, TriangleAlert, User } from "lucide-react";
+import {
+  Bell,
+  CalendarSync,
+  KeyRound,
+  Shield,
+  TriangleAlert,
+  User,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 
 export type SettingsSectionKey =
   | "profile"
   | "security"
   | "notifications"
+  | "calendar-sync"
   | "api-tokens"
   | "danger";
 
@@ -30,6 +38,12 @@ export const SETTINGS_SECTIONS: SettingsSection[] = [
     label: "Notifications",
     href: "/settings/notifications",
     Icon: Bell,
+  },
+  {
+    key: "calendar-sync",
+    label: "Calendar sync",
+    href: "/settings/calendar-sync",
+    Icon: CalendarSync,
   },
   {
     key: "api-tokens",

--- a/pwa/lib/calendarFeed.ts
+++ b/pwa/lib/calendarFeed.ts
@@ -1,0 +1,43 @@
+import { ENTRYPOINT } from "@/config/entrypoint";
+
+/**
+ * Client for the per-user read-only iCal calendar feed (#calendar-sync). The
+ * feed token is stored hashed server-side, so the plaintext subscribe URL is
+ * only ever returned once — from {@link regenerateCalendarFeed}. `GET` reports
+ * status only.
+ */
+export interface CalendarFeedStatus {
+  enabled: boolean;
+  createdAt: string | null;
+  lastAccessedAt: string | null;
+}
+
+export const fetchCalendarFeedStatus = async (): Promise<CalendarFeedStatus> => {
+  const res = await fetch(`${ENTRYPOINT}/me/calendar-feed`, {
+    credentials: "include",
+    headers: { Accept: "application/json" },
+  });
+  if (!res.ok) throw new Error("Failed to load calendar feed status.");
+  return res.json();
+};
+
+/** (Re)generate the feed token; returns the one-shot subscribe URL. */
+export const regenerateCalendarFeed = async (): Promise<string> => {
+  const res = await fetch(`${ENTRYPOINT}/me/calendar-feed/regenerate`, {
+    method: "POST",
+    credentials: "include",
+    headers: { Accept: "application/json" },
+  });
+  if (!res.ok) throw new Error("Failed to generate calendar feed URL.");
+  const data: { feedUrl?: string } = await res.json();
+  if (!data.feedUrl) throw new Error("Feed URL missing from response.");
+  return data.feedUrl;
+};
+
+export const revokeCalendarFeed = async (): Promise<void> => {
+  const res = await fetch(`${ENTRYPOINT}/me/calendar-feed`, {
+    method: "DELETE",
+    credentials: "include",
+  });
+  if (!res.ok) throw new Error("Failed to revoke calendar feed.");
+};

--- a/pwa/pages/settings/calendar-sync.tsx
+++ b/pwa/pages/settings/calendar-sync.tsx
@@ -1,0 +1,19 @@
+import SettingsShell from "@/components/settings/SettingsShell";
+import CalendarSyncCard from "@/components/settings/CalendarSyncCard";
+import { Card, CardContent } from "@/components/ui/card";
+
+const CalendarSyncPage = () => (
+  <SettingsShell
+    active="calendar-sync"
+    title="Calendar sync"
+    description="Subscribe to your tasks from Google, Outlook, or Apple Calendar."
+  >
+    <Card>
+      <CardContent className="pt-6">
+        <CalendarSyncCard />
+      </CardContent>
+    </Card>
+  </SettingsShell>
+);
+
+export default CalendarSyncPage;


### PR DESCRIPTION
## Summary

Adds one-way calendar sync: a private, read-only iCal (`.ics`) feed users subscribe to in Google/Outlook/Apple Calendar so their tasks appear as calendar events.

- **Token model** — `CalendarFeedToken` (one per user, `sha256`-hashed like `PasswordResetToken`/export tokens; plaintext only ever in the subscribe URL, never re-derivable) + migration.
- **Public feed** — `GET /calendar/feed/{token}.ics`, token-authenticated (no session — calendar clients can't log in), `text/calendar; charset=utf-8`; unknown/rotated token → 404.
- **iCal rendering** — hand-rolled RFC 5545 (`api/src/Ical/`): CRLF + 75-octet line folding + TEXT escaping, a `VTIMEZONE` builder from IANA transitions, and a feed builder emitting VEVENTs (SUMMARY, DESCRIPTION, deep-link URL, stable UID, STATUS) for the user's owned **or** assigned due-dated tasks. No new dependency.
- **Recurrence** — maps clean rules to a single `RRULE` (freq/interval, weekly `BYDAY`, monthly-nth `BYDAY=2TH`, `UNTIL` in UTC / `COUNT`); rules that can't (e.g. monthly day-of-month ≥ 29, whose Aura clamp differs from `BYMONTHDAY`) fall back to bounded occurrence expansion via the existing `RecurrenceCalculator`, honoring EXDATEs.
- **Reminders → VALARM** — relative → `TRIGGER:-PT15M`; absolute → `TRIGGER;VALUE=DATE-TIME:…Z`.
- **Timezone** — rendered in the user's `timezone` preference (`TZID` + `VTIMEZONE`); UTC users get plain `…Z`.
- **Lifecycle** — `GET /me/calendar-feed` (status), `POST /me/calendar-feed/regenerate` (one-shot URL), `DELETE /me/calendar-feed` (revoke); `ROLE_USER`-gated.
- **PWA** — Settings → **Calendar sync** card: one-shot URL + copy, Regenerate/Revoke, and Google/Outlook/Apple subscribe hints (shadcn primitives + tokens).

Because the token is stored hashed, the subscribe URL is a one-shot reveal (from regenerate) — the card is explicit about this and offers regenerate if lost, matching the existing API-token/export pattern.

## Testing

- **PHPUnit**: full suite (1037 tests) green; new `CalendarFeedTest`, `RecurrenceRuleToRruleTest`, `IcalWriterTest` cover VEVENT/RRULE/VALARM, token valid/invalid/rotated, timezone, and recurrence mapping vs expansion.
- **PHPStan** level 10 + strict-rules: clean. **PHPCS** PSR-12: clean. **Doctrine schema**: in sync.
- **PWA**: `tsc --noEmit` clean; `pnpm lint` 0 errors.
