### PR TITLE
fix: repair broken pnpm-lock.yaml on main (duplicate @next/eslint-plugin-next)

### DIFF
--- a/pwa/pnpm-lock.yaml
+++ b/pwa/pnpm-lock.yaml
@@ -815,12 +815,6 @@ packages:
   '@next/eslint-plugin-next@16.2.10':
     resolution: {integrity: sha512-Gs8D2m21VnJeFo9qvYIIqJH94frWerWYu41BprU1pLtRVF7PCQNLiFZZ3fG+iPuj3K83Cwv/rt+msLOy8Qgu3Q==}
 
-  '@next/eslint-plugin-next@16.2.10':
-    resolution: {integrity: sha512-Gs8D2m21VnJeFo9qvYIIqJH94frWerWYu41BprU1pLtRVF7PCQNLiFZZ3fG+iPuj3K83Cwv/rt+msLOy8Qgu3Q==}
-
-  '@next/eslint-plugin-next@16.2.9':
-    resolution: {integrity: sha512-UZi8+YT/MLgTC9nrrn2Xd4lBYv1B7lVmtWHfPcthAI5Tt/C1LuDe6DfmtCtJ+WQod3ksY4VrKSvk3oMVAnL7qw==}
-
   '@next/swc-darwin-arm64@16.2.10':
     resolution: {integrity: sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==}
     engines: {node: '>= 10'}
@@ -5231,14 +5225,6 @@ snapshots:
   '@next/env@16.2.10': {}
 
   '@next/eslint-plugin-next@16.2.10':
-    dependencies:
-      fast-glob: 3.3.1
-
-  '@next/eslint-plugin-next@16.2.10':
-    dependencies:
-      fast-glob: 3.3.1
-
-  '@next/eslint-plugin-next@16.2.9':
     dependencies:
       fast-glob: 3.3.1
 


### PR DESCRIPTION
## Summary

Admin-merging the Dependabot PRs #585, #587, #589 while they were **behind** main caused GitHub's squash auto-merge to textually merge `pnpm-lock.yaml`, duplicating the `@next/eslint-plugin-next@16.2.10` mapping key and leaving an orphaned `16.2.9` entry. This produced `ERR_PNPM_BROKEN_LOCKFILE` on the main build (`Build images` fails, all downstream jobs skip).

## Fix

Remove the duplicate `16.2.10` and orphaned `16.2.9` blocks from both the `packages:` and `snapshots:` sections. No dependency versions change.

## Verification

`pnpm install --frozen-lockfile` (pnpm 9.1.3) succeeds against the repaired lockfile — package.json ↔ lockfile are consistent.