### PR TITLE
test: raise backend coverage to 85.5% and ratchet floor to 85

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,12 +138,14 @@ jobs:
         # trailing floor argument up as coverage climbs. Nudged to 83.5 after
         # removing the discussion move/copy controllers (fully covered code +
         # their tests), which shaved the api/src average a hair under 84.
-        # Lowered to 81.5 for the SSO + calendar-sync subsystem (#267/#581/#582):
-        # its OAuth-redirect dances (SsoController, OAuthConnectionController) and
-        # provider builders can't be unit-tested without live provider flows. The
-        # unit-testable parts — the Google/Microsoft client wire formats and the
-        # subscription lifecycle — are covered; ratchet back up as flow tests land.
-        run: docker compose exec -T php php bin/coverage-check.php var/coverage.xml 81.5
+        # Lowered to 81.5 for the SSO + calendar-sync subsystem (#267/#581/#582),
+        # then ratcheted back up to 85.0 once that subsystem got real coverage —
+        # MockHttpClient wire-format tests for the Google/Microsoft/Stripe clients,
+        # stub-provider tests for the SSO + OAuth callback dances, the SSO client
+        # factory, a real pg_dump BackupRunner test, and assorted service/entity
+        # units. Continue ratcheting toward 90% as the remaining controllers get
+        # endpoint tests.
+        run: docker compose exec -T php php bin/coverage-check.php var/coverage.xml 85.0
 
   phpstan:
     name: PHPStan

--- a/api/src/Service/SsoClientFactory.php
+++ b/api/src/Service/SsoClientFactory.php
@@ -20,8 +20,11 @@ use TheNetworg\OAuth2\Client\Provider\Azure;
  * provider from the admin-managed {@see SsoConfig} (DB), at request time.
  * Replaces knp's build-time ClientRegistry so credentials can live in the DB.
  * Okta/Auth0 are generic OIDC providers resolved via discovery.
+ *
+ * Not `final` so tests can substitute a stub provider (the OAuth callback can't
+ * otherwise be exercised without a live provider).
  */
-final class SsoClientFactory
+class SsoClientFactory
 {
     /** OAuth scopes per provider (space/comma joining is the provider's own). */
     public const SCOPES = [

--- a/api/tests/Api/OAuthConnectionCallbackTest.php
+++ b/api/tests/Api/OAuthConnectionCallbackTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Tests\Api;
+
+use App\Controller\OAuthConnectionController;
+use App\Entity\OAuthConnection;
+use App\Entity\User;
+use App\Service\CalendarSubscriptionManager;
+use App\Service\OAuthTokenService;
+use App\Service\SsoConfig;
+use App\Tests\Support\StubSsoClientFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use League\OAuth2\Client\Provider\AbstractProvider;
+use League\OAuth2\Client\Provider\ResourceOwnerInterface;
+use League\OAuth2\Client\Token\AccessToken;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+/**
+ * OAuth account-connection callback (#581) — token exchange + connection upsert
+ * — driven with a stubbed league provider so no network is hit.
+ */
+class OAuthConnectionCallbackTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = self::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->em = $em;
+
+        $this->em->createQuery('DELETE FROM App\Entity\OAuthConnection')->execute();
+        $this->em->createQuery('DELETE FROM App\Entity\Space')->execute();
+        $this->em->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testCallbackStoresConnection(): void
+    {
+        $user = new User();
+        $user->setEmail('conn@example.com');
+        $user->setGivenName('C');
+        $user->setFamilyName('U');
+        $user->setPersonalizedColor('#0369a1');
+        $this->em->persist($user);
+        $this->em->flush();
+
+        $owner = $this->createMock(ResourceOwnerInterface::class);
+        $owner->method('toArray')->willReturn(['sub' => 'ext-1', 'email' => 'conn@example.com']);
+        $provider = $this->createMock(AbstractProvider::class);
+        $provider->method('getAccessToken')->willReturn(new AccessToken([
+            'access_token' => 'at',
+            'refresh_token' => 'rt',
+            'expires_in' => 3600,
+        ]));
+        $provider->method('getResourceOwner')->willReturn($owner);
+
+        $container = self::getContainer();
+        $factory = new StubSsoClientFactory(
+            $container->get(SsoConfig::class),
+            new MockHttpClient(),
+            new ArrayAdapter(),
+            $provider,
+        );
+
+        $controller = new OAuthConnectionController(
+            $container->get(SsoConfig::class),
+            $factory,
+            $container->get(OAuthTokenService::class),
+            $this->em,
+            $container->get(CalendarSubscriptionManager::class),
+        );
+        $controller->setContainer($container);
+
+        $request = Request::create('/me/connections/google/check?state=st&code=abc');
+        $session = new Session(new MockArraySessionStorage());
+        $session->set('oauth_conn_state', 'st');
+        $request->setSession($session);
+
+        $response = $controller->check('google', $request, $user);
+
+        $this->assertStringContainsString('connected=google', $response->getTargetUrl());
+        $this->em->clear();
+        $connection = $this->em->getRepository(OAuthConnection::class)->findOneBy(['provider' => 'google']);
+        $this->assertNotNull($connection);
+        $this->assertSame('conn@example.com', $connection->getEmail());
+        $this->assertNotNull($connection->getExpiresAt());
+    }
+}

--- a/api/tests/Api/SsoCallbackTest.php
+++ b/api/tests/Api/SsoCallbackTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace App\Tests\Api;
+
+use App\Controller\SsoController;
+use App\Entity\SsoIdentity;
+use App\Entity\User;
+use App\Service\AvatarColorService;
+use App\Service\PersonalSpaceProvisioner;
+use App\Service\SsoConfig;
+use App\Service\WaitlistSettings;
+use App\Tests\Support\StubSsoClientFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use League\OAuth2\Client\Provider\AbstractProvider;
+use League\OAuth2\Client\Provider\ResourceOwnerInterface;
+use League\OAuth2\Client\Token\AccessToken;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * The SSO OAuth callback happy paths (#267) — sign-in provisioning and account
+ * linking — driven with a stubbed league provider so no network is hit.
+ */
+class SsoCallbackTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = self::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->em = $em;
+
+        $this->em->createQuery('DELETE FROM App\Entity\SsoIdentity')->execute();
+        $this->em->createQuery('DELETE FROM App\Entity\Space')->execute();
+        $this->em->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    /**
+     * @param array<string, mixed> $ownerData
+     */
+    private function controller(array $ownerData): SsoController
+    {
+        $owner = $this->createMock(ResourceOwnerInterface::class);
+        $owner->method('toArray')->willReturn($ownerData);
+
+        $provider = $this->createMock(AbstractProvider::class);
+        $provider->method('getAccessToken')->willReturn(new AccessToken(['access_token' => 'tok']));
+        $provider->method('getResourceOwner')->willReturn($owner);
+
+        $container = self::getContainer();
+        $factory = new StubSsoClientFactory(
+            $container->get(SsoConfig::class),
+            new MockHttpClient(),
+            new ArrayAdapter(),
+            $provider,
+        );
+
+        $controller = new SsoController(
+            $container->get(SsoConfig::class),
+            $factory,
+            $this->em,
+            $container->get(TokenStorageInterface::class),
+            $container->get(AvatarColorService::class),
+            $container->get(PersonalSpaceProvisioner::class),
+            $container->get(WaitlistSettings::class),
+            $container->get(HttpClientInterface::class),
+        );
+        $controller->setContainer($container);
+
+        return $controller;
+    }
+
+    private function callbackRequest(bool $linkMode): Request
+    {
+        $request = Request::create('/auth/sso/google/check?state=st&code=abc');
+        $session = new Session(new MockArraySessionStorage());
+        $session->set('sso_oauth_state', 'st');
+        if ($linkMode) {
+            $session->set('sso_link', true);
+        }
+        $request->setSession($session);
+
+        return $request;
+    }
+
+    public function testCallbackProvisionsAndSignsIn(): void
+    {
+        $controller = $this->controller([
+            'sub' => 'g-100',
+            'email' => 'new@example.com',
+            'email_verified' => true,
+            'given_name' => 'New',
+            'family_name' => 'Person',
+        ]);
+
+        $controller->check('google', $this->callbackRequest(false));
+
+        $this->em->clear();
+        $user = $this->em->getRepository(User::class)->findOneBy(['email' => 'new@example.com']);
+        $this->assertNotNull($user);
+        $this->assertNotNull(
+            $this->em->getRepository(SsoIdentity::class)->findOneBy(['provider' => 'google', 'subject' => 'g-100']),
+        );
+    }
+
+    public function testCallbackLinksToCurrentUser(): void
+    {
+        $user = new User();
+        $user->setEmail('me@example.com');
+        $user->setGivenName('Me');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $this->em->persist($user);
+        $this->em->flush();
+
+        $tokenStorage = self::getContainer()->get(TokenStorageInterface::class);
+        $tokenStorage->setToken(new UsernamePasswordToken($user, 'main', $user->getRoles()));
+
+        $controller = $this->controller([
+            'sub' => 'g-link',
+            'email' => 'me@example.com',
+            'email_verified' => true,
+        ]);
+
+        $response = $controller->check('google', $this->callbackRequest(true));
+
+        $this->assertStringContainsString('/settings/security', $response->getTargetUrl());
+        $this->em->clear();
+        $this->assertNotNull(
+            $this->em->getRepository(SsoIdentity::class)->findOneBy(['provider' => 'google', 'subject' => 'g-link']),
+        );
+    }
+}

--- a/api/tests/Api/SsoEndpointsTest.php
+++ b/api/tests/Api/SsoEndpointsTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\SsoIdentity;
+use App\Entity\User;
+use App\Service\SsoConfig;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * SSO controller endpoints outside the OAuth callback (#267): start/connect
+ * redirects, callback error branches, identity listing + unlink.
+ */
+class SsoEndpointsTest extends ApiTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\SsoIdentity')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\AppSetting')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Space')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    private function configureGoogle(): void
+    {
+        $config = self::getContainer()->get(SsoConfig::class);
+        $config->update('google', ['enabled' => true, 'clientId' => 'gid.apps', 'clientSecret' => 'secret']);
+    }
+
+    public function testStartRedirectsToProviderWhenConfigured(): void
+    {
+        $this->configureGoogle();
+        $client = static::createClient();
+        $client->request('GET', '/auth/sso/google/start?next=/tasks');
+
+        $this->assertResponseStatusCodeSame(302);
+        $this->assertStringContainsString('accounts.google.com', (string) $client->getKernelBrowser()->getResponse()->headers->get("Location"));
+    }
+
+    public function testStartUnknownProviderIs404(): void
+    {
+        static::createClient()->request('GET', '/auth/sso/dropbox/start');
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testConnectRedirectsForAuthedUser(): void
+    {
+        $this->configureGoogle();
+        $client = static::createClient();
+        $client->loginUser($this->createUser('c@example.com', withPassword: true));
+        $client->request('GET', '/me/sso/google/connect');
+
+        $this->assertResponseStatusCodeSame(302);
+    }
+
+    public function testCheckUnknownProviderRedirectsToSigninError(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/auth/sso/dropbox/check?state=x&code=y');
+
+        $this->assertResponseStatusCodeSame(302);
+        $this->assertStringContainsString('/signin?sso_error=unknown_provider', (string) $client->getKernelBrowser()->getResponse()->headers->get("Location"));
+    }
+
+    public function testCheckBadStateRedirects(): void
+    {
+        $this->configureGoogle();
+        $client = static::createClient();
+        // No start() called → no stored state → any state mismatches.
+        $client->request('GET', '/auth/sso/google/check?state=forged&code=y');
+
+        $this->assertResponseStatusCodeSame(302);
+        $this->assertStringContainsString('sso_error=bad_state', (string) $client->getKernelBrowser()->getResponse()->headers->get("Location"));
+    }
+
+    public function testIdentitiesListsLinkedProviders(): void
+    {
+        $this->configureGoogle();
+        $user = $this->createUser('id@example.com', withPassword: true);
+        $this->linkIdentity($user, 'google', 'g-1', 'id@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($user);
+        $body = $client->request('GET', '/me/sso/identities')->toArray();
+
+        $identities = $body['identities'] ?? [];
+        $this->assertIsArray($identities);
+        $this->assertCount(1, $identities);
+        $this->assertTrue($body['hasPassword'] ?? null);
+        $available = $body['available'] ?? [];
+        $this->assertIsArray($available);
+        $this->assertContains('google', $available);
+    }
+
+    public function testUnlinkSucceedsWhenPasswordPresent(): void
+    {
+        $user = $this->createUser('u@example.com', withPassword: true);
+        $this->linkIdentity($user, 'google', 'g-9', 'u@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($user);
+        $client->request('DELETE', '/me/sso/google');
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testUnlinkNotLinkedIs404(): void
+    {
+        $user = $this->createUser('n@example.com', withPassword: true);
+        $client = static::createClient();
+        $client->loginUser($user);
+        $client->request('DELETE', '/me/sso/github');
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testUnlinkOnlySignInMethodIsRejected(): void
+    {
+        // No password + single identity → can't remove the only way in.
+        $user = $this->createUser('only@example.com', withPassword: false);
+        $this->linkIdentity($user, 'google', 'g-only', 'only@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($user);
+        $client->request('DELETE', '/me/sso/google');
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    private function linkIdentity(User $user, string $provider, string $subject, string $email): void
+    {
+        $identity = (new SsoIdentity($provider, $subject))->setEmail($email);
+        $user->addSsoIdentity($identity);
+        $this->entityManager->persist($identity);
+        $this->entityManager->flush();
+    }
+
+    private function createUser(string $email, bool $withPassword): User
+    {
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        if ($withPassword) {
+            $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+            $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        }
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/api/tests/Api/SyncTaskToCalendarBranchesTest.php
+++ b/api/tests/Api/SyncTaskToCalendarBranchesTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Calendar\CalendarSyncException;
+use App\Entity\CalendarEventLink;
+use App\Entity\OAuthConnection;
+use App\Entity\Task;
+use App\Entity\User;
+use App\Tests\Calendar\InMemoryCalendarClient;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Push-sync handler branches (#582) the happy-path test doesn't hit: removing
+ * the due date deletes the event, and an update that finds the event gone
+ * recreates it.
+ */
+class SyncTaskToCalendarBranchesTest extends ApiTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\CalendarEventLink')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\OAuthConnection')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testRemovingDueDateDeletesEvent(): void
+    {
+        $user = $this->createUser('rm@example.com');
+        $this->connectGoogle($user);
+        $client = static::createClient();
+        $client->getKernelBrowser()->disableReboot();
+        $client->loginUser($user);
+
+        $iri = $this->pushTask($client, 'Drop it', '2026-08-15T00:00:00+00:00');
+        $this->assertSame(1, $this->linkCount());
+        $this->calendar()->reset();
+
+        $client->request('PATCH', $iri, [
+            'json' => ['dueDate' => null],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $this->assertSame(0, $this->linkCount());
+        $ops = array_column($this->calendar()->calls, 'op');
+        $this->assertContains('delete', $ops);
+    }
+
+    public function testUpdateOnGoneEventRecreates(): void
+    {
+        $user = $this->createUser('gone@example.com');
+        $this->connectGoogle($user);
+        $client = static::createClient();
+        $client->getKernelBrowser()->disableReboot();
+        $client->loginUser($user);
+
+        $iri = $this->pushTask($client, 'Recreate me', '2026-08-15T00:00:00+00:00');
+        // The next call (the update) reports the event vanished on the provider;
+        // don't reset() so the recreated event gets a distinct id.
+        $this->calendar()->failNext = CalendarSyncException::gone('gone');
+
+        $client->request('PATCH', $iri, [
+            'json' => ['title' => 'Recreated'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        // Stale link dropped + a fresh event created → one link, new event id.
+        $this->entityManager->clear();
+        $link = $this->entityManager->getRepository(CalendarEventLink::class)->findOneBy(['provider' => 'google']);
+        $this->assertNotNull($link);
+        $this->assertNotSame('evt-1', $link->getExternalEventId());
+    }
+
+    public function testDeletingTaskDeletesEvent(): void
+    {
+        $user = $this->createUser('del@example.com');
+        $this->connectGoogle($user);
+        $client = static::createClient();
+        $client->getKernelBrowser()->disableReboot();
+        $client->loginUser($user);
+
+        $iri = $this->pushTask($client, 'Delete task', '2026-08-15T00:00:00+00:00');
+        $this->calendar()->reset();
+
+        $client->request('DELETE', $iri);
+        $this->assertResponseStatusCodeSame(204);
+
+        // TaskDeleteProcessor snapshots the event id then the handler deletes it.
+        $ops = array_column($this->calendar()->calls, 'op');
+        $this->assertContains('delete', $ops);
+        $this->assertSame(0, $this->linkCount());
+    }
+
+    private function pushTask(Client $client, string $title, string $dueDate): string
+    {
+        $body = $client->request('POST', '/tasks', [
+            'json' => ['title' => $title, 'dueDate' => $dueDate],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $iri = $body['@id'] ?? '';
+        $this->assertIsString($iri);
+
+        return $iri;
+    }
+
+    private function calendar(): InMemoryCalendarClient
+    {
+        return static::getContainer()->get(InMemoryCalendarClient::class);
+    }
+
+    private function linkCount(): int
+    {
+        $this->entityManager->clear();
+
+        return (int) $this->entityManager
+            ->createQuery('SELECT COUNT(l.id) FROM App\Entity\CalendarEventLink l')
+            ->getSingleScalarResult();
+    }
+
+    private function connectGoogle(User $user): void
+    {
+        $connection = (new OAuthConnection('google'))
+            ->setUser($user)
+            ->setEmail($user->getEmail())
+            ->setAccessToken('enc')
+            ->setExpiresAt(new \DateTimeImmutable('+1 hour'))
+            ->setScopes(['calendar']);
+        $this->entityManager->persist($connection);
+        $this->entityManager->flush();
+    }
+
+    private function createUser(string $email): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('T');
+        $user->setFamilyName('U');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/api/tests/Billing/StripeGatewayTest.php
+++ b/api/tests/Billing/StripeGatewayTest.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Tests\Billing;
 
+use App\Billing\BillingException;
 use App\Billing\StripeGateway;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 
 /**
  * Unit coverage for the security-critical bit of {@see StripeGateway}: webhook
@@ -70,6 +72,68 @@ class StripeGatewayTest extends TestCase
     {
         $this->assertTrue((new StripeGateway(new MockHttpClient(), 'sk_test', self::SECRET))->isConfigured());
         $this->assertFalse((new StripeGateway(new MockHttpClient(), '', self::SECRET))->isConfigured());
+    }
+
+    public function testCreateCheckoutSessionReturnsUrl(): void
+    {
+        $response = new MockResponse((string) json_encode(['url' => 'https://checkout.stripe.test/s1']));
+        $gateway = new StripeGateway(new MockHttpClient([$response]), 'sk_test', self::SECRET);
+
+        $url = $gateway->createCheckoutSession('price_1', 3, 'https://ok', 'https://no', null, 'a@b.test', ['space_id' => 's1']);
+
+        $this->assertSame('https://checkout.stripe.test/s1', $url);
+        $this->assertSame('POST', $response->getRequestMethod());
+        $this->assertStringContainsString('/checkout/sessions', $response->getRequestUrl());
+    }
+
+    public function testCreateCheckoutSessionMissingUrlThrows(): void
+    {
+        $response = new MockResponse((string) json_encode(['id' => 'cs_1']));
+        $gateway = new StripeGateway(new MockHttpClient([$response]), 'sk_test', self::SECRET);
+
+        $this->expectException(BillingException::class);
+        $gateway->createCheckoutSession('price_1', 1, 'https://ok', 'https://no', 'cus_1', null, []);
+    }
+
+    public function testCreateBillingPortalSessionReturnsUrl(): void
+    {
+        $response = new MockResponse((string) json_encode(['url' => 'https://portal.stripe.test/p1']));
+        $gateway = new StripeGateway(new MockHttpClient([$response]), 'sk_test', self::SECRET);
+
+        $this->assertSame(
+            'https://portal.stripe.test/p1',
+            $gateway->createBillingPortalSession('cus_1', 'https://back'),
+        );
+    }
+
+    public function testCancelSubscriptionAtPeriodEnd(): void
+    {
+        $response = new MockResponse((string) json_encode(['id' => 'sub_1', 'cancel_at_period_end' => true]));
+        $gateway = new StripeGateway(new MockHttpClient([$response]), 'sk_test', self::SECRET);
+
+        $gateway->cancelSubscriptionAtPeriodEnd('sub_1');
+
+        $this->assertStringContainsString('/subscriptions/sub_1', $response->getRequestUrl());
+    }
+
+    public function testApiErrorSurfacesStripeMessage(): void
+    {
+        $response = new MockResponse(
+            (string) json_encode(['error' => ['message' => 'No such price']]),
+            ['http_code' => 400],
+        );
+        $gateway = new StripeGateway(new MockHttpClient([$response]), 'sk_test', self::SECRET);
+
+        $this->expectExceptionMessage('No such price');
+        $gateway->createBillingPortalSession('cus_1', 'https://back');
+    }
+
+    public function testUnconfiguredRequestThrows(): void
+    {
+        $gateway = new StripeGateway(new MockHttpClient(), '', self::SECRET);
+
+        $this->expectException(BillingException::class);
+        $gateway->createBillingPortalSession('cus_1', 'https://back');
     }
 
     private function gateway(): StripeGateway

--- a/api/tests/Calendar/GoogleCalendarClientTest.php
+++ b/api/tests/Calendar/GoogleCalendarClientTest.php
@@ -37,6 +37,61 @@ class GoogleCalendarClientTest extends KernelTestCase
         return $connection;
     }
 
+    /** A connection whose token is expired with no refresh token → unusable. */
+    private function tokenlessConnection(): OAuthConnection
+    {
+        $connection = new OAuthConnection('google');
+        $this->tokens->store($connection, new AccessToken(['access_token' => 'x', 'expires_in' => -100]));
+
+        return $connection;
+    }
+
+    public function testCreateWithoutValidTokenThrows(): void
+    {
+        [$client] = $this->clientReturning(new MockResponse($this->json(['id' => 'x'])));
+        $event = new CalendarEvent('t', null, new \DateTimeImmutable('2026-08-15'), false);
+
+        $this->expectException(CalendarSyncException::class);
+        $client->createEvent($this->tokenlessConnection(), 'primary', $event);
+    }
+
+    public function testApiErrorThrows(): void
+    {
+        [$client] = $this->clientReturning(new MockResponse('', ['http_code' => 500]));
+        $event = new CalendarEvent('t', null, new \DateTimeImmutable('2026-08-15'), false);
+
+        $this->expectException(CalendarSyncException::class);
+        $client->createEvent($this->connection(), 'primary', $event);
+    }
+
+    public function testCreateWithoutIdThrows(): void
+    {
+        [$client] = $this->clientReturning(new MockResponse($this->json(['no_id' => true])));
+        $event = new CalendarEvent('t', null, new \DateTimeImmutable('2026-08-15'), false);
+
+        $this->expectException(CalendarSyncException::class);
+        $client->createEvent($this->connection(), 'primary', $event);
+    }
+
+    public function testListChangesPaginates(): void
+    {
+        $page1 = new MockResponse($this->json([
+            'items' => [['id' => 'a', 'status' => 'confirmed', 'start' => ['date' => '2026-08-20']]],
+            'nextPageToken' => 'p2',
+        ]));
+        $page2 = new MockResponse($this->json([
+            'items' => [['id' => 'b', 'status' => 'confirmed', 'start' => ['dateTime' => '2026-08-21T09:00:00Z']]],
+            'nextSyncToken' => 'final',
+        ]));
+        $client = new GoogleCalendarClient(new MockHttpClient([$page1, $page2]), $this->tokens, $this->mapper);
+
+        $page = $client->listChanges($this->connection(), 'primary', null);
+
+        $this->assertSame('final', $page->nextSyncToken);
+        $this->assertCount(2, $page->changes);
+        $this->assertSame('2026-08-21', $page->changes[1]->date?->format('Y-m-d'));
+    }
+
     /** @return array{0: GoogleCalendarClient, 1: MockResponse} */
     private function clientReturning(MockResponse $response): array
     {
@@ -126,6 +181,19 @@ class GoogleCalendarClientTest extends KernelTestCase
         $client->createEvent($this->connection(), 'primary', $event);
 
         $this->assertSame(['RRULE:FREQ=WEEKLY;BYDAY=MO'], $this->body($response)['recurrence'] ?? null);
+    }
+
+    public function testUpdateEvent(): void
+    {
+        [$client, $response] = $this->clientReturning(new MockResponse($this->json(['id' => 'evt-9'])));
+        $event = new CalendarEvent('Renamed', 'body', new \DateTimeImmutable('2026-08-15'), true);
+
+        $client->updateEvent($this->connection(), 'primary', 'evt-9', $event);
+
+        $this->assertStringContainsString('/events/evt-9', $response->getRequestUrl());
+        $summary = $this->body($response)['summary'] ?? null;
+        $this->assertIsString($summary);
+        $this->assertStringStartsWith('✓', $summary);
     }
 
     public function testDeleteEvent(): void

--- a/api/tests/Calendar/MicrosoftCalendarClientTest.php
+++ b/api/tests/Calendar/MicrosoftCalendarClientTest.php
@@ -37,6 +37,68 @@ class MicrosoftCalendarClientTest extends KernelTestCase
         return $connection;
     }
 
+    private function tokenlessConnection(): OAuthConnection
+    {
+        $connection = new OAuthConnection('microsoft');
+        $this->tokens->store($connection, new AccessToken(['access_token' => 'x', 'expires_in' => -100]));
+
+        return $connection;
+    }
+
+    public function testCreateWithoutValidTokenThrows(): void
+    {
+        [$client] = $this->clientReturning(new MockResponse($this->json(['id' => 'x'])));
+        $event = new CalendarEvent('t', null, new \DateTimeImmutable('2026-08-15'), false);
+
+        $this->expectException(CalendarSyncException::class);
+        $client->createEvent($this->tokenlessConnection(), 'primary', $event);
+    }
+
+    public function testApiErrorThrows(): void
+    {
+        [$client] = $this->clientReturning(new MockResponse('', ['http_code' => 500]));
+        $event = new CalendarEvent('t', null, new \DateTimeImmutable('2026-08-15'), false);
+
+        $this->expectException(CalendarSyncException::class);
+        $client->createEvent($this->connection(), 'primary', $event);
+    }
+
+    public function testCreateWithoutIdThrows(): void
+    {
+        [$client] = $this->clientReturning(new MockResponse($this->json(['no_id' => true])));
+        $event = new CalendarEvent('t', null, new \DateTimeImmutable('2026-08-15'), false);
+
+        $this->expectException(CalendarSyncException::class);
+        $client->createEvent($this->connection(), 'primary', $event);
+    }
+
+    public function testListChangesPaginates(): void
+    {
+        $page1 = new MockResponse($this->json([
+            'value' => [['id' => 'a', 'start' => ['dateTime' => '2026-08-20T00:00:00', 'timeZone' => 'UTC']]],
+            '@odata.nextLink' => 'https://graph.microsoft.com/v1.0/me/calendarView/delta?$skiptoken=2',
+        ]));
+        $page2 = new MockResponse($this->json([
+            'value' => [['id' => 'b', '@removed' => ['reason' => 'deleted']]],
+            '@odata.deltaLink' => 'https://graph.microsoft.com/v1.0/me/calendarView/delta?$deltatoken=final',
+        ]));
+        $client = new MicrosoftCalendarClient(new MockHttpClient([$page1, $page2]), $this->tokens, $this->mapper);
+
+        $page = $client->listChanges($this->connection(), 'primary', null);
+
+        $this->assertStringContainsString('deltatoken=final', (string) $page->nextSyncToken);
+        $this->assertCount(2, $page->changes);
+        $this->assertTrue($page->changes[1]->cancelled);
+    }
+
+    public function testSubscribeWithoutIdThrows(): void
+    {
+        [$client] = $this->clientReturning(new MockResponse($this->json(['no_id' => true])));
+
+        $this->expectException(CalendarSyncException::class);
+        $client->subscribe($this->connection(), 'https://example.test/wh', 'secret');
+    }
+
     /** @return array{0: MicrosoftCalendarClient, 1: MockResponse} */
     private function clientReturning(MockResponse $response): array
     {
@@ -144,6 +206,16 @@ class MicrosoftCalendarClientTest extends KernelTestCase
         $subject = $this->body($response)['subject'] ?? null;
         $this->assertIsString($subject);
         $this->assertStringStartsWith('✓', $subject);
+    }
+
+    public function testDeleteEvent(): void
+    {
+        [$client, $response] = $this->clientReturning(new MockResponse('', ['http_code' => 204]));
+
+        $client->deleteEvent($this->connection(), 'primary', 'evt-1');
+
+        $this->assertSame('DELETE', $response->getRequestMethod());
+        $this->assertStringContainsString('/me/events/evt-1', $response->getRequestUrl());
     }
 
     public function testDeleteGoneEventRaisesGone(): void

--- a/api/tests/CustomField/ValueCoercionsTest.php
+++ b/api/tests/CustomField/ValueCoercionsTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Tests\CustomField;
+
+use App\CustomField\Converter\ValueCoercions;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Source-scalar coercions shared by the custom-field value converters.
+ */
+class ValueCoercionsTest extends TestCase
+{
+    private ValueCoercions $coercions;
+
+    protected function setUp(): void
+    {
+        $this->coercions = new ValueCoercions();
+    }
+
+    public function testToNumberFromNumeric(): void
+    {
+        $this->assertSame(3.0, $this->coercions->toNumber(3, 'numeric', 'integer', []));
+        $this->assertSame(2.5, $this->coercions->toNumber(2.5, 'numeric', 'float', []));
+        $this->assertNull($this->coercions->toNumber('x', 'numeric', 'integer', []));
+    }
+
+    public function testToNumberFromMoney(): void
+    {
+        // USD has 2 fraction digits → 1050 minor = 10.5 major.
+        $this->assertSame(10.5, $this->coercions->toNumber(
+            ['amount' => 1050, 'currency' => 'USD'],
+            'numeric',
+            'money',
+            [],
+        ));
+        $this->assertNull($this->coercions->toNumber('nope', 'numeric', 'money', []));
+        $this->assertNull($this->coercions->toNumber(['amount' => 'x', 'currency' => 'USD'], 'numeric', 'money', []));
+    }
+
+    public function testToNumberFromBooleanAndText(): void
+    {
+        $this->assertSame(1.0, $this->coercions->toNumber(true, 'boolean', 'boolean', []));
+        $this->assertSame(0.0, $this->coercions->toNumber(false, 'boolean', 'boolean', []));
+        $this->assertNull($this->coercions->toNumber('x', 'boolean', 'boolean', []));
+        $this->assertSame(4.0, $this->coercions->toNumber(' 4 ', 'text', 'text', []));
+        $this->assertNull($this->coercions->toNumber('abc', 'text', 'text', []));
+        $this->assertNull($this->coercions->toNumber('x', 'date', 'date', []));
+    }
+
+    public function testStringify(): void
+    {
+        $this->assertSame('hi', $this->coercions->stringify('hi', 'text', 'text', []));
+        $this->assertSame('Yes', $this->coercions->stringify(true, 'boolean', 'boolean', []));
+        $this->assertSame('No', $this->coercions->stringify(false, 'boolean', 'boolean', []));
+        $this->assertNull($this->coercions->stringify(1, 'boolean', 'boolean', []));
+        $this->assertSame('42', $this->coercions->stringify(42, 'numeric', 'integer', []));
+        $this->assertSame('2.5', $this->coercions->stringify(2.5, 'numeric', 'float', []));
+        $this->assertSame('10.50 USD', $this->coercions->stringify(
+            ['amount' => 1050, 'currency' => 'usd'],
+            'numeric',
+            'money',
+            [],
+        ));
+        $this->assertNull($this->coercions->stringify('x', 'numeric', 'money', []));
+    }
+
+    public function testStringifySelectUsesLabel(): void
+    {
+        $config = ['options' => [['key' => 'a', 'label' => 'Alpha'], ['key' => 'b', 'label' => 'Beta']]];
+        $this->assertSame('Alpha', $this->coercions->stringify('a', 'select', 'single', $config));
+        // Unknown key falls back to the raw value.
+        $this->assertSame('z', $this->coercions->stringify('z', 'select', 'single', $config));
+        $this->assertNull($this->coercions->stringify(5, 'select', 'single', $config));
+    }
+
+    public function testParseDate(): void
+    {
+        $this->assertSame('2026-08-15', $this->coercions->parseDate('2026-08-15', 'date', 'date')?->format('Y-m-d'));
+        $this->assertSame('14:30', $this->coercions->parseDate('14:30', 'date', 'time')?->format('H:i'));
+        $this->assertNull($this->coercions->parseDate('not-a-date', 'date', 'date'));
+        $this->assertNull($this->coercions->parseDate(5, 'date', 'date'));
+        // Lenient text parsing.
+        $this->assertSame('2026-01-02', $this->coercions->parseDate('2 Jan 2026', 'text', 'text')?->format('Y-m-d'));
+        $this->assertNull($this->coercions->parseDate('gibberish!!', 'text', 'text'));
+    }
+
+    public function testFractionDigitsAndFloatToString(): void
+    {
+        $this->assertSame(2, $this->coercions->fractionDigits('USD'));
+        $this->assertSame(0, $this->coercions->fractionDigits('JPY'));
+        $this->assertSame(2, $this->coercions->fractionDigits('ZZZ')); // unknown → default 2
+        $this->assertSame('0', $this->coercions->floatToString(0.0));
+        $this->assertSame('1.25', $this->coercions->floatToString(1.25));
+        $this->assertSame('3', $this->coercions->floatToString(3.0));
+    }
+
+    public function testSelectHelpers(): void
+    {
+        $config = ['options' => [['key' => 'a', 'label' => 'Alpha'], ['key' => 'b', 'label' => 'Beta'], 'junk']];
+        $this->assertSame(['a', 'b'], $this->coercions->selectKeys($config));
+        $this->assertSame(['a' => 'Alpha', 'b' => 'Beta'], $this->coercions->selectLabels($config));
+        $this->assertSame('b', $this->coercions->keyForLabel($config, ' beta '));
+        $this->assertNull($this->coercions->keyForLabel($config, 'nope'));
+        $this->assertSame([], $this->coercions->selectKeys(['options' => 'bad']));
+        $this->assertSame([], $this->coercions->selectLabels([]));
+    }
+}

--- a/api/tests/CustomField/ValueConvertersTest.php
+++ b/api/tests/CustomField/ValueConvertersTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Tests\CustomField;
+
+use App\CustomField\Converter\ConversionContext;
+use App\CustomField\Converter\DateValueConverter;
+use App\CustomField\Converter\SelectValueConverter;
+use App\CustomField\Converter\ValueCoercions;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Custom-field value converters (#227): date and select target shaping.
+ */
+class ValueConvertersTest extends TestCase
+{
+    private ValueCoercions $coercions;
+
+    protected function setUp(): void
+    {
+        $this->coercions = new ValueCoercions();
+    }
+
+    /**
+     * @param array<string, mixed> $fromConfig
+     * @param array<string, mixed> $toConfig
+     */
+    private function ctx(
+        string $fromKind,
+        string $fromSubtype,
+        string $toSubtype,
+        array $fromConfig = [],
+        array $toConfig = [],
+    ): ConversionContext {
+        return new ConversionContext($fromKind, $fromSubtype, $fromConfig, $toSubtype, $toConfig);
+    }
+
+    public function testDateTargetKind(): void
+    {
+        $this->assertSame('date', (new DateValueConverter($this->coercions))->targetKind());
+    }
+
+    public function testDateSameSubtype(): void
+    {
+        $converter = new DateValueConverter($this->coercions);
+        $this->assertSame([true, '2026-08-15'], $converter->convert('2026-08-15', $this->ctx('date', 'date', 'date')));
+    }
+
+    public function testDateToDatetime(): void
+    {
+        $converter = new DateValueConverter($this->coercions);
+        [$ok, $out] = $converter->convert('2026-08-15', $this->ctx('date', 'date', 'datetime'));
+        $this->assertTrue($ok);
+        $this->assertIsString($out);
+        $this->assertStringStartsWith('2026-08-15T00:00:00', $out);
+    }
+
+    public function testDateTimeCrossingsFail(): void
+    {
+        $converter = new DateValueConverter($this->coercions);
+        // time → date is meaningless.
+        $this->assertSame([false, null], $converter->convert('14:30', $this->ctx('date', 'time', 'date')));
+        // date → time is meaningless.
+        $this->assertSame([false, null], $converter->convert('2026-08-15', $this->ctx('date', 'date', 'time')));
+    }
+
+    public function testDateFromUnsupportedKindFails(): void
+    {
+        $converter = new DateValueConverter($this->coercions);
+        $this->assertSame([false, null], $converter->convert('x', $this->ctx('numeric', 'integer', 'date')));
+    }
+
+    public function testDateFromTextLenient(): void
+    {
+        $converter = new DateValueConverter($this->coercions);
+        [$ok, $out] = $converter->convert('2 Jan 2026', $this->ctx('text', 'text', 'date'));
+        $this->assertTrue($ok);
+        $this->assertSame('2026-01-02', $out);
+        $this->assertSame([false, null], $converter->convert('nonsense!!', $this->ctx('text', 'text', 'date')));
+    }
+
+    public function testSelectTargetKind(): void
+    {
+        $this->assertSame('select', (new SelectValueConverter($this->coercions))->targetKind());
+    }
+
+    public function testSelectKeyPassesThrough(): void
+    {
+        $converter = new SelectValueConverter($this->coercions);
+        $to = ['options' => [['key' => 'a', 'label' => 'Alpha']]];
+        $this->assertSame([true, 'a'], $converter->convert('a', $this->ctx('select', 'single', 'single', [], $to)));
+    }
+
+    public function testSelectBridgesByLabel(): void
+    {
+        $converter = new SelectValueConverter($this->coercions);
+        $from = ['options' => [['key' => 'old', 'label' => 'Alpha']]];
+        $to = ['options' => [['key' => 'new', 'label' => 'Alpha']]];
+        $this->assertSame([true, 'new'], $converter->convert('old', $this->ctx('select', 'single', 'single', $from, $to)));
+        // No label match → fail.
+        $this->assertSame([false, null], $converter->convert('old', $this->ctx('select', 'single', 'single', $from, ['options' => []])));
+    }
+
+    public function testSelectFromText(): void
+    {
+        $converter = new SelectValueConverter($this->coercions);
+        $to = ['options' => [['key' => 'a', 'label' => 'Alpha']]];
+        // Matches a key.
+        $this->assertSame([true, 'a'], $converter->convert('a', $this->ctx('text', 'text', 'single', [], $to)));
+        // Matches a label.
+        $this->assertSame([true, 'a'], $converter->convert('Alpha', $this->ctx('text', 'text', 'single', [], $to)));
+        // No match.
+        $this->assertSame([false, null], $converter->convert('zzz', $this->ctx('text', 'text', 'single', [], $to)));
+    }
+
+    public function testSelectNonStringFails(): void
+    {
+        $converter = new SelectValueConverter($this->coercions);
+        $this->assertSame([false, null], $converter->convert(5, $this->ctx('select', 'single', 'single')));
+    }
+}

--- a/api/tests/Entity/UserImpersonationTest.php
+++ b/api/tests/Entity/UserImpersonationTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Tests\Entity;
+
+use App\Entity\User;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * User's admin-impersonation consent accessors (category + per-item levels).
+ */
+class UserImpersonationTest extends TestCase
+{
+    private function user(): User
+    {
+        $user = new User();
+        $user->setPreferences([
+            'impersonationAccess' => ['tasks' => 'view', 'projects' => 'edit', 'bad' => 'nonsense'],
+            'impersonationItemAccess' => [
+                'task' => ['uuid-1' => 'none', 'uuid-2' => 'edit', 'uuid-3' => 'bogus'],
+            ],
+        ]);
+
+        return $user;
+    }
+
+    public function testCategoryLevel(): void
+    {
+        $user = $this->user();
+        $this->assertSame('view', $user->getImpersonationLevel('tasks'));
+        $this->assertSame('edit', $user->getImpersonationLevel('projects'));
+        // Invalid stored value → safe default.
+        $this->assertSame('none', $user->getImpersonationLevel('bad'));
+        // Unset category → default none.
+        $this->assertSame('none', $user->getImpersonationLevel('comments'));
+    }
+
+    public function testItemLevelOverrideWinsThenFallsBackToCategory(): void
+    {
+        $user = $this->user();
+        $this->assertSame('none', $user->getImpersonationItemLevel('task', 'uuid-1'));
+        $this->assertSame('edit', $user->getImpersonationItemLevel('task', 'uuid-2'));
+        // Malformed override → ignored, falls back to the 'tasks' category (view).
+        $this->assertSame('view', $user->getImpersonationItemLevel('task', 'uuid-3'));
+        // No override → category default.
+        $this->assertSame('view', $user->getImpersonationItemLevel('task', 'uuid-99'));
+    }
+
+    public function testItemPartition(): void
+    {
+        $partition = $this->user()->impersonationItemPartition('task');
+        $this->assertSame(['uuid-1'], $partition['none']);
+        $this->assertContains('uuid-2', $partition['visible']);
+        $this->assertNotContains('uuid-3', $partition['visible']);
+    }
+
+    public function testPartitionEmptyForUnknownType(): void
+    {
+        $partition = $this->user()->impersonationItemPartition('project');
+        $this->assertSame(['none' => [], 'visible' => []], $partition);
+    }
+}

--- a/api/tests/Service/BackupRunnerRunTest.php
+++ b/api/tests/Service/BackupRunnerRunTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Service\BackupRunner;
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * The dump/archive half of {@see BackupRunner}, run for real against the test
+ * database (pg_dump + the DB are in the container).
+ */
+class BackupRunnerRunTest extends KernelTestCase
+{
+    private string $dir;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->dir = sys_get_temp_dir() . '/backup-run-test-' . bin2hex(random_bytes(6));
+        mkdir($this->dir, 0750, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->glob('/*') as $file) {
+            if (is_file($file)) {
+                @unlink($file);
+            }
+        }
+        @unlink($this->dir . '/media-src/note.txt');
+        @rmdir($this->dir . '/media-src');
+        @rmdir($this->dir);
+        parent::tearDown();
+    }
+
+    /** @return list<string> */
+    private function glob(string $suffix): array
+    {
+        $found = glob($this->dir . $suffix);
+
+        return false === $found ? [] : $found;
+    }
+
+    private function connection(): Connection
+    {
+        $connection = self::getContainer()->get('doctrine')->getConnection();
+        assert($connection instanceof Connection);
+
+        return $connection;
+    }
+
+    public function testRunDumpsDatabaseAndSkipsMissingMedia(): void
+    {
+        $runner = new BackupRunner($this->connection(), $this->dir, $this->dir . '/absent-media', 5);
+
+        $result = $runner->run();
+
+        $this->assertNotEmpty($this->glob('/db-*.sql.gz'), 'a compressed dump is written');
+        $this->assertNull($result->mediaFile, 'no media dir → no archive');
+    }
+
+    public function testRunArchivesMediaWhenPresent(): void
+    {
+        $media = $this->dir . '/media-src';
+        mkdir($media, 0750, true);
+        file_put_contents($media . '/note.txt', 'hello');
+
+        $runner = new BackupRunner($this->connection(), $this->dir, $media, 5);
+        $result = $runner->run();
+
+        $this->assertNotEmpty($this->glob('/media-*.tar.gz'), 'media is archived');
+        $this->assertNotNull($result->mediaFile);
+    }
+}

--- a/api/tests/Service/CalendarSubscriptionManagerTest.php
+++ b/api/tests/Service/CalendarSubscriptionManagerTest.php
@@ -80,6 +80,38 @@ class CalendarSubscriptionManagerTest extends KernelTestCase
         $this->assertContains('unsubscribe', $ops);
     }
 
+    public function testRemoveWithoutSubscriptionIsNoOp(): void
+    {
+        // No ensure() first → nothing to tear down.
+        $this->manager('https://x.test')->remove($this->connection());
+        $this->assertSame([], $this->recorder()->subscriptions);
+    }
+
+    public function testRenewExpiringResubscribesNearExpiry(): void
+    {
+        $connection = $this->connection();
+        $manager = $this->manager('https://x.test');
+        $manager->ensure($connection);
+
+        // Backdate the subscription to just inside the renewal window.
+        $subscription = $this->em->getRepository(CalendarSubscription::class)->findOneBy(['connection' => $connection]);
+        $this->assertNotNull($subscription);
+        $subscription->setExpiresAt(new \DateTimeImmutable('+1 hour'));
+        $this->em->flush();
+        $this->recorder()->reset();
+
+        $manager->renewExpiring();
+
+        $ops = array_column($this->recorder()->subscriptions, 'op');
+        $this->assertContains('subscribe', $ops);
+    }
+
+    public function testRenewExpiringDisabledIsNoOp(): void
+    {
+        $this->manager('')->renewExpiring();
+        $this->assertSame([], $this->recorder()->subscriptions);
+    }
+
     private function manager(string $webhookBaseUrl): CalendarSubscriptionManager
     {
         $registry = self::getContainer()->get(CalendarClientRegistry::class);

--- a/api/tests/Service/ReminderSchedulerExtrasTest.php
+++ b/api/tests/Service/ReminderSchedulerExtrasTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Service\ReminderScheduler;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Additional coverage for {@see ReminderScheduler}: descriptions, the absolute
+ * fire path, and shape edge cases the core test doesn't touch.
+ */
+class ReminderSchedulerExtrasTest extends TestCase
+{
+    private ReminderScheduler $scheduler;
+
+    protected function setUp(): void
+    {
+        $this->scheduler = new ReminderScheduler();
+    }
+
+    public function testDescribeRelative(): void
+    {
+        $this->assertSame('when due', $this->scheduler->describe(['type' => 'relative', 'value' => 0, 'unit' => 'minutes']));
+        $this->assertSame('1 minute before due', $this->scheduler->describe(['type' => 'relative', 'value' => 1, 'unit' => 'minutes']));
+        $this->assertSame('3 hours before due', $this->scheduler->describe(['type' => 'relative', 'value' => 3, 'unit' => 'hours']));
+    }
+
+    public function testDescribeAbsoluteAndUnknown(): void
+    {
+        $this->assertStringStartsWith('on ', $this->scheduler->describe(['type' => 'absolute', 'at' => '2026-08-15T09:00:00Z']));
+        $this->assertSame('at a set time', $this->scheduler->describe(['type' => 'absolute', 'at' => 'garbage']));
+        $this->assertSame('reminder', $this->scheduler->describe(['type' => 'mystery']));
+    }
+
+    public function testRequiresDueDate(): void
+    {
+        $this->assertTrue($this->scheduler->requiresDueDate(['type' => 'relative', 'value' => 5, 'unit' => 'minutes']));
+        $this->assertFalse($this->scheduler->requiresDueDate(['type' => 'absolute', 'at' => '2026-08-15T09:00:00Z']));
+    }
+
+    public function testAbsoluteFireDueWhenPast(): void
+    {
+        $now = new \DateTimeImmutable('2026-08-15T10:00:00Z');
+        $fires = $this->scheduler->dueFires(['type' => 'absolute', 'at' => '2026-08-15T09:00:00Z'], null, $now);
+        $this->assertCount(1, $fires);
+        $this->assertStringStartsWith('abs:', $fires[0]['key']);
+
+        // Future absolute → no fire.
+        $this->assertSame([], $this->scheduler->dueFires(
+            ['type' => 'absolute', 'at' => '2026-08-20T09:00:00Z'],
+            null,
+            $now,
+        ));
+    }
+
+    public function testCanonicalKeyUnknown(): void
+    {
+        $this->assertStringStartsWith('unknown:', $this->scheduler->canonicalKey(['type' => 'nope']));
+    }
+
+    public function testShapeEdges(): void
+    {
+        // repeat present but not a bool → invalid.
+        $this->assertFalse($this->scheduler->isValidShape(['type' => 'relative', 'value' => 1, 'unit' => 'minutes', 'repeat' => 'yes']));
+        // absolute with a valid timestamp → valid.
+        $this->assertTrue($this->scheduler->isValidShape(['type' => 'absolute', 'at' => '2026-08-15T09:00:00Z']));
+        // absolute with unparseable time → invalid.
+        $this->assertFalse($this->scheduler->isValidShape(['type' => 'absolute', 'at' => 'nope']));
+        // negative relative value → invalid.
+        $this->assertFalse($this->scheduler->isValidShape(['type' => 'relative', 'value' => -1, 'unit' => 'minutes']));
+    }
+}

--- a/api/tests/Service/SsoClientFactoryTest.php
+++ b/api/tests/Service/SsoClientFactoryTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Service\SsoClientFactory;
+use App\Service\SsoConfig;
+use Doctrine\ORM\EntityManagerInterface;
+use League\OAuth2\Client\Provider\Apple;
+use League\OAuth2\Client\Provider\Facebook;
+use League\OAuth2\Client\Provider\GenericProvider;
+use League\OAuth2\Client\Provider\Github;
+use League\OAuth2\Client\Provider\Google;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use TheNetworg\OAuth2\Client\Provider\Azure;
+
+/**
+ * Builds a configured league provider per SSO provider from the admin config
+ * (#267). OIDC discovery for okta/auth0 is mocked.
+ */
+class SsoClientFactoryTest extends KernelTestCase
+{
+    private SsoConfig $config;
+    private SsoClientFactory $factory;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = self::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $em->createQuery('DELETE FROM App\Entity\AppSetting')->execute();
+
+        $this->config = self::getContainer()->get(SsoConfig::class);
+
+        $discovery = (string) json_encode([
+            'authorization_endpoint' => 'https://idp.example.com/authorize',
+            'token_endpoint' => 'https://idp.example.com/token',
+            'userinfo_endpoint' => 'https://idp.example.com/userinfo',
+        ]);
+        $mock = new MockHttpClient(static fn (): MockResponse => new MockResponse($discovery));
+        $this->factory = new SsoClientFactory($this->config, $mock, new ArrayAdapter());
+    }
+
+    public function testScopes(): void
+    {
+        $this->assertSame(['read:user', 'user:email'], $this->factory->scopes('github'));
+        $this->assertSame(['email', 'public_profile'], $this->factory->scopes('facebook'));
+        // Unknown provider → OIDC default.
+        $this->assertSame(['openid', 'email', 'profile'], $this->factory->scopes('mystery'));
+    }
+
+    public function testCreateConfiguredBuildsEachProvider(): void
+    {
+        $this->config->update('google', ['enabled' => true, 'clientId' => 'g', 'clientSecret' => 's']);
+        $this->config->update('github', ['enabled' => true, 'clientId' => 'gh', 'clientSecret' => 's']);
+        $this->config->update('facebook', ['enabled' => true, 'clientId' => 'fb', 'clientSecret' => 's']);
+        $this->config->update('microsoft', ['enabled' => true, 'clientId' => 'ms', 'clientSecret' => 's', 'tenant' => 'common']);
+        $this->config->update('apple', [
+            'enabled' => true,
+            'clientId' => 'com.example',
+            'teamId' => 'TEAM',
+            'keyId' => 'KEY',
+            'key' => "-----BEGIN PRIVATE KEY-----\nMIGdummy\n-----END PRIVATE KEY-----",
+        ]);
+        $this->config->update('okta', ['enabled' => true, 'clientId' => 'ok', 'clientSecret' => 's', 'issuer' => 'https://okta.example.com']);
+        $this->config->update('auth0', ['enabled' => true, 'clientId' => 'a0', 'clientSecret' => 's', 'issuer' => 'https://auth0.example.com']);
+
+        $this->assertInstanceOf(Google::class, $this->factory->createConfigured('google', 'https://app/cb'));
+        $this->assertInstanceOf(Github::class, $this->factory->createConfigured('github', 'https://app/cb'));
+        $this->assertInstanceOf(Facebook::class, $this->factory->createConfigured('facebook', 'https://app/cb'));
+        $this->assertInstanceOf(Azure::class, $this->factory->createConfigured('microsoft', 'https://app/cb'));
+        $this->assertInstanceOf(Apple::class, $this->factory->createConfigured('apple', 'https://app/cb'));
+        $this->assertInstanceOf(GenericProvider::class, $this->factory->createConfigured('okta', 'https://app/cb'));
+        $this->assertInstanceOf(GenericProvider::class, $this->factory->createConfigured('auth0', 'https://app/cb'));
+    }
+
+    public function testCreateHonoursEnableToggle(): void
+    {
+        // Configured but NOT enabled → create() (login) is null, createConfigured is not.
+        $this->config->update('google', ['enabled' => false, 'clientId' => 'g', 'clientSecret' => 's']);
+        $this->assertNull($this->factory->create('google', 'https://app/cb'));
+        $this->assertInstanceOf(Google::class, $this->factory->createConfigured('google', 'https://app/cb'));
+
+        // Enabled → create() builds it.
+        $this->config->update('google', ['enabled' => true, 'clientId' => 'g', 'clientSecret' => 's']);
+        $this->assertInstanceOf(Google::class, $this->factory->create('google', 'https://app/cb'));
+    }
+
+    public function testUnconfiguredAndUnknownReturnNull(): void
+    {
+        $this->assertNull($this->factory->createConfigured('google', 'https://app/cb'));
+        $this->assertNull($this->factory->createConfigured('dropbox', 'https://app/cb'));
+    }
+}

--- a/api/tests/Support/StubSsoClientFactory.php
+++ b/api/tests/Support/StubSsoClientFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Tests\Support;
+
+use App\Service\SsoClientFactory;
+use App\Service\SsoConfig;
+use League\OAuth2\Client\Provider\AbstractProvider;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Test double: returns a caller-supplied stub provider from create() /
+ * createConfigured(), so the OAuth callback flows can be exercised without a
+ * live provider. (SsoClientFactory is non-final for exactly this.)
+ */
+class StubSsoClientFactory extends SsoClientFactory
+{
+    public function __construct(
+        SsoConfig $config,
+        HttpClientInterface $httpClient,
+        CacheInterface $cache,
+        private readonly AbstractProvider $stub,
+    ) {
+        parent::__construct($config, $httpClient, $cache);
+    }
+
+    public function create(string $provider, string $redirectUri): ?AbstractProvider
+    {
+        return $this->stub;
+    }
+
+    public function createConfigured(string $provider, string $redirectUri): ?AbstractProvider
+    {
+        return $this->stub;
+    }
+}


### PR DESCRIPTION
Raises the CI coverage floor **81.5 → 85.0** on the back of ~70 new tests, chiefly across the SSO + calendar-sync subsystem (#267/#581/#582) plus assorted services/entities. Line coverage of `api/src` goes from 82.13% → **85.53%**.

## What's covered
- **MockHttpClient wire-format tests** — Google + Microsoft calendar clients (create/update/delete, all-day/timed/recurring payloads, delta parsing, 410 resync, subscribe/unsubscribe, error branches) and the Stripe gateway HTTP methods.
- **OAuth callback dances** via a stub provider — SSO sign-in/provision + account-link, and OAuth account-connection upsert. `SsoClientFactory` is now non-`final` so a stub provider can stand in (testability-only change, no behaviour impact). Plus SSO controller endpoint tests (start/connect/check-errors/identities/unlink) and the client factory (all 7 providers, mocked OIDC discovery).
- **Real pg_dump** — `BackupRunner` run + media-archive against the test DB.
- **Units** — value coercions + date/select converters, `ReminderScheduler` describe/absolute paths, subscription-manager renew/remove, push-handler delete/recreate branches, `User` impersonation-level accessors.

## Verification
- Full suite green: 1181 tests / 4377 assertions.
- PHPStan L10 + PHPCS clean on all changed files.

## Follow-up
Reaching a literal 90% needs endpoint tests for the remaining ~15 controllers/services (TwoFactor, Billing, ProjectCopy, Mcp, Calendar, SpaceMember, MediaObjectDownload, SpaceApiKey, NotificationDispatcher, CommentMentionService, the custom-field-values validator, FooterAggregator, CalendarFeedBuilder, and the SsoController remainder). Deferred to a separate pass.