### PR TITLE
feat: time tracking + invoicing (#444, #445)

### DIFF
--- a/api/composer.json
+++ b/api/composer.json
@@ -10,6 +10,7 @@
         "doctrine/doctrine-bundle": "^3.2",
         "doctrine/doctrine-migrations-bundle": "^4.0",
         "doctrine/orm": "^3.0",
+        "dompdf/dompdf": "^3.1",
         "dragonmantank/cron-expression": "^3.4",
         "drenso/symfony-oidc-bundle": "^4.5",
         "intervention/image": "^4.0",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "79b789ba932c882815973b019135c01d",
+    "content-hash": "7534de0b41e228187d2b480f28a067f2",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -2504,6 +2504,161 @@
             "time": "2026-02-08T16:21:46+00:00"
         },
         {
+            "name": "dompdf/dompdf",
+            "version": "v3.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/dompdf.git",
+                "reference": "f11ead23a8a76d0ff9bbc6c7c8fd7e05ca328496"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/dompdf/zipball/f11ead23a8a76d0ff9bbc6c7c8fd7e05ca328496",
+                "reference": "f11ead23a8a76d0ff9bbc6c7c8fd7e05ca328496",
+                "shasum": ""
+            },
+            "require": {
+                "dompdf/php-font-lib": "^1.0.0",
+                "dompdf/php-svg-lib": "^1.0.0",
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "masterminds/html5": "^2.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "ext-gd": "*",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "mockery/mockery": "^1.3",
+                "phpunit/phpunit": "^7.5 || ^8 || ^9 || ^10 || ^11",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/process": "^4.4 || ^5.4 || ^6.2 || ^7.0"
+            },
+            "suggest": {
+                "ext-gd": "Needed to process images",
+                "ext-gmagick": "Improves image processing performance",
+                "ext-imagick": "Improves image processing performance",
+                "ext-zlib": "Needed for pdf stream compression"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Dompdf\\": "src/"
+                },
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1"
+            ],
+            "authors": [
+                {
+                    "name": "The Dompdf Community",
+                    "homepage": "https://github.com/dompdf/dompdf/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "DOMPDF is a CSS 2.1 compliant HTML to PDF converter",
+            "homepage": "https://github.com/dompdf/dompdf",
+            "support": {
+                "issues": "https://github.com/dompdf/dompdf/issues",
+                "source": "https://github.com/dompdf/dompdf/tree/v3.1.5"
+            },
+            "time": "2026-03-03T13:54:37+00:00"
+        },
+        {
+            "name": "dompdf/php-font-lib",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-font-lib.git",
+                "reference": "a6e9a688a2a80016ac080b97be73d3e10c444c9a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-font-lib/zipball/a6e9a688a2a80016ac080b97be73d3e10c444c9a",
+                "reference": "a6e9a688a2a80016ac080b97be73d3e10c444c9a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8 || ^9 || ^10 || ^11 || ^12"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "FontLib\\": "src/FontLib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The FontLib Community",
+                    "homepage": "https://github.com/dompdf/php-font-lib/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "A library to read, parse, export and make subsets of different types of font files.",
+            "homepage": "https://github.com/dompdf/php-font-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-font-lib/issues",
+                "source": "https://github.com/dompdf/php-font-lib/tree/1.0.2"
+            },
+            "time": "2026-01-20T14:10:26+00:00"
+        },
+        {
+            "name": "dompdf/php-svg-lib",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-svg-lib.git",
+                "reference": "8259ffb930817e72b1ff1caef5d226501f3dfeb1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-svg-lib/zipball/8259ffb930817e72b1ff1caef5d226501f3dfeb1",
+                "reference": "8259ffb930817e72b1ff1caef5d226501f3dfeb1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0",
+                "sabberworm/php-css-parser": "^8.4 || ^9.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8 || ^9 || ^10 || ^11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Svg\\": "src/Svg"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The SvgLib Community",
+                    "homepage": "https://github.com/dompdf/php-svg-lib/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "A library to read, parse and export to PDF SVG files.",
+            "homepage": "https://github.com/dompdf/php-svg-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-svg-lib/issues",
+                "source": "https://github.com/dompdf/php-svg-lib/tree/1.0.2"
+            },
+            "time": "2026-01-02T16:01:13+00:00"
+        },
+        {
             "name": "dragonmantank/cron-expression",
             "version": "v3.6.0",
             "source": {
@@ -3974,6 +4129,73 @@
             "time": "2026-03-23T14:25:21+00:00"
         },
         {
+            "name": "masterminds/html5",
+            "version": "2.10.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Masterminds/html5-php.git",
+                "reference": "fd5018f6815fff903946d0564977b44ce8010e29"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/fd5018f6815fff903946d0564977b44ce8010e29",
+                "reference": "fd5018f6815fff903946d0564977b44ce8010e29",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7.21 || ^6 || ^7 || ^8 || ^9 || ^10"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Masterminds\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Butcher",
+                    "email": "technosophos@gmail.com"
+                },
+                {
+                    "name": "Matt Farina",
+                    "email": "matt@mattfarina.com"
+                },
+                {
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
+                }
+            ],
+            "description": "An HTML5 parser and serializer.",
+            "homepage": "http://masterminds.github.io/html5-php",
+            "keywords": [
+                "HTML5",
+                "dom",
+                "html",
+                "parser",
+                "querypath",
+                "serializer",
+                "xml"
+            ],
+            "support": {
+                "issues": "https://github.com/Masterminds/html5-php/issues",
+                "source": "https://github.com/Masterminds/html5-php/tree/2.10.1"
+            },
+            "time": "2026-06-23T18:43:15+00:00"
+        },
+        {
             "name": "minishlink/web-push",
             "version": "v10.1.0",
             "source": {
@@ -5188,6 +5410,86 @@
                 "source": "https://github.com/ralouphie/getallheaders/tree/develop"
             },
             "time": "2019-03-08T08:55:37+00:00"
+        },
+        {
+            "name": "sabberworm/php-css-parser",
+            "version": "v9.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MyIntervals/PHP-CSS-Parser.git",
+                "reference": "fd3bf9fb173e0df649bc4e3e0d088a1b2417c08f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MyIntervals/PHP-CSS-Parser/zipball/fd3bf9fb173e0df649bc4e3e0d088a1b2417c08f",
+                "reference": "fd3bf9fb173e0df649bc4e3e0d088a1b2417c08f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": "^7.2.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "thecodingmachine/safe": "^1.3 || ^2.5 || ^3.4"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "1.4.0",
+                "phpstan/extension-installer": "1.4.3",
+                "phpstan/phpstan": "1.12.33 || 2.2.2",
+                "phpstan/phpstan-phpunit": "1.4.2 || 2.0.16",
+                "phpstan/phpstan-strict-rules": "1.6.2 || 2.0.11",
+                "phpunit/phpunit": "8.5.52",
+                "rawr/phpunit-data-provider": "3.3.1",
+                "rector/rector": "1.2.10 || 2.4.6",
+                "rector/type-perfect": "1.0.0 || 2.1.3",
+                "squizlabs/php_codesniffer": "4.0.1",
+                "thecodingmachine/phpstan-safe-rule": "1.2.0 || 1.4.3"
+            },
+            "suggest": {
+                "ext-mbstring": "for parsing UTF-8 CSS"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.5.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Rule/Rule.php",
+                    "src/RuleSet/RuleContainer.php"
+                ],
+                "psr-4": {
+                    "Sabberworm\\CSS\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Raphael Schweikert"
+                },
+                {
+                    "name": "Oliver Klee",
+                    "email": "github@oliverklee.de"
+                },
+                {
+                    "name": "Jake Hotson",
+                    "email": "jake.github@qzdesign.co.uk"
+                }
+            ],
+            "description": "Parser for CSS Files written in PHP",
+            "homepage": "https://www.sabberworm.com/blog/2010/6/10/php-css-parser",
+            "keywords": [
+                "css",
+                "parser",
+                "stylesheet"
+            ],
+            "support": {
+                "issues": "https://github.com/MyIntervals/PHP-CSS-Parser/issues",
+                "source": "https://github.com/MyIntervals/PHP-CSS-Parser/tree/v9.4.0"
+            },
+            "time": "2026-06-18T15:10:53+00:00"
         },
         {
             "name": "scheb/2fa-backup-code",
@@ -11011,6 +11313,149 @@
                 }
             ],
             "time": "2026-05-25T06:06:12+00:00"
+        },
+        {
+            "name": "thecodingmachine/safe",
+            "version": "v3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thecodingmachine/safe.git",
+                "reference": "705683a25bacf0d4860c7dea4d7947bfd09eea19"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thecodingmachine/safe/zipball/705683a25bacf0d4860c7dea4d7947bfd09eea19",
+                "reference": "705683a25bacf0d4860c7dea4d7947bfd09eea19",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.4",
+                "phpstan/phpstan": "^2",
+                "phpunit/phpunit": "^10",
+                "squizlabs/php_codesniffer": "^3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/special_cases.php",
+                    "generated/apache.php",
+                    "generated/apcu.php",
+                    "generated/array.php",
+                    "generated/bzip2.php",
+                    "generated/calendar.php",
+                    "generated/classobj.php",
+                    "generated/com.php",
+                    "generated/cubrid.php",
+                    "generated/curl.php",
+                    "generated/datetime.php",
+                    "generated/dir.php",
+                    "generated/eio.php",
+                    "generated/errorfunc.php",
+                    "generated/exec.php",
+                    "generated/fileinfo.php",
+                    "generated/filesystem.php",
+                    "generated/filter.php",
+                    "generated/fpm.php",
+                    "generated/ftp.php",
+                    "generated/funchand.php",
+                    "generated/gettext.php",
+                    "generated/gmp.php",
+                    "generated/gnupg.php",
+                    "generated/hash.php",
+                    "generated/ibase.php",
+                    "generated/ibmDb2.php",
+                    "generated/iconv.php",
+                    "generated/image.php",
+                    "generated/imap.php",
+                    "generated/info.php",
+                    "generated/inotify.php",
+                    "generated/json.php",
+                    "generated/ldap.php",
+                    "generated/libxml.php",
+                    "generated/lzf.php",
+                    "generated/mailparse.php",
+                    "generated/mbstring.php",
+                    "generated/misc.php",
+                    "generated/mysql.php",
+                    "generated/mysqli.php",
+                    "generated/network.php",
+                    "generated/oci8.php",
+                    "generated/opcache.php",
+                    "generated/openssl.php",
+                    "generated/outcontrol.php",
+                    "generated/pcntl.php",
+                    "generated/pcre.php",
+                    "generated/pgsql.php",
+                    "generated/posix.php",
+                    "generated/ps.php",
+                    "generated/pspell.php",
+                    "generated/readline.php",
+                    "generated/rnp.php",
+                    "generated/rpminfo.php",
+                    "generated/rrd.php",
+                    "generated/sem.php",
+                    "generated/session.php",
+                    "generated/shmop.php",
+                    "generated/sockets.php",
+                    "generated/sodium.php",
+                    "generated/solr.php",
+                    "generated/spl.php",
+                    "generated/sqlsrv.php",
+                    "generated/ssdeep.php",
+                    "generated/ssh2.php",
+                    "generated/stream.php",
+                    "generated/strings.php",
+                    "generated/swoole.php",
+                    "generated/uodbc.php",
+                    "generated/uopz.php",
+                    "generated/url.php",
+                    "generated/var.php",
+                    "generated/xdiff.php",
+                    "generated/xml.php",
+                    "generated/xmlrpc.php",
+                    "generated/yaml.php",
+                    "generated/yaz.php",
+                    "generated/zip.php",
+                    "generated/zlib.php"
+                ],
+                "classmap": [
+                    "lib/DateTime.php",
+                    "lib/DateTimeImmutable.php",
+                    "lib/Exceptions/",
+                    "generated/Exceptions/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHP core functions that throw exceptions instead of returning FALSE on error",
+            "support": {
+                "issues": "https://github.com/thecodingmachine/safe/issues",
+                "source": "https://github.com/thecodingmachine/safe/tree/v3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/OskarStark",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/shish",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/silasjoisten",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-04T18:08:13+00:00"
         },
         {
             "name": "thenetworg/oauth2-azure",

--- a/api/migrations/Version20260703100852.php
+++ b/api/migrations/Version20260703100852.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260703100852 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Time tracking (#444): time_entry table + one-running-timer-per-user partial unique index.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE time_entry (id UUID NOT NULL, description TEXT DEFAULT NULL, started_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, ended_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL, duration_seconds INT DEFAULT NULL, billable BOOLEAN NOT NULL, rate_amount INT DEFAULT NULL, rate_currency VARCHAR(3) DEFAULT NULL, billed_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL, space_id UUID NOT NULL, project_id UUID DEFAULT NULL, task_id UUID DEFAULT NULL, user_id UUID NOT NULL, PRIMARY KEY (id))');
+        $this->addSql('CREATE INDEX IDX_6E537C0C23575340 ON time_entry (space_id)');
+        $this->addSql('CREATE INDEX IDX_6E537C0C8DB60186 ON time_entry (task_id)');
+        $this->addSql('CREATE INDEX IDX_6E537C0CA76ED395 ON time_entry (user_id)');
+        $this->addSql('CREATE INDEX idx_time_entry_space_started ON time_entry (space_id, started_at)');
+        $this->addSql('CREATE INDEX idx_time_entry_user_started ON time_entry (user_id, started_at)');
+        $this->addSql('CREATE INDEX idx_time_entry_project ON time_entry (project_id)');
+        $this->addSql('ALTER TABLE time_entry ADD CONSTRAINT FK_6E537C0C23575340 FOREIGN KEY (space_id) REFERENCES space (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE time_entry ADD CONSTRAINT FK_6E537C0C166D1F9C FOREIGN KEY (project_id) REFERENCES project (id) ON DELETE SET NULL NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE time_entry ADD CONSTRAINT FK_6E537C0C8DB60186 FOREIGN KEY (task_id) REFERENCES task (id) ON DELETE SET NULL NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE time_entry ADD CONSTRAINT FK_6E537C0CA76ED395 FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE');
+        // At most one running timer (ended_at IS NULL) per user.
+        $this->addSql('CREATE UNIQUE INDEX uniq_time_entry_running_per_user ON time_entry (user_id) WHERE ended_at IS NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE time_entry DROP CONSTRAINT FK_6E537C0C23575340');
+        $this->addSql('ALTER TABLE time_entry DROP CONSTRAINT FK_6E537C0C166D1F9C');
+        $this->addSql('ALTER TABLE time_entry DROP CONSTRAINT FK_6E537C0C8DB60186');
+        $this->addSql('ALTER TABLE time_entry DROP CONSTRAINT FK_6E537C0CA76ED395');
+        $this->addSql('DROP TABLE time_entry');
+    }
+}

--- a/api/migrations/Version20260703190602.php
+++ b/api/migrations/Version20260703190602.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260703190602 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Invoicing (#445): client, invoice, and invoice_line_item tables.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE client (id UUID NOT NULL, name VARCHAR(200) NOT NULL, email VARCHAR(255) DEFAULT NULL, address TEXT DEFAULT NULL, currency VARCHAR(3) DEFAULT NULL, default_rate_amount INT DEFAULT NULL, notes TEXT DEFAULT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL, space_id UUID NOT NULL, created_by_id UUID NOT NULL, PRIMARY KEY (id))');
+        $this->addSql('CREATE INDEX IDX_C744045523575340 ON client (space_id)');
+        $this->addSql('CREATE INDEX IDX_C7440455B03A8386 ON client (created_by_id)');
+        $this->addSql('CREATE INDEX idx_client_space_name ON client (space_id, name)');
+        $this->addSql('CREATE TABLE invoice (id UUID NOT NULL, number VARCHAR(40) DEFAULT NULL, status VARCHAR(20) NOT NULL, issue_date DATE DEFAULT NULL, due_date DATE DEFAULT NULL, currency VARCHAR(3) NOT NULL, tax_rate INT NOT NULL, notes TEXT DEFAULT NULL, subtotal INT NOT NULL, tax_amount INT NOT NULL, total INT NOT NULL, public_token VARCHAR(64) DEFAULT NULL, sent_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL, paid_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL, space_id UUID NOT NULL, client_id UUID NOT NULL, created_by_id UUID NOT NULL, PRIMARY KEY (id))');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_90651744AE981E3B ON invoice (public_token)');
+        $this->addSql('CREATE INDEX IDX_9065174423575340 ON invoice (space_id)');
+        $this->addSql('CREATE INDEX IDX_90651744B03A8386 ON invoice (created_by_id)');
+        $this->addSql('CREATE INDEX idx_invoice_space_created ON invoice (space_id, created_at)');
+        $this->addSql('CREATE INDEX idx_invoice_client ON invoice (client_id)');
+        $this->addSql('CREATE TABLE invoice_line_item (id UUID NOT NULL, description VARCHAR(500) NOT NULL, quantity DOUBLE PRECISION NOT NULL, unit_amount INT NOT NULL, amount INT NOT NULL, position INT NOT NULL, invoice_id UUID NOT NULL, source_time_entry_id UUID DEFAULT NULL, PRIMARY KEY (id))');
+        $this->addSql('CREATE INDEX IDX_F1F9275B2989F1FD ON invoice_line_item (invoice_id)');
+        $this->addSql('CREATE INDEX IDX_F1F9275BDBDFDBEC ON invoice_line_item (source_time_entry_id)');
+        $this->addSql('CREATE INDEX idx_invoice_line_item_invoice_position ON invoice_line_item (invoice_id, position)');
+        $this->addSql('ALTER TABLE client ADD CONSTRAINT FK_C744045523575340 FOREIGN KEY (space_id) REFERENCES space (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE client ADD CONSTRAINT FK_C7440455B03A8386 FOREIGN KEY (created_by_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE invoice ADD CONSTRAINT FK_9065174423575340 FOREIGN KEY (space_id) REFERENCES space (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE invoice ADD CONSTRAINT FK_9065174419EB6921 FOREIGN KEY (client_id) REFERENCES client (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE invoice ADD CONSTRAINT FK_90651744B03A8386 FOREIGN KEY (created_by_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE invoice_line_item ADD CONSTRAINT FK_F1F9275B2989F1FD FOREIGN KEY (invoice_id) REFERENCES invoice (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE invoice_line_item ADD CONSTRAINT FK_F1F9275BDBDFDBEC FOREIGN KEY (source_time_entry_id) REFERENCES time_entry (id) ON DELETE SET NULL NOT DEFERRABLE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE client DROP CONSTRAINT FK_C744045523575340');
+        $this->addSql('ALTER TABLE client DROP CONSTRAINT FK_C7440455B03A8386');
+        $this->addSql('ALTER TABLE invoice DROP CONSTRAINT FK_9065174423575340');
+        $this->addSql('ALTER TABLE invoice DROP CONSTRAINT FK_9065174419EB6921');
+        $this->addSql('ALTER TABLE invoice DROP CONSTRAINT FK_90651744B03A8386');
+        $this->addSql('ALTER TABLE invoice_line_item DROP CONSTRAINT FK_F1F9275B2989F1FD');
+        $this->addSql('ALTER TABLE invoice_line_item DROP CONSTRAINT FK_F1F9275BDBDFDBEC');
+        $this->addSql('DROP TABLE client');
+        $this->addSql('DROP TABLE invoice');
+        $this->addSql('DROP TABLE invoice_line_item');
+    }
+}

--- a/api/migrations/Version20260703212422.php
+++ b/api/migrations/Version20260703212422.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260703212422 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Recurring invoices (#445): recurrence_frequency, recurrence_interval, next_issue_date on invoice.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE invoice ADD recurrence_frequency VARCHAR(10) DEFAULT NULL');
+        $this->addSql('ALTER TABLE invoice ADD recurrence_interval INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE invoice ADD next_issue_date DATE DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE invoice DROP recurrence_frequency');
+        $this->addSql('ALTER TABLE invoice DROP recurrence_interval');
+        $this->addSql('ALTER TABLE invoice DROP next_issue_date');
+    }
+}

--- a/api/src/Billing/Payment/PaymentGatewayInterface.php
+++ b/api/src/Billing/Payment/PaymentGatewayInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Billing\Payment;
+
+use App\Entity\Invoice;
+
+/**
+ * A pluggable online-payment provider for client invoices (#445). Mirrors the
+ * multi-provider shape of the calendar sync ({@see \App\Calendar\CalendarClientInterface}
+ * / registry): Stripe first, PayPal next, both behind this one seam so the
+ * public pay page and the webhook stay provider-agnostic.
+ *
+ * The same providers back membership billing too — the Stripe implementation
+ * delegates to the existing {@see \App\Billing\StripeGatewayInterface}.
+ */
+interface PaymentGatewayInterface
+{
+    /** Stable provider key, e.g. 'stripe' or 'paypal'. */
+    public function key(): string;
+
+    /** Whether the provider is wired up (keys present) and can take payments. */
+    public function isConfigured(): bool;
+
+    /**
+     * Start a payment for the invoice's outstanding total and return the hosted
+     * URL the buyer is redirected to. The provider stamps enough metadata
+     * (our invoice id) that its webhook can mark the invoice paid.
+     */
+    public function createInvoicePayment(Invoice $invoice, string $successUrl, string $cancelUrl): string;
+}

--- a/api/src/Billing/Payment/PaymentGatewayRegistry.php
+++ b/api/src/Billing/Payment/PaymentGatewayRegistry.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Billing\Payment;
+
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+
+/**
+ * Resolves the active {@see PaymentGatewayInterface} by key (mirrors
+ * {@see \App\Calendar\CalendarClientRegistry}). Stripe is the default; PayPal
+ * slots in by implementing the interface + the `app.payment_gateway` tag.
+ */
+final class PaymentGatewayRegistry
+{
+    /** @var array<string, PaymentGatewayInterface> */
+    private array $byKey = [];
+
+    /**
+     * @param iterable<PaymentGatewayInterface> $gateways
+     */
+    public function __construct(
+        #[AutowireIterator('app.payment_gateway')]
+        iterable $gateways,
+    ) {
+        foreach ($gateways as $gateway) {
+            $this->byKey[$gateway->key()] = $gateway;
+        }
+    }
+
+    public function get(string $key): ?PaymentGatewayInterface
+    {
+        return $this->byKey[$key] ?? null;
+    }
+
+    /** The default provider (Stripe), or null if none is registered. */
+    public function default(): ?PaymentGatewayInterface
+    {
+        return $this->byKey[StripePaymentGateway::KEY] ?? (0 === count($this->byKey) ? null : reset($this->byKey));
+    }
+
+    /**
+     * Keys of the providers that are actually configured — what the PWA offers.
+     *
+     * @return list<string>
+     */
+    public function configuredKeys(): array
+    {
+        $keys = [];
+        foreach ($this->byKey as $key => $gateway) {
+            if ($gateway->isConfigured()) {
+                $keys[] = $key;
+            }
+        }
+
+        return $keys;
+    }
+}

--- a/api/src/Billing/Payment/StripePaymentGateway.php
+++ b/api/src/Billing/Payment/StripePaymentGateway.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Billing\Payment;
+
+use App\Billing\StripeGatewayInterface;
+use App\Entity\Invoice;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * Stripe implementation of {@see PaymentGatewayInterface} for one-off invoice
+ * payment — delegates to the existing {@see StripeGatewayInterface} (HttpClient,
+ * no SDK) so membership billing and invoice payment share one Stripe seam.
+ */
+#[AutoconfigureTag('app.payment_gateway')]
+final class StripePaymentGateway implements PaymentGatewayInterface
+{
+    public const KEY = 'stripe';
+
+    public function __construct(private readonly StripeGatewayInterface $stripe)
+    {
+    }
+
+    public function key(): string
+    {
+        return self::KEY;
+    }
+
+    public function isConfigured(): bool
+    {
+        return $this->stripe->isConfigured();
+    }
+
+    public function createInvoicePayment(Invoice $invoice, string $successUrl, string $cancelUrl): string
+    {
+        $label = $invoice->getNumber();
+        $description = 'Invoice ' . (null !== $label && '' !== $label ? $label : (string) $invoice->getId());
+
+        return $this->stripe->createPaymentCheckout(
+            $invoice->getTotal(),
+            $invoice->getCurrency(),
+            $description,
+            $successUrl,
+            $cancelUrl,
+            $invoice->getClient()?->getEmail(),
+            ['invoice_id' => (string) $invoice->getId()],
+        );
+    }
+}

--- a/api/src/Billing/StripeGateway.php
+++ b/api/src/Billing/StripeGateway.php
@@ -80,6 +80,47 @@ final class StripeGateway implements StripeGatewayInterface
         return $url;
     }
 
+    public function createPaymentCheckout(
+        int $amount,
+        string $currency,
+        string $description,
+        string $successUrl,
+        string $cancelUrl,
+        ?string $customerEmail,
+        array $metadata,
+    ): string {
+        $body = [
+            'mode' => 'payment',
+            'line_items' => [
+                [
+                    'price_data' => [
+                        'currency' => strtolower($currency),
+                        'product_data' => ['name' => $description],
+                        'unit_amount' => max(0, $amount),
+                    ],
+                    'quantity' => 1,
+                ],
+            ],
+            'success_url' => $successUrl,
+            'cancel_url' => $cancelUrl,
+            // Stamp our invoice id on both the session and the payment intent so
+            // the checkout.session.completed webhook resolves it without a retrieve.
+            'metadata' => $metadata,
+            'payment_intent_data' => ['metadata' => $metadata],
+        ];
+        if (null !== $customerEmail) {
+            $body['customer_email'] = $customerEmail;
+        }
+
+        $data = $this->request('POST', '/checkout/sessions', $body);
+        $url = $data['url'] ?? null;
+        if (!is_string($url) || '' === $url) {
+            throw new BillingException('Stripe did not return a Checkout URL.');
+        }
+
+        return $url;
+    }
+
     public function createBillingPortalSession(string $customerId, string $returnUrl): string
     {
         $data = $this->request('POST', '/billing_portal/sessions', [

--- a/api/src/Billing/StripeGatewayInterface.php
+++ b/api/src/Billing/StripeGatewayInterface.php
@@ -42,6 +42,25 @@ interface StripeGatewayInterface
     ): string;
 
     /**
+     * Create a one-off (mode=payment) Checkout Session for a single amount and
+     * return its hosted URL — used for invoice payment, distinct from the
+     * subscription checkout above. $metadata rides onto the session + payment
+     * intent so the webhook can resolve our invoice.
+     *
+     * @param int                   $amount   in minor units of $currency
+     * @param array<string, string> $metadata
+     */
+    public function createPaymentCheckout(
+        int $amount,
+        string $currency,
+        string $description,
+        string $successUrl,
+        string $cancelUrl,
+        ?string $customerEmail,
+        array $metadata,
+    ): string;
+
+    /**
      * Create a Billing Portal session for an existing customer and return its
      * hosted URL.
      */

--- a/api/src/Controller/BillingController.php
+++ b/api/src/Controller/BillingController.php
@@ -8,6 +8,7 @@ use App\Billing\BillingException;
 use App\Billing\StripeGatewayInterface;
 use App\Entity\Space;
 use App\Entity\CancellationFeedback;
+use App\Entity\Invoice;
 use App\Entity\Subscription;
 use App\Entity\User;
 use App\Repository\SubscriptionRepository;
@@ -246,10 +247,42 @@ class BillingController extends AbstractController
             $this->syncSubscription($object, true);
         } elseif ('customer.subscription.created' === $type || 'customer.subscription.updated' === $type) {
             $this->syncSubscription($object, false);
+        } elseif ('checkout.session.completed' === $type) {
+            $this->markInvoicePaid($object);
         }
         // Any other event type is acknowledged and ignored.
 
         return new Response('', Response::HTTP_OK);
+    }
+
+    /**
+     * Mark one of our client invoices (#445) paid off a completed one-off
+     * Checkout Session. Idempotent + safe: only acts on sessions carrying our
+     * `invoice_id` metadata with payment_status=paid, and never resurrects a
+     * void invoice.
+     *
+     * @param array<mixed, mixed> $session
+     */
+    private function markInvoicePaid(array $session): void
+    {
+        $invoiceId = $this->stringAt($session, ['metadata', 'invoice_id']);
+        if (null === $invoiceId) {
+            return; // Not an invoice checkout (e.g. a subscription session).
+        }
+        if ('paid' !== $this->stringAt($session, ['payment_status'])) {
+            return;
+        }
+        $invoice = $this->em->getRepository(Invoice::class)->find($invoiceId);
+        if (!$invoice instanceof Invoice) {
+            $this->logger->warning('Invoice payment webhook could not resolve invoice.', ['invoice_id' => $invoiceId]);
+            return;
+        }
+        if (Invoice::STATUS_PAID === $invoice->getStatus() || Invoice::STATUS_VOID === $invoice->getStatus()) {
+            return;
+        }
+        $invoice->setStatus(Invoice::STATUS_PAID);
+        $invoice->setPaidAt(new \DateTimeImmutable());
+        $this->em->flush();
     }
 
     /**

--- a/api/src/Controller/InvoiceActionController.php
+++ b/api/src/Controller/InvoiceActionController.php
@@ -7,6 +7,7 @@ use App\Entity\User;
 use App\Repository\InvoiceRepository;
 use App\Security\Permission\SpacePermission;
 use App\Security\Permission\SpacePermissionResolver;
+use App\Service\InvoiceMailer;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -33,6 +34,7 @@ class InvoiceActionController extends AbstractController
         private EntityManagerInterface $em,
         private InvoiceRepository $invoices,
         private SpacePermissionResolver $permissions,
+        private InvoiceMailer $mailer,
     ) {
     }
 
@@ -111,6 +113,9 @@ class InvoiceActionController extends AbstractController
         }
         $invoice->setSentAt(new \DateTimeImmutable());
         $this->em->flush();
+
+        // Best-effort: email the client the public link (no-op without an email).
+        $this->mailer->sendInvoice($invoice, $plain);
 
         return $this->json([
             'id' => (string) $invoice->getId(),

--- a/api/src/Controller/InvoiceActionController.php
+++ b/api/src/Controller/InvoiceActionController.php
@@ -81,6 +81,46 @@ class InvoiceActionController extends AbstractController
         return $this->summary($invoice);
     }
 
+    #[Route('/invoices/{id}/send', name: 'invoice_send', methods: ['POST'])]
+    public function send(string $id, #[CurrentUser] ?User $user): JsonResponse
+    {
+        $invoice = $this->authorize($id, $user);
+        if ($invoice instanceof JsonResponse) {
+            return $invoice;
+        }
+        if (Invoice::STATUS_VOID === $invoice->getStatus()) {
+            return $this->json(['error' => 'A void invoice cannot be sent.'], 409);
+        }
+
+        // Assign a number on first send (like issue), so a sent invoice is final.
+        $space = $invoice->getSpace();
+        if (null !== $space && null === $invoice->getNumber()) {
+            $next = $this->invoices->countNumbered($space) + 1;
+            $invoice->setNumber('INV-' . str_pad((string) $next, 4, '0', STR_PAD_LEFT));
+        }
+        if (null === $invoice->getIssueDate()) {
+            $invoice->setIssueDate(new \DateTimeImmutable('today'));
+        }
+
+        // Mint a shareable public token (sha256-hashed at rest, like the export
+        // + password-reset tokens); the plaintext only leaves in the link.
+        $plain = bin2hex(random_bytes(32));
+        $invoice->setPublicToken(hash('sha256', $plain));
+        if (Invoice::STATUS_DRAFT === $invoice->getStatus()) {
+            $invoice->setStatus(Invoice::STATUS_SENT);
+        }
+        $invoice->setSentAt(new \DateTimeImmutable());
+        $this->em->flush();
+
+        return $this->json([
+            'id' => (string) $invoice->getId(),
+            'number' => $invoice->getNumber(),
+            'status' => $invoice->getStatus(),
+            'token' => $plain,
+            'publicUrl' => '/public/invoices/' . $plain,
+        ], 201);
+    }
+
     #[Route('/invoices/{id}/void', name: 'invoice_void', methods: ['POST'])]
     public function void(string $id, #[CurrentUser] ?User $user): JsonResponse
     {

--- a/api/src/Controller/InvoiceActionController.php
+++ b/api/src/Controller/InvoiceActionController.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\Invoice;
+use App\Entity\User;
+use App\Repository\InvoiceRepository;
+use App\Security\Permission\SpacePermission;
+use App\Security\Permission\SpacePermissionResolver;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Invoice lifecycle transitions (#445) that are more than a field edit:
+ *
+ *  - issue: assign the next per-space sequential number + issue date and move
+ *    draft → sent (a draft burns no number, so numbers stay gap-free).
+ *  - mark-paid: record payment manually (bank transfer / cash) — the offline
+ *    path that always exists alongside future online payment.
+ *  - void: cancel an invoice and release its billed time entries so the hours
+ *    can be re-invoiced.
+ *
+ * All are admin-reserved (invoices.update) and hide a non-member's target
+ * behind a 404, like the rest of the access model.
+ */
+class InvoiceActionController extends AbstractController
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private InvoiceRepository $invoices,
+        private SpacePermissionResolver $permissions,
+    ) {
+    }
+
+    #[Route('/invoices/{id}/issue', name: 'invoice_issue', methods: ['POST'])]
+    public function issue(string $id, #[CurrentUser] ?User $user): JsonResponse
+    {
+        $invoice = $this->authorize($id, $user);
+        if ($invoice instanceof JsonResponse) {
+            return $invoice;
+        }
+
+        if (Invoice::STATUS_DRAFT !== $invoice->getStatus()) {
+            return $this->json(['error' => 'Only a draft invoice can be issued.'], 409);
+        }
+
+        $space = $invoice->getSpace();
+        if (null !== $space && null === $invoice->getNumber()) {
+            $next = $this->invoices->countNumbered($space) + 1;
+            $invoice->setNumber('INV-' . str_pad((string) $next, 4, '0', STR_PAD_LEFT));
+        }
+        if (null === $invoice->getIssueDate()) {
+            $invoice->setIssueDate(new \DateTimeImmutable('today'));
+        }
+        $invoice->setStatus(Invoice::STATUS_SENT);
+        $this->em->flush();
+
+        return $this->summary($invoice);
+    }
+
+    #[Route('/invoices/{id}/mark-paid', name: 'invoice_mark_paid', methods: ['POST'])]
+    public function markPaid(string $id, #[CurrentUser] ?User $user): JsonResponse
+    {
+        $invoice = $this->authorize($id, $user);
+        if ($invoice instanceof JsonResponse) {
+            return $invoice;
+        }
+
+        if (Invoice::STATUS_VOID === $invoice->getStatus()) {
+            return $this->json(['error' => 'A void invoice cannot be marked paid.'], 409);
+        }
+
+        $invoice->setStatus(Invoice::STATUS_PAID);
+        $invoice->setPaidAt(new \DateTimeImmutable());
+        $this->em->flush();
+
+        return $this->summary($invoice);
+    }
+
+    #[Route('/invoices/{id}/void', name: 'invoice_void', methods: ['POST'])]
+    public function void(string $id, #[CurrentUser] ?User $user): JsonResponse
+    {
+        $invoice = $this->authorize($id, $user);
+        if ($invoice instanceof JsonResponse) {
+            return $invoice;
+        }
+
+        // Release the billed time entries so the hours can be re-invoiced.
+        foreach ($invoice->getLineItems() as $line) {
+            $line->getSourceTimeEntry()?->setBilledAt(null);
+        }
+        $invoice->setStatus(Invoice::STATUS_VOID);
+        $this->em->flush();
+
+        return $this->summary($invoice);
+    }
+
+    /**
+     * Load the invoice and confirm the caller may manage it, or return the error
+     * response to short-circuit with.
+     */
+    private function authorize(string $id, ?User $user): Invoice|JsonResponse
+    {
+        if (null === $user) {
+            return $this->json(['error' => 'Not authenticated.'], 401);
+        }
+        if (!Uuid::isValid($id)) {
+            return $this->json(['error' => 'Invoice not found.'], 404);
+        }
+        $invoice = $this->invoices->find($id);
+        $space = $invoice?->getSpace();
+        if (
+            null === $invoice || null === $space
+            || (!$this->isGranted('ROLE_ADMIN') && !$space->hasMember($user))
+        ) {
+            return $this->json(['error' => 'Invoice not found.'], 404);
+        }
+        if (
+            !$this->isGranted('ROLE_ADMIN')
+            && !$this->permissions->canByExplicitGrant($user, $space, SpacePermission::INVOICES, SpacePermission::UPDATE)
+        ) {
+            return $this->json(['error' => 'You cannot manage invoices in this space.'], 403);
+        }
+
+        return $invoice;
+    }
+
+    private function summary(Invoice $invoice): JsonResponse
+    {
+        return $this->json([
+            '@id' => '/invoices/' . $invoice->getId(),
+            'id' => (string) $invoice->getId(),
+            'number' => $invoice->getNumber(),
+            'status' => $invoice->getStatus(),
+            'issueDate' => $invoice->getIssueDate()?->format('Y-m-d'),
+            'paidAt' => $invoice->getPaidAt()?->format(\DateTimeInterface::ATOM),
+            'total' => $invoice->getTotal(),
+        ]);
+    }
+}

--- a/api/src/Controller/InvoiceFromTimeController.php
+++ b/api/src/Controller/InvoiceFromTimeController.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\Client;
+use App\Entity\Invoice;
+use App\Entity\InvoiceLineItem;
+use App\Entity\Project;
+use App\Entity\Space;
+use App\Entity\User;
+use App\Repository\TimeEntryRepository;
+use App\Security\Permission\SpacePermission;
+use App\Security\Permission\SpacePermissionResolver;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Generates a draft {@see Invoice} from a space's unbilled, billable, completed
+ * {@see \App\Entity\TimeEntry} rows (#444 + #445 — the paired heart of the two
+ * features). One line item per entry: hours × the entry's rate (falling back to
+ * the client's default), each line back-linking its source entry, and every
+ * pulled entry stamped `billedAt` so the same time can't be billed twice.
+ *
+ * Body: `{ space, client, project? }` (IRIs). Optionally narrowed to one
+ * project. Auth: creating invoices is admin-reserved — the caller must be a
+ * space admin or hold an explicit invoicing role (mirrors the entity gate).
+ *
+ * v1 assumes a single currency (the client's); rate-currency mismatches on
+ * individual entries are not converted.
+ */
+class InvoiceFromTimeController extends AbstractController
+{
+    private const SECONDS_PER_HOUR = 3600.0;
+
+    public function __construct(
+        private EntityManagerInterface $em,
+        private TimeEntryRepository $timeEntries,
+        private SpacePermissionResolver $permissions,
+    ) {
+    }
+
+    #[Route('/invoices/from-time-entries', name: 'invoice_from_time', methods: ['POST'], priority: 10)]
+    public function __invoke(Request $request, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if (null === $user) {
+            return $this->json(['error' => 'Not authenticated.'], 401);
+        }
+
+        $payload = $request->toArray();
+
+        $space = $this->resolve($payload['space'] ?? null, Space::class);
+        if (!$space instanceof Space || (!$this->isGranted('ROLE_ADMIN') && !$space->hasMember($user))) {
+            return $this->json(['error' => 'Space not found.'], 404);
+        }
+        if (
+            !$this->isGranted('ROLE_ADMIN')
+            && !$this->permissions->canByExplicitGrant($user, $space, SpacePermission::INVOICES, SpacePermission::CREATE)
+        ) {
+            return $this->json(['error' => 'You cannot create invoices in this space.'], 403);
+        }
+
+        $client = $this->resolve($payload['client'] ?? null, Client::class);
+        if (
+            !$client instanceof Client
+            || true !== $client->getSpace()?->getId()?->equals($space->getId())
+        ) {
+            return $this->json(['error' => 'Client not found in this space.'], 404);
+        }
+
+        $project = null;
+        if (isset($payload['project']) && is_string($payload['project']) && '' !== trim($payload['project'])) {
+            $resolved = $this->resolve($payload['project'], Project::class);
+            if (
+                !$resolved instanceof Project
+                || true !== $resolved->getSpace()?->getId()?->equals($space->getId())
+            ) {
+                return $this->json(['error' => 'Project not found in this space.'], 404);
+            }
+            $project = $resolved;
+        }
+
+        $entries = $this->timeEntries->findInvoiceable($space, $project);
+        if (0 === count($entries)) {
+            return $this->json(['error' => 'No unbilled billable time to invoice.'], 422);
+        }
+
+        $now = new \DateTimeImmutable();
+        $currency = $client->getCurrency() ?? 'USD';
+        $invoice = (new Invoice())
+            ->setSpace($space)
+            ->setClient($client)
+            ->setCurrency($currency)
+            ->setCreatedBy($user);
+
+        $subtotal = 0;
+        $position = 0;
+        foreach ($entries as $entry) {
+            $hours = round(($entry->getDurationSeconds() ?? 0) / self::SECONDS_PER_HOUR, 2);
+            $unitAmount = $entry->getRateAmount() ?? $client->getDefaultRateAmount() ?? 0;
+            $amount = (int) round($hours * $unitAmount);
+            $subtotal += $amount;
+
+            $line = (new InvoiceLineItem())
+                ->setDescription($this->lineLabel($entry->getDescription(), $entry->getProject()))
+                ->setQuantity($hours)
+                ->setUnitAmount($unitAmount)
+                ->setAmount($amount)
+                ->setPosition($position++)
+                ->setSourceTimeEntry($entry);
+            $invoice->addLineItem($line);
+
+            $entry->setBilledAt($now);
+        }
+
+        $invoice->setSubtotal($subtotal);
+        $invoice->setTaxAmount(0);
+        $invoice->setTotal($subtotal);
+
+        $this->em->persist($invoice);
+        $this->em->flush();
+
+        return $this->json([
+            '@id' => '/invoices/' . $invoice->getId(),
+            'id' => (string) $invoice->getId(),
+            'status' => $invoice->getStatus(),
+            'currency' => $invoice->getCurrency(),
+            'subtotal' => $invoice->getSubtotal(),
+            'total' => $invoice->getTotal(),
+            'lineItemCount' => count($entries),
+        ], 201);
+    }
+
+    private function lineLabel(?string $description, ?Project $project): string
+    {
+        $label = null !== $description ? trim($description) : '';
+        if ('' !== $label) {
+            return mb_substr($label, 0, InvoiceLineItem::MAX_DESCRIPTION_LENGTH);
+        }
+        if (null !== $project) {
+            return mb_substr('Time — ' . $project->getTitle(), 0, InvoiceLineItem::MAX_DESCRIPTION_LENGTH);
+        }
+
+        return 'Tracked time';
+    }
+
+    /**
+     * @param class-string $class
+     */
+    private function resolve(mixed $iri, string $class): ?object
+    {
+        if (!is_string($iri) || '' === trim($iri)) {
+            return null;
+        }
+        $trimmed = trim($iri);
+        $id = Uuid::isValid($trimmed)
+            ? $trimmed
+            : substr($trimmed, (int) strrpos($trimmed, '/') + 1);
+        if (!Uuid::isValid($id)) {
+            return null;
+        }
+
+        return $this->em->getRepository($class)->find($id);
+    }
+}

--- a/api/src/Controller/InvoicePdfController.php
+++ b/api/src/Controller/InvoicePdfController.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\User;
+use App\Repository\InvoiceRepository;
+use App\Security\Permission\SpacePermission;
+use App\Security\Permission\SpacePermissionResolver;
+use App\Service\InvoicePdfRenderer;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Streams an {@see \App\Entity\Invoice} as a PDF (#445), rendered on demand by
+ * {@see InvoicePdfRenderer}. Admin-reserved (invoices.read) and 404-hides a
+ * non-member's target, like the rest of the invoicing surface.
+ */
+class InvoicePdfController extends AbstractController
+{
+    public function __construct(
+        private InvoiceRepository $invoices,
+        private SpacePermissionResolver $permissions,
+        private InvoicePdfRenderer $renderer,
+    ) {
+    }
+
+    #[Route('/invoices/{id}/pdf', name: 'invoice_pdf', methods: ['GET'])]
+    public function __invoke(string $id, #[CurrentUser] ?User $user): Response
+    {
+        if (null === $user) {
+            return $this->json(['error' => 'Not authenticated.'], 401);
+        }
+        if (!Uuid::isValid($id)) {
+            return $this->json(['error' => 'Invoice not found.'], 404);
+        }
+        $invoice = $this->invoices->find($id);
+        $space = $invoice?->getSpace();
+        if (
+            null === $invoice || null === $space
+            || (!$this->isGranted('ROLE_ADMIN') && !$space->hasMember($user))
+        ) {
+            return $this->json(['error' => 'Invoice not found.'], 404);
+        }
+        if (
+            !$this->isGranted('ROLE_ADMIN')
+            && !$this->permissions->canByExplicitGrant($user, $space, SpacePermission::INVOICES, SpacePermission::READ)
+        ) {
+            return $this->json(['error' => 'You cannot view invoices in this space.'], 403);
+        }
+
+        $pdf = $this->renderer->render($invoice);
+
+        return new Response($pdf, Response::HTTP_OK, [
+            'Content-Type' => 'application/pdf',
+            'Content-Disposition' => sprintf('inline; filename="%s"', $this->renderer->filename($invoice)),
+        ]);
+    }
+}

--- a/api/src/Controller/PublicInvoiceController.php
+++ b/api/src/Controller/PublicInvoiceController.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\Invoice;
+use App\Repository\InvoiceRepository;
+use App\Service\InvoicePdfRenderer;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * The public, unauthenticated invoice view (#445) a client reaches from the
+ * shareable link minted by {@see InvoiceActionController::send()}. The token is
+ * sha256-hashed at rest, so a leaked DB row can't reconstruct a link; an unknown
+ * or void token 404s. Online payment (Stripe, then PayPal) attaches here later.
+ */
+class PublicInvoiceController extends AbstractController
+{
+    public function __construct(
+        private InvoiceRepository $invoices,
+        private InvoicePdfRenderer $renderer,
+    ) {
+    }
+
+    #[Route('/public/invoices/{token}', name: 'public_invoice_view', methods: ['GET'])]
+    public function view(string $token): JsonResponse
+    {
+        $invoice = $this->resolve($token);
+        if (null === $invoice) {
+            return $this->json(['error' => 'Invoice not found.'], 404);
+        }
+
+        $lines = [];
+        foreach ($invoice->getLineItems() as $line) {
+            $lines[] = [
+                'description' => $line->getDescription(),
+                'quantity' => $line->getQuantity(),
+                'unitAmount' => $line->getUnitAmount(),
+                'amount' => $line->getAmount(),
+            ];
+        }
+
+        return $this->json([
+            'number' => $invoice->getNumber(),
+            'status' => $invoice->getStatus(),
+            'currency' => $invoice->getCurrency(),
+            'issueDate' => $invoice->getIssueDate()?->format('Y-m-d'),
+            'dueDate' => $invoice->getDueDate()?->format('Y-m-d'),
+            'from' => $invoice->getSpace()?->getName(),
+            'billTo' => $invoice->getClient()?->getName(),
+            'lineItems' => $lines,
+            'subtotal' => $invoice->getSubtotal(),
+            'taxAmount' => $invoice->getTaxAmount(),
+            'total' => $invoice->getTotal(),
+            'pdfUrl' => '/public/invoices/' . $token . '/pdf',
+        ]);
+    }
+
+    #[Route('/public/invoices/{token}/pdf', name: 'public_invoice_pdf', methods: ['GET'])]
+    public function pdf(string $token): Response
+    {
+        $invoice = $this->resolve($token);
+        if (null === $invoice) {
+            return $this->json(['error' => 'Invoice not found.'], 404);
+        }
+
+        return new Response($this->renderer->render($invoice), Response::HTTP_OK, [
+            'Content-Type' => 'application/pdf',
+            'Content-Disposition' => sprintf('inline; filename="%s"', $this->renderer->filename($invoice)),
+        ]);
+    }
+
+    private function resolve(string $token): ?Invoice
+    {
+        if ('' === trim($token)) {
+            return null;
+        }
+        $invoice = $this->invoices->findByPublicTokenHash(hash('sha256', $token));
+        if (null === $invoice || Invoice::STATUS_VOID === $invoice->getStatus()) {
+            return null;
+        }
+
+        return $invoice;
+    }
+}

--- a/api/src/Controller/PublicInvoiceController.php
+++ b/api/src/Controller/PublicInvoiceController.php
@@ -2,10 +2,13 @@
 
 namespace App\Controller;
 
+use App\Billing\BillingException;
+use App\Billing\Payment\PaymentGatewayRegistry;
 use App\Entity\Invoice;
 use App\Repository\InvoiceRepository;
 use App\Service\InvoicePdfRenderer;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -21,6 +24,9 @@ class PublicInvoiceController extends AbstractController
     public function __construct(
         private InvoiceRepository $invoices,
         private InvoicePdfRenderer $renderer,
+        private PaymentGatewayRegistry $gateways,
+        #[Autowire('%env(default::APP_FRONTEND_URL)%')]
+        private string $frontendUrl,
     ) {
     }
 
@@ -70,6 +76,35 @@ class PublicInvoiceController extends AbstractController
             'Content-Type' => 'application/pdf',
             'Content-Disposition' => sprintf('inline; filename="%s"', $this->renderer->filename($invoice)),
         ]);
+    }
+
+    #[Route('/public/invoices/{token}/pay', name: 'public_invoice_pay', methods: ['POST'])]
+    public function pay(string $token): JsonResponse
+    {
+        $invoice = $this->resolve($token);
+        if (null === $invoice) {
+            return $this->json(['error' => 'Invoice not found.'], 404);
+        }
+        if (Invoice::STATUS_PAID === $invoice->getStatus()) {
+            return $this->json(['error' => 'This invoice is already paid.'], 409);
+        }
+        if ($invoice->getTotal() <= 0) {
+            return $this->json(['error' => 'Nothing to pay on this invoice.'], 409);
+        }
+
+        $gateway = $this->gateways->default();
+        if (null === $gateway || !$gateway->isConfigured()) {
+            return $this->json(['error' => 'Online payment is not available.'], 503);
+        }
+
+        $base = rtrim($this->frontendUrl, '/') . '/i/' . $token;
+        try {
+            $url = $gateway->createInvoicePayment($invoice, $base . '?paid=1', $base);
+        } catch (BillingException $e) {
+            return $this->json(['error' => 'Could not start payment: ' . $e->getMessage()], 502);
+        }
+
+        return $this->json(['provider' => $gateway->key(), 'url' => $url], 201);
     }
 
     private function resolve(string $token): ?Invoice

--- a/api/src/Doctrine/ClientAccessExtension.php
+++ b/api/src/Doctrine/ClientAccessExtension.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Doctrine;
+
+use App\Entity\Client;
+use App\Security\Permission\SpacePermission;
+
+/**
+ * Scopes Client queries to the spaces the current user belongs to (#445), via
+ * the `client.space` FK, and read-gates on the admin-reserved `invoices`
+ * permission category. See {@see AbstractSpaceAccessExtension}.
+ */
+final class ClientAccessExtension extends AbstractSpaceAccessExtension
+{
+    protected function getResourceClass(): string
+    {
+        return Client::class;
+    }
+
+    protected function getAliasPrefix(): string
+    {
+        return 'client_access';
+    }
+
+    protected function getImpersonationItemType(): ?string
+    {
+        return null;
+    }
+
+    protected function getPermissionCategory(): string
+    {
+        return SpacePermission::INVOICES;
+    }
+}

--- a/api/src/Doctrine/InvoiceAccessExtension.php
+++ b/api/src/Doctrine/InvoiceAccessExtension.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Doctrine;
+
+use App\Entity\Invoice;
+use App\Security\Permission\SpacePermission;
+
+/**
+ * Scopes Invoice queries to the spaces the current user belongs to (#445), via
+ * the `invoice.space` FK, and read-gates on the admin-reserved `invoices`
+ * permission category. See {@see AbstractSpaceAccessExtension}.
+ */
+final class InvoiceAccessExtension extends AbstractSpaceAccessExtension
+{
+    protected function getResourceClass(): string
+    {
+        return Invoice::class;
+    }
+
+    protected function getAliasPrefix(): string
+    {
+        return 'invoice_access';
+    }
+
+    protected function getImpersonationItemType(): ?string
+    {
+        return null;
+    }
+
+    protected function getPermissionCategory(): string
+    {
+        return SpacePermission::INVOICES;
+    }
+}

--- a/api/src/Doctrine/TimeEntryAccessExtension.php
+++ b/api/src/Doctrine/TimeEntryAccessExtension.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Doctrine;
+
+use App\Entity\TimeEntry;
+use App\Security\Permission\SpacePermission;
+
+/**
+ * Scopes TimeEntry queries to the spaces the current user belongs to (#444),
+ * via the denormalised `time_entry.space` FK. Time entries have no per-item
+ * impersonation overrides, so {@see getImpersonationItemType()} is null; reads
+ * are role-gated on the `time_entries` category. See
+ * {@see AbstractSpaceAccessExtension} for the shared membership predicate.
+ */
+final class TimeEntryAccessExtension extends AbstractSpaceAccessExtension
+{
+    protected function getResourceClass(): string
+    {
+        return TimeEntry::class;
+    }
+
+    protected function getAliasPrefix(): string
+    {
+        return 'time_entry_access';
+    }
+
+    protected function getImpersonationItemType(): ?string
+    {
+        return null;
+    }
+
+    protected function getPermissionCategory(): string
+    {
+        return SpacePermission::TIME_ENTRIES;
+    }
+}

--- a/api/src/Entity/Client.php
+++ b/api/src/Entity/Client.php
@@ -1,0 +1,244 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Doctrine\Orm\Filter\OrderFilter;
+use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
+use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use App\Repository\ClientRepository;
+use App\State\ClientCreatorProcessor;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * A billing party a space invoices (#445) — the person or company on the "bill
+ * to" of an {@see Invoice}. A deliberately minimal slice of a future CRM: name,
+ * contact, a default billing currency and hourly rate that seed new invoices.
+ *
+ * Space-scoped and gated on the admin-reserved `invoices` permission category,
+ * so only space admins (or a member granted an invoicing role) manage clients.
+ */
+#[ApiResource(
+    shortName: 'Client',
+    operations: [
+        new GetCollection(
+            security: "is_granted('ROLE_USER')",
+        ),
+        new Post(
+            security: "is_granted('ROLE_USER')",
+            securityPostDenormalize: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or (object.getSpace() !== null and object.getSpace().hasMember(user) and is_granted('space.invoices.create', object)))",
+            processor: ClientCreatorProcessor::class,
+        ),
+        new Get(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or (object.getSpace().hasMember(user) and is_granted('space.invoices.read', object)))",
+        ),
+        new Patch(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getSpace().isAdmin(user) or (object.getSpace().hasMember(user) and is_granted('space.invoices.update', object)))",
+        ),
+        new Delete(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getSpace().isAdmin(user) or (object.getSpace().hasMember(user) and is_granted('space.invoices.delete', object)))",
+        ),
+    ],
+    normalizationContext: ['groups' => ['client:read']],
+    denormalizationContext: ['groups' => ['client:write']],
+    order: ['name' => 'ASC'],
+)]
+#[ApiFilter(SearchFilter::class, properties: ['space' => 'exact', 'name' => 'partial'])]
+#[ApiFilter(OrderFilter::class, properties: ['name', 'createdAt'])]
+#[ORM\Entity(repositoryClass: ClientRepository::class)]
+#[ORM\Table(name: 'client')]
+#[ORM\Index(columns: ['space_id', 'name'], name: 'idx_client_space_name')]
+#[ORM\HasLifecycleCallbacks]
+class Client
+{
+    public const MAX_NAME_LENGTH = 200;
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
+    #[Groups(['client:read', 'invoice:read'])]
+    private ?Uuid $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Space::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    #[Assert\NotNull(message: 'Space is required.')]
+    #[Groups(['client:read', 'client:write'])]
+    private ?Space $space = null;
+
+    #[ORM\Column(length: self::MAX_NAME_LENGTH)]
+    #[Assert\NotBlank(message: 'A client name is required.')]
+    #[Assert\Length(max: self::MAX_NAME_LENGTH)]
+    #[Groups(['client:read', 'client:write', 'invoice:read'])]
+    private string $name = '';
+
+    #[ORM\Column(length: 255, nullable: true)]
+    #[Assert\Email]
+    #[Groups(['client:read', 'client:write'])]
+    private ?string $email = null;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    #[Groups(['client:read', 'client:write'])]
+    private ?string $address = null;
+
+    /** Default billing currency (ISO 4217); seeds new invoices for this client. */
+    #[ORM\Column(type: 'string', length: 3, nullable: true)]
+    #[Assert\Currency]
+    #[Groups(['client:read', 'client:write'])]
+    private ?string $currency = null;
+
+    /** Default hourly rate in minor units of {@see $currency}. */
+    #[ORM\Column(type: 'integer', nullable: true)]
+    #[Assert\PositiveOrZero]
+    #[Groups(['client:read', 'client:write'])]
+    private ?int $defaultRateAmount = null;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    #[Groups(['client:read', 'client:write'])]
+    private ?string $notes = null;
+
+    #[ApiProperty(readableLink: false)]
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    #[Groups(['client:read'])]
+    private ?User $createdBy = null;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    #[Groups(['client:read'])]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    #[Groups(['client:read'])]
+    private ?\DateTimeImmutable $updatedAt = null;
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    #[ORM\PreUpdate]
+    public function onPreUpdate(): void
+    {
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?Uuid
+    {
+        return $this->id;
+    }
+
+    public function getSpace(): ?Space
+    {
+        return $this->space;
+    }
+
+    public function setSpace(?Space $space): self
+    {
+        $this->space = $space;
+
+        return $this;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getEmail(): ?string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(?string $email): self
+    {
+        $this->email = $email;
+
+        return $this;
+    }
+
+    public function getAddress(): ?string
+    {
+        return $this->address;
+    }
+
+    public function setAddress(?string $address): self
+    {
+        $this->address = $address;
+
+        return $this;
+    }
+
+    public function getCurrency(): ?string
+    {
+        return $this->currency;
+    }
+
+    public function setCurrency(?string $currency): self
+    {
+        $this->currency = $currency;
+
+        return $this;
+    }
+
+    public function getDefaultRateAmount(): ?int
+    {
+        return $this->defaultRateAmount;
+    }
+
+    public function setDefaultRateAmount(?int $defaultRateAmount): self
+    {
+        $this->defaultRateAmount = $defaultRateAmount;
+
+        return $this;
+    }
+
+    public function getNotes(): ?string
+    {
+        return $this->notes;
+    }
+
+    public function setNotes(?string $notes): self
+    {
+        $this->notes = $notes;
+
+        return $this;
+    }
+
+    public function getCreatedBy(): ?User
+    {
+        return $this->createdBy;
+    }
+
+    public function setCreatedBy(?User $createdBy): self
+    {
+        $this->createdBy = $createdBy;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): ?\DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+}

--- a/api/src/Entity/Invoice.php
+++ b/api/src/Entity/Invoice.php
@@ -1,0 +1,451 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Doctrine\Orm\Filter\OrderFilter;
+use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
+use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use App\Repository\InvoiceRepository;
+use App\State\InvoiceProcessor;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+
+/**
+ * An invoice a space bills to a {@see Client} (#445), the sibling of time
+ * tracking: its {@see $lineItems} can be generated from unbilled billable
+ * {@see TimeEntry} rows or entered by hand.
+ *
+ * Monetary totals ({@see $subtotal}/{@see $taxAmount}/{@see $total}, all minor
+ * units of {@see $currency}) are derived server-side by InvoiceProcessor from
+ * the line items and {@see $taxRate} (basis points) — never trusted from the
+ * payload. The invoice pins a single currency; mixing is rejected in v1.
+ *
+ * Space-scoped and gated on the admin-reserved `invoices` permission category.
+ * Online payment (Stripe, then PayPal) and PDF rendering ride the public
+ * {@see $publicToken} in later phases.
+ */
+#[ApiResource(
+    shortName: 'Invoice',
+    operations: [
+        new GetCollection(
+            security: "is_granted('ROLE_USER')",
+        ),
+        new Post(
+            security: "is_granted('ROLE_USER')",
+            securityPostDenormalize: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or (object.getSpace() !== null and object.getSpace().hasMember(user) and is_granted('space.invoices.create', object)))",
+            processor: InvoiceProcessor::class,
+        ),
+        new Get(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or (object.getSpace().hasMember(user) and is_granted('space.invoices.read', object)))",
+        ),
+        new Patch(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getSpace().isAdmin(user) or (object.getSpace().hasMember(user) and is_granted('space.invoices.update', object)))",
+            processor: InvoiceProcessor::class,
+        ),
+        new Delete(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getSpace().isAdmin(user) or (object.getSpace().hasMember(user) and is_granted('space.invoices.delete', object)))",
+        ),
+    ],
+    normalizationContext: ['groups' => ['invoice:read']],
+    denormalizationContext: ['groups' => ['invoice:write']],
+    order: ['createdAt' => 'DESC'],
+)]
+#[ApiFilter(SearchFilter::class, properties: ['space' => 'exact', 'client' => 'exact', 'status' => 'exact'])]
+#[ApiFilter(OrderFilter::class, properties: ['createdAt', 'issueDate', 'dueDate', 'number'])]
+#[ORM\Entity(repositoryClass: InvoiceRepository::class)]
+#[ORM\Table(name: 'invoice')]
+#[ORM\Index(columns: ['space_id', 'created_at'], name: 'idx_invoice_space_created')]
+#[ORM\Index(columns: ['client_id'], name: 'idx_invoice_client')]
+#[ORM\HasLifecycleCallbacks]
+#[Assert\Callback('validateConsistency')]
+class Invoice
+{
+    public const STATUS_DRAFT = 'draft';
+    public const STATUS_SENT = 'sent';
+    public const STATUS_PAID = 'paid';
+    public const STATUS_OVERDUE = 'overdue';
+    public const STATUS_VOID = 'void';
+
+    /** @var list<string> */
+    public const STATUSES = [
+        self::STATUS_DRAFT,
+        self::STATUS_SENT,
+        self::STATUS_PAID,
+        self::STATUS_OVERDUE,
+        self::STATUS_VOID,
+    ];
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
+    #[Groups(['invoice:read'])]
+    private ?Uuid $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Space::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    #[Assert\NotNull(message: 'Space is required.')]
+    #[Groups(['invoice:read', 'invoice:write'])]
+    private ?Space $space = null;
+
+    #[ApiProperty(readableLink: true)]
+    #[ORM\ManyToOne(targetEntity: Client::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    #[Assert\NotNull(message: 'A client is required.')]
+    #[Groups(['invoice:read', 'invoice:write'])]
+    private ?Client $client = null;
+
+    /** Sequential per-space number, assigned when the invoice is issued (null while draft). */
+    #[ORM\Column(length: 40, nullable: true)]
+    #[Groups(['invoice:read'])]
+    private ?string $number = null;
+
+    #[ORM\Column(length: 20)]
+    #[Assert\Choice(choices: self::STATUSES, message: 'Invalid invoice status.')]
+    #[Groups(['invoice:read', 'invoice:write'])]
+    private string $status = self::STATUS_DRAFT;
+
+    #[ORM\Column(type: 'date_immutable', nullable: true)]
+    #[Groups(['invoice:read', 'invoice:write'])]
+    private ?\DateTimeImmutable $issueDate = null;
+
+    #[ORM\Column(type: 'date_immutable', nullable: true)]
+    #[Groups(['invoice:read', 'invoice:write'])]
+    private ?\DateTimeImmutable $dueDate = null;
+
+    #[ORM\Column(type: 'string', length: 3)]
+    #[Assert\NotBlank(message: 'A currency is required.')]
+    #[Assert\Currency]
+    #[Groups(['invoice:read', 'invoice:write'])]
+    private string $currency = 'USD';
+
+    /** Tax rate in basis points (e.g. 875 = 8.75%). */
+    #[ORM\Column(type: 'integer')]
+    #[Assert\Range(min: 0, max: 100000)]
+    #[Groups(['invoice:read', 'invoice:write'])]
+    private int $taxRate = 0;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    #[Groups(['invoice:read', 'invoice:write'])]
+    private ?string $notes = null;
+
+    /**
+     * @var Collection<int, InvoiceLineItem>
+     */
+    #[ORM\OneToMany(mappedBy: 'invoice', targetEntity: InvoiceLineItem::class, cascade: ['persist'], orphanRemoval: true)]
+    #[ORM\OrderBy(['position' => 'ASC'])]
+    #[Assert\Valid]
+    #[Groups(['invoice:read', 'invoice:write'])]
+    private Collection $lineItems;
+
+    /** Sum of line amounts, minor units. Derived. */
+    #[ORM\Column(type: 'integer')]
+    #[Groups(['invoice:read'])]
+    private int $subtotal = 0;
+
+    /** subtotal × taxRate, minor units. Derived. */
+    #[ORM\Column(type: 'integer')]
+    #[Groups(['invoice:read'])]
+    private int $taxAmount = 0;
+
+    /** subtotal + taxAmount, minor units. Derived. */
+    #[ORM\Column(type: 'integer')]
+    #[Groups(['invoice:read'])]
+    private int $total = 0;
+
+    #[ApiProperty(readableLink: false)]
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    #[Groups(['invoice:read'])]
+    private ?User $createdBy = null;
+
+    /** sha256 of the public-view/pay token; the plaintext only ever leaves in email/links. */
+    #[ORM\Column(length: 64, nullable: true, unique: true)]
+    private ?string $publicToken = null;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    #[Groups(['invoice:read'])]
+    private ?\DateTimeImmutable $sentAt = null;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    #[Groups(['invoice:read'])]
+    private ?\DateTimeImmutable $paidAt = null;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    #[Groups(['invoice:read'])]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    #[Groups(['invoice:read'])]
+    private ?\DateTimeImmutable $updatedAt = null;
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTimeImmutable();
+        $this->lineItems = new ArrayCollection();
+    }
+
+    #[ORM\PreUpdate]
+    public function onPreUpdate(): void
+    {
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function validateConsistency(ExecutionContextInterface $context): void
+    {
+        if (
+            null !== $this->client && null !== $this->space
+            && true !== $this->client->getSpace()?->getId()?->equals($this->space->getId())
+        ) {
+            $context->buildViolation('Client must belong to the same space.')
+                ->atPath('client')
+                ->addViolation();
+        }
+    }
+
+    public function getId(): ?Uuid
+    {
+        return $this->id;
+    }
+
+    public function getSpace(): ?Space
+    {
+        return $this->space;
+    }
+
+    public function setSpace(?Space $space): self
+    {
+        $this->space = $space;
+
+        return $this;
+    }
+
+    public function getClient(): ?Client
+    {
+        return $this->client;
+    }
+
+    public function setClient(?Client $client): self
+    {
+        $this->client = $client;
+
+        return $this;
+    }
+
+    public function getNumber(): ?string
+    {
+        return $this->number;
+    }
+
+    public function setNumber(?string $number): self
+    {
+        $this->number = $number;
+
+        return $this;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(string $status): self
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    public function getIssueDate(): ?\DateTimeImmutable
+    {
+        return $this->issueDate;
+    }
+
+    public function setIssueDate(?\DateTimeImmutable $issueDate): self
+    {
+        $this->issueDate = $issueDate;
+
+        return $this;
+    }
+
+    public function getDueDate(): ?\DateTimeImmutable
+    {
+        return $this->dueDate;
+    }
+
+    public function setDueDate(?\DateTimeImmutable $dueDate): self
+    {
+        $this->dueDate = $dueDate;
+
+        return $this;
+    }
+
+    public function getCurrency(): string
+    {
+        return $this->currency;
+    }
+
+    public function setCurrency(string $currency): self
+    {
+        $this->currency = $currency;
+
+        return $this;
+    }
+
+    public function getTaxRate(): int
+    {
+        return $this->taxRate;
+    }
+
+    public function setTaxRate(int $taxRate): self
+    {
+        $this->taxRate = $taxRate;
+
+        return $this;
+    }
+
+    public function getNotes(): ?string
+    {
+        return $this->notes;
+    }
+
+    public function setNotes(?string $notes): self
+    {
+        $this->notes = $notes;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, InvoiceLineItem>
+     */
+    public function getLineItems(): Collection
+    {
+        return $this->lineItems;
+    }
+
+    public function addLineItem(InvoiceLineItem $lineItem): self
+    {
+        if (!$this->lineItems->contains($lineItem)) {
+            $this->lineItems->add($lineItem);
+            $lineItem->setInvoice($this);
+        }
+
+        return $this;
+    }
+
+    public function removeLineItem(InvoiceLineItem $lineItem): self
+    {
+        if ($this->lineItems->removeElement($lineItem) && $lineItem->getInvoice() === $this) {
+            $lineItem->setInvoice(null);
+        }
+
+        return $this;
+    }
+
+    public function getSubtotal(): int
+    {
+        return $this->subtotal;
+    }
+
+    public function setSubtotal(int $subtotal): self
+    {
+        $this->subtotal = $subtotal;
+
+        return $this;
+    }
+
+    public function getTaxAmount(): int
+    {
+        return $this->taxAmount;
+    }
+
+    public function setTaxAmount(int $taxAmount): self
+    {
+        $this->taxAmount = $taxAmount;
+
+        return $this;
+    }
+
+    public function getTotal(): int
+    {
+        return $this->total;
+    }
+
+    public function setTotal(int $total): self
+    {
+        $this->total = $total;
+
+        return $this;
+    }
+
+    public function getCreatedBy(): ?User
+    {
+        return $this->createdBy;
+    }
+
+    public function setCreatedBy(?User $createdBy): self
+    {
+        $this->createdBy = $createdBy;
+
+        return $this;
+    }
+
+    public function getPublicToken(): ?string
+    {
+        return $this->publicToken;
+    }
+
+    public function setPublicToken(?string $publicToken): self
+    {
+        $this->publicToken = $publicToken;
+
+        return $this;
+    }
+
+    public function getSentAt(): ?\DateTimeImmutable
+    {
+        return $this->sentAt;
+    }
+
+    public function setSentAt(?\DateTimeImmutable $sentAt): self
+    {
+        $this->sentAt = $sentAt;
+
+        return $this;
+    }
+
+    public function getPaidAt(): ?\DateTimeImmutable
+    {
+        return $this->paidAt;
+    }
+
+    public function setPaidAt(?\DateTimeImmutable $paidAt): self
+    {
+        $this->paidAt = $paidAt;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): ?\DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+}

--- a/api/src/Entity/Invoice.php
+++ b/api/src/Entity/Invoice.php
@@ -87,6 +87,13 @@ class Invoice
         self::STATUS_VOID,
     ];
 
+    public const FREQ_WEEKLY = 'weekly';
+    public const FREQ_MONTHLY = 'monthly';
+    public const FREQ_YEARLY = 'yearly';
+
+    /** @var list<string> */
+    public const FREQUENCIES = [self::FREQ_WEEKLY, self::FREQ_MONTHLY, self::FREQ_YEARLY];
+
     #[ORM\Id]
     #[ORM\Column(type: 'uuid', unique: true)]
     #[ORM\GeneratedValue(strategy: 'CUSTOM')]
@@ -140,6 +147,25 @@ class Invoice
     #[ORM\Column(type: 'text', nullable: true)]
     #[Groups(['invoice:read', 'invoice:write'])]
     private ?string $notes = null;
+
+    /**
+     * When set, this invoice is a recurring template: the sweep clones it into a
+     * fresh draft each time {@see $nextIssueDate} arrives. One of weekly / monthly
+     * / yearly, repeated every {@see $recurrenceInterval}.
+     */
+    #[ORM\Column(length: 10, nullable: true)]
+    #[Assert\Choice(choices: self::FREQUENCIES, message: 'Invalid recurrence frequency.')]
+    #[Groups(['invoice:read', 'invoice:write'])]
+    private ?string $recurrenceFrequency = null;
+
+    #[ORM\Column(type: 'integer', nullable: true)]
+    #[Assert\Positive]
+    #[Groups(['invoice:read', 'invoice:write'])]
+    private ?int $recurrenceInterval = null;
+
+    #[ORM\Column(type: 'date_immutable', nullable: true)]
+    #[Groups(['invoice:read', 'invoice:write'])]
+    private ?\DateTimeImmutable $nextIssueDate = null;
 
     /**
      * @var Collection<int, InvoiceLineItem>
@@ -213,6 +239,76 @@ class Invoice
                 ->atPath('client')
                 ->addViolation();
         }
+
+        if (null !== $this->recurrenceFrequency) {
+            if (null === $this->recurrenceInterval || $this->recurrenceInterval < 1) {
+                $context->buildViolation('A recurring invoice needs an interval of at least 1.')
+                    ->atPath('recurrenceInterval')
+                    ->addViolation();
+            }
+            if (null === $this->nextIssueDate) {
+                $context->buildViolation('A recurring invoice needs a next issue date.')
+                    ->atPath('nextIssueDate')
+                    ->addViolation();
+            }
+        }
+    }
+
+    public function isRecurring(): bool
+    {
+        return null !== $this->recurrenceFrequency;
+    }
+
+    /** The interval string for DateTimeImmutable::modify(), e.g. "+1 month". */
+    public function recurrenceStep(): ?string
+    {
+        if (null === $this->recurrenceFrequency || null === $this->recurrenceInterval) {
+            return null;
+        }
+        $unit = match ($this->recurrenceFrequency) {
+            self::FREQ_WEEKLY => 'week',
+            self::FREQ_MONTHLY => 'month',
+            self::FREQ_YEARLY => 'year',
+            default => null,
+        };
+
+        return null === $unit ? null : sprintf('+%d %s', $this->recurrenceInterval, $unit);
+    }
+
+    public function getRecurrenceFrequency(): ?string
+    {
+        return $this->recurrenceFrequency;
+    }
+
+    public function setRecurrenceFrequency(?string $recurrenceFrequency): self
+    {
+        $this->recurrenceFrequency = $recurrenceFrequency;
+
+        return $this;
+    }
+
+    public function getRecurrenceInterval(): ?int
+    {
+        return $this->recurrenceInterval;
+    }
+
+    public function setRecurrenceInterval(?int $recurrenceInterval): self
+    {
+        $this->recurrenceInterval = $recurrenceInterval;
+
+        return $this;
+    }
+
+    public function getNextIssueDate(): ?\DateTimeImmutable
+    {
+        return $this->nextIssueDate;
+    }
+
+    public function setNextIssueDate(?\DateTimeImmutable $nextIssueDate): self
+    {
+        $this->nextIssueDate = $nextIssueDate;
+
+        return $this;
     }
 
     public function getId(): ?Uuid

--- a/api/src/Entity/InvoiceLineItem.php
+++ b/api/src/Entity/InvoiceLineItem.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Metadata\ApiProperty;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * One line on an {@see Invoice} (#445). Written as part of the invoice's
+ * `lineItems` array (like Task custom-field values) rather than through its own
+ * endpoint. {@see $amount} (quantity × unit price, minor units) is derived
+ * server-side by InvoiceProcessor, never trusted from the payload.
+ *
+ * {@see $sourceTimeEntry} back-links a line generated from tracked time so the
+ * two stay traceable and the entry can be un-billed if the invoice is voided.
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'invoice_line_item')]
+#[ORM\Index(columns: ['invoice_id', 'position'], name: 'idx_invoice_line_item_invoice_position')]
+class InvoiceLineItem
+{
+    public const MAX_DESCRIPTION_LENGTH = 500;
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
+    #[Groups(['invoice:read'])]
+    private ?Uuid $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Invoice::class, inversedBy: 'lineItems')]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private ?Invoice $invoice = null;
+
+    #[ORM\Column(length: self::MAX_DESCRIPTION_LENGTH)]
+    #[Assert\NotBlank(message: 'A line description is required.')]
+    #[Assert\Length(max: self::MAX_DESCRIPTION_LENGTH)]
+    #[Groups(['invoice:read', 'invoice:write'])]
+    private string $description = '';
+
+    /** Hours or units (may be fractional). */
+    #[ORM\Column(type: 'float')]
+    #[Assert\PositiveOrZero]
+    #[Groups(['invoice:read', 'invoice:write'])]
+    private float $quantity = 1.0;
+
+    /** Price per unit/hour in minor units of the invoice's currency. */
+    #[ORM\Column(type: 'integer')]
+    #[Groups(['invoice:read', 'invoice:write'])]
+    private int $unitAmount = 0;
+
+    /** Derived: round(quantity × unitAmount), in minor units. Read-only. */
+    #[ORM\Column(type: 'integer')]
+    #[Groups(['invoice:read'])]
+    private int $amount = 0;
+
+    #[ORM\Column(type: 'integer')]
+    #[Groups(['invoice:read', 'invoice:write'])]
+    private int $position = 0;
+
+    #[ApiProperty(readableLink: false)]
+    #[ORM\ManyToOne(targetEntity: TimeEntry::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    #[Groups(['invoice:read', 'invoice:write'])]
+    private ?TimeEntry $sourceTimeEntry = null;
+
+    public function getId(): ?Uuid
+    {
+        return $this->id;
+    }
+
+    public function getInvoice(): ?Invoice
+    {
+        return $this->invoice;
+    }
+
+    public function setInvoice(?Invoice $invoice): self
+    {
+        $this->invoice = $invoice;
+
+        return $this;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): self
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function getQuantity(): float
+    {
+        return $this->quantity;
+    }
+
+    public function setQuantity(float $quantity): self
+    {
+        $this->quantity = $quantity;
+
+        return $this;
+    }
+
+    public function getUnitAmount(): int
+    {
+        return $this->unitAmount;
+    }
+
+    public function setUnitAmount(int $unitAmount): self
+    {
+        $this->unitAmount = $unitAmount;
+
+        return $this;
+    }
+
+    public function getAmount(): int
+    {
+        return $this->amount;
+    }
+
+    public function setAmount(int $amount): self
+    {
+        $this->amount = $amount;
+
+        return $this;
+    }
+
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function setPosition(int $position): self
+    {
+        $this->position = $position;
+
+        return $this;
+    }
+
+    public function getSourceTimeEntry(): ?TimeEntry
+    {
+        return $this->sourceTimeEntry;
+    }
+
+    public function setSourceTimeEntry(?TimeEntry $sourceTimeEntry): self
+    {
+        $this->sourceTimeEntry = $sourceTimeEntry;
+
+        return $this;
+    }
+}

--- a/api/src/Entity/TimeEntry.php
+++ b/api/src/Entity/TimeEntry.php
@@ -74,6 +74,14 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 #[ORM\Index(columns: ['space_id', 'started_at'], name: 'idx_time_entry_space_started')]
 #[ORM\Index(columns: ['user_id', 'started_at'], name: 'idx_time_entry_user_started')]
 #[ORM\Index(columns: ['project_id'], name: 'idx_time_entry_project')]
+// Partial unique index (at most one running timer per user). Declared here with
+// the `where` option so doctrine:schema:validate matches the migration's
+// CREATE UNIQUE INDEX ... WHERE ended_at IS NULL (mirrors Space's personal-space index).
+#[ORM\UniqueConstraint(
+    name: 'uniq_time_entry_running_per_user',
+    columns: ['user_id'],
+    options: ['where' => '(ended_at IS NULL)'],
+)]
 #[ORM\HasLifecycleCallbacks]
 #[Assert\Callback('validateConsistency')]
 class TimeEntry

--- a/api/src/Entity/TimeEntry.php
+++ b/api/src/Entity/TimeEntry.php
@@ -1,0 +1,386 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Doctrine\Orm\Filter\BooleanFilter;
+use ApiPlatform\Doctrine\Orm\Filter\DateFilter;
+use ApiPlatform\Doctrine\Orm\Filter\ExistsFilter;
+use ApiPlatform\Doctrine\Orm\Filter\OrderFilter;
+use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
+use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use App\Repository\TimeEntryRepository;
+use App\State\TimeEntryUserProcessor;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+
+/**
+ * A billable (or non-billable) chunk of tracked time (#444). The atomic unit of
+ * time tracking: it records who spent how long on what, optionally tied to a
+ * project and/or task, at an optional hourly rate. Once pulled onto an invoice
+ * (#445) it is locked via {@see $billedAt} so the same time can't be billed twice.
+ *
+ * A running timer is a TimeEntry with {@see $endedAt} still null; a partial
+ * unique index (added in the migration) enforces at most one running entry per
+ * user. {@see $durationSeconds} is derived server-side from started/ended.
+ *
+ * Space-scoped like the rest of the content model: `space` is required and drives
+ * {@see App\Doctrine\TimeEntryAccessExtension}. Any member may track their own
+ * time (the `time_entries` permission category is on by default); edit/delete is
+ * owner-or-admin.
+ */
+#[ApiResource(
+    shortName: 'TimeEntry',
+    operations: [
+        new GetCollection(
+            security: "is_granted('ROLE_USER')",
+        ),
+        new Post(
+            security: "is_granted('ROLE_USER')",
+            securityPostDenormalize: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or (object.getSpace() !== null and object.getSpace().hasMember(user) and is_granted('space.time_entries.create', object)))",
+            processor: TimeEntryUserProcessor::class,
+        ),
+        new Get(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or (object.getSpace().hasMember(user) and is_granted('space.time_entries.read', object)))",
+        ),
+        new Patch(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getUser() == user or object.getSpace().isAdmin(user) or (object.getSpace().hasMember(user) and is_granted('space.time_entries.update', object)))",
+            processor: TimeEntryUserProcessor::class,
+        ),
+        new Delete(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getUser() == user or object.getSpace().isAdmin(user) or (object.getSpace().hasMember(user) and is_granted('space.time_entries.delete', object)))",
+        ),
+    ],
+    normalizationContext: ['groups' => ['time_entry:read']],
+    denormalizationContext: ['groups' => ['time_entry:write']],
+    order: ['startedAt' => 'DESC'],
+)]
+#[ApiFilter(SearchFilter::class, properties: ['space' => 'exact', 'project' => 'exact', 'task' => 'exact', 'user' => 'exact'])]
+#[ApiFilter(BooleanFilter::class, properties: ['billable'])]
+#[ApiFilter(ExistsFilter::class, properties: ['endedAt'])]
+#[ApiFilter(DateFilter::class, properties: ['startedAt'])]
+#[ApiFilter(OrderFilter::class, properties: ['startedAt', 'createdAt'])]
+#[ORM\Entity(repositoryClass: TimeEntryRepository::class)]
+#[ORM\Table(name: 'time_entry')]
+#[ORM\Index(columns: ['space_id', 'started_at'], name: 'idx_time_entry_space_started')]
+#[ORM\Index(columns: ['user_id', 'started_at'], name: 'idx_time_entry_user_started')]
+#[ORM\Index(columns: ['project_id'], name: 'idx_time_entry_project')]
+#[ORM\HasLifecycleCallbacks]
+#[Assert\Callback('validateConsistency')]
+class TimeEntry
+{
+    public const MAX_DESCRIPTION_LENGTH = 1000;
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
+    #[Groups(['time_entry:read'])]
+    private ?Uuid $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Space::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    #[Assert\NotNull(message: 'Space is required.')]
+    #[Groups(['time_entry:read', 'time_entry:write'])]
+    private ?Space $space = null;
+
+    #[ApiProperty(readableLink: false)]
+    #[ORM\ManyToOne(targetEntity: Project::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    #[Groups(['time_entry:read', 'time_entry:write'])]
+    private ?Project $project = null;
+
+    #[ApiProperty(readableLink: false)]
+    #[ORM\ManyToOne(targetEntity: Task::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    #[Groups(['time_entry:read', 'time_entry:write'])]
+    private ?Task $task = null;
+
+    /** The user who tracked the time. Stamped server-side, never from the payload. */
+    #[ApiProperty(readableLink: false)]
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    #[Groups(['time_entry:read'])]
+    private ?User $user = null;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    #[Assert\Length(max: self::MAX_DESCRIPTION_LENGTH)]
+    #[Groups(['time_entry:read', 'time_entry:write'])]
+    private ?string $description = null;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    #[Assert\NotNull(message: 'A start time is required.')]
+    #[Groups(['time_entry:read', 'time_entry:write'])]
+    private ?\DateTimeImmutable $startedAt = null;
+
+    /** Null while the timer is running. */
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    #[Groups(['time_entry:read', 'time_entry:write'])]
+    private ?\DateTimeImmutable $endedAt = null;
+
+    /** Derived from started/ended on persist; null while running. */
+    #[ORM\Column(type: 'integer', nullable: true)]
+    #[Groups(['time_entry:read'])]
+    private ?int $durationSeconds = null;
+
+    #[ORM\Column(type: 'boolean')]
+    #[Groups(['time_entry:read', 'time_entry:write'])]
+    private bool $billable = true;
+
+    /** Hourly rate in minor units (e.g. cents); paired with {@see $rateCurrency}. */
+    #[ORM\Column(type: 'integer', nullable: true)]
+    #[Assert\PositiveOrZero]
+    #[Groups(['time_entry:read', 'time_entry:write'])]
+    private ?int $rateAmount = null;
+
+    #[ORM\Column(type: 'string', length: 3, nullable: true)]
+    #[Assert\Currency]
+    #[Groups(['time_entry:read', 'time_entry:write'])]
+    private ?string $rateCurrency = null;
+
+    /** Set when the entry is pulled onto an invoice; locks it against re-billing. */
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    #[Groups(['time_entry:read'])]
+    private ?\DateTimeImmutable $billedAt = null;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    #[Groups(['time_entry:read'])]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    #[Groups(['time_entry:read'])]
+    private ?\DateTimeImmutable $updatedAt = null;
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    /**
+     * Derive duration + denormalise the space from project/task so the access
+     * extension can scope by `space` alone (mirrors TaskSection::syncSpaceFromProject).
+     */
+    #[ORM\PrePersist]
+    #[ORM\PreUpdate]
+    public function syncDerived(): void
+    {
+        if (null === $this->space) {
+            if (null !== $this->task && null !== $this->task->getProject()) {
+                $this->space = $this->task->getProject()->getSpace();
+            } elseif (null !== $this->project) {
+                $this->space = $this->project->getSpace();
+            }
+        }
+
+        $this->durationSeconds = null;
+        if (null !== $this->startedAt && null !== $this->endedAt) {
+            $this->durationSeconds = max(0, $this->endedAt->getTimestamp() - $this->startedAt->getTimestamp());
+        }
+    }
+
+    public function validateConsistency(ExecutionContextInterface $context): void
+    {
+        if (null !== $this->startedAt && null !== $this->endedAt && $this->endedAt < $this->startedAt) {
+            $context->buildViolation('End time must be after the start time.')
+                ->atPath('endedAt')
+                ->addViolation();
+        }
+
+        if (
+            null !== $this->project && null !== $this->space
+            && true !== $this->project->getSpace()?->getId()?->equals($this->space->getId())
+        ) {
+            $context->buildViolation('Project must belong to the same space.')
+                ->atPath('project')
+                ->addViolation();
+        }
+
+        $taskSpace = $this->task?->getProject()?->getSpace();
+        if (
+            null !== $this->task && null !== $this->space
+            && true !== $taskSpace?->getId()?->equals($this->space->getId())
+        ) {
+            $context->buildViolation('Task must belong to the same space.')
+                ->atPath('task')
+                ->addViolation();
+        }
+
+        if (null !== $this->rateAmount && null === $this->rateCurrency) {
+            $context->buildViolation('A currency is required when a rate is set.')
+                ->atPath('rateCurrency')
+                ->addViolation();
+        }
+    }
+
+    public function getId(): ?Uuid
+    {
+        return $this->id;
+    }
+
+    public function getSpace(): ?Space
+    {
+        return $this->space;
+    }
+
+    public function setSpace(?Space $space): self
+    {
+        $this->space = $space;
+
+        return $this;
+    }
+
+    public function getProject(): ?Project
+    {
+        return $this->project;
+    }
+
+    public function setProject(?Project $project): self
+    {
+        $this->project = $project;
+
+        return $this;
+    }
+
+    public function getTask(): ?Task
+    {
+        return $this->task;
+    }
+
+    public function setTask(?Task $task): self
+    {
+        $this->task = $task;
+
+        return $this;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(?User $user): self
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(?string $description): self
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function getStartedAt(): ?\DateTimeImmutable
+    {
+        return $this->startedAt;
+    }
+
+    public function setStartedAt(?\DateTimeImmutable $startedAt): self
+    {
+        $this->startedAt = $startedAt;
+
+        return $this;
+    }
+
+    public function getEndedAt(): ?\DateTimeImmutable
+    {
+        return $this->endedAt;
+    }
+
+    public function setEndedAt(?\DateTimeImmutable $endedAt): self
+    {
+        $this->endedAt = $endedAt;
+
+        return $this;
+    }
+
+    public function isRunning(): bool
+    {
+        return null === $this->endedAt;
+    }
+
+    public function getDurationSeconds(): ?int
+    {
+        return $this->durationSeconds;
+    }
+
+    public function isBillable(): bool
+    {
+        return $this->billable;
+    }
+
+    public function setBillable(bool $billable): self
+    {
+        $this->billable = $billable;
+
+        return $this;
+    }
+
+    public function getRateAmount(): ?int
+    {
+        return $this->rateAmount;
+    }
+
+    public function setRateAmount(?int $rateAmount): self
+    {
+        $this->rateAmount = $rateAmount;
+
+        return $this;
+    }
+
+    public function getRateCurrency(): ?string
+    {
+        return $this->rateCurrency;
+    }
+
+    public function setRateCurrency(?string $rateCurrency): self
+    {
+        $this->rateCurrency = $rateCurrency;
+
+        return $this;
+    }
+
+    public function getBilledAt(): ?\DateTimeImmutable
+    {
+        return $this->billedAt;
+    }
+
+    public function setBilledAt(?\DateTimeImmutable $billedAt): self
+    {
+        $this->billedAt = $billedAt;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): ?\DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    #[ORM\PreUpdate]
+    public function onPreUpdate(): void
+    {
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+}

--- a/api/src/EventListener/AccessPolicyListener.php
+++ b/api/src/EventListener/AccessPolicyListener.php
@@ -64,6 +64,8 @@ final class AccessPolicyListener
         'notifications' => 'notifications',
         'media-objects' => 'files',
         'time_entries' => 'time_entries',
+        'clients' => 'invoices',
+        'invoices' => 'invoices',
     ];
 
     /**

--- a/api/src/EventListener/AccessPolicyListener.php
+++ b/api/src/EventListener/AccessPolicyListener.php
@@ -63,6 +63,7 @@ final class AccessPolicyListener
         'comments' => 'comments',
         'notifications' => 'notifications',
         'media-objects' => 'files',
+        'time_entries' => 'time_entries',
     ];
 
     /**

--- a/api/src/Message/MarkOverdueInvoices.php
+++ b/api/src/Message/MarkOverdueInvoices.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Message;
+
+/**
+ * Scheduler message: flip sent invoices whose due date has passed to overdue
+ * (#445). Attached to the default schedule daily by
+ * App\Scheduler\MainScheduleProvider; carries no payload — the handler
+ * re-derives everything from the database.
+ */
+final class MarkOverdueInvoices
+{
+}

--- a/api/src/Message/SpawnRecurringInvoices.php
+++ b/api/src/Message/SpawnRecurringInvoices.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Message;
+
+/**
+ * Scheduler message: clone due recurring-template invoices into fresh drafts
+ * (#445). Attached to the default schedule daily by
+ * App\Scheduler\MainScheduleProvider; carries no payload.
+ */
+final class SpawnRecurringInvoices
+{
+}

--- a/api/src/MessageHandler/MarkOverdueInvoicesHandler.php
+++ b/api/src/MessageHandler/MarkOverdueInvoicesHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\MessageHandler;
+
+use App\Message\MarkOverdueInvoices;
+use App\Repository\InvoiceRepository;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * Marks past-due sent invoices overdue when the scheduler fires
+ * App\Message\MarkOverdueInvoices (daily). Idempotent — a re-run just finds
+ * fewer (or no) still-sent past-due invoices.
+ */
+#[AsMessageHandler]
+final class MarkOverdueInvoicesHandler
+{
+    public function __construct(
+        private InvoiceRepository $invoices,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(MarkOverdueInvoices $message): void
+    {
+        $today = new \DateTimeImmutable('today');
+        $count = $this->invoices->markOverdue($today);
+
+        if ($count > 0) {
+            $this->logger->info(sprintf('Marked %d invoice(s) overdue.', $count));
+        }
+    }
+}

--- a/api/src/MessageHandler/SpawnRecurringInvoicesHandler.php
+++ b/api/src/MessageHandler/SpawnRecurringInvoicesHandler.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\MessageHandler;
+
+use App\Message\SpawnRecurringInvoices;
+use App\Service\RecurringInvoiceSpawner;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * Spawns due recurring invoices when the scheduler fires
+ * App\Message\SpawnRecurringInvoices (daily).
+ */
+#[AsMessageHandler]
+final class SpawnRecurringInvoicesHandler
+{
+    public function __construct(
+        private RecurringInvoiceSpawner $spawner,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(SpawnRecurringInvoices $message): void
+    {
+        $count = $this->spawner->spawnDue(new \DateTimeImmutable('today'));
+
+        if ($count > 0) {
+            $this->logger->info(sprintf('Spawned %d recurring invoice(s).', $count));
+        }
+    }
+}

--- a/api/src/Repository/ClientRepository.php
+++ b/api/src/Repository/ClientRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Client;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Client>
+ */
+class ClientRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Client::class);
+    }
+}

--- a/api/src/Repository/InvoiceRepository.php
+++ b/api/src/Repository/InvoiceRepository.php
@@ -33,4 +33,10 @@ class InvoiceRepository extends ServiceEntityRepository
 
         return (int) $count;
     }
+
+    /** Resolve an invoice from a public-link token (caller passes the sha256 hash). */
+    public function findByPublicTokenHash(string $hash): ?Invoice
+    {
+        return $this->findOneBy(['publicToken' => $hash]);
+    }
 }

--- a/api/src/Repository/InvoiceRepository.php
+++ b/api/src/Repository/InvoiceRepository.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Invoice;
+use App\Entity\Space;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Invoice>
+ */
+class InvoiceRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Invoice::class);
+    }
+
+    /**
+     * Count invoices already issued a number in a space — the basis for the next
+     * sequential number when an invoice is issued.
+     */
+    public function countNumbered(Space $space): int
+    {
+        $count = $this->createQueryBuilder('i')
+            ->select('COUNT(i.id)')
+            ->andWhere('i.space = :space')
+            ->andWhere('i.number IS NOT NULL')
+            ->setParameter('space', $space)
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        return (int) $count;
+    }
+}

--- a/api/src/Repository/InvoiceRepository.php
+++ b/api/src/Repository/InvoiceRepository.php
@@ -41,6 +41,22 @@ class InvoiceRepository extends ServiceEntityRepository
     }
 
     /**
+     * Recurring-template invoices whose next issue date has arrived.
+     *
+     * @return list<Invoice>
+     */
+    public function findDueRecurring(\DateTimeImmutable $today): array
+    {
+        return $this->createQueryBuilder('i')
+            ->andWhere('i.recurrenceFrequency IS NOT NULL')
+            ->andWhere('i.nextIssueDate IS NOT NULL')
+            ->andWhere('i.nextIssueDate <= :today')
+            ->setParameter('today', $today)
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
      * Flip every sent invoice whose due date has passed to overdue, in one bulk
      * UPDATE. Returns how many were changed. Paid/void/draft are left alone.
      */

--- a/api/src/Repository/InvoiceRepository.php
+++ b/api/src/Repository/InvoiceRepository.php
@@ -39,4 +39,23 @@ class InvoiceRepository extends ServiceEntityRepository
     {
         return $this->findOneBy(['publicToken' => $hash]);
     }
+
+    /**
+     * Flip every sent invoice whose due date has passed to overdue, in one bulk
+     * UPDATE. Returns how many were changed. Paid/void/draft are left alone.
+     */
+    public function markOverdue(\DateTimeImmutable $today): int
+    {
+        return $this->createQueryBuilder('i')
+            ->update()
+            ->set('i.status', ':overdue')
+            ->where('i.status = :sent')
+            ->andWhere('i.dueDate IS NOT NULL')
+            ->andWhere('i.dueDate < :today')
+            ->setParameter('overdue', Invoice::STATUS_OVERDUE)
+            ->setParameter('sent', Invoice::STATUS_SENT)
+            ->setParameter('today', $today)
+            ->getQuery()
+            ->execute();
+    }
 }

--- a/api/src/Repository/TimeEntryRepository.php
+++ b/api/src/Repository/TimeEntryRepository.php
@@ -2,6 +2,8 @@
 
 namespace App\Repository;
 
+use App\Entity\Project;
+use App\Entity\Space;
 use App\Entity\TimeEntry;
 use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
@@ -34,5 +36,27 @@ class TimeEntryRepository extends ServiceEntityRepository
         assert(null === $result || $result instanceof TimeEntry);
 
         return $result;
+    }
+
+    /**
+     * Completed, billable, not-yet-billed entries in a space — the pool an
+     * invoice draws from. Optionally narrowed to one project.
+     *
+     * @return list<TimeEntry>
+     */
+    public function findInvoiceable(Space $space, ?Project $project = null): array
+    {
+        $qb = $this->createQueryBuilder('t')
+            ->andWhere('t.space = :space')
+            ->andWhere('t.billable = true')
+            ->andWhere('t.endedAt IS NOT NULL')
+            ->andWhere('t.billedAt IS NULL')
+            ->setParameter('space', $space)
+            ->orderBy('t.startedAt', 'ASC');
+        if (null !== $project) {
+            $qb->andWhere('t.project = :project')->setParameter('project', $project);
+        }
+
+        return $qb->getQuery()->getResult();
     }
 }

--- a/api/src/Repository/TimeEntryRepository.php
+++ b/api/src/Repository/TimeEntryRepository.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\TimeEntry;
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<TimeEntry>
+ */
+class TimeEntryRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, TimeEntry::class);
+    }
+
+    /**
+     * The user's currently-running timer (endedAt IS NULL), if any. The partial
+     * unique index guarantees at most one, so this is deterministic.
+     */
+    public function findRunningForUser(User $user): ?TimeEntry
+    {
+        $result = $this->createQueryBuilder('t')
+            ->andWhere('t.user = :user')
+            ->andWhere('t.endedAt IS NULL')
+            ->setParameter('user', $user)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        assert(null === $result || $result instanceof TimeEntry);
+
+        return $result;
+    }
+}

--- a/api/src/Scheduler/MainScheduleProvider.php
+++ b/api/src/Scheduler/MainScheduleProvider.php
@@ -6,6 +6,7 @@ use App\Message\CaptureUsageSnapshot;
 use App\Message\DispatchNotificationDigest;
 use App\Message\DispatchTaskReminders;
 use App\Message\MarkOverdueInvoices;
+use App\Message\SpawnRecurringInvoices;
 use App\Message\PruneAccountExports;
 use App\Message\PruneSpaceExports;
 use App\Message\PullCalendarChanges;
@@ -97,6 +98,9 @@ final class MainScheduleProvider implements ScheduleProviderInterface
                 // Overdue invoices: flip sent invoices past their due date to
                 // overdue, daily at 03:50 UTC (InvoiceRepository::markOverdue).
                 RecurringMessage::cron('50 3 * * *', new MarkOverdueInvoices(), $utc),
+                // Recurring invoices: clone due templates into fresh drafts,
+                // daily at 03:55 UTC (App\Service\RecurringInvoiceSpawner).
+                RecurringMessage::cron('55 3 * * *', new SpawnRecurringInvoices(), $utc),
             )
             ->stateful($this->cache)
             ->processOnlyLastMissedRun(true)

--- a/api/src/Scheduler/MainScheduleProvider.php
+++ b/api/src/Scheduler/MainScheduleProvider.php
@@ -5,6 +5,7 @@ namespace App\Scheduler;
 use App\Message\CaptureUsageSnapshot;
 use App\Message\DispatchNotificationDigest;
 use App\Message\DispatchTaskReminders;
+use App\Message\MarkOverdueInvoices;
 use App\Message\PruneAccountExports;
 use App\Message\PruneSpaceExports;
 use App\Message\PullCalendarChanges;
@@ -93,6 +94,9 @@ final class MainScheduleProvider implements ScheduleProviderInterface
                 // (App\Service\CalendarPuller, #582 Phase B). Bounds two-way
                 // lag until push-notification channels land (Phase D).
                 RecurringMessage::cron('*/15 * * * *', new PullCalendarChanges(), $utc),
+                // Overdue invoices: flip sent invoices past their due date to
+                // overdue, daily at 03:50 UTC (InvoiceRepository::markOverdue).
+                RecurringMessage::cron('50 3 * * *', new MarkOverdueInvoices(), $utc),
             )
             ->stateful($this->cache)
             ->processOnlyLastMissedRun(true)

--- a/api/src/Security/Access/AccessPolicy.php
+++ b/api/src/Security/Access/AccessPolicy.php
@@ -34,6 +34,7 @@ final class AccessPolicy
         'comments',
         'notifications',
         'files',
+        'time_entries',
         // Account surfaces (token actors only — not impersonation, which uses
         // User::IMPERSONATION_CATEGORIES). 'profile' gates /api/me + /me/preferences;
         // 'security' gates /me/2fa, /me/sessions, account lifecycle, change-password.

--- a/api/src/Security/Access/AccessPolicy.php
+++ b/api/src/Security/Access/AccessPolicy.php
@@ -35,6 +35,7 @@ final class AccessPolicy
         'notifications',
         'files',
         'time_entries',
+        'invoices',
         // Account surfaces (token actors only — not impersonation, which uses
         // User::IMPERSONATION_CATEGORIES). 'profile' gates /api/me + /me/preferences;
         // 'security' gates /me/2fa, /me/sessions, account lifecycle, change-password.

--- a/api/src/Security/Permission/SpacePermission.php
+++ b/api/src/Security/Permission/SpacePermission.php
@@ -35,6 +35,8 @@ final class SpacePermission
     public const FILES = 'files';
     public const API_KEYS = 'api_keys';
     public const TIME_ENTRIES = 'time_entries';
+    /** Invoicing + its clients (clients ride this category). Admin-reserved by default. */
+    public const INVOICES = 'invoices';
 
     /** @var list<string> */
     public const CATEGORIES = [
@@ -49,7 +51,17 @@ final class SpacePermission
         self::FILES,
         self::API_KEYS,
         self::TIME_ENTRIES,
+        self::INVOICES,
     ];
+
+    /**
+     * Categories not granted to a plain member by default — an admin must
+     * assign a custom role to unlock them. Everything else is on by default so
+     * a space behaves as before until an admin tightens it.
+     *
+     * @var list<string>
+     */
+    public const ADMIN_RESERVED = [self::API_KEYS, self::INVOICES];
 
     public static function isCategory(string $category): bool
     {
@@ -83,8 +95,10 @@ final class SpacePermission
     public static function fullMatrix(): array
     {
         $matrix = self::matrixOf(true);
-        foreach (self::ACTIONS as $action) {
-            $matrix[self::API_KEYS][$action] = false;
+        foreach (self::ADMIN_RESERVED as $category) {
+            foreach (self::ACTIONS as $action) {
+                $matrix[$category][$action] = false;
+            }
         }
 
         return $matrix;
@@ -100,8 +114,8 @@ final class SpacePermission
     {
         $matrix = self::emptyMatrix();
         foreach (self::CATEGORIES as $category) {
-            // Guests never see API-key management (admin-reserved).
-            if (self::API_KEYS === $category) {
+            // Guests never see admin-reserved surfaces (API keys, invoicing).
+            if (in_array($category, self::ADMIN_RESERVED, true)) {
                 continue;
             }
             $matrix[$category][self::READ] = true;

--- a/api/src/Security/Permission/SpacePermission.php
+++ b/api/src/Security/Permission/SpacePermission.php
@@ -34,6 +34,7 @@ final class SpacePermission
     public const GROUPS = 'groups';
     public const FILES = 'files';
     public const API_KEYS = 'api_keys';
+    public const TIME_ENTRIES = 'time_entries';
 
     /** @var list<string> */
     public const CATEGORIES = [
@@ -47,6 +48,7 @@ final class SpacePermission
         self::GROUPS,
         self::FILES,
         self::API_KEYS,
+        self::TIME_ENTRIES,
     ];
 
     public static function isCategory(string $category): bool

--- a/api/src/Security/Permission/SpacePermissionResolver.php
+++ b/api/src/Security/Permission/SpacePermissionResolver.php
@@ -186,7 +186,12 @@ final class SpacePermissionResolver
             }
             $roles = $this->effectiveRoles($space, $membership);
             if (null === $roles) {
-                continue; // no roles + no Member role → unrestricted
+                // No roles + no Member role → unrestricted, EXCEPT admin-reserved
+                // categories, which require an explicit grant (mirrors the voter).
+                if (in_array($category, SpacePermission::ADMIN_RESERVED, true)) {
+                    $denied[] = (string) $space->getId();
+                }
+                continue;
             }
             $allowed = false;
             foreach ($roles as $role) {

--- a/api/src/Security/Permission/SpacePermissionVoter.php
+++ b/api/src/Security/Permission/SpacePermissionVoter.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Security\Permission;
 
+use App\Entity\Client;
 use App\Entity\Comment;
 use App\Entity\CustomFieldDefinition;
 use App\Entity\Discussion;
+use App\Entity\Invoice;
 use App\Entity\Page;
 use App\Entity\Project;
 use App\Entity\Space;
@@ -59,8 +61,16 @@ final class SpacePermissionVoter extends Voter
             return false;
         }
         [, $category, $action] = explode('.', $attribute);
+        $space = $this->resolveSpace($subject);
 
-        return $this->resolver->can($user, $this->resolveSpace($subject), $category, $action);
+        // Admin-reserved categories (api keys, invoicing) must not be swept in by
+        // the "member with no roles is unrestricted" back-compat rule — they need
+        // an explicit grant (space admin or an assigned role).
+        if (in_array($category, SpacePermission::ADMIN_RESERVED, true)) {
+            return $this->resolver->canByExplicitGrant($user, $space, $category, $action);
+        }
+
+        return $this->resolver->can($user, $space, $category, $action);
     }
 
     /**
@@ -79,6 +89,8 @@ final class SpacePermissionVoter extends Voter
             $subject instanceof UserGroup => $subject->getSpace(),
             $subject instanceof TaskSection => $subject->getProject()?->getSpace(),
             $subject instanceof TimeEntry => $subject->getSpace(),
+            $subject instanceof Client => $subject->getSpace(),
+            $subject instanceof Invoice => $subject->getSpace(),
             $subject instanceof TaskRelationship => $subject->getSource()?->getProject()?->getSpace(),
             $subject instanceof Comment => $this->commentSpace($subject),
             default => null,

--- a/api/src/Security/Permission/SpacePermissionVoter.php
+++ b/api/src/Security/Permission/SpacePermissionVoter.php
@@ -14,6 +14,7 @@ use App\Entity\Tag;
 use App\Entity\Task;
 use App\Entity\TaskRelationship;
 use App\Entity\TaskSection;
+use App\Entity\TimeEntry;
 use App\Entity\User;
 use App\Entity\UserGroup;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -77,6 +78,7 @@ final class SpacePermissionVoter extends Voter
             $subject instanceof Tag => $subject->getSpace(),
             $subject instanceof UserGroup => $subject->getSpace(),
             $subject instanceof TaskSection => $subject->getProject()?->getSpace(),
+            $subject instanceof TimeEntry => $subject->getSpace(),
             $subject instanceof TaskRelationship => $subject->getSource()?->getProject()?->getSpace(),
             $subject instanceof Comment => $this->commentSpace($subject),
             default => null,

--- a/api/src/Service/InvoiceMailer.php
+++ b/api/src/Service/InvoiceMailer.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Invoice;
+use App\Service\Mail\MailDispatcher;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+
+/**
+ * Emails a client the "here's your invoice" link when it's sent (#445). The
+ * link carries the plaintext public token (only its sha256 is stored) and
+ * points at the PWA's public /i/{token} page, where the client can view,
+ * download the PDF, and pay. No-ops when the client has no email on file.
+ */
+final class InvoiceMailer
+{
+    public function __construct(
+        private readonly MailDispatcher $mail,
+    ) {
+    }
+
+    public function sendInvoice(Invoice $invoice, string $plainToken): void
+    {
+        $to = $invoice->getClient()?->getEmail();
+        if (null === $to || '' === trim($to)) {
+            return;
+        }
+
+        $from = $invoice->getSpace()?->getName() ?? 'Madori';
+        $number = $invoice->getNumber() ?? 'invoice';
+
+        $email = (new TemplatedEmail())
+            ->to($to)
+            ->subject(sprintf('%s from %s', ucfirst($number), $from))
+            ->htmlTemplate('emails/invoice.html.twig')
+            ->textTemplate('emails/invoice.txt.twig')
+            ->context([
+                'invoice' => $invoice,
+                'client' => $invoice->getClient(),
+                'fromName' => $from,
+                'viewUrl' => $this->mail->frontendLink('/i/' . $plainToken),
+            ]);
+
+        $this->mail->send($email);
+    }
+}

--- a/api/src/Service/InvoicePdfRenderer.php
+++ b/api/src/Service/InvoicePdfRenderer.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\Invoice;
+use Dompdf\Dompdf;
+use Dompdf\Options;
+use Twig\Environment;
+
+/**
+ * Renders an {@see Invoice} to a PDF byte string via a Twig template + dompdf
+ * (pure PHP, no wkhtmltopdf binary — fits the slim FrankenPHP image). We own the
+ * layout + numbering, so no third-party invoicing product is needed; the PDF is
+ * generated on demand and streamed by {@see \App\Controller\InvoicePdfController}.
+ */
+final class InvoicePdfRenderer
+{
+    public function __construct(private Environment $twig)
+    {
+    }
+
+    public function render(Invoice $invoice): string
+    {
+        $html = $this->twig->render('invoice/pdf.html.twig', ['invoice' => $invoice]);
+
+        $options = new Options();
+        $options->set('isRemoteEnabled', false);
+        $options->set('defaultFont', 'Helvetica');
+
+        $dompdf = new Dompdf($options);
+        $dompdf->loadHtml($html);
+        $dompdf->setPaper('A4');
+        $dompdf->render();
+
+        return $dompdf->output();
+    }
+
+    /** A safe download filename for the invoice. */
+    public function filename(Invoice $invoice): string
+    {
+        $number = $invoice->getNumber();
+        $base = null !== $number && '' !== $number ? $number : 'invoice-' . $invoice->getId();
+        $safe = preg_replace('/[^A-Za-z0-9._-]/', '-', $base);
+
+        return ($safe ?? 'invoice') . '.pdf';
+    }
+}

--- a/api/src/Service/RecurringInvoiceSpawner.php
+++ b/api/src/Service/RecurringInvoiceSpawner.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Invoice;
+use App\Entity\InvoiceLineItem;
+use App\Repository\InvoiceRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Clones each due recurring-template invoice (#445) into a fresh draft — copying
+ * client, currency, tax, notes, and line items (but not the source's recurrence
+ * or its lines' time-entry links) — then advances the template's next issue date
+ * by one interval. One clone + one advance per template per run; a template
+ * still due after that is picked up on the next daily run.
+ */
+final class RecurringInvoiceSpawner
+{
+    private const BASIS_POINTS = 10000;
+
+    public function __construct(
+        private readonly InvoiceRepository $invoices,
+        private readonly EntityManagerInterface $em,
+    ) {
+    }
+
+    public function spawnDue(\DateTimeImmutable $today): int
+    {
+        $spawned = 0;
+        foreach ($this->invoices->findDueRecurring($today) as $template) {
+            $step = $template->recurrenceStep();
+            if (null === $step) {
+                continue;
+            }
+
+            $clone = (new Invoice())
+                ->setSpace($template->getSpace())
+                ->setClient($template->getClient())
+                ->setCurrency($template->getCurrency())
+                ->setTaxRate($template->getTaxRate())
+                ->setNotes($template->getNotes())
+                ->setCreatedBy($template->getCreatedBy());
+
+            $subtotal = 0;
+            foreach ($template->getLineItems() as $line) {
+                $clone->addLineItem(
+                    (new InvoiceLineItem())
+                        ->setDescription($line->getDescription())
+                        ->setQuantity($line->getQuantity())
+                        ->setUnitAmount($line->getUnitAmount())
+                        ->setAmount($line->getAmount())
+                        ->setPosition($line->getPosition()),
+                );
+                $subtotal += $line->getAmount();
+            }
+            $tax = (int) round($subtotal * $template->getTaxRate() / self::BASIS_POINTS);
+            $clone->setSubtotal($subtotal)->setTaxAmount($tax)->setTotal($subtotal + $tax);
+            $this->em->persist($clone);
+
+            $next = $template->getNextIssueDate();
+            if (null !== $next) {
+                $template->setNextIssueDate($next->modify($step));
+            }
+            ++$spawned;
+        }
+
+        if ($spawned > 0) {
+            $this->em->flush();
+        }
+
+        return $spawned;
+    }
+}

--- a/api/src/State/ClientCreatorProcessor.php
+++ b/api/src/State/ClientCreatorProcessor.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\Entity\Client;
+use App\Security\AuthenticatedUserResolver;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Stamps the current user as the client's creator on create (preserved on
+ * update), server-side rather than from the payload — matching
+ * DiscussionAuthorProcessor's trust model.
+ *
+ * @implements ProcessorInterface<Client, Client>
+ */
+final class ClientCreatorProcessor implements ProcessorInterface
+{
+    /**
+     * @param ProcessorInterface<Client, Client> $persistProcessor
+     */
+    public function __construct(
+        #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
+        private ProcessorInterface $persistProcessor,
+        private AuthenticatedUserResolver $auth,
+    ) {
+    }
+
+    /**
+     * @param Client $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Client
+    {
+        $user = $this->auth->requireUser('manage clients');
+
+        if (null === $data->getCreatedBy()) {
+            $data->setCreatedBy($user);
+        }
+
+        return $this->persistProcessor->process($data, $operation, $uriVariables, $context);
+    }
+}

--- a/api/src/State/InvoiceProcessor.php
+++ b/api/src/State/InvoiceProcessor.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\Entity\Invoice;
+use App\Security\AuthenticatedUserResolver;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Stamps the creator on create, then recomputes every monetary total from the
+ * line items server-side (never trusting client-sent amounts): each line's
+ * amount = round(quantity × unitAmount); the invoice's subtotal = Σ amounts;
+ * taxAmount = round(subtotal × taxRate / 10000); total = subtotal + taxAmount.
+ *
+ * Runs on both create and update so edited line items always re-total.
+ *
+ * @implements ProcessorInterface<Invoice, Invoice>
+ */
+final class InvoiceProcessor implements ProcessorInterface
+{
+    private const BASIS_POINTS = 10000;
+
+    /**
+     * @param ProcessorInterface<Invoice, Invoice> $persistProcessor
+     */
+    public function __construct(
+        #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
+        private ProcessorInterface $persistProcessor,
+        private AuthenticatedUserResolver $auth,
+    ) {
+    }
+
+    /**
+     * @param Invoice $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Invoice
+    {
+        $user = $this->auth->requireUser('manage invoices');
+
+        if (null === $data->getCreatedBy()) {
+            $data->setCreatedBy($user);
+        }
+
+        $this->recompute($data);
+
+        return $this->persistProcessor->process($data, $operation, $uriVariables, $context);
+    }
+
+    private function recompute(Invoice $invoice): void
+    {
+        $subtotal = 0;
+        foreach ($invoice->getLineItems() as $line) {
+            $amount = (int) round($line->getQuantity() * $line->getUnitAmount());
+            $line->setAmount($amount);
+            $subtotal += $amount;
+        }
+
+        $taxAmount = (int) round($subtotal * $invoice->getTaxRate() / self::BASIS_POINTS);
+        $invoice->setSubtotal($subtotal);
+        $invoice->setTaxAmount($taxAmount);
+        $invoice->setTotal($subtotal + $taxAmount);
+    }
+}

--- a/api/src/State/TimeEntryUserProcessor.php
+++ b/api/src/State/TimeEntryUserProcessor.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\Entity\TimeEntry;
+use App\Repository\TimeEntryRepository;
+use App\Security\AuthenticatedUserResolver;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Stamps the current user as the time entry's tracker on create, mirroring the
+ * trust model of DiscussionAuthorProcessor / TaskOwnerProcessor — the owner is
+ * set server-side, never from the payload. On update the existing owner is
+ * preserved (the processor also runs on Patch), so a member can't reassign a
+ * time entry to someone else.
+ *
+ * Starting a new running timer (a fresh entry with no endedAt) auto-stops the
+ * user's previous running timer first, so the "one running timer per user"
+ * invariant (a partial unique index) is upheld gracefully instead of surfacing
+ * a constraint violation. The stop is flushed before the insert so the two
+ * running rows never coexist (a partial unique index can't be deferred).
+ *
+ * @implements ProcessorInterface<TimeEntry, TimeEntry>
+ */
+final class TimeEntryUserProcessor implements ProcessorInterface
+{
+    /**
+     * @param ProcessorInterface<TimeEntry, TimeEntry> $persistProcessor
+     */
+    public function __construct(
+        #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
+        private ProcessorInterface $persistProcessor,
+        private AuthenticatedUserResolver $auth,
+        private TimeEntryRepository $timeEntries,
+        private EntityManagerInterface $em,
+    ) {
+    }
+
+    /**
+     * @param TimeEntry $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): TimeEntry
+    {
+        $user = $this->auth->requireUser('track time');
+
+        $isCreate = null === $data->getUser();
+        if ($isCreate) {
+            $data->setUser($user);
+
+            // Starting a new running timer stops the previous one first.
+            if (null === $data->getEndedAt()) {
+                $running = $this->timeEntries->findRunningForUser($user);
+                if (null !== $running && $running !== $data) {
+                    $running->setEndedAt(new \DateTimeImmutable());
+                    $this->em->flush();
+                }
+            }
+        }
+
+        return $this->persistProcessor->process($data, $operation, $uriVariables, $context);
+    }
+}

--- a/api/templates/emails/invoice.html.twig
+++ b/api/templates/emails/invoice.html.twig
@@ -1,0 +1,18 @@
+{# @var invoice \App\Entity\Invoice #}
+{# @var client \App\Entity\Client #}
+<p>Hi {{ client.name }},</p>
+
+<p>
+    {{ fromName }} has sent you
+    {% if invoice.number %}invoice <strong>{{ invoice.number }}</strong>{% else %}an invoice{% endif %}
+    for <strong>{{ (invoice.total / 100)|number_format(2) }} {{ invoice.currency }}</strong>{% if invoice.dueDate %},
+    due {{ invoice.dueDate|date('F j, Y') }}{% endif %}.
+</p>
+
+<p>
+    <a href="{{ viewUrl }}">View and pay your invoice</a>
+</p>
+
+<p style="color: #9ca3af; font-size: 12px;">
+    You can review the line items, download a PDF, and pay online from that page.
+</p>

--- a/api/templates/emails/invoice.txt.twig
+++ b/api/templates/emails/invoice.txt.twig
@@ -1,0 +1,9 @@
+{# @var invoice \App\Entity\Invoice #}
+{# @var client \App\Entity\Client #}
+Hi {{ client.name }},
+
+{{ fromName }} has sent you {% if invoice.number %}invoice {{ invoice.number }}{% else %}an invoice{% endif %} for {{ (invoice.total / 100)|number_format(2) }} {{ invoice.currency }}{% if invoice.dueDate %}, due {{ invoice.dueDate|date('F j, Y') }}{% endif %}.
+
+View and pay your invoice: {{ viewUrl }}
+
+You can review the line items, download a PDF, and pay online from that page.

--- a/api/templates/invoice/pdf.html.twig
+++ b/api/templates/invoice/pdf.html.twig
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<style>
+    * { font-family: Helvetica, Arial, sans-serif; }
+    body { color: #1f2937; font-size: 12px; margin: 0; }
+    h1 { font-size: 26px; margin: 0 0 4px; letter-spacing: 1px; }
+    .muted { color: #6b7280; }
+    .header { border-bottom: 2px solid #111827; padding-bottom: 12px; margin-bottom: 20px; }
+    .header .status { float: right; text-transform: uppercase; font-size: 11px; font-weight: bold;
+        border: 1px solid #9ca3af; border-radius: 4px; padding: 3px 8px; color: #374151; }
+    .parties { width: 100%; margin-bottom: 24px; }
+    .parties td { vertical-align: top; width: 50%; }
+    .label { text-transform: uppercase; font-size: 10px; letter-spacing: 1px; color: #6b7280; margin-bottom: 4px; }
+    .name { font-weight: bold; font-size: 13px; }
+    table.lines { width: 100%; border-collapse: collapse; margin-bottom: 16px; }
+    table.lines th { text-align: left; border-bottom: 1px solid #d1d5db; padding: 6px 8px; font-size: 10px;
+        text-transform: uppercase; letter-spacing: 1px; color: #6b7280; }
+    table.lines td { padding: 8px; border-bottom: 1px solid #f3f4f6; }
+    .num { text-align: right; }
+    .totals { width: 40%; margin-left: 60%; }
+    .totals td { padding: 4px 8px; }
+    .totals .grand td { border-top: 2px solid #111827; font-weight: bold; font-size: 14px; }
+    .notes { margin-top: 28px; padding-top: 12px; border-top: 1px solid #e5e7eb; white-space: pre-wrap; }
+</style>
+</head>
+<body>
+{% set c = invoice.currency %}
+{% macro money(amount, currency) %}{{ (amount / 100)|number_format(2) }} {{ currency }}{% endmacro %}
+{% import _self as fmt %}
+
+<div class="header">
+    <span class="status">{{ invoice.status }}</span>
+    <h1>INVOICE</h1>
+    <div class="muted">{{ invoice.number ?? 'Draft' }}</div>
+</div>
+
+<table class="parties">
+    <tr>
+        <td>
+            <div class="label">From</div>
+            <div class="name">{{ invoice.space.name ?? '' }}</div>
+        </td>
+        <td>
+            <div class="label">Bill to</div>
+            <div class="name">{{ invoice.client.name ?? '' }}</div>
+            {% if invoice.client.email %}<div class="muted">{{ invoice.client.email }}</div>{% endif %}
+            {% if invoice.client.address %}<div class="muted">{{ invoice.client.address|nl2br }}</div>{% endif %}
+        </td>
+    </tr>
+</table>
+
+<table class="parties">
+    <tr>
+        <td>
+            <div class="label">Issue date</div>
+            <div>{{ invoice.issueDate ? invoice.issueDate|date('M j, Y') : '—' }}</div>
+        </td>
+        <td>
+            <div class="label">Due date</div>
+            <div>{{ invoice.dueDate ? invoice.dueDate|date('M j, Y') : '—' }}</div>
+        </td>
+    </tr>
+</table>
+
+<table class="lines">
+    <thead>
+        <tr>
+            <th>Description</th>
+            <th class="num">Qty</th>
+            <th class="num">Unit</th>
+            <th class="num">Amount</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for line in invoice.lineItems %}
+        <tr>
+            <td>{{ line.description }}</td>
+            <td class="num">{{ line.quantity }}</td>
+            <td class="num">{{ fmt.money(line.unitAmount, c) }}</td>
+            <td class="num">{{ fmt.money(line.amount, c) }}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+
+<table class="totals">
+    <tr>
+        <td>Subtotal</td>
+        <td class="num">{{ fmt.money(invoice.subtotal, c) }}</td>
+    </tr>
+    {% if invoice.taxAmount > 0 %}
+    <tr>
+        <td>Tax ({{ (invoice.taxRate / 100)|number_format(2) }}%)</td>
+        <td class="num">{{ fmt.money(invoice.taxAmount, c) }}</td>
+    </tr>
+    {% endif %}
+    <tr class="grand">
+        <td>Total</td>
+        <td class="num">{{ fmt.money(invoice.total, c) }}</td>
+    </tr>
+</table>
+
+{% if invoice.notes %}
+<div class="notes">{{ invoice.notes }}</div>
+{% endif %}
+</body>
+</html>

--- a/api/tests/Api/ClientInvoiceTest.php
+++ b/api/tests/Api/ClientInvoiceTest.php
@@ -355,6 +355,44 @@ class ClientInvoiceTest extends ApiTestCase
         $this->assertSame('overdue', $refreshed['status'] ?? null);
     }
 
+    public function testRecurringInvoiceSpawnsAFreshDraft(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $space = $this->createSharedSpace($admin);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $invoice = $client->request('POST', '/invoices', [
+            'json' => [
+                'space' => $spaceIri,
+                'client' => $clientRow['@id'],
+                'currency' => 'USD',
+                'recurrenceFrequency' => 'monthly',
+                'recurrenceInterval' => 1,
+                'nextIssueDate' => '2020-01-01',
+                'lineItems' => [['description' => 'Retainer', 'quantity' => 1, 'unitAmount' => 20000]],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertSame('monthly', $invoice['recurrenceFrequency'] ?? null);
+
+        // Run the recurring spawn.
+        $spawner = static::getContainer()->get(\App\Service\RecurringInvoiceSpawner::class);
+        assert($spawner instanceof \App\Service\RecurringInvoiceSpawner);
+        $spawned = $spawner->spawnDue(new \DateTimeImmutable('today'));
+        $this->assertSame(1, $spawned);
+
+        // Now two invoices: the template + the fresh draft clone.
+        $list = $client->request('GET', '/invoices?space=' . $spaceIri)->toArray();
+        $this->assertSame(2, $list['totalItems'] ?? null);
+    }
+
     public function testInvoicePdfRenders(): void
     {
         $admin = $this->createUser('admin@example.com');

--- a/api/tests/Api/ClientInvoiceTest.php
+++ b/api/tests/Api/ClientInvoiceTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\Invoice;
+use App\Entity\Space;
+use App\Entity\SpaceMembership;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Invoicing (#445): clients + invoices are gated on the admin-reserved
+ * `invoices` category (only space admins or members granted an invoicing role),
+ * and invoice totals are derived server-side from the line items.
+ */
+class ClientInvoiceTest extends ApiTestCase
+{
+    use SpaceMembershipFixture;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = static::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Invoice')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Client')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\SpaceMembership')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Space')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testAdminCreatesClientAndInvoiceWithDerivedTotals(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $space = $this->createSharedSpace($admin);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $clientIri = $clientRow['@id'];
+        $this->assertIsString($clientIri);
+
+        $invoice = $client->request('POST', '/invoices', [
+            'json' => [
+                'space' => $spaceIri,
+                'client' => $clientIri,
+                'currency' => 'USD',
+                'taxRate' => 1000, // 10%
+                'lineItems' => [
+                    ['description' => 'Design', 'quantity' => 2, 'unitAmount' => 5000, 'position' => 0],
+                    ['description' => 'Build', 'quantity' => 1.5, 'unitAmount' => 8000, 'position' => 1],
+                ],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+
+        // 2×5000 + 1.5×8000 = 22000; tax 10% = 2200; total 24200 — all derived server-side.
+        $this->assertSame(22000, $invoice['subtotal'] ?? null);
+        $this->assertSame(2200, $invoice['taxAmount'] ?? null);
+        $this->assertSame(24200, $invoice['total'] ?? null);
+        $this->assertSame(Invoice::STATUS_DRAFT, $invoice['status'] ?? null);
+        $this->assertCount(2, $invoice['lineItems'] ?? []);
+    }
+
+    public function testMemberWithoutInvoiceRoleCannotCreateClient(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $member = $this->createUser('member@example.com');
+        $space = $this->createSharedSpace($admin, $member);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        $client = static::createClient();
+        $client->loginUser($member);
+        $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Sneaky Co'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        // invoices is admin-reserved: a plain member has no explicit grant.
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testMemberCannotSeeInvoicesInCollection(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $member = $this->createUser('member@example.com');
+        $space = $this->createSharedSpace($admin, $member);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        // Admin creates a client + invoice.
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $client->request('POST', '/invoices', [
+            'json' => [
+                'space' => $spaceIri,
+                'client' => $clientRow['@id'],
+                'currency' => 'USD',
+                'lineItems' => [['description' => 'Work', 'quantity' => 1, 'unitAmount' => 1000]],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+
+        // The member (no invoicing grant) sees an empty invoice list.
+        $client->loginUser($member);
+        $list = $client->request('GET', '/invoices?space=' . $spaceIri)->toArray();
+        $this->assertSame(0, $list['totalItems'] ?? null);
+    }
+
+    private function createSharedSpace(User $admin, ?User $member = null): Space
+    {
+        $space = (new Space())->setName('Studio')->setCreatedBy($admin);
+        $this->entityManager->persist($space);
+        $adminMembership = (new SpaceMembership())
+            ->setUser($admin)
+            ->setRole(Space::ROLE_ADMIN);
+        $space->addUserMembership($adminMembership);
+        $this->entityManager->persist($adminMembership);
+        if (null !== $member) {
+            $memberMembership = (new SpaceMembership())
+                ->setUser($member)
+                ->setRole(Space::ROLE_MEMBER);
+            $space->addUserMembership($memberMembership);
+            $this->entityManager->persist($memberMembership);
+        }
+        $this->entityManager->flush();
+
+        return $space;
+    }
+
+    private function createUser(string $email): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/api/tests/Api/ClientInvoiceTest.php
+++ b/api/tests/Api/ClientInvoiceTest.php
@@ -73,7 +73,9 @@ class ClientInvoiceTest extends ApiTestCase
         $this->assertSame(2200, $invoice['taxAmount'] ?? null);
         $this->assertSame(24200, $invoice['total'] ?? null);
         $this->assertSame(Invoice::STATUS_DRAFT, $invoice['status'] ?? null);
-        $this->assertCount(2, $invoice['lineItems'] ?? []);
+        $lineItems = $invoice['lineItems'] ?? [];
+        $this->assertIsArray($lineItems);
+        $this->assertCount(2, $lineItems);
     }
 
     public function testMemberWithoutInvoiceRoleCannotCreateClient(): void
@@ -227,7 +229,7 @@ class ClientInvoiceTest extends ApiTestCase
         ])->toArray();
 
         // Voiding releases the billed entry, so it can be re-invoiced.
-        $client->request('POST', $invoice['@id'] . '/void', [
+        $client->request('POST', $this->iri($invoice) . '/void', [
             'json' => [],
             'headers' => ['Content-Type' => 'application/json'],
         ]);
@@ -262,7 +264,7 @@ class ClientInvoiceTest extends ApiTestCase
             'headers' => ['Content-Type' => 'application/ld+json'],
         ])->toArray();
 
-        $sent = $client->request('POST', $invoice['@id'] . '/send', [
+        $sent = $client->request('POST', $this->iri($invoice) . '/send', [
             'json' => [],
             'headers' => ['Content-Type' => 'application/json'],
         ])->toArray();
@@ -304,13 +306,15 @@ class ClientInvoiceTest extends ApiTestCase
             'headers' => ['Content-Type' => 'application/ld+json'],
         ])->toArray();
 
-        $client->request('POST', $invoice['@id'] . '/send', [
+        $client->request('POST', $this->iri($invoice) . '/send', [
             'json' => [],
             'headers' => ['Content-Type' => 'application/json'],
         ]);
         $this->assertResponseStatusCodeSame(201);
         $this->assertEmailCount(1);
-        $this->assertEmailAddressContains($this->getMailerMessage(), 'To', 'billing@acme.test');
+        $message = $this->getMailerMessage();
+        $this->assertNotNull($message);
+        $this->assertEmailAddressContains($message, 'To', 'billing@acme.test');
     }
 
     public function testOverdueSweepFlipsPastDueSentInvoices(): void
@@ -347,7 +351,6 @@ class ClientInvoiceTest extends ApiTestCase
 
         // Run the daily overdue sweep.
         $repo = $this->entityManager->getRepository(Invoice::class);
-        assert($repo instanceof \App\Repository\InvoiceRepository);
         $changed = $repo->markOverdue(new \DateTimeImmutable('today'));
         $this->assertSame(1, $changed);
 
@@ -384,7 +387,6 @@ class ClientInvoiceTest extends ApiTestCase
 
         // Run the recurring spawn.
         $spawner = static::getContainer()->get(\App\Service\RecurringInvoiceSpawner::class);
-        assert($spawner instanceof \App\Service\RecurringInvoiceSpawner);
         $spawned = $spawner->spawnDue(new \DateTimeImmutable('today'));
         $this->assertSame(1, $spawned);
 
@@ -415,7 +417,7 @@ class ClientInvoiceTest extends ApiTestCase
             'headers' => ['Content-Type' => 'application/ld+json'],
         ])->toArray();
 
-        $response = $client->request('GET', $invoice['@id'] . '/pdf');
+        $response = $client->request('GET', $this->iri($invoice) . '/pdf');
         $this->assertResponseIsSuccessful();
         $this->assertResponseHeaderSame('content-type', 'application/pdf');
         // A real PDF starts with the %PDF- magic bytes.
@@ -505,6 +507,19 @@ class ClientInvoiceTest extends ApiTestCase
             'headers' => ['Content-Type' => 'application/ld+json'],
         ]);
         $this->assertResponseStatusCodeSame(201);
+    }
+
+    /**
+     * The `@id` of a decoded resource, narrowed to string for concatenation.
+     *
+     * @param array<int|string, mixed> $row
+     */
+    private function iri(array $row): string
+    {
+        $iri = $row['@id'] ?? null;
+        $this->assertIsString($iri);
+
+        return $iri;
     }
 
     private function createSharedSpace(User $admin, ?User $member = null): Space

--- a/api/tests/Api/ClientInvoiceTest.php
+++ b/api/tests/Api/ClientInvoiceTest.php
@@ -161,6 +161,84 @@ class ClientInvoiceTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(422);
     }
 
+    public function testIssueAssignsNumberThenMarkPaid(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $space = $this->createSharedSpace($admin);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->trackTime($client, $spaceIri, '2026-07-03T09:00:00+00:00', '2026-07-03T10:00:00+00:00', true, 6000);
+        $invoice = $client->request('POST', '/invoices/from-time-entries', [
+            'json' => ['space' => $spaceIri, 'client' => $clientRow['@id']],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $invoiceIri = $invoice['@id'];
+        $this->assertIsString($invoiceIri);
+
+        // Issue → first per-space number + sent status.
+        $issued = $client->request('POST', $invoiceIri . '/issue', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $this->assertResponseIsSuccessful();
+        $this->assertSame('INV-0001', $issued['number'] ?? null);
+        $this->assertSame('sent', $issued['status'] ?? null);
+
+        // Re-issuing a non-draft is rejected.
+        $client->request('POST', $invoiceIri . '/issue', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(409);
+
+        // Mark paid.
+        $paid = $client->request('POST', $invoiceIri . '/mark-paid', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $this->assertSame('paid', $paid['status'] ?? null);
+        $this->assertNotNull($paid['paidAt'] ?? null);
+    }
+
+    public function testVoidReleasesBilledTime(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $space = $this->createSharedSpace($admin);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->trackTime($client, $spaceIri, '2026-07-03T09:00:00+00:00', '2026-07-03T10:00:00+00:00', true, 6000);
+
+        $invoice = $client->request('POST', '/invoices/from-time-entries', [
+            'json' => ['space' => $spaceIri, 'client' => $clientRow['@id']],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+
+        // Voiding releases the billed entry, so it can be re-invoiced.
+        $client->request('POST', $invoice['@id'] . '/void', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $client->request('POST', '/invoices/from-time-entries', [
+            'json' => ['space' => $spaceIri, 'client' => $clientRow['@id']],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+    }
+
     private function trackTime(
         \ApiPlatform\Symfony\Bundle\Test\Client $client,
         string $spaceIri,

--- a/api/tests/Api/ClientInvoiceTest.php
+++ b/api/tests/Api/ClientInvoiceTest.php
@@ -313,6 +313,48 @@ class ClientInvoiceTest extends ApiTestCase
         $this->assertEmailAddressContains($this->getMailerMessage(), 'To', 'billing@acme.test');
     }
 
+    public function testOverdueSweepFlipsPastDueSentInvoices(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $space = $this->createSharedSpace($admin);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $invoice = $client->request('POST', '/invoices', [
+            'json' => [
+                'space' => $spaceIri,
+                'client' => $clientRow['@id'],
+                'currency' => 'USD',
+                'dueDate' => '2020-01-01',
+                'lineItems' => [['description' => 'Work', 'quantity' => 1, 'unitAmount' => 5000]],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $invoiceIri = $invoice['@id'];
+        $this->assertIsString($invoiceIri);
+
+        // Send it so it's "sent" (and past-due).
+        $client->request('POST', $invoiceIri . '/send', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+
+        // Run the daily overdue sweep.
+        $repo = $this->entityManager->getRepository(Invoice::class);
+        assert($repo instanceof \App\Repository\InvoiceRepository);
+        $changed = $repo->markOverdue(new \DateTimeImmutable('today'));
+        $this->assertSame(1, $changed);
+
+        $refreshed = $client->request('GET', $invoiceIri)->toArray();
+        $this->assertSame('overdue', $refreshed['status'] ?? null);
+    }
+
     public function testInvoicePdfRenders(): void
     {
         $admin = $this->createUser('admin@example.com');

--- a/api/tests/Api/ClientInvoiceTest.php
+++ b/api/tests/Api/ClientInvoiceTest.php
@@ -7,6 +7,7 @@ use App\Entity\Invoice;
 use App\Entity\Space;
 use App\Entity\SpaceMembership;
 use App\Entity\User;
+use App\Tests\Billing\InMemoryStripeGateway;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
@@ -308,6 +309,69 @@ class ClientInvoiceTest extends ApiTestCase
         $this->assertResponseHeaderSame('content-type', 'application/pdf');
         // A real PDF starts with the %PDF- magic bytes.
         $this->assertStringStartsWith('%PDF-', $response->getContent());
+    }
+
+    public function testPublicPayStartsCheckoutThenWebhookMarksPaid(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $space = $this->createSharedSpace($admin);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $invoice = $client->request('POST', '/invoices', [
+            'json' => [
+                'space' => $spaceIri,
+                'client' => $clientRow['@id'],
+                'currency' => 'USD',
+                'lineItems' => [['description' => 'Work', 'quantity' => 2, 'unitAmount' => 5000]],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $invoiceIri = $invoice['@id'];
+        $this->assertIsString($invoiceIri);
+        $invoiceId = substr($invoiceIri, (int) strrpos($invoiceIri, '/') + 1);
+
+        $sent = $client->request('POST', $invoiceIri . '/send', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $token = $sent['token'];
+        $this->assertIsString($token);
+
+        // The public pay endpoint starts a Stripe checkout (in-memory in tests).
+        $pay = $client->request('POST', '/public/invoices/' . $token . '/pay', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertSame('stripe', $pay['provider'] ?? null);
+        $this->assertSame(InMemoryStripeGateway::PAYMENT_URL, $pay['url'] ?? null);
+
+        // The provider's completed-checkout webhook marks the invoice paid.
+        $event = [
+            'type' => 'checkout.session.completed',
+            'data' => ['object' => [
+                'payment_status' => 'paid',
+                'metadata' => ['invoice_id' => $invoiceId],
+            ]],
+        ];
+        $client->request('POST', '/billing/webhook', [
+            'body' => json_encode($event),
+            'headers' => [
+                'Stripe-Signature' => InMemoryStripeGateway::VALID_SIGNATURE,
+                'Content-Type' => 'application/json',
+            ],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $refreshed = $client->request('GET', $invoiceIri)->toArray();
+        $this->assertSame('paid', $refreshed['status'] ?? null);
+        $this->assertNotNull($refreshed['paidAt'] ?? null);
     }
 
     private function trackTime(

--- a/api/tests/Api/ClientInvoiceTest.php
+++ b/api/tests/Api/ClientInvoiceTest.php
@@ -282,6 +282,37 @@ class ClientInvoiceTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(404);
     }
 
+    public function testSendEmailsTheClient(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $space = $this->createSharedSpace($admin);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'email' => 'billing@acme.test', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $invoice = $client->request('POST', '/invoices', [
+            'json' => [
+                'space' => $spaceIri,
+                'client' => $clientRow['@id'],
+                'currency' => 'USD',
+                'lineItems' => [['description' => 'Work', 'quantity' => 1, 'unitAmount' => 5000]],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+
+        $client->request('POST', $invoice['@id'] . '/send', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertEmailCount(1);
+        $this->assertEmailAddressContains($this->getMailerMessage(), 'To', 'billing@acme.test');
+    }
+
     public function testInvoicePdfRenders(): void
     {
         $admin = $this->createUser('admin@example.com');

--- a/api/tests/Api/ClientInvoiceTest.php
+++ b/api/tests/Api/ClientInvoiceTest.php
@@ -239,6 +239,48 @@ class ClientInvoiceTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(201);
     }
 
+    public function testSendMintsPublicLinkAndPublicViewWorks(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $space = $this->createSharedSpace($admin);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $invoice = $client->request('POST', '/invoices', [
+            'json' => [
+                'space' => $spaceIri,
+                'client' => $clientRow['@id'],
+                'currency' => 'USD',
+                'lineItems' => [['description' => 'Work', 'quantity' => 2, 'unitAmount' => 5000]],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+
+        $sent = $client->request('POST', $invoice['@id'] . '/send', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertSame('INV-0001', $sent['number'] ?? null);
+        $token = $sent['token'] ?? null;
+        $this->assertIsString($token);
+
+        // The public token view resolves the invoice (no auth required by route).
+        $public = $client->request('GET', '/public/invoices/' . $token)->toArray();
+        $this->assertSame('INV-0001', $public['number'] ?? null);
+        $this->assertSame(10000, $public['total'] ?? null);
+        $this->assertSame('Acme Co', $public['billTo'] ?? null);
+
+        // An unknown token 404s.
+        $client->request('GET', '/public/invoices/deadbeef');
+        $this->assertResponseStatusCodeSame(404);
+    }
+
     public function testInvoicePdfRenders(): void
     {
         $admin = $this->createUser('admin@example.com');

--- a/api/tests/Api/ClientInvoiceTest.php
+++ b/api/tests/Api/ClientInvoiceTest.php
@@ -123,6 +123,66 @@ class ClientInvoiceTest extends ApiTestCase
         $this->assertSame(0, $list['totalItems'] ?? null);
     }
 
+    public function testGenerateInvoiceFromTrackedTime(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $space = $this->createSharedSpace($admin);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+
+        // Two billable completed entries + one non-billable (excluded).
+        $this->trackTime($client, $spaceIri, '2026-07-03T09:00:00+00:00', '2026-07-03T10:00:00+00:00', true, 6000);
+        $this->trackTime($client, $spaceIri, '2026-07-03T11:00:00+00:00', '2026-07-03T11:30:00+00:00', true, 8000);
+        $this->trackTime($client, $spaceIri, '2026-07-03T12:00:00+00:00', '2026-07-03T13:00:00+00:00', false, 9000);
+
+        $response = $client->request('POST', '/invoices/from-time-entries', [
+            'json' => ['space' => $spaceIri, 'client' => $clientRow['@id']],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertSame(201, $response->getStatusCode(), $response->getContent(false));
+        $result = $response->toArray();
+
+        // 1h×6000 + 0.5h×8000 = 10000; the non-billable entry is excluded.
+        $this->assertSame(2, $result['lineItemCount'] ?? null);
+        $this->assertSame(10000, $result['subtotal'] ?? null);
+
+        // The pulled entries are now billed, so a second run has nothing to bill.
+        $client->request('POST', '/invoices/from-time-entries', [
+            'json' => ['space' => $spaceIri, 'client' => $clientRow['@id']],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    private function trackTime(
+        \ApiPlatform\Symfony\Bundle\Test\Client $client,
+        string $spaceIri,
+        string $startedAt,
+        string $endedAt,
+        bool $billable,
+        int $rateAmount,
+    ): void {
+        $client->request('POST', '/time_entries', [
+            'json' => [
+                'space' => $spaceIri,
+                'startedAt' => $startedAt,
+                'endedAt' => $endedAt,
+                'billable' => $billable,
+                'rateAmount' => $rateAmount,
+                'rateCurrency' => 'USD',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+    }
+
     private function createSharedSpace(User $admin, ?User $member = null): Space
     {
         $space = (new Space())->setName('Studio')->setCreatedBy($admin);

--- a/api/tests/Api/ClientInvoiceTest.php
+++ b/api/tests/Api/ClientInvoiceTest.php
@@ -239,6 +239,35 @@ class ClientInvoiceTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(201);
     }
 
+    public function testInvoicePdfRenders(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $space = $this->createSharedSpace($admin);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $invoice = $client->request('POST', '/invoices', [
+            'json' => [
+                'space' => $spaceIri,
+                'client' => $clientRow['@id'],
+                'currency' => 'USD',
+                'lineItems' => [['description' => 'Design work', 'quantity' => 2, 'unitAmount' => 5000]],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+
+        $response = $client->request('GET', $invoice['@id'] . '/pdf');
+        $this->assertResponseIsSuccessful();
+        $this->assertResponseHeaderSame('content-type', 'application/pdf');
+        // A real PDF starts with the %PDF- magic bytes.
+        $this->assertStringStartsWith('%PDF-', $response->getContent());
+    }
+
     private function trackTime(
         \ApiPlatform\Symfony\Bundle\Test\Client $client,
         string $spaceIri,

--- a/api/tests/Api/TimeEntryTest.php
+++ b/api/tests/Api/TimeEntryTest.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\Project;
+use App\Entity\Space;
+use App\Entity\TimeEntry;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Time tracking (#444): create/list scoping, server-side owner stamping, derived
+ * duration, the running-timer lifecycle, and validation.
+ */
+class TimeEntryTest extends ApiTestCase
+{
+    use SpaceMembershipFixture;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = static::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\TimeEntry')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Task')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Project')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testMemberTracksTimeAndDurationIsDerived(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $spaceIri = $this->spaceIri($project);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        $entry = $client->request('POST', '/time_entries', [
+            'json' => [
+                'space' => $spaceIri,
+                'project' => '/projects/' . $project->getId(),
+                'description' => 'Wiring the timer',
+                'startedAt' => '2026-07-03T09:00:00+00:00',
+                'endedAt' => '2026-07-03T10:30:00+00:00',
+                'billable' => true,
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+
+        $this->assertResponseStatusCodeSame(201);
+        // 1h30m = 5400s, derived server-side.
+        $this->assertSame(5400, $entry['durationSeconds'] ?? null);
+
+        // Owner stamped server-side, not from the payload.
+        $row = $this->entityManager->getRepository(TimeEntry::class)
+            ->findOneBy(['description' => 'Wiring the timer']);
+        $this->assertNotNull($row);
+        $this->assertSame((string) $alice->getId(), (string) $row->getUser()?->getId());
+
+        $list = $client->request('GET', '/time_entries?space=' . $spaceIri)->toArray();
+        $this->assertSame(1, $list['totalItems'] ?? null);
+    }
+
+    public function testNonMemberCannotSeeEntries(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $stranger = $this->createUser('stranger@example.com');
+        $project = $this->createProject($alice, 'Private');
+        $spaceIri = $this->spaceIri($project);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+        $created = $client->request('POST', '/time_entries', [
+            'json' => [
+                'space' => $spaceIri,
+                'startedAt' => '2026-07-03T09:00:00+00:00',
+                'endedAt' => '2026-07-03T09:30:00+00:00',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $iri = $created['@id'];
+        $this->assertIsString($iri);
+
+        $client->loginUser($stranger);
+        $list = $client->request('GET', '/time_entries?space=' . $spaceIri)->toArray();
+        $this->assertSame(0, $list['totalItems'] ?? null);
+
+        $client->request('GET', $iri);
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testRunningTimerHasNoDurationUntilStopped(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $spaceIri = $this->spaceIri($project);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        // Start: no endedAt → running, no duration.
+        $running = $client->request('POST', '/time_entries', [
+            'json' => [
+                'space' => $spaceIri,
+                'startedAt' => '2026-07-03T09:00:00+00:00',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        // Running timer: no duration yet (serialized as null or omitted).
+        $this->assertNull($running['durationSeconds'] ?? null);
+        $iri = $running['@id'];
+        $this->assertIsString($iri);
+
+        // Stop: patch endedAt → duration derived.
+        $stopped = $client->request('PATCH', $iri, [
+            'json' => ['endedAt' => '2026-07-03T09:15:00+00:00'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ])->toArray();
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(900, $stopped['durationSeconds'] ?? null);
+    }
+
+    public function testStartingASecondTimerStopsTheFirst(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $spaceIri = $this->spaceIri($project);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        $first = $client->request('POST', '/time_entries', [
+            'json' => ['space' => $spaceIri, 'startedAt' => '2026-07-03T09:00:00+00:00'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $firstIri = $first['@id'];
+        $this->assertIsString($firstIri);
+
+        // Starting a second running timer must not violate the one-running-per-user
+        // invariant — the first is auto-stopped.
+        $client->request('POST', '/time_entries', [
+            'json' => ['space' => $spaceIri, 'startedAt' => '2026-07-03T11:00:00+00:00'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+
+        // The first now has an end time; exactly one running entry remains.
+        $first = $client->request('GET', $firstIri)->toArray();
+        $this->assertNotNull($first['endedAt'] ?? null);
+
+        $running = $client->request('GET', '/time_entries?space=' . $spaceIri . '&exists[endedAt]=false')
+            ->toArray();
+        $this->assertSame(1, $running['totalItems'] ?? null);
+    }
+
+    public function testEndBeforeStartIsRejected(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $project = $this->createProject($alice, 'Backend');
+        $spaceIri = $this->spaceIri($project);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        $client->request('POST', '/time_entries', [
+            'json' => [
+                'space' => $spaceIri,
+                'startedAt' => '2026-07-03T10:00:00+00:00',
+                'endedAt' => '2026-07-03T09:00:00+00:00',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    private function spaceIri(Project $project): string
+    {
+        $space = $project->getSpace();
+        assert($space instanceof Space);
+
+        return '/spaces/' . $space->getId();
+    }
+
+    private function createProject(User $owner, string $title): Project
+    {
+        $project = new Project();
+        $project->setOwner($owner);
+        $project->setTitle($title);
+        $this->addProjectMember($project, $owner);
+        $this->entityManager->persist($project);
+        $this->entityManager->flush();
+
+        return $project;
+    }
+
+    private function createUser(string $email): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/api/tests/Billing/InMemoryStripeGateway.php
+++ b/api/tests/Billing/InMemoryStripeGateway.php
@@ -16,10 +16,14 @@ final class InMemoryStripeGateway implements StripeGatewayInterface
 {
     public const VALID_SIGNATURE = 'test-valid-signature';
     public const CHECKOUT_URL = 'https://checkout.stripe.test/session';
+    public const PAYMENT_URL = 'https://checkout.stripe.test/pay';
     public const PORTAL_URL = 'https://billing.stripe.test/portal';
 
     /** @var list<array{priceId: string, quantity: int, customerId: ?string, customerEmail: ?string, metadata: array<string, string>}> */
     public array $checkoutSessions = [];
+
+    /** @var list<array{amount: int, currency: string, description: string, metadata: array<string, string>}> */
+    public array $paymentSessions = [];
 
     /** @var list<array{customerId: string, returnUrl: string}> */
     public array $portalSessions = [];
@@ -52,6 +56,25 @@ final class InMemoryStripeGateway implements StripeGatewayInterface
         ];
 
         return self::CHECKOUT_URL;
+    }
+
+    public function createPaymentCheckout(
+        int $amount,
+        string $currency,
+        string $description,
+        string $successUrl,
+        string $cancelUrl,
+        ?string $customerEmail,
+        array $metadata,
+    ): string {
+        $this->paymentSessions[] = [
+            'amount' => $amount,
+            'currency' => $currency,
+            'description' => $description,
+            'metadata' => $metadata,
+        ];
+
+        return self::PAYMENT_URL;
     }
 
     public function createBillingPortalSession(string $customerId, string $returnUrl): string
@@ -88,6 +111,7 @@ final class InMemoryStripeGateway implements StripeGatewayInterface
     public function reset(): void
     {
         $this->checkoutSessions = [];
+        $this->paymentSessions = [];
         $this->portalSessions = [];
         $this->canceledSubscriptions = [];
         $this->configured = true;

--- a/pwa/components/common/SidebarNav.tsx
+++ b/pwa/components/common/SidebarNav.tsx
@@ -10,6 +10,7 @@ import {
   ShieldCheck,
   SlidersHorizontal,
   Tag,
+  Clock,
 } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
@@ -566,6 +567,28 @@ const SidebarNav = ({
                 <Link href="/custom-fields">
                   <SlidersHorizontal className="size-3.5 shrink-0 text-cyan-600 dark:text-cyan-400" />
                   <span className="truncate">Custom fields</span>
+                </Link>
+              </Button>,
+            )}
+          </span>
+        )}
+
+        {activeSpace && (
+          <span>
+            {wrap(
+              <Button
+                asChild
+                variant="ghost"
+                size="sm"
+                className={cn(
+                  "w-full min-w-0 justify-start gap-1.5 font-normal",
+                  router.pathname.startsWith("/time") &&
+                    "bg-accent text-accent-foreground",
+                )}
+              >
+                <Link href="/time">
+                  <Clock className="size-3.5 shrink-0 text-orange-600 dark:text-orange-400" />
+                  <span className="truncate">Time</span>
                 </Link>
               </Button>,
             )}

--- a/pwa/components/common/SidebarNav.tsx
+++ b/pwa/components/common/SidebarNav.tsx
@@ -11,6 +11,8 @@ import {
   SlidersHorizontal,
   Tag,
   Clock,
+  Receipt,
+  Users,
 } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
@@ -480,9 +482,10 @@ const SidebarNav = ({
   includeSpaceSwitcher = false,
 }: SidebarNavProps) => {
   const { user, isAuthenticated } = useAuth();
-  const { activeSpace } = useActiveSpace();
+  const { activeSpace, can } = useActiveSpace();
   const router = useRouter();
   const isAdmin = user?.roles?.includes("ROLE_ADMIN");
+  const canInvoices = can("invoices", "read");
   const wrap = itemWrapper ?? ((c) => c);
 
   if (!isAuthenticated || !user) return null;
@@ -589,6 +592,50 @@ const SidebarNav = ({
                 <Link href="/time">
                   <Clock className="size-3.5 shrink-0 text-orange-600 dark:text-orange-400" />
                   <span className="truncate">Time</span>
+                </Link>
+              </Button>,
+            )}
+          </span>
+        )}
+
+        {activeSpace && canInvoices && (
+          <span>
+            {wrap(
+              <Button
+                asChild
+                variant="ghost"
+                size="sm"
+                className={cn(
+                  "w-full min-w-0 justify-start gap-1.5 font-normal",
+                  router.pathname.startsWith("/clients") &&
+                    "bg-accent text-accent-foreground",
+                )}
+              >
+                <Link href="/clients">
+                  <Users className="size-3.5 shrink-0 text-blue-600 dark:text-blue-400" />
+                  <span className="truncate">Clients</span>
+                </Link>
+              </Button>,
+            )}
+          </span>
+        )}
+
+        {activeSpace && canInvoices && (
+          <span>
+            {wrap(
+              <Button
+                asChild
+                variant="ghost"
+                size="sm"
+                className={cn(
+                  "w-full min-w-0 justify-start gap-1.5 font-normal",
+                  router.pathname.startsWith("/invoices") &&
+                    "bg-accent text-accent-foreground",
+                )}
+              >
+                <Link href="/invoices">
+                  <Receipt className="size-3.5 shrink-0 text-blue-600 dark:text-blue-400" />
+                  <span className="truncate">Invoices</span>
                 </Link>
               </Button>,
             )}

--- a/pwa/components/tasks/TaskDetailDrawer.tsx
+++ b/pwa/components/tasks/TaskDetailDrawer.tsx
@@ -21,6 +21,7 @@ import AttachmentsPanel from "@/components/tasks/AttachmentsPanel";
 import DueDateCell from "@/components/tasks/DueDateCell";
 import RecurrenceEditor from "@/components/tasks/RecurrenceEditor";
 import RemindersEditor from "@/components/tasks/RemindersEditor";
+import TimeTrackingPanel from "@/components/tasks/TimeTrackingPanel";
 import TaskRelationshipsPanel from "@/components/tasks/TaskRelationshipsPanel";
 import CommentsPanel from "@/components/common/CommentsPanel";
 import ActivityPanel from "@/components/activity/ActivityPanel";
@@ -569,6 +570,13 @@ const TaskDetailDrawer = ({
                 dueDate={task.dueDate}
                 onChange={(next) => void patchTask({ reminders: next })}
               />
+
+              <div className="space-y-1.5">
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Time
+                </p>
+                <TimeTrackingPanel taskIri={task["@id"]} projectIri={task.project} />
+              </div>
 
               <Tabs defaultValue="comments" className="mt-auto border-t pt-4">
                 <TabsList variant="line">

--- a/pwa/components/tasks/TimeTrackingPanel.tsx
+++ b/pwa/components/tasks/TimeTrackingPanel.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Play, Square } from "lucide-react";
+import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
+import { apiGetCollection, apiSend } from "@/lib/apiClient";
+import {
+  TimeEntry,
+  elapsedSeconds,
+  formatClock,
+  formatDuration,
+  isRunning,
+} from "@/lib/timeEntryTypes";
+import { Button } from "@/components/ui/button";
+
+const MERGE_PATCH = "application/merge-patch+json";
+
+interface Props {
+  taskIri: string;
+  projectIri: string | null;
+}
+
+/**
+ * Per-task time tracking inside the task drawer (#444): start/stop a timer
+ * scoped to this task, see the total tracked, and the individual entries. Sends
+ * the active space IRI (the backend validates the task belongs to it).
+ */
+const TimeTrackingPanel = ({ taskIri, projectIri }: Props) => {
+  const { activeSpace } = useActiveSpace();
+  const queryClient = useQueryClient();
+  const [nowTick, setNowTick] = useState(() => Date.now());
+  const [error, setError] = useState<string | null>(null);
+
+  const spaceIri = activeSpace?.["@id"] ?? null;
+
+  const entriesQuery = useQuery({
+    queryKey: ["time_entries", "task", taskIri],
+    queryFn: () =>
+      apiGetCollection<TimeEntry>(`/time_entries?task=${encodeURIComponent(taskIri)}`, {
+        errorMessage: "Failed to load time entries.",
+      }),
+  });
+  const entries = useMemo(() => entriesQuery.data ?? [], [entriesQuery.data]);
+  const running = entries.find(isRunning) ?? null;
+  const refresh = () => {
+    void queryClient.invalidateQueries({ queryKey: ["time_entries"] });
+  };
+
+  useEffect(() => {
+    if (!running) return;
+    const t = setInterval(() => setNowTick(Date.now()), 1000);
+    return () => clearInterval(t);
+  }, [running]);
+
+  const totalSeconds = useMemo(
+    () => entries.reduce((sum, e) => sum + (e.durationSeconds ?? 0), 0),
+    [entries],
+  );
+
+  const start = useMutation({
+    mutationFn: () =>
+      apiSend<TimeEntry>("POST", "/time_entries", {
+        errorMessage: "Failed to start the timer.",
+        body: {
+          task: taskIri,
+          startedAt: new Date().toISOString(),
+          billable: true,
+          ...(projectIri ? { project: projectIri } : {}),
+          ...(spaceIri ? { space: spaceIri } : {}),
+        },
+      }),
+    onSuccess: () => {
+      setError(null);
+      refresh();
+    },
+    onError: (e) => setError(e instanceof Error ? e.message : "Failed to start the timer."),
+  });
+
+  const stop = useMutation({
+    mutationFn: (entry: TimeEntry) =>
+      apiSend<TimeEntry>("PATCH", entry["@id"], {
+        contentType: MERGE_PATCH,
+        errorMessage: "Failed to stop the timer.",
+        body: { endedAt: new Date().toISOString() },
+      }),
+    onSuccess: () => refresh(),
+    onError: (e) => setError(e instanceof Error ? e.message : "Failed to stop the timer."),
+  });
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-sm text-muted-foreground">
+          {totalSeconds > 0 ? `Total: ${formatDuration(totalSeconds)}` : "No time tracked"}
+        </span>
+        {running ? (
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={() => stop.mutate(running)}
+            disabled={stop.isPending}
+            className="gap-1.5"
+          >
+            <Square className="size-3.5" />
+            {formatClock(elapsedSeconds(running, nowTick))}
+          </Button>
+        ) : (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => start.mutate()}
+            disabled={start.isPending}
+            className="gap-1.5"
+          >
+            <Play className="size-3.5" /> Start timer
+          </Button>
+        )}
+      </div>
+
+      {error && <p className="text-xs text-destructive">{error}</p>}
+
+      {entries.length > 0 && (
+        <ul className="space-y-1">
+          {entries.map((entry) => (
+            <li
+              key={entry["@id"]}
+              className="flex items-center justify-between gap-2 text-xs text-muted-foreground"
+            >
+              <span className="truncate">
+                {new Date(entry.startedAt).toLocaleDateString(undefined, {
+                  month: "short",
+                  day: "numeric",
+                })}
+                {entry.description ? ` · ${entry.description}` : ""}
+              </span>
+              <span className="shrink-0 font-mono tabular-nums">
+                {isRunning(entry)
+                  ? formatClock(elapsedSeconds(entry, nowTick))
+                  : formatDuration(entry.durationSeconds ?? 0)}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default TimeTrackingPanel;

--- a/pwa/lib/invoiceTypes.ts
+++ b/pwa/lib/invoiceTypes.ts
@@ -1,0 +1,84 @@
+import { currencyFractionDigits } from "@/lib/currencies";
+
+/** Wire shapes + helpers for `/clients` and `/invoices` (#445). */
+
+export interface Client {
+  "@id": string;
+  id: string;
+  space: string;
+  name: string;
+  email: string | null;
+  address: string | null;
+  currency: string | null;
+  defaultRateAmount: number | null;
+  notes: string | null;
+  createdAt: string;
+  updatedAt: string | null;
+}
+
+/** Client as embedded on an invoice (readableLink). */
+export interface InvoiceClient {
+  "@id": string;
+  id: string;
+  name: string;
+}
+
+export interface InvoiceLineItem {
+  "@id"?: string;
+  id?: string;
+  description: string;
+  quantity: number;
+  unitAmount: number;
+  amount?: number;
+  position?: number;
+}
+
+export type InvoiceStatus = "draft" | "sent" | "paid" | "overdue" | "void";
+
+export interface Invoice {
+  "@id": string;
+  id: string;
+  space: string;
+  client: InvoiceClient | string;
+  number: string | null;
+  status: InvoiceStatus;
+  issueDate: string | null;
+  dueDate: string | null;
+  currency: string;
+  taxRate: number;
+  notes: string | null;
+  lineItems: InvoiceLineItem[];
+  subtotal: number;
+  taxAmount: number;
+  total: number;
+  sentAt: string | null;
+  paidAt: string | null;
+  createdAt: string;
+  updatedAt: string | null;
+}
+
+export const STATUS_META: Record<InvoiceStatus, { label: string; badgeClass: string }> = {
+  draft: { label: "Draft", badgeClass: "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300" },
+  sent: { label: "Sent", badgeClass: "bg-sky-100 text-sky-700 dark:bg-sky-950 dark:text-sky-300" },
+  paid: { label: "Paid", badgeClass: "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300" },
+  overdue: { label: "Overdue", badgeClass: "bg-rose-100 text-rose-700 dark:bg-rose-950 dark:text-rose-300" },
+  void: { label: "Void", badgeClass: "bg-slate-100 text-slate-500 line-through dark:bg-slate-800" },
+};
+
+/** Format a minor-units amount as currency (e.g. 10000, "USD" -> "$100.00"). */
+export const formatMoney = (minor: number, currency: string): string => {
+  const digits = currencyFractionDigits(currency);
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency,
+      minimumFractionDigits: digits,
+      maximumFractionDigits: digits,
+    }).format(minor / 10 ** digits);
+  } catch {
+    return `${(minor / 10 ** digits).toFixed(digits)} ${currency}`;
+  }
+};
+
+export const clientName = (client: InvoiceClient | string): string =>
+  typeof client === "string" ? "" : client.name;

--- a/pwa/lib/invoiceTypes.ts
+++ b/pwa/lib/invoiceTypes.ts
@@ -51,6 +51,9 @@ export interface Invoice {
   subtotal: number;
   taxAmount: number;
   total: number;
+  recurrenceFrequency: "weekly" | "monthly" | "yearly" | null;
+  recurrenceInterval: number | null;
+  nextIssueDate: string | null;
   sentAt: string | null;
   paidAt: string | null;
   createdAt: string;

--- a/pwa/lib/roleTypes.ts
+++ b/pwa/lib/roleTypes.ts
@@ -23,6 +23,8 @@ export const PERMISSION_CATEGORIES = [
   "groups",
   "files",
   "api_keys",
+  "time_entries",
+  "invoices",
 ] as const;
 export type PermissionCategory = (typeof PERMISSION_CATEGORIES)[number];
 
@@ -37,6 +39,8 @@ export const CATEGORY_LABELS: Record<PermissionCategory, string> = {
   groups: "Groups",
   files: "Files",
   api_keys: "API keys",
+  time_entries: "Time tracking",
+  invoices: "Invoicing",
 };
 
 export const ACTION_LABELS: Record<PermissionAction, string> = {

--- a/pwa/lib/timeEntryTypes.ts
+++ b/pwa/lib/timeEntryTypes.ts
@@ -1,0 +1,63 @@
+/** Wire shapes + helpers for `/time_entries` (#444). */
+
+export interface TimeEntry {
+  "@id": string;
+  id: string;
+  space: string;
+  project: string | null;
+  task: string | null;
+  user: string;
+  description: string | null;
+  startedAt: string;
+  endedAt: string | null;
+  durationSeconds: number | null;
+  billable: boolean;
+  rateAmount: number | null;
+  rateCurrency: string | null;
+  billedAt: string | null;
+  createdAt: string;
+  updatedAt: string | null;
+}
+
+export interface TimeEntryCollection {
+  member?: TimeEntry[];
+  "hydra:member"?: TimeEntry[];
+}
+
+/** A running timer has no end time yet. */
+export const isRunning = (entry: TimeEntry): boolean => entry.endedAt === null;
+
+/** Seconds between start and end (or now, for a running timer). */
+export const elapsedSeconds = (entry: TimeEntry, now: number = Date.now()): number => {
+  if (entry.durationSeconds !== null) {
+    return entry.durationSeconds;
+  }
+  const start = new Date(entry.startedAt).getTime();
+  return Math.max(0, Math.floor((now - start) / 1000));
+};
+
+/** Format a duration in seconds as "1h 30m" / "45m" / "12s". */
+export const formatDuration = (totalSeconds: number): string => {
+  const s = Math.max(0, Math.floor(totalSeconds));
+  const hours = Math.floor(s / 3600);
+  const minutes = Math.floor((s % 3600) / 60);
+  const seconds = s % 60;
+  if (hours > 0) {
+    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m`;
+  }
+  return `${seconds}s`;
+};
+
+/** A stopwatch-style "1:30:05" clock for a live running timer. */
+export const formatClock = (totalSeconds: number): string => {
+  const s = Math.max(0, Math.floor(totalSeconds));
+  const hours = Math.floor(s / 3600);
+  const minutes = Math.floor((s % 3600) / 60);
+  const seconds = s % 60;
+  const mm = minutes.toString().padStart(2, "0");
+  const ss = seconds.toString().padStart(2, "0");
+  return hours > 0 ? `${hours}:${mm}:${ss}` : `${minutes}:${ss}`;
+};

--- a/pwa/pages/clients/index.tsx
+++ b/pwa/pages/clients/index.tsx
@@ -1,0 +1,233 @@
+import Head from "next/head";
+import { useRouter } from "next/router";
+import { FormEvent, useEffect, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Users } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
+import { apiGetCollection, apiSend } from "@/lib/apiClient";
+import { signinHrefForCurrent } from "@/lib/authRedirect";
+import { Client, formatMoney } from "@/lib/invoiceTypes";
+import { CURRENCIES } from "@/lib/currencies";
+import PageHeader from "@/components/common/PageHeader";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+
+const ClientsPage = () => {
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
+  const { activeSpace, can } = useActiveSpace();
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const [showComposer, setShowComposer] = useState(false);
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [address, setAddress] = useState("");
+  const [currency, setCurrency] = useState("USD");
+  const [defaultRate, setDefaultRate] = useState("");
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) {
+      router.replace(signinHrefForCurrent(router.asPath));
+    }
+  }, [authLoading, isAuthenticated, router]);
+
+  const spaceIri = activeSpace?.["@id"] ?? null;
+  const clientsQuery = useQuery({
+    queryKey: ["clients", spaceIri],
+    enabled: isAuthenticated,
+    queryFn: () =>
+      apiGetCollection<Client>(
+        spaceIri ? `/clients?space=${encodeURIComponent(spaceIri)}` : "/clients",
+        { errorMessage: "Failed to load clients." },
+      ),
+  });
+  const clients = clientsQuery.data ?? [];
+  const refresh = () => queryClient.invalidateQueries({ queryKey: ["clients"] });
+
+  const createMutation = useMutation({
+    mutationFn: () => {
+      const rateMinor = defaultRate.trim() ? Math.round(parseFloat(defaultRate) * 100) : null;
+      return apiSend<Client>("POST", "/clients", {
+        errorMessage: "Failed to create client.",
+        body: {
+          name: name.trim(),
+          email: email.trim() || null,
+          address: address.trim() || null,
+          currency,
+          ...(rateMinor !== null ? { defaultRateAmount: rateMinor } : {}),
+          ...(spaceIri ? { space: spaceIri } : {}),
+        },
+      });
+    },
+    onSuccess: () => {
+      setName("");
+      setEmail("");
+      setAddress("");
+      setDefaultRate("");
+      setShowComposer(false);
+      setActionError(null);
+      void refresh();
+    },
+    onError: (e) => setActionError(e instanceof Error ? e.message : "Failed to create client."),
+  });
+
+  const handleCreate = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!name.trim()) return;
+    createMutation.mutate();
+  };
+
+  const canCreate = can("invoices", "create");
+  const error = actionError || (clientsQuery.isError ? "Failed to load clients." : null);
+
+  if (authLoading || !isAuthenticated) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-muted">
+        <p className="text-muted-foreground">Loading…</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Clients — Madori</title>
+      </Head>
+      <div className="min-h-screen bg-background px-4 py-12">
+        <div className="mx-auto max-w-4xl">
+          <PageHeader
+            title="Clients"
+            icon={<Users className="size-6 text-blue-600 dark:text-blue-400" />}
+            count={clientsQuery.isLoading ? undefined : clients.length}
+            actions={
+              canCreate ? (
+                <Button variant="outline" size="sm" onClick={() => setShowComposer((v) => !v)}>
+                  {showComposer ? "Cancel" : "New client"}
+                </Button>
+              ) : undefined
+            }
+          />
+
+          {showComposer && (
+            <Card className="mb-6">
+              <CardContent className="py-6">
+                <form onSubmit={handleCreate} className="space-y-4">
+                  <div className="space-y-1.5">
+                    <Label htmlFor="cl-name">Name</Label>
+                    <Input
+                      id="cl-name"
+                      value={name}
+                      onChange={(e) => setName(e.target.value)}
+                      required
+                      maxLength={200}
+                      autoFocus
+                    />
+                  </div>
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <div className="space-y-1.5">
+                      <Label htmlFor="cl-email">
+                        Email <span className="font-normal text-muted-foreground">(optional)</span>
+                      </Label>
+                      <Input
+                        id="cl-email"
+                        type="email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                      />
+                    </div>
+                    <div className="grid grid-cols-2 gap-4">
+                      <div className="space-y-1.5">
+                        <Label htmlFor="cl-currency">Currency</Label>
+                        <select
+                          id="cl-currency"
+                          value={currency}
+                          onChange={(e) => setCurrency(e.target.value)}
+                          className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
+                        >
+                          {CURRENCIES.map((c) => (
+                            <option key={c.code} value={c.code}>
+                              {c.code}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+                      <div className="space-y-1.5">
+                        <Label htmlFor="cl-rate">Rate / hr</Label>
+                        <Input
+                          id="cl-rate"
+                          type="number"
+                          step="0.01"
+                          min="0"
+                          value={defaultRate}
+                          onChange={(e) => setDefaultRate(e.target.value)}
+                          placeholder="0.00"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="cl-address">
+                      Address <span className="font-normal text-muted-foreground">(optional)</span>
+                    </Label>
+                    <Textarea
+                      id="cl-address"
+                      value={address}
+                      onChange={(e) => setAddress(e.target.value)}
+                      rows={2}
+                    />
+                  </div>
+                  <Button type="submit" disabled={createMutation.isPending || !name.trim()}>
+                    {createMutation.isPending ? "Saving…" : "Create client"}
+                  </Button>
+                </form>
+              </CardContent>
+            </Card>
+          )}
+
+          {error && (
+            <Alert variant="destructive" className="mb-4">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          {clientsQuery.isLoading ? (
+            <p className="text-muted-foreground">Loading…</p>
+          ) : clients.length === 0 ? (
+            <Card>
+              <CardContent className="py-10 text-center text-muted-foreground">
+                No clients yet. Add one to start invoicing.
+              </CardContent>
+            </Card>
+          ) : (
+            <ul className="divide-y rounded-md border">
+              {clients.map((client) => (
+                <li key={client["@id"]} className="flex items-center justify-between gap-4 px-4 py-3">
+                  <div className="min-w-0">
+                    <p className="truncate font-medium">{client.name}</p>
+                    {client.email && (
+                      <p className="truncate text-xs text-muted-foreground">{client.email}</p>
+                    )}
+                  </div>
+                  <div className="shrink-0 text-right text-sm text-muted-foreground">
+                    {client.currency ?? "—"}
+                    {client.defaultRateAmount != null && client.currency && (
+                      <span> · {formatMoney(client.defaultRateAmount, client.currency)}/hr</span>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ClientsPage;

--- a/pwa/pages/i/[token].tsx
+++ b/pwa/pages/i/[token].tsx
@@ -1,0 +1,242 @@
+import Head from "next/head";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import { Download, Receipt } from "lucide-react";
+import { ENTRYPOINT } from "@/config/entrypoint";
+import { formatMoney, InvoiceStatus, STATUS_META } from "@/lib/invoiceTypes";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+interface PublicLine {
+  description: string;
+  quantity: number;
+  unitAmount: number;
+  amount: number;
+}
+
+interface PublicInvoice {
+  number: string | null;
+  status: InvoiceStatus;
+  currency: string;
+  issueDate: string | null;
+  dueDate: string | null;
+  from: string | null;
+  billTo: string | null;
+  lineItems: PublicLine[];
+  subtotal: number;
+  taxAmount: number;
+  total: number;
+}
+
+const fmtDate = (iso: string | null): string =>
+  iso ? new Date(iso).toLocaleDateString(undefined, { dateStyle: "medium" }) : "—";
+
+/**
+ * Public, unauthenticated invoice view a client reaches from the shared link
+ * (#445). Views the invoice, downloads the PDF, and pays online when a gateway
+ * is configured.
+ */
+const PublicInvoicePage = () => {
+  const router = useRouter();
+  const { token } = router.query;
+  const inviteToken = typeof token === "string" ? token : null;
+
+  const [invoice, setInvoice] = useState<PublicInvoice | null>(null);
+  const [notFound, setNotFound] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [paying, setPaying] = useState(false);
+
+  useEffect(() => {
+    if (!inviteToken) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch(
+          `${ENTRYPOINT}/public/invoices/${encodeURIComponent(inviteToken)}`,
+          { headers: { Accept: "application/json" } },
+        );
+        if (cancelled) return;
+        if (res.status === 404) {
+          setNotFound(true);
+          return;
+        }
+        if (!res.ok) throw new Error("Failed to load the invoice.");
+        setInvoice((await res.json()) as PublicInvoice);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to load the invoice.");
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [inviteToken]);
+
+  const downloadPdf = async () => {
+    if (!inviteToken) return;
+    try {
+      const res = await fetch(
+        `${ENTRYPOINT}/public/invoices/${encodeURIComponent(inviteToken)}/pdf`,
+        { headers: { Accept: "application/pdf" } },
+      );
+      if (!res.ok) {
+        setError("Could not open the PDF.");
+        return;
+      }
+      window.open(URL.createObjectURL(await res.blob()), "_blank");
+    } catch {
+      setError("Could not open the PDF.");
+    }
+  };
+
+  const payOnline = async () => {
+    if (!inviteToken) return;
+    setPaying(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `${ENTRYPOINT}/public/invoices/${encodeURIComponent(inviteToken)}/pay`,
+        { method: "POST", headers: { Accept: "application/json" } },
+      );
+      const data = (await res.json().catch(() => ({}))) as { url?: string; error?: string };
+      if (res.ok && data.url) {
+        window.location.href = data.url;
+        return;
+      }
+      setError(data.error ?? "Online payment is not available.");
+    } catch {
+      setError("Could not start payment.");
+    } finally {
+      setPaying(false);
+    }
+  };
+
+  let body;
+  if (notFound) {
+    body = (
+      <div className="space-y-2 text-center">
+        <Receipt className="mx-auto h-10 w-10 text-muted-foreground" aria-hidden />
+        <h1 className="text-xl font-semibold">Invoice not found</h1>
+        <p className="text-sm text-muted-foreground">
+          This link isn&apos;t valid — it may have been revoked or the invoice voided.
+        </p>
+      </div>
+    );
+  } else if (error && !invoice) {
+    body = (
+      <div className="space-y-2 text-center">
+        <h1 className="text-xl font-semibold">Something went wrong</h1>
+        <p className="text-sm text-muted-foreground">{error}</p>
+      </div>
+    );
+  } else if (!invoice) {
+    body = <p className="text-center text-sm text-muted-foreground">Loading invoice…</p>;
+  } else {
+    const meta = STATUS_META[invoice.status];
+    body = (
+      <div className="space-y-6">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-semibold">Invoice {invoice.number ?? ""}</h1>
+            {invoice.from && <p className="text-sm text-muted-foreground">From {invoice.from}</p>}
+          </div>
+          <span className={cn("rounded px-2 py-1 text-xs font-medium", meta.badgeClass)}>
+            {meta.label}
+          </span>
+        </div>
+
+        <div className="grid gap-4 text-sm sm:grid-cols-3">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Bill to</p>
+            <p>{invoice.billTo ?? "—"}</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Issued</p>
+            <p>{fmtDate(invoice.issueDate)}</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Due</p>
+            <p>{fmtDate(invoice.dueDate)}</p>
+          </div>
+        </div>
+
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+              <th className="py-2">Description</th>
+              <th className="py-2 text-right">Qty</th>
+              <th className="py-2 text-right">Unit</th>
+              <th className="py-2 text-right">Amount</th>
+            </tr>
+          </thead>
+          <tbody>
+            {invoice.lineItems.map((line, i) => (
+              <tr key={i} className="border-b">
+                <td className="py-2">{line.description}</td>
+                <td className="py-2 text-right tabular-nums">{line.quantity}</td>
+                <td className="py-2 text-right tabular-nums">
+                  {formatMoney(line.unitAmount, invoice.currency)}
+                </td>
+                <td className="py-2 text-right tabular-nums">
+                  {formatMoney(line.amount, invoice.currency)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        <div className="ml-auto w-full max-w-xs space-y-1 text-sm">
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Subtotal</span>
+            <span className="tabular-nums">{formatMoney(invoice.subtotal, invoice.currency)}</span>
+          </div>
+          {invoice.taxAmount > 0 && (
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Tax</span>
+              <span className="tabular-nums">{formatMoney(invoice.taxAmount, invoice.currency)}</span>
+            </div>
+          )}
+          <div className="flex justify-between border-t pt-1 text-base font-semibold">
+            <span>Total</span>
+            <span className="tabular-nums">{formatMoney(invoice.total, invoice.currency)}</span>
+          </div>
+        </div>
+
+        {error && <p className="text-center text-sm text-destructive">{error}</p>}
+
+        <div className="flex flex-wrap items-center justify-end gap-3">
+          <Button variant="outline" onClick={() => void downloadPdf()} className="gap-1.5">
+            <Download className="h-4 w-4" aria-hidden /> PDF
+          </Button>
+          {invoice.status !== "paid" && invoice.status !== "void" && invoice.total > 0 && (
+            <Button onClick={() => void payOnline()} disabled={paying}>
+              {paying ? "Starting…" : "Pay online"}
+            </Button>
+          )}
+          {invoice.status === "paid" && (
+            <span className="text-sm font-medium text-emerald-600 dark:text-emerald-400">
+              Paid — thank you
+            </span>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Invoice — Madori</title>
+      </Head>
+      <div className="container mx-auto max-w-2xl px-4 py-16">
+        <Card>
+          <CardContent className="py-8">{body}</CardContent>
+        </Card>
+      </div>
+    </>
+  );
+};
+
+export default PublicInvoicePage;

--- a/pwa/pages/invoices/[id].tsx
+++ b/pwa/pages/invoices/[id].tsx
@@ -1,0 +1,443 @@
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { ArrowLeft, Download, Plus, Trash2 } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { apiGet, apiSend } from "@/lib/apiClient";
+import { signinHrefForCurrent } from "@/lib/authRedirect";
+import {
+  Invoice,
+  InvoiceStatus,
+  STATUS_META,
+  clientName,
+  formatMoney,
+} from "@/lib/invoiceTypes";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+
+const MERGE_PATCH = "application/merge-patch+json";
+
+interface EditableLine {
+  key: string;
+  description: string;
+  quantity: string;
+  unit: string; // major units
+}
+
+const InvoiceDetailPage = () => {
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
+  const router = useRouter();
+  const { id } = router.query;
+  const invoiceId = typeof id === "string" ? id : null;
+
+  const [lines, setLines] = useState<EditableLine[]>([]);
+  const [dueDate, setDueDate] = useState("");
+  const [notes, setNotes] = useState("");
+  const [taxPercent, setTaxPercent] = useState("0");
+  const [freq, setFreq] = useState("");
+  const [interval, setInterval] = useState("1");
+  const [nextIssue, setNextIssue] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) {
+      router.replace(signinHrefForCurrent(router.asPath));
+    }
+  }, [authLoading, isAuthenticated, router]);
+
+  const invoiceQuery = useQuery({
+    queryKey: ["invoice", invoiceId],
+    enabled: isAuthenticated && invoiceId !== null,
+    queryFn: () =>
+      apiGet<Invoice>(`/invoices/${invoiceId}`, { errorMessage: "Failed to load the invoice." }),
+  });
+  const invoice = invoiceQuery.data ?? null;
+  const currency = invoice?.currency ?? "USD";
+  const editable = invoice?.status === "draft";
+
+  // Seed the editable state once the invoice loads.
+  useEffect(() => {
+    if (!invoice) return;
+    setLines(
+      invoice.lineItems.map((l, i) => ({
+        key: `${i}`,
+        description: l.description,
+        quantity: String(l.quantity),
+        unit: (l.unitAmount / 100).toFixed(2),
+      })),
+    );
+    setDueDate(invoice.dueDate ?? "");
+    setNotes(invoice.notes ?? "");
+    setTaxPercent(String(invoice.taxRate / 100));
+    setFreq(invoice.recurrenceFrequency ?? "");
+    setInterval(String(invoice.recurrenceInterval ?? 1));
+    setNextIssue(invoice.nextIssueDate ?? "");
+  }, [invoice]);
+
+  const preview = useMemo(() => {
+    const subtotal = lines.reduce((sum, l) => {
+      const qty = parseFloat(l.quantity) || 0;
+      const unitMinor = Math.round((parseFloat(l.unit) || 0) * 100);
+      return sum + Math.round(qty * unitMinor);
+    }, 0);
+    const tax = Math.round((subtotal * (parseFloat(taxPercent) || 0) * 100) / 10000);
+    return { subtotal, tax, total: subtotal + tax };
+  }, [lines, taxPercent]);
+
+  const addLine = () =>
+    setLines((prev) => [
+      ...prev,
+      { key: `new-${prev.length}-${Date.now()}`, description: "", quantity: "1", unit: "0.00" },
+    ]);
+  const removeLine = (key: string) => setLines((prev) => prev.filter((l) => l.key !== key));
+  const updateLine = (key: string, patch: Partial<EditableLine>) =>
+    setLines((prev) => prev.map((l) => (l.key === key ? { ...l, ...patch } : l)));
+
+  const save = async () => {
+    if (!invoice) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const recurring = freq !== "";
+      await apiSend<Invoice>("PATCH", invoice["@id"], {
+        contentType: MERGE_PATCH,
+        errorMessage: "Failed to save.",
+        body: {
+          dueDate: dueDate || null,
+          notes: notes.trim() || null,
+          taxRate: Math.round((parseFloat(taxPercent) || 0) * 100),
+          lineItems: lines.map((l, i) => ({
+            description: l.description.trim() || "—",
+            quantity: parseFloat(l.quantity) || 0,
+            unitAmount: Math.round((parseFloat(l.unit) || 0) * 100),
+            position: i,
+          })),
+          recurrenceFrequency: recurring ? freq : null,
+          recurrenceInterval: recurring ? parseInt(interval, 10) || 1 : null,
+          nextIssueDate: recurring ? nextIssue || null : null,
+        },
+      });
+      setNotice("Saved.");
+      void invoiceQuery.refetch();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to save.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const runAction = async (action: string) => {
+    if (!invoice) return;
+    setError(null);
+    try {
+      const res = await apiSend<{ token?: string }>("POST", `${invoice["@id"]}/${action}`, {
+        contentType: "application/json",
+        errorMessage: `Failed to ${action.replace("-", " ")}.`,
+        body: {},
+      });
+      if (action === "send" && res?.token) {
+        setNotice(`Sent. Link: ${window.location.origin}/i/${res.token}`);
+      }
+      void invoiceQuery.refetch();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Action failed.");
+    }
+  };
+
+  const openPdf = async () => {
+    if (!invoice) return;
+    const res = await fetch(`${invoice["@id"]}/pdf`, {
+      credentials: "include",
+      headers: { Accept: "application/pdf" },
+    });
+    if (res.ok) window.open(URL.createObjectURL(await res.blob()), "_blank");
+    else setError("Could not open the PDF.");
+  };
+
+  if (authLoading || !isAuthenticated) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-muted">
+        <p className="text-muted-foreground">Loading…</p>
+      </div>
+    );
+  }
+
+  const status: InvoiceStatus | null = invoice?.status ?? null;
+
+  return (
+    <>
+      <Head>
+        <title>Invoice — Madori</title>
+      </Head>
+      <div className="min-h-screen bg-background px-4 py-12">
+        <div className="mx-auto max-w-3xl">
+          <Link
+            href="/invoices"
+            className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+          >
+            <ArrowLeft className="size-4" /> Invoices
+          </Link>
+
+          {invoiceQuery.isLoading ? (
+            <p className="text-muted-foreground">Loading…</p>
+          ) : !invoice ? (
+            <Alert variant="destructive">
+              <AlertDescription>Invoice not found.</AlertDescription>
+            </Alert>
+          ) : (
+            <>
+              <div className="mb-6 flex items-center justify-between gap-4">
+                <div>
+                  <h1 className="flex items-center gap-2 text-2xl font-semibold">
+                    {invoice.number ?? "Draft invoice"}
+                    {status && (
+                      <span
+                        className={cn(
+                          "rounded px-2 py-0.5 text-xs font-medium",
+                          STATUS_META[status].badgeClass,
+                        )}
+                      >
+                        {STATUS_META[status].label}
+                      </span>
+                    )}
+                  </h1>
+                  <p className="text-sm text-muted-foreground">{clientName(invoice.client)}</p>
+                </div>
+                <Button variant="outline" size="sm" onClick={() => void openPdf()} className="gap-1.5">
+                  <Download className="size-4" /> PDF
+                </Button>
+              </div>
+
+              {notice && (
+                <Alert className="mb-4">
+                  <AlertDescription>{notice}</AlertDescription>
+                </Alert>
+              )}
+              {error && (
+                <Alert variant="destructive" className="mb-4">
+                  <AlertDescription>{error}</AlertDescription>
+                </Alert>
+              )}
+
+              <Card className="mb-6">
+                <CardContent className="space-y-4 py-6">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+                        <th className="py-2">Description</th>
+                        <th className="w-20 py-2 text-right">Qty</th>
+                        <th className="w-28 py-2 text-right">Unit</th>
+                        <th className="w-28 py-2 text-right">Amount</th>
+                        {editable && <th className="w-8" />}
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {lines.map((line) => {
+                        const amount = Math.round(
+                          (parseFloat(line.quantity) || 0) * Math.round((parseFloat(line.unit) || 0) * 100),
+                        );
+                        return (
+                          <tr key={line.key} className="border-b">
+                            <td className="py-1.5 pr-2">
+                              {editable ? (
+                                <Input
+                                  value={line.description}
+                                  onChange={(e) => updateLine(line.key, { description: e.target.value })}
+                                  className="h-8"
+                                />
+                              ) : (
+                                line.description
+                              )}
+                            </td>
+                            <td className="py-1.5 text-right">
+                              {editable ? (
+                                <Input
+                                  type="number"
+                                  step="0.25"
+                                  value={line.quantity}
+                                  onChange={(e) => updateLine(line.key, { quantity: e.target.value })}
+                                  className="h-8 text-right"
+                                />
+                              ) : (
+                                line.quantity
+                              )}
+                            </td>
+                            <td className="py-1.5 text-right">
+                              {editable ? (
+                                <Input
+                                  type="number"
+                                  step="0.01"
+                                  value={line.unit}
+                                  onChange={(e) => updateLine(line.key, { unit: e.target.value })}
+                                  className="h-8 text-right"
+                                />
+                              ) : (
+                                formatMoney(Math.round((parseFloat(line.unit) || 0) * 100), currency)
+                              )}
+                            </td>
+                            <td className="py-1.5 text-right tabular-nums">{formatMoney(amount, currency)}</td>
+                            {editable && (
+                              <td className="py-1.5 text-right">
+                                <Button
+                                  variant="ghost"
+                                  size="icon"
+                                  onClick={() => removeLine(line.key)}
+                                  aria-label="Remove line"
+                                >
+                                  <Trash2 className="size-4 text-muted-foreground" />
+                                </Button>
+                              </td>
+                            )}
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+
+                  {editable && (
+                    <Button variant="outline" size="sm" onClick={addLine} className="gap-1.5">
+                      <Plus className="size-4" /> Add line
+                    </Button>
+                  )}
+
+                  <div className="ml-auto w-full max-w-xs space-y-1 text-sm">
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">Subtotal</span>
+                      <span className="tabular-nums">{formatMoney(preview.subtotal, currency)}</span>
+                    </div>
+                    {preview.tax > 0 && (
+                      <div className="flex justify-between">
+                        <span className="text-muted-foreground">Tax</span>
+                        <span className="tabular-nums">{formatMoney(preview.tax, currency)}</span>
+                      </div>
+                    )}
+                    <div className="flex justify-between border-t pt-1 text-base font-semibold">
+                      <span>Total</span>
+                      <span className="tabular-nums">{formatMoney(preview.total, currency)}</span>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+
+              {editable && (
+                <Card className="mb-6">
+                  <CardContent className="space-y-4 py-6">
+                    <div className="grid gap-4 sm:grid-cols-2">
+                      <div className="space-y-1.5">
+                        <Label htmlFor="inv-due">Due date</Label>
+                        <Input
+                          id="inv-due"
+                          type="date"
+                          value={dueDate}
+                          onChange={(e) => setDueDate(e.target.value)}
+                        />
+                      </div>
+                      <div className="space-y-1.5">
+                        <Label htmlFor="inv-tax">Tax %</Label>
+                        <Input
+                          id="inv-tax"
+                          type="number"
+                          step="0.01"
+                          min="0"
+                          value={taxPercent}
+                          onChange={(e) => setTaxPercent(e.target.value)}
+                        />
+                      </div>
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="inv-notes">Notes</Label>
+                      <Textarea
+                        id="inv-notes"
+                        value={notes}
+                        onChange={(e) => setNotes(e.target.value)}
+                        rows={2}
+                      />
+                    </div>
+                    <div className="grid gap-4 sm:grid-cols-3">
+                      <div className="space-y-1.5">
+                        <Label htmlFor="inv-freq">Repeat</Label>
+                        <select
+                          id="inv-freq"
+                          value={freq}
+                          onChange={(e) => setFreq(e.target.value)}
+                          className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
+                        >
+                          <option value="">Never</option>
+                          <option value="weekly">Weekly</option>
+                          <option value="monthly">Monthly</option>
+                          <option value="yearly">Yearly</option>
+                        </select>
+                      </div>
+                      {freq !== "" && (
+                        <>
+                          <div className="space-y-1.5">
+                            <Label htmlFor="inv-interval">Every</Label>
+                            <Input
+                              id="inv-interval"
+                              type="number"
+                              min="1"
+                              value={interval}
+                              onChange={(e) => setInterval(e.target.value)}
+                            />
+                          </div>
+                          <div className="space-y-1.5">
+                            <Label htmlFor="inv-next">Next issue</Label>
+                            <Input
+                              id="inv-next"
+                              type="date"
+                              value={nextIssue}
+                              onChange={(e) => setNextIssue(e.target.value)}
+                            />
+                          </div>
+                        </>
+                      )}
+                    </div>
+                    <Button onClick={() => void save()} disabled={saving}>
+                      {saving ? "Saving…" : "Save"}
+                    </Button>
+                  </CardContent>
+                </Card>
+              )}
+
+              {status !== "void" && (
+                <div className="flex flex-wrap gap-2">
+                  {status === "draft" && (
+                    <Button variant="outline" onClick={() => void runAction("issue")}>
+                      Issue
+                    </Button>
+                  )}
+                  <Button variant="outline" onClick={() => void runAction("send")}>
+                    Send
+                  </Button>
+                  {status !== "paid" && (
+                    <Button variant="outline" onClick={() => void runAction("mark-paid")}>
+                      Mark paid
+                    </Button>
+                  )}
+                  <Button
+                    variant="ghost"
+                    className="text-destructive"
+                    onClick={() => void runAction("void")}
+                  >
+                    Void
+                  </Button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default InvoiceDetailPage;

--- a/pwa/pages/invoices/index.tsx
+++ b/pwa/pages/invoices/index.tsx
@@ -209,7 +209,7 @@ const InvoicesPage = () => {
                 const meta = STATUS_META[invoice.status];
                 return (
                   <li key={invoice["@id"]} className="flex items-center justify-between gap-4 px-4 py-3">
-                    <div className="min-w-0">
+                    <Link href={`/invoices/${invoice.id}`} className="min-w-0 flex-1 hover:opacity-80">
                       <p className="flex items-center gap-2 font-medium">
                         {invoice.number ?? "Draft"}
                         <span className={cn("rounded px-1.5 py-0.5 text-xs font-medium", meta.badgeClass)}>
@@ -219,7 +219,7 @@ const InvoicesPage = () => {
                       <p className="truncate text-xs text-muted-foreground">
                         {clientName(invoice.client) || "—"}
                       </p>
-                    </div>
+                    </Link>
                     <div className="flex shrink-0 items-center gap-3">
                       <span className="font-medium tabular-nums">
                         {formatMoney(invoice.total, invoice.currency)}

--- a/pwa/pages/invoices/index.tsx
+++ b/pwa/pages/invoices/index.tsx
@@ -1,0 +1,285 @@
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { MoreHorizontal, Receipt } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
+import { apiGetCollection, apiSend } from "@/lib/apiClient";
+import { signinHrefForCurrent } from "@/lib/authRedirect";
+import {
+  Client,
+  Invoice,
+  STATUS_META,
+  clientName,
+  formatMoney,
+} from "@/lib/invoiceTypes";
+import PageHeader from "@/components/common/PageHeader";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+type InvoiceAction = "issue" | "send" | "mark-paid" | "void";
+
+const InvoicesPage = () => {
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
+  const { activeSpace, can } = useActiveSpace();
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const [genClient, setGenClient] = useState("");
+  const [notice, setNotice] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) {
+      router.replace(signinHrefForCurrent(router.asPath));
+    }
+  }, [authLoading, isAuthenticated, router]);
+
+  const spaceIri = activeSpace?.["@id"] ?? null;
+
+  const invoicesQuery = useQuery({
+    queryKey: ["invoices", spaceIri],
+    enabled: isAuthenticated,
+    queryFn: () =>
+      apiGetCollection<Invoice>(
+        spaceIri ? `/invoices?space=${encodeURIComponent(spaceIri)}` : "/invoices",
+        { errorMessage: "Failed to load invoices." },
+      ),
+  });
+  const clientsQuery = useQuery({
+    queryKey: ["clients", spaceIri],
+    enabled: isAuthenticated,
+    queryFn: () =>
+      apiGetCollection<Client>(
+        spaceIri ? `/clients?space=${encodeURIComponent(spaceIri)}` : "/clients",
+        { errorMessage: "Failed to load clients." },
+      ),
+  });
+  const invoices = invoicesQuery.data ?? [];
+  const clients = clientsQuery.data ?? [];
+  const refresh = () => queryClient.invalidateQueries({ queryKey: ["invoices"] });
+
+  const generate = useMutation({
+    mutationFn: () =>
+      apiSend<{ id: string; lineItemCount: number }>("POST", "/invoices/from-time-entries", {
+        contentType: "application/json",
+        errorMessage: "Failed to generate an invoice.",
+        body: { space: spaceIri, client: genClient },
+      }),
+    onSuccess: (res) => {
+      setError(null);
+      setNotice(`Draft invoice created from ${res?.lineItemCount ?? 0} time entr${(res?.lineItemCount ?? 0) === 1 ? "y" : "ies"}.`);
+      setGenClient("");
+      void refresh();
+    },
+    onError: (e) => setError(e instanceof Error ? e.message : "Failed to generate an invoice."),
+  });
+
+  const act = useMutation({
+    mutationFn: ({ invoice, action }: { invoice: Invoice; action: InvoiceAction }) =>
+      apiSend<{ token?: string; publicUrl?: string }>("POST", `${invoice["@id"]}/${action}`, {
+        contentType: "application/json",
+        errorMessage: `Failed to ${action.replace("-", " ")} the invoice.`,
+        body: {},
+      }),
+    onSuccess: (res, { action }) => {
+      setError(null);
+      if (action === "send" && res?.token) {
+        setNotice(`Invoice sent. Shareable link: ${window.location.origin}/i/${res.token}`);
+      } else {
+        setNotice(null);
+      }
+      void refresh();
+    },
+    onError: (e) => setError(e instanceof Error ? e.message : "Action failed."),
+  });
+
+  const openPdf = async (invoice: Invoice) => {
+    try {
+      const res = await fetch(`${invoice["@id"]}/pdf`, {
+        credentials: "include",
+        headers: { Accept: "application/pdf" },
+      });
+      if (!res.ok) {
+        setError("Could not open the PDF.");
+        return;
+      }
+      const blobUrl = URL.createObjectURL(await res.blob());
+      window.open(blobUrl, "_blank");
+    } catch {
+      setError("Could not open the PDF.");
+    }
+  };
+
+  const canManage = can("invoices", "create");
+
+  if (authLoading || !isAuthenticated) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-muted">
+        <p className="text-muted-foreground">Loading…</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Invoices — Madori</title>
+      </Head>
+      <div className="min-h-screen bg-background px-4 py-12">
+        <div className="mx-auto max-w-4xl">
+          <PageHeader
+            title="Invoices"
+            icon={<Receipt className="size-6 text-blue-600 dark:text-blue-400" />}
+            count={invoicesQuery.isLoading ? undefined : invoices.length}
+          />
+
+          {canManage && (
+            <Card className="mb-6">
+              <CardContent className="flex flex-wrap items-end gap-3 py-4">
+                <div className="space-y-1.5">
+                  <Label htmlFor="gen-client">Generate from tracked time</Label>
+                  <select
+                    id="gen-client"
+                    value={genClient}
+                    onChange={(e) => setGenClient(e.target.value)}
+                    className="h-9 w-64 max-w-full rounded-md border border-input bg-background px-3 text-sm"
+                  >
+                    <option value="">Select a client…</option>
+                    {clients.map((c) => (
+                      <option key={c["@id"]} value={c["@id"]}>
+                        {c.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <Button
+                  onClick={() => generate.mutate()}
+                  disabled={!genClient || generate.isPending}
+                >
+                  {generate.isPending ? "Generating…" : "Generate draft"}
+                </Button>
+                {clients.length === 0 && (
+                  <p className="text-sm text-muted-foreground">
+                    Add a{" "}
+                    <Link href="/clients" className="text-primary hover:underline">
+                      client
+                    </Link>{" "}
+                    first.
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+          )}
+
+          {notice && (
+            <Alert className="mb-4">
+              <AlertDescription>{notice}</AlertDescription>
+            </Alert>
+          )}
+          {error && (
+            <Alert variant="destructive" className="mb-4">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          {invoicesQuery.isLoading ? (
+            <p className="text-muted-foreground">Loading…</p>
+          ) : invoices.length === 0 ? (
+            <Card>
+              <CardContent className="py-10 text-center text-muted-foreground">
+                No invoices yet. Generate one from tracked time above.
+              </CardContent>
+            </Card>
+          ) : (
+            <ul className="divide-y rounded-md border">
+              {invoices.map((invoice) => {
+                const meta = STATUS_META[invoice.status];
+                return (
+                  <li key={invoice["@id"]} className="flex items-center justify-between gap-4 px-4 py-3">
+                    <div className="min-w-0">
+                      <p className="flex items-center gap-2 font-medium">
+                        {invoice.number ?? "Draft"}
+                        <span className={cn("rounded px-1.5 py-0.5 text-xs font-medium", meta.badgeClass)}>
+                          {meta.label}
+                        </span>
+                      </p>
+                      <p className="truncate text-xs text-muted-foreground">
+                        {clientName(invoice.client) || "—"}
+                      </p>
+                    </div>
+                    <div className="flex shrink-0 items-center gap-3">
+                      <span className="font-medium tabular-nums">
+                        {formatMoney(invoice.total, invoice.currency)}
+                      </span>
+                      {canManage && (
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button variant="ghost" size="icon" aria-label="Invoice actions">
+                              <MoreHorizontal className="size-4" />
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            <DropdownMenuItem onClick={() => void openPdf(invoice)}>
+                              View PDF
+                            </DropdownMenuItem>
+                            {invoice.status === "draft" && (
+                              <DropdownMenuItem
+                                onClick={() => act.mutate({ invoice, action: "issue" })}
+                              >
+                                Issue
+                              </DropdownMenuItem>
+                            )}
+                            {invoice.status !== "void" && (
+                              <DropdownMenuItem
+                                onClick={() => act.mutate({ invoice, action: "send" })}
+                              >
+                                Send
+                              </DropdownMenuItem>
+                            )}
+                            {invoice.status !== "paid" && invoice.status !== "void" && (
+                              <DropdownMenuItem
+                                onClick={() => act.mutate({ invoice, action: "mark-paid" })}
+                              >
+                                Mark paid
+                              </DropdownMenuItem>
+                            )}
+                            {invoice.status !== "void" && (
+                              <>
+                                <DropdownMenuSeparator />
+                                <DropdownMenuItem
+                                  className="text-destructive"
+                                  onClick={() => act.mutate({ invoice, action: "void" })}
+                                >
+                                  Void
+                                </DropdownMenuItem>
+                              </>
+                            )}
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      )}
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default InvoicesPage;

--- a/pwa/pages/time/index.tsx
+++ b/pwa/pages/time/index.tsx
@@ -1,0 +1,347 @@
+import Head from "next/head";
+import { useRouter } from "next/router";
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Clock, Play, Square } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
+import { apiGetCollection, apiSend } from "@/lib/apiClient";
+import { signinHrefForCurrent } from "@/lib/authRedirect";
+import {
+  TimeEntry,
+  elapsedSeconds,
+  formatClock,
+  formatDuration,
+  isRunning,
+} from "@/lib/timeEntryTypes";
+import PageHeader from "@/components/common/PageHeader";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+
+const MERGE_PATCH = "application/merge-patch+json";
+
+/** "YYYY-MM-DDTHH:mm" for a datetime-local input, in local time. */
+const toLocalInput = (d: Date): string => {
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+};
+
+const dayLabel = (iso: string): string =>
+  new Date(iso).toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+
+const TimePage = () => {
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
+  const { activeSpace, can } = useActiveSpace();
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const [showComposer, setShowComposer] = useState(false);
+  const [description, setDescription] = useState("");
+  const [startedAt, setStartedAt] = useState(() => toLocalInput(new Date()));
+  const [endedAt, setEndedAt] = useState("");
+  const [billable, setBillable] = useState(true);
+  const [rate, setRate] = useState("");
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [nowTick, setNowTick] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) {
+      router.replace(signinHrefForCurrent(router.asPath));
+    }
+  }, [authLoading, isAuthenticated, router]);
+
+  const spaceIri = activeSpace?.["@id"] ?? null;
+  const entriesQuery = useQuery({
+    queryKey: ["time_entries", spaceIri],
+    enabled: isAuthenticated,
+    queryFn: () =>
+      apiGetCollection<TimeEntry>(
+        spaceIri ? `/time_entries?space=${encodeURIComponent(spaceIri)}` : "/time_entries",
+        { errorMessage: "Failed to load time entries." },
+      ),
+  });
+  const entries = useMemo(() => entriesQuery.data ?? [], [entriesQuery.data]);
+  const running = entries.find(isRunning) ?? null;
+  const refresh = () => queryClient.invalidateQueries({ queryKey: ["time_entries"] });
+
+  // Tick once a second only while a timer is running.
+  useEffect(() => {
+    if (!running) return;
+    const t = setInterval(() => setNowTick(Date.now()), 1000);
+    return () => clearInterval(t);
+  }, [running]);
+
+  const startTimer = useMutation({
+    mutationFn: () =>
+      apiSend<TimeEntry>("POST", "/time_entries", {
+        errorMessage: "Failed to start the timer.",
+        body: {
+          startedAt: new Date().toISOString(),
+          billable: true,
+          ...(spaceIri ? { space: spaceIri } : {}),
+        },
+      }),
+    onSuccess: () => {
+      setActionError(null);
+      void refresh();
+    },
+    onError: (e) => setActionError(e instanceof Error ? e.message : "Failed to start the timer."),
+  });
+
+  const stopTimer = useMutation({
+    mutationFn: (entry: TimeEntry) =>
+      apiSend<TimeEntry>("PATCH", entry["@id"], {
+        contentType: MERGE_PATCH,
+        errorMessage: "Failed to stop the timer.",
+        body: { endedAt: new Date().toISOString() },
+      }),
+    onSuccess: () => void refresh(),
+    onError: (e) => setActionError(e instanceof Error ? e.message : "Failed to stop the timer."),
+  });
+
+  const logEntry = useMutation({
+    mutationFn: () => {
+      const rateMinor = rate.trim() ? Math.round(parseFloat(rate) * 100) : null;
+      return apiSend<TimeEntry>("POST", "/time_entries", {
+        errorMessage: "Failed to log time.",
+        body: {
+          description: description.trim() || null,
+          startedAt: new Date(startedAt).toISOString(),
+          endedAt: endedAt ? new Date(endedAt).toISOString() : null,
+          billable,
+          ...(rateMinor !== null ? { rateAmount: rateMinor, rateCurrency: "USD" } : {}),
+          ...(spaceIri ? { space: spaceIri } : {}),
+        },
+      });
+    },
+    onSuccess: () => {
+      setDescription("");
+      setEndedAt("");
+      setRate("");
+      setStartedAt(toLocalInput(new Date()));
+      setShowComposer(false);
+      setActionError(null);
+      void refresh();
+    },
+    onError: (e) => setActionError(e instanceof Error ? e.message : "Failed to log time."),
+  });
+
+  const handleLog = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    logEntry.mutate();
+  };
+
+  const grouped = useMemo(() => {
+    const byDay = new Map<string, TimeEntry[]>();
+    for (const entry of entries) {
+      const key = dayLabel(entry.startedAt);
+      const list = byDay.get(key) ?? [];
+      list.push(entry);
+      byDay.set(key, list);
+    }
+    return Array.from(byDay.entries());
+  }, [entries]);
+
+  const canCreate = can("time_entries", "create");
+  const error = actionError || (entriesQuery.isError ? "Failed to load time entries." : null);
+
+  if (authLoading || !isAuthenticated) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-muted">
+        <p className="text-muted-foreground">Loading…</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Time — Madori</title>
+      </Head>
+      <div className="min-h-screen bg-background px-4 py-12">
+        <div className="mx-auto max-w-4xl">
+          <PageHeader
+            title="Time"
+            icon={<Clock className="size-6 text-orange-600 dark:text-orange-400" />}
+            count={entriesQuery.isLoading ? undefined : entries.length}
+            actions={
+              canCreate ? (
+                <Button variant="outline" size="sm" onClick={() => setShowComposer((v) => !v)}>
+                  {showComposer ? "Cancel" : "Log time"}
+                </Button>
+              ) : undefined
+            }
+          />
+
+          {canCreate && (
+            <Card className="mb-6">
+              <CardContent className="flex items-center justify-between gap-4 py-4">
+                {running ? (
+                  <>
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-medium">
+                        {running.description?.trim() || "Running timer"}
+                      </p>
+                      <p className="font-mono text-2xl tabular-nums">
+                        {formatClock(elapsedSeconds(running, nowTick))}
+                      </p>
+                    </div>
+                    <Button
+                      variant="destructive"
+                      onClick={() => stopTimer.mutate(running)}
+                      disabled={stopTimer.isPending}
+                    >
+                      <Square className="size-4" /> Stop
+                    </Button>
+                  </>
+                ) : (
+                  <>
+                    <p className="text-sm text-muted-foreground">
+                      Start a timer, or log past time.
+                    </p>
+                    <Button onClick={() => startTimer.mutate()} disabled={startTimer.isPending}>
+                      <Play className="size-4" /> Start timer
+                    </Button>
+                  </>
+                )}
+              </CardContent>
+            </Card>
+          )}
+
+          {showComposer && (
+            <Card className="mb-6">
+              <CardContent className="py-6">
+                <form onSubmit={handleLog} className="space-y-4">
+                  <div className="space-y-1.5">
+                    <Label htmlFor="te-desc">
+                      Description{" "}
+                      <span className="font-normal text-muted-foreground">(optional)</span>
+                    </Label>
+                    <Input
+                      id="te-desc"
+                      value={description}
+                      onChange={(e) => setDescription(e.target.value)}
+                      maxLength={1000}
+                      placeholder="What did you work on?"
+                    />
+                  </div>
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <div className="space-y-1.5">
+                      <Label htmlFor="te-start">Start</Label>
+                      <Input
+                        id="te-start"
+                        type="datetime-local"
+                        value={startedAt}
+                        onChange={(e) => setStartedAt(e.target.value)}
+                        required
+                      />
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="te-end">
+                        End{" "}
+                        <span className="font-normal text-muted-foreground">(blank = running)</span>
+                      </Label>
+                      <Input
+                        id="te-end"
+                        type="datetime-local"
+                        value={endedAt}
+                        onChange={(e) => setEndedAt(e.target.value)}
+                      />
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-6">
+                    <div className="flex items-center gap-2">
+                      <Switch id="te-billable" checked={billable} onCheckedChange={setBillable} />
+                      <Label htmlFor="te-billable">Billable</Label>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Label htmlFor="te-rate">Rate / hr</Label>
+                      <Input
+                        id="te-rate"
+                        type="number"
+                        step="0.01"
+                        min="0"
+                        value={rate}
+                        onChange={(e) => setRate(e.target.value)}
+                        className="w-28"
+                        placeholder="0.00"
+                      />
+                    </div>
+                  </div>
+                  <Button type="submit" disabled={logEntry.isPending}>
+                    {logEntry.isPending ? "Logging…" : "Log time"}
+                  </Button>
+                </form>
+              </CardContent>
+            </Card>
+          )}
+
+          {error && (
+            <Alert variant="destructive" className="mb-4">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          {entriesQuery.isLoading ? (
+            <p className="text-muted-foreground">Loading…</p>
+          ) : entries.length === 0 ? (
+            <Card>
+              <CardContent className="py-10 text-center text-muted-foreground">
+                No time logged yet. Start a timer or log past time.
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="space-y-6">
+              {grouped.map(([day, dayEntries]) => (
+                <section key={day}>
+                  <h2 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    {day}
+                  </h2>
+                  <ul className="divide-y rounded-md border">
+                    {dayEntries.map((entry) => (
+                      <li key={entry["@id"]} className="flex items-center justify-between gap-4 px-4 py-3">
+                        <div className="min-w-0">
+                          <p className="truncate text-sm">
+                            {entry.description?.trim() || (
+                              <span className="text-muted-foreground">No description</span>
+                            )}
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            {new Date(entry.startedAt).toLocaleTimeString(undefined, {
+                              hour: "numeric",
+                              minute: "2-digit",
+                            })}
+                          </p>
+                        </div>
+                        <div className="flex shrink-0 items-center gap-2">
+                          {!entry.billable && <Badge variant="secondary">Non-billable</Badge>}
+                          {entry.billedAt && <Badge variant="secondary">Invoiced</Badge>}
+                          <span className="font-mono text-sm tabular-nums">
+                            {isRunning(entry)
+                              ? formatClock(elapsedSeconds(entry, nowTick))
+                              : formatDuration(entry.durationSeconds ?? 0)}
+                          </span>
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default TimePage;


### PR DESCRIPTION
Paired **time tracking (#444)** and **invoicing (#445)**, built together so invoices generate straight from tracked time. 15 commits; full backend suite green (1197 tests), PWA typecheck + lint clean.

## The loop
Track time → add a client → **generate a draft invoice from unbilled billable time** → edit line items / set it recurring → issue (numbered) → PDF → send (emails the client a shareable link) → client opens `/i/{token}`, downloads the PDF, **pays online via Stripe** → webhook marks it paid → past-due invoices auto-flip to overdue → recurring templates spawn fresh drafts daily.

## Backend
- **TimeEntry** — space-scoped, permission-gated (`time_entries`), server-derived duration, one-running-timer partial index, auto-stop-prior-timer processor.
- **Invoicing** — `Client` / `Invoice` / `InvoiceLineItem`, admin-reserved `invoices` category (enforced strictly via the voter → `canByExplicitGrant` + read-filtering; new `SpacePermission::ADMIN_RESERVED`), server-authoritative totals. Generate-from-time (`POST /invoices/from-time-entries`, stamps `billedAt` — no double-billing). Lifecycle: issue (gap-free `INV-000N`) / mark-paid / void (releases billed time). dompdf PDF. Send mints a sha256 public token + emails the client. Daily overdue sweep. Recurring invoices (weekly/monthly/yearly spawn job).
- **Payments** — `App\Billing\Payment\PaymentGatewayInterface` + `PaymentGatewayRegistry` (mirrors `CalendarClientRegistry`; Stripe default, **PayPal drops in as one tagged class**). Public `POST /public/invoices/{token}/pay` → hosted checkout; `BillingController` webhook handles `checkout.session.completed`. Reuses the existing `StripeGateway` (HttpClient, no SDK); ships behind the existing Stripe env gate (503 until keys are set), like the rest of billing.

## Frontend
`/time` (live timer + log), per-task timer in the task drawer, `/clients`, `/invoices` (list + generate-from-time + row actions), **`/invoices/{id}`** (edit line items with live total, due/tax/notes, set recurrence, inline actions), public `/i/{token}` (view + PDF + pay). New permission categories added to the role editor so admins can grant time-tracking/invoicing to roles.

## Notes for reviewers
- Admin-reserved invoicing means only space admins (or a member granted an invoicing role) manage clients/invoices — time tracking is on for all members.
- All money is server-derived from line items + tax; nothing trusted from the payload.
- **PayPal** is a follow-up (needs sandbox creds + live testing) — tracked separately; the registry is ready for it.

Closes #444
Closes #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)