### PR TITLE
feat(billing): enforce org-guest seat invariant on space membership

### DIFF
--- a/api/src/Controller/SpaceMemberController.php
+++ b/api/src/Controller/SpaceMemberController.php
@@ -149,10 +149,18 @@ class SpaceMemberController extends AbstractController
 
         // `role` (admin/member) and `roles` (custom space-role IRIs) are both
         // optional — a PATCH may change either or both.
+        // An org guest can never be elevated in an org space — they're
+        // confined to the restricted guest role (the seat invariant).
+        $memberUser = $membership->getUser();
+        $isOrgGuest = null !== $memberUser && $this->memberAdder->isOrgGuest($space, $memberUser);
+
         if (array_key_exists('role', $payload)) {
             $role = is_string($payload['role'] ?? null) ? $payload['role'] : '';
             if (!in_array($role, Space::ALLOWED_ROLES, true)) {
                 return $this->json(['error' => 'Role must be one of: admin, member.'], 422);
+            }
+            if ($isOrgGuest && Space::ROLE_ADMIN === $role) {
+                return $this->json(['error' => 'Organization guests cannot be space admins.'], 403);
             }
 
             // Never let the last admin be demoted — a space must always
@@ -172,6 +180,16 @@ class SpaceMemberController extends AbstractController
             $resolved = $this->resolveRoles($space, $payload['roles']);
             if ($resolved instanceof JsonResponse) {
                 return $resolved;
+            }
+            if ($isOrgGuest) {
+                foreach ($resolved as $spaceRole) {
+                    if (SpaceRole::BUILTIN_GUEST !== $spaceRole->getBuiltinKey()) {
+                        return $this->json(
+                            ['error' => 'Organization guests can only hold the guest role.'],
+                            403,
+                        );
+                    }
+                }
             }
             $membership->clearRoles();
             foreach ($resolved as $spaceRole) {

--- a/api/src/Service/SpaceMemberAdder.php
+++ b/api/src/Service/SpaceMemberAdder.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Service;
 
+use App\Entity\Organization;
 use App\Entity\Space;
 use App\Entity\SpaceInvite;
 use App\Entity\SpaceMembership;
+use App\Entity\SpaceRole;
 use App\Entity\User;
 use App\Entity\UserInvite;
 use App\Repository\SpaceInviteRepository;
@@ -65,7 +67,14 @@ final class SpaceMemberAdder
 
             $membership = (new SpaceMembership())
                 ->setUser($candidate)
-                ->setRole($role);
+                ->setRole($this->guestCappedRole($space, $candidate, $role));
+            // Org guests are confined to the restricted guest space-role — the
+            // seat invariant (#billing Phase 1c): a free guest can never be
+            // elevated into a paying seat's capabilities.
+            $guestRole = $this->guestRoleFor($space, $candidate);
+            if (null !== $guestRole) {
+                $membership->addRole($guestRole);
+            }
             $space->addUserMembership($membership);
             $this->em->persist($membership);
 
@@ -77,6 +86,34 @@ final class SpaceMemberAdder
         }
 
         return $this->upsertInvite($space, $email, $invitedBy, $role);
+    }
+
+    /**
+     * True when the space is org-owned and the user is a Guest of that org, so
+     * they may only ever hold the restricted guest space-role.
+     */
+    public function isOrgGuest(Space $space, User $user): bool
+    {
+        $org = $space->getOrganization();
+
+        return null !== $org && Organization::ROLE_GUEST === $org->roleFor($user);
+    }
+
+    /** Downgrade an org guest's requested space role — they can't be admins. */
+    private function guestCappedRole(Space $space, User $user, string $requested): string
+    {
+        return $this->isOrgGuest($space, $user) ? Space::ROLE_MEMBER : $requested;
+    }
+
+    /** The space's built-in guest role, when the user is an org guest. */
+    private function guestRoleFor(Space $space, User $user): ?SpaceRole
+    {
+        if (!$this->isOrgGuest($space, $user)) {
+            return null;
+        }
+
+        return $this->em->getRepository(SpaceRole::class)
+            ->findOneBy(['space' => $space, 'builtinKey' => SpaceRole::BUILTIN_GUEST]);
     }
 
     /**

--- a/api/tests/Api/OrganizationGuestInvariantTest.php
+++ b/api/tests/Api/OrganizationGuestInvariantTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Entity\Organization;
+use App\Entity\Space;
+use App\Entity\SpaceRole;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * The seat invariant (#billing Phase 1c): an organization Guest can only ever
+ * hold the restricted guest space-role in any of the org's spaces — never a
+ * space admin, never a paying seat's capabilities.
+ */
+class OrganizationGuestInvariantTest extends ApiTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\OrganizationMembership')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Organization')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\SpaceMembership')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\SpaceRole')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Space')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testGuestAddedToSpaceIsCappedToMemberWithGuestRole(): void
+    {
+        $owner = $this->createUser('owner@example.com');
+        $org = $this->makeOrg($owner, 'Acme Inc');
+        $guest = $this->createUser('guest@example.com');
+        $org->addMember($guest, Organization::ROLE_GUEST);
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($owner);
+
+        $space = $this->makeOrgSpace($client, $org, 'Team Space');
+
+        // Add the org guest to the space, *asking* for admin — it must be
+        // downgraded to member and pinned to the built-in guest role.
+        $client->request('POST', '/spaces/' . $space . '/members', [
+            'json' => ['email' => 'guest@example.com', 'role' => Space::ROLE_ADMIN],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $this->entityManager->clear();
+        $reloaded = $this->entityManager->getRepository(Space::class)->find($space);
+        $this->assertInstanceOf(Space::class, $reloaded);
+        $membership = null;
+        foreach ($reloaded->getUserMemberships() as $m) {
+            if ('guest@example.com' === $m->getUser()?->getEmail()) {
+                $membership = $m;
+            }
+        }
+        $this->assertNotNull($membership, 'guest should have a space membership');
+        $this->assertSame(Space::ROLE_MEMBER, $membership->getRole(), 'guest must not be a space admin');
+
+        $builtinKeys = [];
+        foreach ($membership->getRoles() as $role) {
+            $builtinKeys[] = $role->getBuiltinKey();
+        }
+        $this->assertContains(SpaceRole::BUILTIN_GUEST, $builtinKeys, 'guest must hold the guest space-role');
+    }
+
+    public function testGuestCannotBePromotedToSpaceAdmin(): void
+    {
+        $owner = $this->createUser('owner@example.com');
+        $org = $this->makeOrg($owner, 'Acme Inc');
+        $guest = $this->createUser('guest@example.com');
+        $org->addMember($guest, Organization::ROLE_GUEST);
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($owner);
+        $space = $this->makeOrgSpace($client, $org, 'Team Space');
+
+        $client->request('POST', '/spaces/' . $space . '/members', [
+            'json' => ['email' => 'guest@example.com', 'role' => Space::ROLE_MEMBER],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $this->entityManager->clear();
+        $reloaded = $this->entityManager->getRepository(Space::class)->find($space);
+        $this->assertInstanceOf(Space::class, $reloaded);
+        $membershipId = null;
+        foreach ($reloaded->getUserMemberships() as $m) {
+            if ('guest@example.com' === $m->getUser()?->getEmail()) {
+                $membershipId = (string) $m->getId();
+            }
+        }
+        $this->assertNotNull($membershipId);
+
+        $client->request('PATCH', '/spaces/' . $space . '/members/' . $membershipId, [
+            'json' => ['role' => Space::ROLE_ADMIN],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    private function makeOrgSpace(Client $client, Organization $org, string $name): string
+    {
+        $body = $client->request('POST', '/spaces', [
+            'json' => ['name' => $name, 'organization' => '/organizations/' . $org->getId()],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $id = $body['id'] ?? null;
+        $this->assertIsString($id);
+
+        return $id;
+    }
+
+    private function makeOrg(User $owner, string $name): Organization
+    {
+        $org = (new Organization())->setName($name)->setSlug('o-' . bin2hex(random_bytes(4)))->setCreatedBy($owner);
+        $org->addMember($owner, Organization::ROLE_OWNER);
+        $this->entityManager->persist($org);
+        $this->entityManager->flush();
+
+        return $org;
+    }
+
+    private function createUser(string $email): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}


### PR DESCRIPTION
## Phase 1c — Guest seat invariant

An organization **Guest** can only ever hold the restricted guest space-role in any of the org's spaces — never a space admin, never a paying seat's capabilities. This is the enforcement half of the freemium seat model: guests are free and don't count as a seat, so they must be prevented from being elevated into a member/admin's write capabilities.

### Changes
- `SpaceMemberAdder::add()` — when adding an existing user who is an org guest, the requested role is downgraded to `member` and the space's built-in `guest` SpaceRole is pinned onto the membership. New `isOrgGuest()` helper (public, reused by the controller).
- `SpaceMemberController::changeRole()` — rejects (403) promoting an org guest to space admin, and rejects assigning them any non-guest custom role.
- `OrganizationGuestInvariantTest` — org guest added to an org space is capped to member + guest-role; org guest cannot be PATCHed to space admin.

### Verification
- `OrganizationGuestInvariantTest`: OK (2 tests, 13 assertions)
- PHPStan L10 + strict-rules: clean on changed files
- PHPCS: clean

Deferred (per plan): seat→Stripe quantity sync.