### PR TITLE
feat(pwa): organization management pages (#billing Phase 1d)

### DIFF
--- a/pwa/components/common/UserMenu.tsx
+++ b/pwa/components/common/UserMenu.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { useRouter } from "next/router";
 import {
+  Building2,
   ChevronDown,
   ListChecks,
   LogOut,
@@ -25,6 +26,7 @@ import { cn } from "@/lib/utils";
 // action below the divider.
 const USER_MENU_LINKS = [
   { href: "/my-tasks", label: "My Tasks", icon: ListChecks },
+  { href: "/organizations", label: "Organizations", icon: Building2 },
   { href: "/feedback", label: "Feedback", icon: MessagesSquare },
   { href: "/settings/profile", label: "Settings", icon: Settings },
 ];

--- a/pwa/lib/organizationTypes.ts
+++ b/pwa/lib/organizationTypes.ts
@@ -1,0 +1,85 @@
+import type { AvatarUser } from "@/components/user/UserAvatar";
+
+/**
+ * Shapes for the `/organizations` API (`organization:read`). Shared across the
+ * organizations index + detail pages so the wire contract lives in one place.
+ *
+ * Organizations are the GitHub-style account layer above Spaces (#billing
+ * Phase 1): a Space can belong to a person (personal) or to an Organization
+ * (team). Org roles are more granular than a space's admin/member.
+ */
+
+/** The five org roles, most→least privileged. `seat` = everyone but guest. */
+export const ORG_ROLES = ["owner", "admin", "billing", "member", "guest"] as const;
+export type OrgRole = (typeof ORG_ROLES)[number];
+
+/** Roles that occupy a paid seat (mirrors `Organization::BILLABLE_ROLES`). */
+export const ORG_SEAT_ROLES: readonly OrgRole[] = ["owner", "admin", "billing", "member"];
+
+/** Roles allowed to manage the org (mirrors `Organization::ADMIN_ROLES`). */
+export const ORG_ADMIN_ROLES: readonly OrgRole[] = ["owner", "admin"];
+
+export const ORG_ROLE_LABELS: Record<OrgRole, string> = {
+  owner: "Owner",
+  admin: "Admin",
+  billing: "Billing",
+  member: "Member",
+  guest: "Guest",
+};
+
+export const ORG_ROLE_DESCRIPTIONS: Record<OrgRole, string> = {
+  owner: "Full control, including deleting the organization. Can't be removed while sole owner.",
+  admin: "Manage members, spaces, and settings.",
+  billing: "Manage the subscription and payment method.",
+  member: "Access the organization's spaces and content. Occupies a seat.",
+  guest: "Limited access. Free — doesn't count toward seats.",
+};
+
+export interface OrgMemberUser {
+  id: string;
+  email: string;
+  givenName?: string | null;
+  familyName?: string | null;
+  nickname?: string | null;
+  personalizedColor?: string;
+  avatarUrls?: { thumb?: string; profile?: string } | null;
+}
+
+/** One row of `Organization::getMemberList()`. */
+export interface OrgMember {
+  id: string;
+  role: OrgRole;
+  joinedAt: string;
+  user: OrgMemberUser;
+}
+
+export interface OrganizationSummary {
+  "@id": string;
+  id: string;
+  email?: string | null;
+}
+
+export interface Organization {
+  "@id": string;
+  id: string;
+  name: string;
+  slug: string;
+  createdBy: OrganizationSummary | string | null;
+  memberList: OrgMember[];
+  seatCount: number;
+  createdAt: string;
+}
+
+export interface OrganizationCollection {
+  member?: Organization[];
+  "hydra:member"?: Organization[];
+}
+
+/** An `OrgMemberUser` always has a usable avatar color; default if absent. */
+export const toOrgAvatarUser = (user: OrgMemberUser): AvatarUser => ({
+  ...user,
+  personalizedColor: user.personalizedColor ?? "#64748b",
+});
+
+export const isOrgAdminRole = (role: OrgRole | null | undefined): boolean =>
+  !!role && ORG_ADMIN_ROLES.includes(role);

--- a/pwa/pages/organizations/[id].tsx
+++ b/pwa/pages/organizations/[id].tsx
@@ -1,0 +1,329 @@
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { ArrowLeft, Building2, Check, MoreHorizontal, Trash2, UserPlus } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { signinHrefForCurrent } from "@/lib/authRedirect";
+import { apiGet, apiSend, ApiError } from "@/lib/apiClient";
+import {
+  type Organization,
+  type OrgMember,
+  type OrgRole,
+  isOrgAdminRole,
+  ORG_ROLE_DESCRIPTIONS,
+  ORG_ROLE_LABELS,
+  ORG_ROLES,
+  toOrgAvatarUser,
+} from "@/lib/organizationTypes";
+import { displayName } from "@/lib/userDisplay";
+import UserAvatar from "@/components/user/UserAvatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+
+// Roles an admin can assign from the member row. Owner transfer is a heavier
+// action (kept out of the quick menu until a dedicated flow exists).
+const ASSIGNABLE_ROLES: OrgRole[] = ["admin", "billing", "member", "guest"];
+
+const OrganizationDetail = () => {
+  const { user, isAuthenticated, isLoading: authLoading } = useAuth();
+  const router = useRouter();
+  const orgId = typeof router.query.id === "string" ? router.query.id : null;
+
+  const [org, setOrg] = useState<Organization | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteRole, setInviteRole] = useState<OrgRole>("member");
+  const [inviting, setInviting] = useState(false);
+
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) {
+      router.replace(signinHrefForCurrent(router.asPath));
+    }
+  }, [authLoading, isAuthenticated, router]);
+
+  const load = useCallback(async () => {
+    if (!orgId) return;
+    setLoading(true);
+    setNotFound(false);
+    try {
+      const data = await apiGet<Organization>(`/organizations/${orgId}`);
+      setOrg(data);
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 404) setNotFound(true);
+      setOrg(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [orgId]);
+
+  useEffect(() => {
+    if (isAuthenticated && orgId) void load();
+  }, [isAuthenticated, orgId, load]);
+
+  const myRole: OrgRole | null = useMemo(() => {
+    if (!org || !user) return null;
+    return org.memberList.find((m) => m.user.id === user.id)?.role ?? null;
+  }, [org, user]);
+
+  const isAdmin = isOrgAdminRole(myRole);
+
+  const ownerCount = useMemo(
+    () => (org?.memberList.filter((m) => m.role === "owner").length ?? 0),
+    [org],
+  );
+
+  const addMember = async () => {
+    const email = inviteEmail.trim().toLowerCase();
+    if (!email) return;
+    setInviting(true);
+    setError(null);
+    try {
+      await apiSend("POST", `/organizations/${orgId}/members`, {
+        body: { email, role: inviteRole },
+      });
+      setInviteEmail("");
+      setInviteRole("member");
+      await load();
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : "Could not add the member.");
+    } finally {
+      setInviting(false);
+    }
+  };
+
+  const changeRole = async (member: OrgMember, role: OrgRole) => {
+    if (member.role === role) return;
+    setError(null);
+    try {
+      await apiSend("PATCH", `/organizations/${orgId}/members/${member.user.id}`, {
+        body: { role },
+        contentType: "application/merge-patch+json",
+      });
+      await load();
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : "Could not change the role.");
+    }
+  };
+
+  const removeMember = async (member: OrgMember) => {
+    setError(null);
+    try {
+      await apiSend("DELETE", `/organizations/${orgId}/members/${member.user.id}`);
+      await load();
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : "Could not remove the member.");
+    }
+  };
+
+  if (authLoading || !isAuthenticated) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-muted-foreground">Loading…</p>
+      </div>
+    );
+  }
+
+  if (notFound) {
+    return (
+      <main className="px-6 py-16 max-w-2xl mx-auto text-center">
+        <h1 className="text-lg font-semibold">Organization not found</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          It may have been deleted, or you&apos;re no longer a member.
+        </p>
+        <Button asChild variant="outline" className="mt-4">
+          <Link href="/organizations">Back to organizations</Link>
+        </Button>
+      </main>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>{org ? `${org.name} - Madori` : "Organization - Madori"}</title>
+      </Head>
+
+      <main className="px-6 py-8 max-w-4xl mx-auto">
+        <Link
+          href="/organizations"
+          className="mb-4 inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          Organizations
+        </Link>
+
+        {loading && !org ? (
+          <p className="text-muted-foreground">Loading…</p>
+        ) : !org ? (
+          <p className="text-muted-foreground">Couldn&apos;t load this organization.</p>
+        ) : (
+          <>
+            <div className="mb-6 flex items-start gap-3">
+              <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-md bg-cyan-600/10 text-cyan-700">
+                <Building2 className="h-6 w-6" aria-hidden />
+              </div>
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <h1 className="truncate text-xl font-semibold">{org.name}</h1>
+                  {myRole && (
+                    <Badge variant="secondary">{ORG_ROLE_LABELS[myRole]}</Badge>
+                  )}
+                </div>
+                <p className="text-sm text-muted-foreground">{org.slug}</p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {org.seatCount} {org.seatCount === 1 ? "seat" : "seats"} ·{" "}
+                  {org.memberList.length}{" "}
+                  {org.memberList.length === 1 ? "member" : "members"}
+                </p>
+              </div>
+            </div>
+
+            {error && (
+              <Alert variant="destructive" className="mb-4">
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+
+            {isAdmin && (
+              <section className="mb-6 rounded-lg border p-4">
+                <h2 className="mb-3 flex items-center gap-2 text-sm font-semibold">
+                  <UserPlus className="h-4 w-4" aria-hidden />
+                  Add a member
+                </h2>
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+                  <div className="flex-1 space-y-1.5">
+                    <Label htmlFor="invite-email">Email</Label>
+                    <Input
+                      id="invite-email"
+                      type="email"
+                      value={inviteEmail}
+                      onChange={(e) => setInviteEmail(e.target.value)}
+                      placeholder="teammate@example.com"
+                    />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label>Role</Label>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button variant="outline" className="w-full sm:w-36 justify-between">
+                          {ORG_ROLE_LABELS[inviteRole]}
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="start">
+                        {ASSIGNABLE_ROLES.map((role) => (
+                          <DropdownMenuItem key={role} onSelect={() => setInviteRole(role)}>
+                            <div>
+                              <p className="font-medium">{ORG_ROLE_LABELS[role]}</p>
+                              <p className="text-xs text-muted-foreground">
+                                {ORG_ROLE_DESCRIPTIONS[role]}
+                              </p>
+                            </div>
+                          </DropdownMenuItem>
+                        ))}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
+                  <Button onClick={() => void addMember()} disabled={inviting || !inviteEmail.trim()}>
+                    {inviting ? "Adding…" : "Add"}
+                  </Button>
+                </div>
+                <p className="mt-2 text-xs text-muted-foreground">
+                  The person must already have a Madori account. Guests are free and
+                  don&apos;t count toward seats.
+                </p>
+              </section>
+            )}
+
+            <section className="rounded-lg border">
+              <div className="border-b px-4 py-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                Members
+              </div>
+              <ul className="divide-y" data-testid="org-member-list">
+                {org.memberList.map((member) => {
+                  const isSelf = member.user.id === user?.id;
+                  const isLastOwner = member.role === "owner" && ownerCount <= 1;
+                  return (
+                    <li
+                      key={member.id}
+                      className="flex items-center gap-3 px-4 py-3"
+                      data-testid="org-member"
+                    >
+                      <UserAvatar user={toOrgAvatarUser(member.user)} size="sm" />
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-medium">
+                          {displayName(member.user)}
+                          {isSelf && (
+                            <span className="ml-1.5 text-xs text-muted-foreground">(you)</span>
+                          )}
+                        </p>
+                        <p className="truncate text-xs text-muted-foreground">
+                          {member.user.email}
+                        </p>
+                      </div>
+                      {isAdmin ? (
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button variant="ghost" size="sm" className="gap-1.5">
+                              {ORG_ROLE_LABELS[member.role]}
+                              <MoreHorizontal className="h-3.5 w-3.5" />
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            {ORG_ROLES.map((role) => (
+                              <DropdownMenuItem
+                                key={role}
+                                onSelect={() => void changeRole(member, role)}
+                                disabled={isLastOwner && role !== "owner"}
+                                className={cn("gap-2", member.role === role && "font-semibold")}
+                              >
+                                <Check
+                                  className={cn(
+                                    "h-3.5 w-3.5",
+                                    member.role === role ? "opacity-100" : "opacity-0",
+                                  )}
+                                />
+                                {ORG_ROLE_LABELS[role]}
+                              </DropdownMenuItem>
+                            ))}
+                            <DropdownMenuSeparator />
+                            <DropdownMenuItem
+                              onSelect={() => void removeMember(member)}
+                              disabled={isLastOwner}
+                              className="gap-2 text-destructive focus:text-destructive"
+                            >
+                              <Trash2 className="h-3.5 w-3.5" />
+                              Remove
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      ) : (
+                        <Badge variant="outline">{ORG_ROLE_LABELS[member.role]}</Badge>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            </section>
+          </>
+        )}
+      </main>
+    </>
+  );
+};
+
+export default OrganizationDetail;

--- a/pwa/pages/organizations/index.tsx
+++ b/pwa/pages/organizations/index.tsx
@@ -1,0 +1,218 @@
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Building2, Plus } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { signinHrefForCurrent } from "@/lib/authRedirect";
+import { apiGetCollection, apiSend, ApiError } from "@/lib/apiClient";
+import {
+  type Organization,
+  type OrgRole,
+  ORG_ROLE_LABELS,
+} from "@/lib/organizationTypes";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import PageHeader from "@/components/common/PageHeader";
+
+const OrganizationsIndex = () => {
+  const { user, isAuthenticated, isLoading: authLoading } = useAuth();
+  const router = useRouter();
+
+  const [orgs, setOrgs] = useState<Organization[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) {
+      router.replace(signinHrefForCurrent(router.asPath));
+    }
+  }, [authLoading, isAuthenticated, router]);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const list = await apiGetCollection<Organization>("/organizations");
+      setOrgs(list);
+    } catch {
+      setOrgs([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isAuthenticated) void load();
+  }, [isAuthenticated, load]);
+
+  const roleFor = (org: Organization): OrgRole | null => {
+    if (!user) return null;
+    return org.memberList.find((m) => m.user.id === user.id)?.role ?? null;
+  };
+
+  const sorted = useMemo(
+    () =>
+      [...orgs].sort(
+        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      ),
+    [orgs],
+  );
+
+  const handleCreate = async () => {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setError("A name is required.");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const created = await apiSend<Organization>("POST", "/organizations", {
+        body: { name: trimmed },
+      });
+      setCreateOpen(false);
+      setName("");
+      if (created?.id) {
+        router.push(`/organizations/${created.id}`);
+      } else {
+        void load();
+      }
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : "Could not create the organization.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (authLoading || !isAuthenticated || !user) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-muted-foreground">Loading…</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Organizations - Madori</title>
+      </Head>
+
+      <main className="px-6 py-8 max-w-5xl mx-auto">
+        <PageHeader
+          title="Organizations"
+          icon={<Building2 className="h-6 w-6 text-cyan-600" />}
+          subtitle="Team accounts that own shared spaces and a subscription. Members occupy seats; guests are free."
+          count={orgs.length}
+          actions={
+            <Button
+              size="sm"
+              className="gap-1.5 bg-emerald-600 hover:bg-emerald-500 text-white"
+              onClick={() => {
+                setError(null);
+                setName("");
+                setCreateOpen(true);
+              }}
+            >
+              <Plus className="h-3.5 w-3.5" />
+              New organization
+            </Button>
+          }
+        />
+
+        {loading && orgs.length === 0 ? (
+          <p className="text-muted-foreground">Loading organizations…</p>
+        ) : sorted.length === 0 ? (
+          <div className="rounded-lg border border-dashed p-10 text-center text-sm text-muted-foreground">
+            You don&apos;t belong to any organizations yet. Create one to invite
+            teammates and manage a shared subscription.
+          </div>
+        ) : (
+          <ul className="grid gap-3 sm:grid-cols-1 lg:grid-cols-2" data-testid="org-list">
+            {sorted.map((org) => {
+              const role = roleFor(org);
+              return (
+                <li key={org["@id"]} data-testid="org-item">
+                  <Link
+                    href={`/organizations/${org.id}`}
+                    className="flex items-start gap-3 rounded-lg border p-4 transition-colors hover:bg-accent"
+                  >
+                    <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-cyan-600/10 text-cyan-700">
+                      <Building2 className="h-5 w-5" aria-hidden />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <p className="truncate font-semibold">{org.name}</p>
+                        {role && (
+                          <Badge variant="secondary" className="shrink-0">
+                            {ORG_ROLE_LABELS[role]}
+                          </Badge>
+                        )}
+                      </div>
+                      <p className="truncate text-xs text-muted-foreground">
+                        {org.slug}
+                      </p>
+                      <p className="mt-2 text-xs text-muted-foreground">
+                        {org.seatCount} {org.seatCount === 1 ? "seat" : "seats"} ·{" "}
+                        {org.memberList.length}{" "}
+                        {org.memberList.length === 1 ? "member" : "members"}
+                      </p>
+                    </div>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </main>
+
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>New organization</DialogTitle>
+            <DialogDescription>
+              You&apos;ll be the owner. Add teammates and set up billing once it&apos;s created.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="org-name">Name</Label>
+            <Input
+              id="org-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Acme Inc"
+              autoFocus
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !submitting) void handleCreate();
+              }}
+            />
+            {error && <p className="text-sm text-destructive">{error}</p>}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCreateOpen(false)} disabled={submitting}>
+              Cancel
+            </Button>
+            <Button onClick={() => void handleCreate()} disabled={submitting}>
+              {submitting ? "Creating…" : "Create organization"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};
+
+export default OrganizationsIndex;


### PR DESCRIPTION
## Phase 1d (part 1) — Organization management UX

The GitHub-style **Organization** account layer above Spaces now has a management surface in the PWA. Backend endpoints (`/organizations` CRUD + `/organizations/{id}/members`) already shipped in Phase 1a; this wires the UI.

### Changes
- **`pwa/lib/organizationTypes.ts`** — shared wire types + role vocab (owner/admin/billing/member/guest) mirroring `Organization::*_ROLES`.
- **`/organizations`** (index) — lists the orgs you belong to with role + seat/member counts, and a create dialog (POST `/organizations`, redirects into the new org).
- **`/organizations/{id}`** (detail) — member roster with avatars; admins get add-by-email, per-member role dropdown (PATCH), and remove (DELETE), all keeping the last owner protected (server-enforced, surfaced inline). Non-admins see a read-only roster.
- **`UserMenu`** — new *Organizations* link in the account menu.

### Verification
- `pnpm typecheck`: clean
- `pnpm lint`: 0 errors (pre-existing warnings only, none in new files)

### Follow-up
Part 2 adds the **Organization billing card** (checkout/portal/cancel) + a personal `/settings/billing` page.