### PR TITLE
feat(pwa): account billing UI for orgs + personal plans (#billing Phase 1d)

### DIFF
--- a/pwa/components/billing/AccountBillingCard.tsx
+++ b/pwa/components/billing/AccountBillingCard.tsx
@@ -1,0 +1,339 @@
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import { CheckCircle2, CreditCard, Loader2, Sparkles } from "lucide-react";
+import { ENTRYPOINT } from "@/config/entrypoint";
+import { cn } from "@/lib/utils";
+import CancellationSurvey from "@/components/feedback/CancellationSurvey";
+import { cancellationFeedbackBody } from "@/lib/cancellationReasons";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+interface AccountBillingStatus {
+  plan: string;
+  planLabel: string;
+  status: string | null;
+  active: boolean;
+  billingAvailable: boolean;
+  seats?: number | null;
+  seatCount?: number | null;
+  billingInterval: string | null;
+  currentPeriodEnd: string | null;
+  cancelAtPeriodEnd: boolean;
+  isAdmin?: boolean;
+}
+
+type Interval = "month" | "year";
+
+interface Props {
+  /** API base for the account, e.g. `/me/billing` or `/organizations/{id}/billing`. */
+  endpointBase: string;
+  /** The plan a free account can self-upgrade to (label + blurb). */
+  upgradeLabel: string;
+  upgradeBlurb: string;
+  /** Shown under a paid Business org — Enterprise is sales-led. */
+  enterpriseNote?: boolean;
+}
+
+/**
+ * Plan & billing card shared by the personal ({@link /settings/billing}) and
+ * organization ({@link /organizations/[id]/settings}) surfaces. Reads the
+ * account's billing status and routes upgrade/manage/cancel through the
+ * Stripe-hosted Checkout / Customer Portal (we just follow the returned URL).
+ * Mirrors the space billing card; the billable unit is the account.
+ */
+const AccountBillingCard = ({ endpointBase, upgradeLabel, upgradeBlurb, enterpriseNote }: Props) => {
+  const router = useRouter();
+  const [status, setStatus] = useState<AccountBillingStatus | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [interval, setInterval] = useState<Interval>("month");
+  const [error, setError] = useState<string | null>(null);
+
+  const [cancelOpen, setCancelOpen] = useState(false);
+  const [reason, setReason] = useState("");
+  const [comment, setComment] = useState("");
+  const [cancelBusy, setCancelBusy] = useState(false);
+  const [cancelError, setCancelError] = useState<string | null>(null);
+
+  const billingParam = router.query.billing;
+  const checkoutOutcome =
+    billingParam === "success" || billingParam === "cancelled" ? billingParam : null;
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch(`${ENTRYPOINT}${endpointBase}`, {
+        credentials: "include",
+        headers: { Accept: "application/json" },
+      });
+      if (!res.ok) return;
+      setStatus((await res.json()) as AccountBillingStatus);
+    } catch {
+      // Non-fatal — the rest of the page still works without the card.
+    }
+  }, [endpointBase]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const post = async (action: "checkout" | "portal") => {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(`${ENTRYPOINT}${endpointBase}/${action}`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(action === "checkout" ? { interval } : {}),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || typeof data.url !== "string") {
+        throw new Error(data.error || "Could not reach billing. Please try again.");
+      }
+      window.location.href = data.url;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong.");
+      setBusy(false);
+    }
+  };
+
+  const feedback = cancellationFeedbackBody(reason, comment);
+
+  const closeCancel = () => {
+    setCancelOpen(false);
+    setReason("");
+    setComment("");
+    setCancelError(null);
+  };
+
+  const submitCancel = async () => {
+    if (!feedback) return;
+    setCancelBusy(true);
+    setCancelError(null);
+    try {
+      const res = await fetch(`${ENTRYPOINT}${endpointBase}/cancel`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(feedback),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data.error || "Could not cancel. Please try again.");
+      }
+      closeCancel();
+      await load();
+    } catch (err) {
+      setCancelError(err instanceof Error ? err.message : "Something went wrong.");
+    } finally {
+      setCancelBusy(false);
+    }
+  };
+
+  if (!status) return null;
+
+  const isPaid = status.active;
+  const canManage = status.isAdmin !== false;
+  const renews = status.currentPeriodEnd
+    ? new Date(status.currentPeriodEnd).toLocaleDateString(undefined, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      })
+    : null;
+  const seats = status.seats ?? status.seatCount ?? null;
+
+  return (
+    <Card className="mb-6">
+      <CardContent className="pt-6 space-y-4">
+        <div className="flex items-center justify-between gap-2">
+          <h2 className="font-semibold">Plan &amp; billing</h2>
+          <Badge
+            variant={isPaid ? "secondary" : "outline"}
+            className={cn(isPaid && "bg-violet-100 text-violet-700 hover:bg-violet-100")}
+          >
+            {status.planLabel}
+          </Badge>
+        </div>
+
+        {checkoutOutcome === "success" && (
+          <Alert>
+            <AlertDescription className="flex items-center gap-2">
+              <CheckCircle2 className="h-4 w-4 text-emerald-600" aria-hidden />
+              Thanks! Your subscription is being activated — it&apos;ll show here once
+              Stripe confirms it.
+            </AlertDescription>
+          </Alert>
+        )}
+        {checkoutOutcome === "cancelled" && (
+          <Alert>
+            <AlertDescription>Checkout was cancelled — no charge was made.</AlertDescription>
+          </Alert>
+        )}
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        {isPaid ? (
+          <div className="flex items-center justify-between gap-3 rounded-md border px-4 py-3">
+            <div className="min-w-0">
+              <p className="font-medium flex items-center gap-1.5">
+                <Sparkles className="h-4 w-4 text-violet-600" aria-hidden />
+                {status.planLabel} plan
+              </p>
+              <p className="text-sm text-muted-foreground">
+                {status.cancelAtPeriodEnd
+                  ? `Cancels${renews ? ` on ${renews}` : ""} — access continues until then.`
+                  : renews
+                    ? `Renews ${renews}${seats ? ` · ${seats} seats` : ""}.`
+                    : "Active."}
+                {status.status === "past_due" &&
+                  " Payment is past due — update your card to avoid losing access."}
+              </p>
+            </div>
+            {canManage && (
+              <div className="flex shrink-0 items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="gap-1.5"
+                  onClick={() => void post("portal")}
+                  disabled={busy}
+                >
+                  <CreditCard className="h-4 w-4" aria-hidden />
+                  Manage billing
+                </Button>
+                {!status.cancelAtPeriodEnd && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-muted-foreground hover:text-destructive"
+                    onClick={() => setCancelOpen(true)}
+                    disabled={busy}
+                  >
+                    Cancel
+                  </Button>
+                )}
+              </div>
+            )}
+          </div>
+        ) : (
+          <>
+            {status.billingAvailable && canManage ? (
+              <div className="rounded-md border px-4 py-3 space-y-3">
+                <div>
+                  <p className="font-medium flex items-center gap-1.5">
+                    <Sparkles className="h-4 w-4 text-violet-600" aria-hidden />
+                    Upgrade to {upgradeLabel}
+                  </p>
+                  <p className="text-sm text-muted-foreground">{upgradeBlurb}</p>
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <div
+                    className="inline-flex rounded-md border p-0.5"
+                    role="group"
+                    aria-label="Billing interval"
+                  >
+                    {(["month", "year"] as const).map((opt) => (
+                      <button
+                        key={opt}
+                        type="button"
+                        onClick={() => setInterval(opt)}
+                        className={cn(
+                          "rounded px-2.5 py-1 text-xs font-medium",
+                          interval === opt
+                            ? "bg-violet-600 text-white"
+                            : "text-muted-foreground hover:text-foreground",
+                        )}
+                      >
+                        {opt === "month" ? "Monthly" : "Yearly"}
+                      </button>
+                    ))}
+                  </div>
+                  <Button
+                    size="sm"
+                    className="gap-1.5 bg-violet-600 hover:bg-violet-500 text-white"
+                    onClick={() => void post("checkout")}
+                    disabled={busy}
+                  >
+                    <Sparkles className="h-4 w-4" aria-hidden />
+                    {busy ? "Starting…" : `Upgrade to ${upgradeLabel}`}
+                  </Button>
+                </div>
+              </div>
+            ) : !status.billingAvailable ? (
+              <p className="text-sm text-muted-foreground">
+                Paid plans aren&apos;t enabled on this instance yet.
+              </p>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                You&apos;re on the {status.planLabel} plan.
+              </p>
+            )}
+            {enterpriseNote && (
+              <p className="text-xs text-muted-foreground">
+                Need SSO, SCIM, or a custom contract?{" "}
+                <a href="mailto:sales@madori.app" className="underline hover:text-foreground">
+                  Talk to us about Enterprise
+                </a>
+                .
+              </p>
+            )}
+          </>
+        )}
+      </CardContent>
+
+      <Dialog open={cancelOpen} onOpenChange={(o) => (o ? setCancelOpen(true) : closeCancel())}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Cancel subscription</DialogTitle>
+            <DialogDescription>
+              Your plan stays active until the end of the current billing period
+              {renews ? ` (${renews})` : ""} — you won&apos;t be charged again.
+            </DialogDescription>
+          </DialogHeader>
+          {cancelError && (
+            <Alert variant="destructive">
+              <AlertDescription>{cancelError}</AlertDescription>
+            </Alert>
+          )}
+          <CancellationSurvey
+            idPrefix="sub-cancel"
+            reason={reason}
+            comment={comment}
+            onReasonChange={setReason}
+            onCommentChange={setComment}
+            disabled={cancelBusy}
+          />
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={closeCancel} disabled={cancelBusy}>
+              Keep subscription
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={() => void submitCancel()}
+              disabled={cancelBusy || !feedback}
+              data-testid="sub-cancel-confirm"
+            >
+              {cancelBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : "Cancel subscription"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+};
+
+export default AccountBillingCard;

--- a/pwa/components/settings/SettingsNav.tsx
+++ b/pwa/components/settings/SettingsNav.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import {
   Bell,
   CalendarSync,
+  CreditCard,
   KeyRound,
   Shield,
   TriangleAlert,
@@ -14,6 +15,7 @@ export type SettingsSectionKey =
   | "security"
   | "notifications"
   | "calendar-sync"
+  | "billing"
   | "api-tokens"
   | "danger";
 
@@ -44,6 +46,12 @@ export const SETTINGS_SECTIONS: SettingsSection[] = [
     label: "Calendar sync",
     href: "/settings/calendar-sync",
     Icon: CalendarSync,
+  },
+  {
+    key: "billing",
+    label: "Billing",
+    href: "/settings/billing",
+    Icon: CreditCard,
   },
   {
     key: "api-tokens",

--- a/pwa/pages/organizations/[id].tsx
+++ b/pwa/pages/organizations/[id].tsx
@@ -2,7 +2,7 @@ import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { ArrowLeft, Building2, Check, MoreHorizontal, Trash2, UserPlus } from "lucide-react";
+import { ArrowLeft, Building2, Check, MoreHorizontal, Settings, Trash2, UserPlus } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { signinHrefForCurrent } from "@/lib/authRedirect";
 import { apiGet, apiSend, ApiError } from "@/lib/apiClient";
@@ -177,7 +177,7 @@ const OrganizationDetail = () => {
               <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-md bg-cyan-600/10 text-cyan-700">
                 <Building2 className="h-6 w-6" aria-hidden />
               </div>
-              <div className="min-w-0">
+              <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-2">
                   <h1 className="truncate text-xl font-semibold">{org.name}</h1>
                   {myRole && (
@@ -191,6 +191,14 @@ const OrganizationDetail = () => {
                   {org.memberList.length === 1 ? "member" : "members"}
                 </p>
               </div>
+              {isAdmin && (
+                <Button asChild variant="outline" size="sm" className="gap-1.5 shrink-0">
+                  <Link href={`/organizations/${org.id}/settings`}>
+                    <Settings className="h-3.5 w-3.5" />
+                    Settings
+                  </Link>
+                </Button>
+              )}
             </div>
 
             {error && (

--- a/pwa/pages/organizations/[id]/settings.tsx
+++ b/pwa/pages/organizations/[id]/settings.tsx
@@ -1,0 +1,105 @@
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useCallback, useEffect, useState } from "react";
+import { ArrowLeft, Building2 } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { signinHrefForCurrent } from "@/lib/authRedirect";
+import { apiGet, ApiError } from "@/lib/apiClient";
+import { type Organization } from "@/lib/organizationTypes";
+import { Button } from "@/components/ui/button";
+import AccountBillingCard from "@/components/billing/AccountBillingCard";
+
+const OrganizationSettings = () => {
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
+  const router = useRouter();
+  const orgId = typeof router.query.id === "string" ? router.query.id : null;
+
+  const [org, setOrg] = useState<Organization | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) {
+      router.replace(signinHrefForCurrent(router.asPath));
+    }
+  }, [authLoading, isAuthenticated, router]);
+
+  const load = useCallback(async () => {
+    if (!orgId) return;
+    setLoading(true);
+    setNotFound(false);
+    try {
+      setOrg(await apiGet<Organization>(`/organizations/${orgId}`));
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 404) setNotFound(true);
+      setOrg(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [orgId]);
+
+  useEffect(() => {
+    if (isAuthenticated && orgId) void load();
+  }, [isAuthenticated, orgId, load]);
+
+  if (authLoading || !isAuthenticated) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-muted-foreground">Loading…</p>
+      </div>
+    );
+  }
+
+  if (notFound) {
+    return (
+      <main className="px-6 py-16 max-w-2xl mx-auto text-center">
+        <h1 className="text-lg font-semibold">Organization not found</h1>
+        <Button asChild variant="outline" className="mt-4">
+          <Link href="/organizations">Back to organizations</Link>
+        </Button>
+      </main>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>{org ? `${org.name} settings - Madori` : "Organization settings - Madori"}</title>
+      </Head>
+
+      <main className="px-6 py-8 max-w-3xl mx-auto">
+        <Link
+          href={orgId ? `/organizations/${orgId}` : "/organizations"}
+          className="mb-4 inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          {org?.name ?? "Organization"}
+        </Link>
+
+        <div className="mb-6 flex items-center gap-3">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-cyan-600/10 text-cyan-700">
+            <Building2 className="h-5 w-5" aria-hidden />
+          </div>
+          <div>
+            <h1 className="text-xl font-semibold">Organization settings</h1>
+            <p className="text-sm text-muted-foreground">{org?.name}</p>
+          </div>
+        </div>
+
+        {loading && !org ? (
+          <p className="text-muted-foreground">Loading…</p>
+        ) : (
+          <AccountBillingCard
+            endpointBase={`/organizations/${orgId}/billing`}
+            upgradeLabel="Business"
+            upgradeBlurb="Unlimited members, automations, reporting, SSO, and AI assist for everyone in the organization."
+            enterpriseNote
+          />
+        )}
+      </main>
+    </>
+  );
+};
+
+export default OrganizationSettings;

--- a/pwa/pages/settings/billing.tsx
+++ b/pwa/pages/settings/billing.tsx
@@ -1,0 +1,18 @@
+import SettingsShell from "@/components/settings/SettingsShell";
+import AccountBillingCard from "@/components/billing/AccountBillingCard";
+
+const BillingSettingsPage = () => (
+  <SettingsShell
+    active="billing"
+    title="Billing"
+    description="Your personal plan. Covers the spaces you own personally — team spaces are billed to their organization."
+  >
+    <AccountBillingCard
+      endpointBase="/me/billing"
+      upgradeLabel="Pro"
+      upgradeBlurb="Unlock calendar sync, time tracking, invoicing, and the timeline across your personal spaces."
+    />
+  </SettingsShell>
+);
+
+export default BillingSettingsPage;


### PR DESCRIPTION
## Phase 1d (part 2) — Account billing UI

Wires the PWA to the account-billing endpoints shipped in Phase 1b (`/organizations/{id}/billing` and `/me/billing`), completing the org UX.

### Changes
- **`AccountBillingCard`** (`pwa/components/billing/`) — a reusable plan & billing card generalizing `SpaceBillingCard`: plan badge, monthly/yearly Stripe checkout, manage-billing portal, and cancel-with-`CancellationSurvey`. Reads the account's status and follows the returned Stripe-hosted URL. Hides management for non-admins (`isAdmin === false`).
- **`/organizations/{id}/settings`** — org billing (Business self-serve upgrade, seat count, Enterprise "talk to sales" note), reachable from an admin-only **Settings** button on the org detail page.
- **`/settings/billing`** — personal Pro plan, with a new **Billing** entry in the settings subnav.

### Verification
- `pnpm typecheck`: clean
- `pnpm lint`: 0 errors (pre-existing warnings only)

Completes the Phase 1d org UX. Billing enforcement remains dark behind `app.billing_enforcement_enabled` until Stripe is wired.