### PR TITLE
refactor(pwa): move Time nav link next to Calendar

### DIFF
--- a/pwa/components/common/SidebarNav.tsx
+++ b/pwa/components/common/SidebarNav.tsx
@@ -522,6 +522,28 @@ const SidebarNav = ({
           </span>
         )}
 
+        {activeSpace && (
+          <span>
+            {wrap(
+              <Button
+                asChild
+                variant="ghost"
+                size="sm"
+                className={cn(
+                  "w-full min-w-0 justify-start gap-1.5 font-normal",
+                  router.pathname.startsWith("/time") &&
+                    "bg-accent text-accent-foreground",
+                )}
+              >
+                <Link href="/time">
+                  <Clock className="size-3.5 shrink-0 text-orange-600 dark:text-orange-400" />
+                  <span className="truncate">Time</span>
+                </Link>
+              </Button>,
+            )}
+          </span>
+        )}
+
         {activeSpace &&
           CONTENT_SECTIONS.map((section) => (
             <ContentSection
@@ -570,28 +592,6 @@ const SidebarNav = ({
                 <Link href="/custom-fields">
                   <SlidersHorizontal className="size-3.5 shrink-0 text-cyan-600 dark:text-cyan-400" />
                   <span className="truncate">Custom fields</span>
-                </Link>
-              </Button>,
-            )}
-          </span>
-        )}
-
-        {activeSpace && (
-          <span>
-            {wrap(
-              <Button
-                asChild
-                variant="ghost"
-                size="sm"
-                className={cn(
-                  "w-full min-w-0 justify-start gap-1.5 font-normal",
-                  router.pathname.startsWith("/time") &&
-                    "bg-accent text-accent-foreground",
-                )}
-              >
-                <Link href="/time">
-                  <Clock className="size-3.5 shrink-0 text-orange-600 dark:text-orange-400" />
-                  <span className="truncate">Time</span>
                 </Link>
               </Button>,
             )}


### PR DESCRIPTION
Places the **Time** sidebar link directly beneath **Calendar** (it previously sat below the content sections, after Tags/Custom fields). Pure reorder — no behavior change.

Verified: `pnpm typecheck` clean, `pnpm lint` 0 errors.