### PR TITLE
feat(billing): engagement polish — inline UI, per-category billable, contract files

### DIFF
--- a/api/migrations/Version20260706025536.php
+++ b/api/migrations/Version20260706025536.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260706025536 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add engagement_category.billable — billability moves from the time entry to the category.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE engagement_category ADD billable BOOLEAN DEFAULT true NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE engagement_category DROP billable');
+    }
+}

--- a/api/migrations/Version20260706031202.php
+++ b/api/migrations/Version20260706031202.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260706031202 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add engagement.description (markdown) + engagement_attachment join table (contract files).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE engagement_attachment (engagement_id UUID NOT NULL, media_object_id UUID NOT NULL, PRIMARY KEY (engagement_id, media_object_id))');
+        $this->addSql('CREATE INDEX IDX_B432A70ED30F6F97 ON engagement_attachment (engagement_id)');
+        $this->addSql('CREATE INDEX IDX_B432A70E64DE5A5 ON engagement_attachment (media_object_id)');
+        $this->addSql('ALTER TABLE engagement_attachment ADD CONSTRAINT FK_B432A70ED30F6F97 FOREIGN KEY (engagement_id) REFERENCES engagement (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE engagement_attachment ADD CONSTRAINT FK_B432A70E64DE5A5 FOREIGN KEY (media_object_id) REFERENCES media_object (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE engagement ADD description TEXT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE engagement_attachment DROP CONSTRAINT FK_B432A70ED30F6F97');
+        $this->addSql('ALTER TABLE engagement_attachment DROP CONSTRAINT FK_B432A70E64DE5A5');
+        $this->addSql('DROP TABLE engagement_attachment');
+        $this->addSql('ALTER TABLE engagement DROP description');
+    }
+}

--- a/api/src/Controller/MediaObjectDownloadController.php
+++ b/api/src/Controller/MediaObjectDownloadController.php
@@ -2,10 +2,13 @@
 
 namespace App\Controller;
 
+use App\Entity\Engagement;
 use App\Entity\MediaObject;
 use App\Entity\Space;
 use App\Entity\Task;
 use App\Entity\User;
+use App\Security\Permission\SpacePermission;
+use App\Security\Permission\SpacePermissionResolver;
 use Doctrine\ORM\EntityManagerInterface;
 use League\Flysystem\FilesystemException;
 use League\Flysystem\FilesystemOperator;
@@ -41,6 +44,7 @@ class MediaObjectDownloadController extends AbstractController
         private EntityManagerInterface $em,
         #[Autowire(service: 'media.storage')]
         private FilesystemOperator $storage,
+        private SpacePermissionResolver $permissions,
     ) {
     }
 
@@ -108,8 +112,8 @@ class MediaObjectDownloadController extends AbstractController
 
     /**
      * The caller may download the MediaObject if they own it OR if at least
-     * one task or space they belong to attaches it. Mirrors the Task and
-     * Space GET security expressions.
+     * one task, space, or engagement they can read attaches it. Mirrors the
+     * Task / Space / Engagement GET security expressions.
      */
     private function canAccess(MediaObject $media, User $user): bool
     {
@@ -118,10 +122,12 @@ class MediaObjectDownloadController extends AbstractController
         }
         if ($this->isGranted('ROLE_ADMIN')) {
             return $this->mediaIsAttachedToAnyTask($media)
-                || $this->mediaIsAttachedToAnySpace($media);
+                || $this->mediaIsAttachedToAnySpace($media)
+                || $this->mediaIsAttachedToAnyEngagement($media);
         }
         return $this->mediaIsAttachedToReadableTask($media, $user)
-            || $this->mediaIsAttachedToReadableSpace($media, $user);
+            || $this->mediaIsAttachedToReadableSpace($media, $user)
+            || $this->mediaIsAttachedToReadableEngagement($media, $user);
     }
 
     private function mediaIsAttachedToAnyTask(MediaObject $media): bool
@@ -202,5 +208,49 @@ class MediaObjectDownloadController extends AbstractController
             ->getQuery()
             ->getSingleScalarResult();
         return $count > 0;
+    }
+
+    private function mediaIsAttachedToAnyEngagement(MediaObject $media): bool
+    {
+        $count = (int) $this->em->getRepository(Engagement::class)
+            ->createQueryBuilder('e')
+            ->select('COUNT(e.id)')
+            ->where(':media MEMBER OF e.attachments')
+            ->setParameter('media', $media)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getSingleScalarResult();
+        return $count > 0;
+    }
+
+    /**
+     * Engagement attachments are contract-sensitive: readable only by a space
+     * admin or a member holding an explicit `invoices.read` grant — the same
+     * bar as the Engagement GET security expression. A media is attached to at
+     * most a handful of engagements, so the per-row permission check is cheap.
+     */
+    private function mediaIsAttachedToReadableEngagement(MediaObject $media, User $user): bool
+    {
+        $engagements = $this->em->getRepository(Engagement::class)
+            ->createQueryBuilder('e')
+            ->where(':media MEMBER OF e.attachments')
+            ->setParameter('media', $media)
+            ->getQuery()
+            ->getResult();
+
+        foreach ($engagements as $engagement) {
+            $space = $engagement->getSpace();
+            if (null === $space) {
+                continue;
+            }
+            if (
+                $space->isAdmin($user)
+                || $this->permissions->canByExplicitGrant($user, $space, SpacePermission::INVOICES, SpacePermission::READ)
+            ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/api/src/DataFixtures/AdminDeskFixtures.php
+++ b/api/src/DataFixtures/AdminDeskFixtures.php
@@ -13,6 +13,7 @@ use App\Entity\Engagement;
 use App\Entity\EngagementCategory;
 use App\Entity\Invoice;
 use App\Entity\InvoiceLineItem;
+use App\Entity\MediaObject;
 use App\Entity\Page;
 use App\Entity\Space;
 use App\Entity\SpaceMembership;
@@ -26,18 +27,20 @@ use App\Entity\UserGroup;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
+use League\Flysystem\FilesystemOperator;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
  * Admin (Ada) demo data — two spaces so an admin sign-in is interesting:
  *
- *  - **Admin desk** — a fully-populated shared space with at least one of
+ *  - **everything** — a fully-populated shared space with at least one of
  *    every content type: a board (with task sections, tasks — one recurring
  *    with a reminder, a custom field & value, a task relationship, and task
  *    comments), a page with a sub-page and a page comment, a discussion +
  *    comment, tags, groups, and the full billing chain (client → engagement
  *    with a category/rate → a tracked time entry → a draft invoice). It also
  *    holds a second, deliberately **empty board** for the empty-state UI.
- *  - **Sandbox** — a deliberately empty shared space, so the empty-space UI
+ *  - **nothing** — a deliberately empty shared space, so the empty-space UI
  *    is reachable without deleting anything.
  *
  * Admin (Ada) is intentionally not a member of the user-side "Launch team"
@@ -46,6 +49,12 @@ use Doctrine\Persistence\ObjectManager;
 class AdminDeskFixtures extends Fixture implements DependentFixtureInterface
 {
     public const ADMIN_DESK_SPACE_REFERENCE = 'space-admin-desk';
+
+    public function __construct(
+        #[Autowire(service: 'media.storage')]
+        private readonly FilesystemOperator $storage,
+    ) {
+    }
 
     public function getDependencies(): array
     {
@@ -63,12 +72,12 @@ class AdminDeskFixtures extends Fixture implements DependentFixtureInterface
         /** @var User $liam */
         $liam = $this->getReference('user-liam', User::class);
 
-        // --- Admin desk: a fully-populated shared space ---
+        // --- everything: a fully-populated shared space ---
         $desk = (new Space())
-            ->setName('Admin desk')
+            ->setName('everything')
             ->setDescription(
-                'Housekeeping, account chores, and one-off admin tasks — the '
-                . 'workspace that keeps the lights on.',
+                'Has at least one of every content type — the space to open when '
+                . 'you want to see a populated UI.',
             )
             ->setCreatedBy($ada);
         $manager->persist($desk);
@@ -215,19 +224,39 @@ class AdminDeskFixtures extends Fixture implements DependentFixtureInterface
         $devCategory = (new EngagementCategory())->setName('Development')->setRateAmount(12000)->setPosition(0);
         $engagement = (new Engagement())
             ->setSpace($desk)->setClient($client)->setCreatedBy($ada)
-            ->setName('Acme website')->setCurrency('USD');
+            ->setName('Acme website')->setCurrency('USD')
+            ->setDescription(
+                "## Scope\n\nBuild + launch the Acme marketing site.\n\n"
+                . "- Net-30 terms\n- Weekly status call\n- Contract on file in the Files tab",
+            );
         $engagement->addCategory($devCategory);
         $manager->persist($engagement);
         // Roll the admin board up to this engagement.
         $board->setEngagement($engagement);
+
+        // A fake signed contract file attached to the engagement (Files tab).
+        $contractBody = "ACME MASTER SERVICES AGREEMENT\n\n"
+            . "This sample agreement is seeded so the engagement's contract files "
+            . "have something to show.\n\n- Term: 12 months\n- Billing: Net-30\n"
+            . "- Signed: Ada Admin\n";
+        $contractPath = 'attachments/fixture-acme-contract.txt';
+        $this->storage->write($contractPath, $contractBody);
+        $contract = (new MediaObject())
+            ->setOwner($ada)
+            ->setKind(MediaObject::KIND_ATTACHMENT)
+            ->setVariants(['original' => $contractPath])
+            ->setOriginalName('acme-contract.txt')
+            ->setMimeType('text/plain')
+            ->setByteSize(\strlen($contractBody));
+        $manager->persist($contract);
+        $engagement->addAttachment($contract);
 
         $entry = (new TimeEntry())
             ->setSpace($desk)->setUser($ada)
             ->setEngagement($engagement)->setCategory($devCategory)
             ->setDescription('Set up the staging environment.')
             ->setStartedAt(new \DateTimeImmutable('-2 days 09:00'))
-            ->setEndedAt(new \DateTimeImmutable('-2 days 11:00'))
-            ->setBillable(true);
+            ->setEndedAt(new \DateTimeImmutable('-2 days 11:00'));
         $manager->persist($entry);
 
         // A draft invoice for the client (2h × $120 = $240).
@@ -249,9 +278,9 @@ class AdminDeskFixtures extends Fixture implements DependentFixtureInterface
             ->setDescription('Nothing here yet — handy for testing the empty board state.');
         $manager->persist($emptyBoard);
 
-        // --- Sandbox: an intentionally empty shared space ---
+        // --- nothing: an intentionally empty shared space ---
         $sandbox = (new Space())
-            ->setName('Sandbox')
+            ->setName('nothing')
             ->setDescription('An empty space — nothing here yet. Handy for trying the empty states.')
             ->setCreatedBy($ada);
         $manager->persist($sandbox);

--- a/api/src/Entity/Engagement.php
+++ b/api/src/Entity/Engagement.php
@@ -15,6 +15,7 @@ use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
 use App\Repository\EngagementRepository;
 use App\State\EngagementCreatorProcessor;
+use App\Validator\ValidEngagementAttachments;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
@@ -69,6 +70,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 #[ORM\Index(columns: ['client_id'], name: 'idx_engagement_client')]
 #[ORM\HasLifecycleCallbacks]
 #[Assert\Callback('validateConsistency')]
+#[ValidEngagementAttachments]
 class Engagement
 {
     public const MAX_NAME_LENGTH = 200;
@@ -105,6 +107,11 @@ class Engagement
     #[Groups(['engagement:read', 'engagement:write', 'time_entry:read'])]
     private ?string $currency = null;
 
+    /** Optional long-form notes (markdown) — scope, terms, key contacts. */
+    #[ORM\Column(type: 'text', nullable: true)]
+    #[Groups(['engagement:read', 'engagement:write'])]
+    private ?string $description = null;
+
     #[ORM\Column(type: 'boolean')]
     #[Groups(['engagement:read', 'engagement:write'])]
     private bool $archived = false;
@@ -131,6 +138,21 @@ class Engagement
     #[ORM\OneToMany(mappedBy: 'engagement', targetEntity: Board::class)]
     private Collection $assignedProjects;
 
+    /**
+     * Contract + supporting files attached to this engagement. Same upload
+     * flow as {@see Space::$attachments}: PATCH an `attachments` array of
+     * MediaObject IRIs after POST /media-objects (kind=attachment).
+     * {@see ValidEngagementAttachments} enforces uploader-is-member + kind.
+     *
+     * @var Collection<int, MediaObject>
+     */
+    #[ORM\ManyToMany(targetEntity: MediaObject::class)]
+    #[ORM\JoinTable(name: 'engagement_attachment')]
+    #[ORM\JoinColumn(name: 'engagement_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
+    #[ORM\InverseJoinColumn(name: 'media_object_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
+    #[Groups(['engagement:read', 'engagement:write'])]
+    private Collection $attachments;
+
     #[ApiProperty(readableLink: false)]
     #[ORM\ManyToOne(targetEntity: User::class)]
     #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
@@ -149,6 +171,7 @@ class Engagement
     {
         $this->categories = new ArrayCollection();
         $this->assignedProjects = new ArrayCollection();
+        $this->attachments = new ArrayCollection();
         $this->createdAt = new \DateTimeImmutable();
     }
 
@@ -233,6 +256,42 @@ class Engagement
     public function setCurrency(?string $currency): self
     {
         $this->currency = $currency;
+
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(?string $description): self
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, MediaObject>
+     */
+    public function getAttachments(): Collection
+    {
+        return $this->attachments;
+    }
+
+    public function addAttachment(MediaObject $media): self
+    {
+        if (!$this->attachments->contains($media)) {
+            $this->attachments->add($media);
+        }
+
+        return $this;
+    }
+
+    public function removeAttachment(MediaObject $media): self
+    {
+        $this->attachments->removeElement($media);
 
         return $this;
     }

--- a/api/src/Entity/EngagementCategory.php
+++ b/api/src/Entity/EngagementCategory.php
@@ -63,6 +63,15 @@ class EngagementCategory
     #[Groups(['engagement:read', 'engagement:write'])]
     private int $position = 0;
 
+    /**
+     * Whether time tracked against this category is billable. Billability lives
+     * on the category (not the individual entry): a {@see TimeEntry} snapshots
+     * this onto itself on save, so invoices pull the right pool of time.
+     */
+    #[ORM\Column(type: 'boolean', options: ['default' => true])]
+    #[Groups(['engagement:read', 'engagement:write', 'time_entry:read'])]
+    private bool $billable = true;
+
     public function getId(): ?Uuid
     {
         return $this->id;
@@ -112,6 +121,18 @@ class EngagementCategory
     public function setPosition(int $position): self
     {
         $this->position = $position;
+
+        return $this;
+    }
+
+    public function isBillable(): bool
+    {
+        return $this->billable;
+    }
+
+    public function setBillable(bool $billable): self
+    {
+        $this->billable = $billable;
 
         return $this;
     }

--- a/api/src/Entity/MediaObject.php
+++ b/api/src/Entity/MediaObject.php
@@ -61,7 +61,7 @@ class MediaObject
     #[ORM\Column(type: 'uuid', unique: true)]
     #[ORM\GeneratedValue(strategy: 'CUSTOM')]
     #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
-    #[Groups(['media_object:read', 'task:read', 'space:read'])]
+    #[Groups(['media_object:read', 'task:read', 'space:read', 'engagement:read'])]
     private ?Uuid $id = null;
 
     #[ORM\ManyToOne(targetEntity: User::class)]
@@ -69,7 +69,7 @@ class MediaObject
     private ?User $owner = null;
 
     #[ORM\Column(length: 32)]
-    #[Groups(['media_object:read', 'task:read', 'space:read'])]
+    #[Groups(['media_object:read', 'task:read', 'space:read', 'engagement:read'])]
     private string $kind = self::KIND_ATTACHMENT;
 
     /** @var array<string, string> */
@@ -77,19 +77,19 @@ class MediaObject
     private array $variants = [];
 
     #[ORM\Column(length: 255)]
-    #[Groups(['media_object:read', 'task:read', 'space:read'])]
+    #[Groups(['media_object:read', 'task:read', 'space:read', 'engagement:read'])]
     private string $originalName = '';
 
     #[ORM\Column(length: 100)]
-    #[Groups(['media_object:read', 'task:read', 'space:read'])]
+    #[Groups(['media_object:read', 'task:read', 'space:read', 'engagement:read'])]
     private string $mimeType = '';
 
     #[ORM\Column(type: 'integer')]
-    #[Groups(['media_object:read', 'task:read', 'space:read'])]
+    #[Groups(['media_object:read', 'task:read', 'space:read', 'engagement:read'])]
     private int $byteSize = 0;
 
     #[ORM\Column(type: 'datetime_immutable')]
-    #[Groups(['media_object:read', 'task:read', 'space:read'])]
+    #[Groups(['media_object:read', 'task:read', 'space:read', 'engagement:read'])]
     private \DateTimeImmutable $createdOn;
 
     public function __construct()
@@ -185,7 +185,7 @@ class MediaObject
      *
      * @return array<string, string>
      */
-    #[Groups(['media_object:read', 'task:read', 'space:read'])]
+    #[Groups(['media_object:read', 'task:read', 'space:read', 'engagement:read'])]
     public function getVariantUrls(): array
     {
         $urls = [];
@@ -202,7 +202,7 @@ class MediaObject
      * attachment kinds keeps the frontend selector trivial: prefer
      * `downloadUrl` when present, fall back to `variantUrls.original`.
      */
-    #[Groups(['media_object:read', 'task:read', 'space:read'])]
+    #[Groups(['media_object:read', 'task:read', 'space:read', 'engagement:read'])]
     public function getDownloadUrl(): ?string
     {
         if (self::KIND_ATTACHMENT !== $this->kind) {

--- a/api/src/Entity/TimeEntry.php
+++ b/api/src/Entity/TimeEntry.php
@@ -148,8 +148,9 @@ class TimeEntry
     #[Groups(['time_entry:read'])]
     private ?int $durationSeconds = null;
 
+    /** Derived from the {@see $category}'s billability on save — not client-set. */
     #[ORM\Column(type: 'boolean')]
-    #[Groups(['time_entry:read', 'time_entry:write'])]
+    #[Groups(['time_entry:read'])]
     private bool $billable = true;
 
     /**
@@ -199,11 +200,12 @@ class TimeEntry
             $this->space = $this->engagement->getSpace();
         }
 
-        // Snapshot the rate from the category + board currency so a later rate
-        // change never rewrites already-logged (or billed) time.
+        // Snapshot the rate + billability from the category + board currency so a
+        // later category change never rewrites already-logged (or billed) time.
         if (null !== $this->category) {
             $this->rateAmount = $this->category->getRateAmount();
             $this->rateCurrency = $this->engagement?->getCurrency();
+            $this->billable = $this->category->isBillable();
         }
 
         $this->durationSeconds = null;

--- a/api/src/Validator/ValidEngagementAttachments.php
+++ b/api/src/Validator/ValidEngagementAttachments.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Class-level constraint on Engagement. Asserts that every MediaObject in
+ * `attachments`:
+ *   - was uploaded by a member of the engagement's space (any direct or
+ *     group-inherited member), AND
+ *   - has kind=attachment (avatars are private to their owner's profile
+ *     and shouldn't end up as an engagement attachment by accident).
+ *
+ * Mirrors {@see ValidSpaceAttachments}.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class ValidEngagementAttachments extends Constraint
+{
+    public string $messageNotMember = 'You can only attach files uploaded by a space member.';
+    public string $messageWrongKind = 'Only attachment-kind media can be attached to an engagement.';
+
+    public function getTargets(): string
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/api/src/Validator/ValidEngagementAttachmentsValidator.php
+++ b/api/src/Validator/ValidEngagementAttachmentsValidator.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Validator;
+
+use App\Entity\Engagement;
+use App\Entity\MediaObject;
+use App\Entity\User;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+final class ValidEngagementAttachmentsValidator extends ConstraintValidator
+{
+    public function __construct(private Security $security)
+    {
+    }
+
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof ValidEngagementAttachments) {
+            throw new UnexpectedTypeException($constraint, ValidEngagementAttachments::class);
+        }
+
+        if (null === $value) {
+            return;
+        }
+
+        if (!$value instanceof Engagement) {
+            throw new UnexpectedValueException($value, Engagement::class);
+        }
+
+        $space = $value->getSpace();
+        $memberIds = [];
+        if (null !== $space) {
+            foreach ($space->getEffectiveUsers() as $id => $member) {
+                $memberIds[$id] = true;
+            }
+        }
+        // Include the current user so the very first attachment during create
+        // doesn't 422 before the space membership graph is fully resolved.
+        $current = $this->security->getUser();
+        if ($current instanceof User && null !== $current->getId()) {
+            $memberIds[(string) $current->getId()] = true;
+        }
+
+        foreach ($value->getAttachments() as $attachment) {
+            $owner = $attachment->getOwner();
+            if (null === $owner || null === $owner->getId() || !isset($memberIds[(string) $owner->getId()])) {
+                $this->context->buildViolation($constraint->messageNotMember)
+                    ->atPath('attachments')
+                    ->addViolation();
+                return;
+            }
+            if ($attachment->getKind() !== MediaObject::KIND_ATTACHMENT) {
+                $this->context->buildViolation($constraint->messageWrongKind)
+                    ->atPath('attachments')
+                    ->addViolation();
+                return;
+            }
+        }
+    }
+}

--- a/api/tests/Api/ClientInvoiceTest.php
+++ b/api/tests/Api/ClientInvoiceTest.php
@@ -142,12 +142,13 @@ class ClientInvoiceTest extends ApiTestCase
             'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
             'headers' => ['Content-Type' => 'application/ld+json'],
         ])->toArray();
-        [$bpIri, $devCat, $buildCat] = $this->createEngagement($client, $spaceIri, $this->iri($clientRow));
+        [$bpIri, $devCat, $buildCat, $internalCat] = $this->createEngagement($client, $spaceIri, $this->iri($clientRow));
 
-        // Two billable completed entries (distinct category rates) + one non-billable (excluded).
-        $this->trackTime($client, $spaceIri, $bpIri, $devCat, '2026-07-03T09:00:00+00:00', '2026-07-03T10:00:00+00:00', true);
-        $this->trackTime($client, $spaceIri, $bpIri, $buildCat, '2026-07-03T11:00:00+00:00', '2026-07-03T11:30:00+00:00', true);
-        $this->trackTime($client, $spaceIri, $bpIri, $devCat, '2026-07-03T12:00:00+00:00', '2026-07-03T13:00:00+00:00', false);
+        // Two billable completed entries (distinct category rates) + one on the
+        // non-billable "Internal" category (excluded from the invoice).
+        $this->trackTime($client, $spaceIri, $bpIri, $devCat, '2026-07-03T09:00:00+00:00', '2026-07-03T10:00:00+00:00');
+        $this->trackTime($client, $spaceIri, $bpIri, $buildCat, '2026-07-03T11:00:00+00:00', '2026-07-03T11:30:00+00:00');
+        $this->trackTime($client, $spaceIri, $bpIri, $internalCat, '2026-07-03T12:00:00+00:00', '2026-07-03T13:00:00+00:00');
 
         $response = $client->request('POST', '/invoices/from-time-entries', [
             'json' => ['engagement' => $bpIri],
@@ -181,7 +182,7 @@ class ClientInvoiceTest extends ApiTestCase
             'headers' => ['Content-Type' => 'application/ld+json'],
         ])->toArray();
         [$bpIri, $devCat] = $this->createEngagement($client, $spaceIri, $this->iri($clientRow));
-        $this->trackTime($client, $spaceIri, $bpIri, $devCat, '2026-07-03T09:00:00+00:00', '2026-07-03T10:00:00+00:00', true);
+        $this->trackTime($client, $spaceIri, $bpIri, $devCat, '2026-07-03T09:00:00+00:00', '2026-07-03T10:00:00+00:00');
         $invoice = $client->request('POST', '/invoices/from-time-entries', [
             'json' => ['engagement' => $bpIri],
             'headers' => ['Content-Type' => 'application/json'],
@@ -227,7 +228,7 @@ class ClientInvoiceTest extends ApiTestCase
             'headers' => ['Content-Type' => 'application/ld+json'],
         ])->toArray();
         [$bpIri, $devCat] = $this->createEngagement($client, $spaceIri, $this->iri($clientRow));
-        $this->trackTime($client, $spaceIri, $bpIri, $devCat, '2026-07-03T09:00:00+00:00', '2026-07-03T10:00:00+00:00', true);
+        $this->trackTime($client, $spaceIri, $bpIri, $devCat, '2026-07-03T09:00:00+00:00', '2026-07-03T10:00:00+00:00');
 
         $invoice = $client->request('POST', '/invoices/from-time-entries', [
             'json' => ['engagement' => $bpIri],
@@ -500,8 +501,8 @@ class ClientInvoiceTest extends ApiTestCase
         string $categoryIri,
         string $startedAt,
         string $endedAt,
-        bool $billable,
     ): void {
+        // Billability is derived from the category, not sent per entry.
         $client->request('POST', '/time_entries', [
             'json' => [
                 'space' => $spaceIri,
@@ -509,7 +510,6 @@ class ClientInvoiceTest extends ApiTestCase
                 'category' => $categoryIri,
                 'startedAt' => $startedAt,
                 'endedAt' => $endedAt,
-                'billable' => $billable,
             ],
             'headers' => ['Content-Type' => 'application/ld+json'],
         ]);
@@ -517,11 +517,13 @@ class ClientInvoiceTest extends ApiTestCase
     }
 
     /**
-     * Admin creates a engagement (for $clientIri) with two categories —
-     * "Dev" @ 6000 and "Build" @ 8000 — so tracked-time tests can hit distinct
-     * rates. Returns [engagementIri, devCategoryIri, buildCategoryIri].
+     * Admin creates a engagement (for $clientIri) with three categories — two
+     * billable ("Dev" @ 6000, "Build" @ 8000) with distinct rates and one
+     * non-billable ("Internal" @ 0) — so tracked-time tests can hit distinct
+     * rates and the non-billable exclusion. Billability is a per-category flag.
+     * Returns [engagementIri, devCategoryIri, buildCategoryIri, internalCategoryIri].
      *
-     * @return array{0: string, 1: string, 2: string}
+     * @return array{0: string, 1: string, 2: string, 3: string}
      */
     private function createEngagement(
         \ApiPlatform\Symfony\Bundle\Test\Client $client,
@@ -537,6 +539,7 @@ class ClientInvoiceTest extends ApiTestCase
                 'categories' => [
                     ['name' => 'Dev', 'rateAmount' => 6000, 'position' => 0],
                     ['name' => 'Build', 'rateAmount' => 8000, 'position' => 1],
+                    ['name' => 'Internal', 'rateAmount' => 0, 'position' => 2, 'billable' => false],
                 ],
             ],
             'headers' => ['Content-Type' => 'application/ld+json'],
@@ -557,8 +560,9 @@ class ClientInvoiceTest extends ApiTestCase
         }
         $this->assertArrayHasKey('Dev', $byName);
         $this->assertArrayHasKey('Build', $byName);
+        $this->assertArrayHasKey('Internal', $byName);
 
-        return [$bpIri, $byName['Dev'], $byName['Build']];
+        return [$bpIri, $byName['Dev'], $byName['Build'], $byName['Internal']];
     }
 
     /**

--- a/api/tests/Api/EngagementTest.php
+++ b/api/tests/Api/EngagementTest.php
@@ -6,10 +6,12 @@ use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use App\Entity\Engagement;
 use App\Entity\Client;
 use App\Entity\Board;
+use App\Entity\MediaObject;
 use App\Entity\Space;
 use App\Entity\SpaceMembership;
 use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
+use League\Flysystem\FilesystemOperator;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 /**
@@ -19,17 +21,21 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 class EngagementTest extends ApiTestCase
 {
     private EntityManagerInterface $entityManager;
+    private FilesystemOperator $storage;
 
     protected function setUp(): void
     {
         self::bootKernel();
-        $em = static::getContainer()->get('doctrine')->getManager();
+        $container = static::getContainer();
+        $em = $container->get('doctrine')->getManager();
         assert($em instanceof EntityManagerInterface);
         $this->entityManager = $em;
+        $this->storage = $container->get('media.storage');
 
         $this->entityManager->createQuery('DELETE FROM App\Entity\TimeEntry')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\EngagementCategory')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Engagement')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\MediaObject')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Client')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Board')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\SpaceMembership')->execute();
@@ -120,6 +126,107 @@ class EngagementTest extends ApiTestCase
         $reloaded = $this->entityManager->getRepository(Board::class)->find($taskProject->getId());
         $this->assertInstanceOf(Board::class, $reloaded);
         $this->assertSame((string) $engagement->getId(), (string) $reloaded->getEngagement()?->getId());
+    }
+
+    public function testDescriptionAndContractAttachmentRoundTrip(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $space = $this->createSharedSpace($admin);
+        $spaceIri = '/spaces/' . $space->getId();
+        $media = $this->createMediaObject($admin);
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+
+        $engagement = $client->request('POST', '/engagements', [
+            'json' => ['space' => $spaceIri, 'client' => $clientRow['@id'], 'name' => 'Retainer'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $engagementIri = $engagement['@id'] ?? null;
+        $this->assertIsString($engagementIri);
+
+        $client->request('PATCH', $engagementIri, [
+            'json' => [
+                'description' => "## Scope\n\n- Weekly retainer\n- Net-30 terms",
+                'attachments' => ['/media-objects/' . $media->getId()],
+            ],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains([
+            'description' => "## Scope\n\n- Weekly retainer\n- Net-30 terms",
+            'attachments' => [
+                [
+                    '@type' => 'MediaObject',
+                    'kind' => 'attachment',
+                    'downloadUrl' => '/media-objects/' . $media->getId() . '/download',
+                ],
+            ],
+        ]);
+    }
+
+    public function testContractDownloadGatedToInvoiceReaders(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $coAdmin = $this->createUser('coadmin@example.com');
+        $member = $this->createUser('member@example.com');
+        $space = $this->createSharedSpace($admin, $member);
+        $this->addAdmin($space, $coAdmin);
+
+        // Contract file uploaded + attached by the first admin.
+        $media = $this->createMediaObject($admin);
+        $client = (new Client())->setSpace($space)->setName('Acme')->setCreatedBy($admin);
+        $this->entityManager->persist($client);
+        $engagement = (new Engagement())
+            ->setSpace($space)->setClient($client)->setName('Retainer')->setCreatedBy($admin);
+        $engagement->addAttachment($media);
+        $this->entityManager->persist($engagement);
+        $this->entityManager->flush();
+
+        $downloadUrl = '/media-objects/' . $media->getId() . '/download';
+        $httpClient = static::createClient();
+
+        // A second space admin (not the uploader) can download it.
+        $httpClient->loginUser($coAdmin);
+        $httpClient->request('GET', $downloadUrl);
+        $this->assertResponseIsSuccessful();
+
+        // A plain member (no invoices grant) cannot — 404, not 403, to avoid leaking existence.
+        $httpClient->loginUser($member);
+        $httpClient->request('GET', $downloadUrl);
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    private function createMediaObject(User $owner, string $kind = MediaObject::KIND_ATTACHMENT): MediaObject
+    {
+        $bytes = 'CONTRACT-PDF';
+        $path = 'attachments/engagement-test-' . bin2hex(random_bytes(4)) . '-contract.pdf';
+        $this->storage->write($path, $bytes);
+
+        $media = (new MediaObject())
+            ->setOwner($owner)
+            ->setKind($kind)
+            ->setVariants(['original' => $path])
+            ->setOriginalName('contract.pdf')
+            ->setMimeType('application/pdf')
+            ->setByteSize(\strlen($bytes));
+        $this->entityManager->persist($media);
+        $this->entityManager->flush();
+
+        return $media;
+    }
+
+    private function addAdmin(Space $space, User $user): void
+    {
+        $membership = (new SpaceMembership())->setUser($user)->setRole(Space::ROLE_ADMIN);
+        $space->addUserMembership($membership);
+        $this->entityManager->persist($membership);
+        $this->entityManager->flush();
     }
 
     private function createSharedSpace(User $admin, ?User $member = null): Space

--- a/api/tests/Api/TimeEntryTest.php
+++ b/api/tests/Api/TimeEntryTest.php
@@ -59,7 +59,6 @@ class TimeEntryTest extends ApiTestCase
                 'description' => 'Wiring the timer',
                 'startedAt' => '2026-07-03T09:00:00+00:00',
                 'endedAt' => '2026-07-03T10:30:00+00:00',
-                'billable' => true,
             ],
             'headers' => ['Content-Type' => 'application/ld+json'],
         ])->toArray();

--- a/pwa/components/common/PageHeader.tsx
+++ b/pwa/components/common/PageHeader.tsx
@@ -4,10 +4,9 @@ import { cn } from "@/lib/utils";
 /**
  * Shared page header for top-level routes. Standardises the visual
  * rhythm at the top of every page: an optional leading icon, the title,
- * an optional count badge, an optional subtitle, an optional right-side
- * action cluster (e.g. a "New X" button), an optional toolbar row
- * (search bar / filters) below, a divider, and a comfortable gap before
- * the page body.
+ * an optional subtitle, an optional right-side action cluster (e.g. a
+ * "New X" button), an optional toolbar row (search bar / filters) below,
+ * a divider, and a comfortable gap before the page body.
  *
  * Use it instead of hand-rolling `<h1 className="…">` blocks so the
  * spacing stays consistent — when we tweak the rhythm here, every
@@ -18,7 +17,6 @@ import { cn } from "@/lib/utils";
  *     title="Tags"
  *     subtitle="Shared across everyone in the space."
  *     icon={<TagIcon className="h-6 w-6 text-cyan-600" />}
- *     count={tags.length}
  *     actions={<Button>Add tag</Button>}
  *   >
  *     <SearchInput … />
@@ -30,8 +28,6 @@ interface Props {
   /** Icon rendered immediately left of the title. Size it yourself
    *  (e.g. `className="h-6 w-6"`). */
   icon?: ReactNode;
-  /** Count badge rendered right of the title (skipped when null/undefined). */
-  count?: number | null;
   /** Right-aligned action cluster. Buttons baseline-align with the
    *  bottom of the subtitle. */
   actions?: ReactNode;
@@ -47,7 +43,6 @@ const PageHeader = ({
   title,
   subtitle,
   icon,
-  count,
   actions,
   children,
   className,
@@ -59,14 +54,6 @@ const PageHeader = ({
           <div className="flex items-center gap-2">
             {icon}
             <h1 className="text-3xl font-bold tracking-tight">{title}</h1>
-            {count !== null && count !== undefined && (
-              <span
-                className="rounded-full bg-muted-foreground/15 px-2 py-0.5 text-xs font-medium text-muted-foreground"
-                data-testid="page-header-count"
-              >
-                {count}
-              </span>
-            )}
           </div>
           {subtitle && (
             <p className="mt-2 text-sm text-muted-foreground">{subtitle}</p>

--- a/pwa/components/discussions/DiscussionsPanel.tsx
+++ b/pwa/components/discussions/DiscussionsPanel.tsx
@@ -356,7 +356,6 @@ const DiscussionsPanel = ({
           title={title}
           icon={icon}
           subtitle={description}
-          count={discussions.length}
           actions={newButton}
         >
           {searchBox}

--- a/pwa/pages/boards/index.tsx
+++ b/pwa/pages/boards/index.tsx
@@ -202,7 +202,6 @@ const Boards = () => {
             icon={
               <BoardsIcon className={cn("h-6 w-6 shrink-0", boardsMeta.iconClass)} />
             }
-            count={boardsQuery.isLoading ? null : boards.length}
             actions={
               can("boards", "create") ? (
                 <Button

--- a/pwa/pages/clients/index.tsx
+++ b/pwa/pages/clients/index.tsx
@@ -2,7 +2,7 @@ import Head from "next/head";
 import { useRouter } from "next/router";
 import { FormEvent, useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Users } from "lucide-react";
+import { Plus, Users } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
 import { apiGetCollection, apiSend } from "@/lib/apiClient";
@@ -12,10 +12,12 @@ import { CURRENCIES } from "@/lib/currencies";
 import PageHeader from "@/components/common/PageHeader";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
+import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+
+const SELECT_CLASS = "h-9 w-full rounded-md border border-input bg-background px-3 text-sm";
 
 const ClientsPage = () => {
   const { isAuthenticated, isLoading: authLoading } = useAuth();
@@ -104,91 +106,7 @@ const ClientsPage = () => {
           <PageHeader
             title="Clients"
             icon={<Users className="size-6 text-blue-600 dark:text-blue-400" />}
-            count={clientsQuery.isLoading ? undefined : clients.length}
-            actions={
-              canCreate ? (
-                <Button variant="outline" size="sm" onClick={() => setShowComposer((v) => !v)}>
-                  {showComposer ? "Cancel" : "New client"}
-                </Button>
-              ) : undefined
-            }
           />
-
-          {showComposer && (
-            <Card className="mb-6">
-              <CardContent className="py-6">
-                <form onSubmit={handleCreate} className="space-y-4">
-                  <div className="space-y-1.5">
-                    <Label htmlFor="cl-name">Name</Label>
-                    <Input
-                      id="cl-name"
-                      value={name}
-                      onChange={(e) => setName(e.target.value)}
-                      required
-                      maxLength={200}
-                      autoFocus
-                    />
-                  </div>
-                  <div className="grid gap-4 sm:grid-cols-2">
-                    <div className="space-y-1.5">
-                      <Label htmlFor="cl-email">
-                        Email <span className="font-normal text-muted-foreground">(optional)</span>
-                      </Label>
-                      <Input
-                        id="cl-email"
-                        type="email"
-                        value={email}
-                        onChange={(e) => setEmail(e.target.value)}
-                      />
-                    </div>
-                    <div className="grid grid-cols-2 gap-4">
-                      <div className="space-y-1.5">
-                        <Label htmlFor="cl-currency">Currency</Label>
-                        <select
-                          id="cl-currency"
-                          value={currency}
-                          onChange={(e) => setCurrency(e.target.value)}
-                          className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
-                        >
-                          {CURRENCIES.map((c) => (
-                            <option key={c.code} value={c.code}>
-                              {c.code}
-                            </option>
-                          ))}
-                        </select>
-                      </div>
-                      <div className="space-y-1.5">
-                        <Label htmlFor="cl-rate">Rate / hr</Label>
-                        <Input
-                          id="cl-rate"
-                          type="number"
-                          step="0.01"
-                          min="0"
-                          value={defaultRate}
-                          onChange={(e) => setDefaultRate(e.target.value)}
-                          placeholder="0.00"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <div className="space-y-1.5">
-                    <Label htmlFor="cl-address">
-                      Address <span className="font-normal text-muted-foreground">(optional)</span>
-                    </Label>
-                    <Textarea
-                      id="cl-address"
-                      value={address}
-                      onChange={(e) => setAddress(e.target.value)}
-                      rows={2}
-                    />
-                  </div>
-                  <Button type="submit" disabled={createMutation.isPending || !name.trim()}>
-                    {createMutation.isPending ? "Saving…" : "Create client"}
-                  </Button>
-                </form>
-              </CardContent>
-            </Card>
-          )}
 
           {error && (
             <Alert variant="destructive" className="mb-4">
@@ -198,31 +116,149 @@ const ClientsPage = () => {
 
           {clientsQuery.isLoading ? (
             <p className="text-muted-foreground">Loading…</p>
-          ) : clients.length === 0 ? (
-            <Card>
-              <CardContent className="py-10 text-center text-muted-foreground">
-                No clients yet. Add one to start invoicing.
-              </CardContent>
-            </Card>
           ) : (
-            <ul className="divide-y rounded-md border">
-              {clients.map((client) => (
-                <li key={client["@id"]} className="flex items-center justify-between gap-4 px-4 py-3">
-                  <div className="min-w-0">
-                    <p className="truncate font-medium">{client.name}</p>
-                    {client.email && (
-                      <p className="truncate text-xs text-muted-foreground">{client.email}</p>
+            <Card>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+                      <th className="px-4 py-2 font-medium">Name</th>
+                      <th className="px-4 py-2 font-medium">Email</th>
+                      <th className="px-4 py-2 font-medium">Currency</th>
+                      <th className="px-4 py-2 text-right font-medium">Rate / hr</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {/* Inline "Add client" row, pinned to the top. */}
+                    {canCreate &&
+                      (showComposer ? (
+                        <tr className="border-b bg-muted/10">
+                          <td colSpan={4} className="px-4 py-4">
+                            <form onSubmit={handleCreate} className="space-y-4">
+                              <div className="space-y-1.5">
+                                <Label htmlFor="cl-name">Name</Label>
+                                <Input
+                                  id="cl-name"
+                                  value={name}
+                                  onChange={(e) => setName(e.target.value)}
+                                  required
+                                  maxLength={200}
+                                  autoFocus
+                                />
+                              </div>
+                              <div className="grid gap-4 sm:grid-cols-2">
+                                <div className="space-y-1.5">
+                                  <Label htmlFor="cl-email">
+                                    Email{" "}
+                                    <span className="font-normal text-muted-foreground">(optional)</span>
+                                  </Label>
+                                  <Input
+                                    id="cl-email"
+                                    type="email"
+                                    value={email}
+                                    onChange={(e) => setEmail(e.target.value)}
+                                  />
+                                </div>
+                                <div className="grid grid-cols-2 gap-4">
+                                  <div className="space-y-1.5">
+                                    <Label htmlFor="cl-currency">Currency</Label>
+                                    <select
+                                      id="cl-currency"
+                                      value={currency}
+                                      onChange={(e) => setCurrency(e.target.value)}
+                                      className={SELECT_CLASS}
+                                    >
+                                      {CURRENCIES.map((c) => (
+                                        <option key={c.code} value={c.code}>
+                                          {c.code}
+                                        </option>
+                                      ))}
+                                    </select>
+                                  </div>
+                                  <div className="space-y-1.5">
+                                    <Label htmlFor="cl-rate">Rate / hr</Label>
+                                    <Input
+                                      id="cl-rate"
+                                      type="number"
+                                      step="0.01"
+                                      min="0"
+                                      value={defaultRate}
+                                      onChange={(e) => setDefaultRate(e.target.value)}
+                                      placeholder="0.00"
+                                    />
+                                  </div>
+                                </div>
+                              </div>
+                              <div className="space-y-1.5">
+                                <Label htmlFor="cl-address">
+                                  Address{" "}
+                                  <span className="font-normal text-muted-foreground">(optional)</span>
+                                </Label>
+                                <Textarea
+                                  id="cl-address"
+                                  value={address}
+                                  onChange={(e) => setAddress(e.target.value)}
+                                  rows={2}
+                                />
+                              </div>
+                              <div className="flex items-center justify-end gap-2">
+                                <Button
+                                  type="button"
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => setShowComposer(false)}
+                                >
+                                  Cancel
+                                </Button>
+                                <Button
+                                  type="submit"
+                                  size="sm"
+                                  disabled={createMutation.isPending || !name.trim()}
+                                >
+                                  {createMutation.isPending ? "Saving…" : "Create client"}
+                                </Button>
+                              </div>
+                            </form>
+                          </td>
+                        </tr>
+                      ) : (
+                        <tr className="border-b">
+                          <td colSpan={4} className="px-4 py-2">
+                            <button
+                              type="button"
+                              onClick={() => setShowComposer(true)}
+                              className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+                            >
+                              <Plus className="h-4 w-4" /> Add client
+                            </button>
+                          </td>
+                        </tr>
+                      ))}
+
+                    {clients.length === 0 ? (
+                      <tr>
+                        <td colSpan={4} className="px-4 py-10 text-center text-muted-foreground">
+                          No clients yet. Use “Add client” to start invoicing.
+                        </td>
+                      </tr>
+                    ) : (
+                      clients.map((client) => (
+                        <tr key={client["@id"]} className="border-b align-middle last:border-0">
+                          <td className="px-4 py-3 font-medium">{client.name}</td>
+                          <td className="px-4 py-3 text-muted-foreground">{client.email || "—"}</td>
+                          <td className="px-4 py-3 text-muted-foreground">{client.currency ?? "—"}</td>
+                          <td className="px-4 py-3 text-right tabular-nums text-muted-foreground">
+                            {client.defaultRateAmount != null && client.currency
+                              ? formatMoney(client.defaultRateAmount, client.currency)
+                              : "—"}
+                          </td>
+                        </tr>
+                      ))
                     )}
-                  </div>
-                  <div className="shrink-0 text-right text-sm text-muted-foreground">
-                    {client.currency ?? "—"}
-                    {client.defaultRateAmount != null && client.currency && (
-                      <span> · {formatMoney(client.defaultRateAmount, client.currency)}/hr</span>
-                    )}
-                  </div>
-                </li>
-              ))}
-            </ul>
+                  </tbody>
+                </table>
+              </div>
+            </Card>
           )}
         </div>
       </div>

--- a/pwa/pages/dev/components/page-header.tsx
+++ b/pwa/pages/dev/components/page-header.tsx
@@ -56,13 +56,12 @@ const PageHeaderPage = () => (
         ),
       },
       {
-        title: "Icon, count, action + search toolbar",
+        title: "Icon, action + search toolbar",
         description:
-          "Pass `icon` for a leading glyph, `count` for the badge next to the title, `actions` for the top-right button, and `children` for a full-width toolbar (search / filters) below the title row.",
+          "Pass `icon` for a leading glyph, `actions` for the top-right button, and `children` for a full-width toolbar (search / filters) below the title row.",
         code: `<PageHeader
   title="Tags"
   icon={<TagIcon className="h-6 w-6 text-cyan-600" />}
-  count={12}
   subtitle="Shared across everyone in the space."
   actions={<Button size="sm">Add tag</Button>}
 >
@@ -72,7 +71,6 @@ const PageHeaderPage = () => (
           <PageHeader
             title="Tags"
             icon={<TagIcon className="h-6 w-6 text-cyan-600" />}
-            count={12}
             subtitle="Shared across everyone in the space."
             actions={<Button size="sm">Add tag</Button>}
           >

--- a/pwa/pages/engagements/index.tsx
+++ b/pwa/pages/engagements/index.tsx
@@ -1,27 +1,33 @@
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Briefcase, Plus, Trash2, X } from "lucide-react";
+import { Briefcase, Paperclip, Plus, Trash2, X } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
-import { apiGetCollection, apiSend, ApiError } from "@/lib/apiClient";
+import { apiGet, apiGetCollection, apiSend, ApiError } from "@/lib/apiClient";
 import { signinHrefForCurrent } from "@/lib/authRedirect";
 import PageHeader from "@/components/common/PageHeader";
+import MarkdownEditor from "@/components/editor/MarkdownEditor";
+import AttachmentsPanel, { type Attachment } from "@/components/tasks/AttachmentsPanel";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+  Sheet,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
 
 const SELECT_CLASS =
   "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
+
+const COL_COUNT = 4;
 
 interface ClientRow {
   "@id": string;
@@ -39,15 +45,18 @@ interface CategoryRow {
   name: string;
   rateAmount: number;
   position: number;
+  billable: boolean;
 }
 interface Engagement {
   "@id": string;
   id: string;
   name: string;
   currency: string | null;
+  description: string | null;
   archived: boolean;
   client: string;
   categories: CategoryRow[];
+  attachments: Attachment[];
   assignedProjectList: { id: string; title: string }[];
 }
 
@@ -55,12 +64,15 @@ interface Engagement {
 interface DraftCategory {
   name: string;
   rate: string;
+  billable: boolean;
 }
 
 const toMinor = (rate: string): number => Math.round((parseFloat(rate) || 0) * 100);
 const toMajor = (minor: number): string => (minor / 100).toFixed(2);
 const money = (minor: number, currency: string | null): string =>
   new Intl.NumberFormat(undefined, { style: "currency", currency: currency || "USD" }).format(minor / 100);
+
+const NEW = "new";
 
 const EngagementsPage = () => {
   const { isAuthenticated, isLoading: authLoading } = useAuth();
@@ -74,14 +86,16 @@ const EngagementsPage = () => {
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
 
-  // Editor dialog state (create + edit share it).
-  const [open, setOpen] = useState(false);
-  const [editing, setEditing] = useState<Engagement | null>(null);
+  // Which engagement the side panel is showing: null (closed) | NEW (create) |
+  // an engagement IRI (view/edit that one).
+  const [sheetFor, setSheetFor] = useState<string | null>(null);
   const [name, setName] = useState("");
   const [clientIri, setClientIri] = useState("");
   const [currency, setCurrency] = useState("USD");
-  const [cats, setCats] = useState<DraftCategory[]>([{ name: "", rate: "" }]);
+  const [description, setDescription] = useState("");
+  const [cats, setCats] = useState<DraftCategory[]>([{ name: "", rate: "", billable: true }]);
   const [assigned, setAssigned] = useState<string[]>([]);
+  const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [saving, setSaving] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
 
@@ -120,31 +134,40 @@ const EngagementsPage = () => {
     if (isAuthenticated && spaceIri) void load();
   }, [isAuthenticated, spaceIri, load]);
 
+  const editing = useMemo(
+    () => (sheetFor && sheetFor !== NEW ? projects.find((p) => p["@id"] === sheetFor) ?? null : null),
+    [sheetFor, projects],
+  );
+
   const openCreate = () => {
-    setEditing(null);
     setName("");
     setClientIri(clients[0]?.["@id"] ?? "");
     setCurrency(clients[0]?.currency ?? "USD");
-    setCats([{ name: "", rate: "" }]);
+    setDescription("");
+    setCats([{ name: "", rate: "", billable: true }]);
     setAssigned([]);
+    setAttachments([]);
     setFormError(null);
-    setOpen(true);
+    setSheetFor(NEW);
   };
 
   const openEdit = (bp: Engagement) => {
-    setEditing(bp);
     setName(bp.name);
     setClientIri(bp.client);
     setCurrency(bp.currency ?? "USD");
+    setDescription(bp.description ?? "");
     setCats(
       bp.categories.length > 0
-        ? bp.categories.map((c) => ({ name: c.name, rate: toMajor(c.rateAmount) }))
-        : [{ name: "", rate: "" }],
+        ? bp.categories.map((c) => ({ name: c.name, rate: toMajor(c.rateAmount), billable: c.billable }))
+        : [{ name: "", rate: "", billable: true }],
     );
     setAssigned(bp.assignedProjectList.map((p) => `/boards/${p.id}`));
+    setAttachments(bp.attachments ?? []);
     setFormError(null);
-    setOpen(true);
+    setSheetFor(bp["@id"]);
   };
+
+  const closeSheet = () => setSheetFor(null);
 
   const save = async () => {
     if (!name.trim()) {
@@ -159,20 +182,34 @@ const EngagementsPage = () => {
     setFormError(null);
     const categories = cats
       .filter((c) => c.name.trim())
-      .map((c, i) => ({ name: c.name.trim(), rateAmount: toMinor(c.rate), position: i }));
+      .map((c, i) => ({
+        name: c.name.trim(),
+        rateAmount: toMinor(c.rate),
+        position: i,
+        billable: c.billable,
+      }));
+    const attachmentIris = attachments.map((a) => a["@id"]);
+    const editingIri = sheetFor && sheetFor !== NEW ? sheetFor : null;
     try {
-      const payload = { space: spaceIri, client: clientIri, name: name.trim(), currency, categories };
-      const saved = editing
-        ? await apiSend<Engagement>("PATCH", editing["@id"], {
-            body: { name: name.trim(), client: clientIri, currency, categories },
+      const shared = {
+        client: clientIri,
+        name: name.trim(),
+        currency,
+        description: description.trim() || null,
+        categories,
+        attachments: attachmentIris,
+      };
+      const saved = editingIri
+        ? await apiSend<Engagement>("PATCH", editingIri, {
+            body: shared,
             contentType: "application/merge-patch+json",
           })
-        : await apiSend<Engagement>("POST", "/engagements", { body: payload });
-      const bpIri = saved?.["@id"] ?? editing?.["@id"];
+        : await apiSend<Engagement>("POST", "/engagements", { body: { space: spaceIri, ...shared } });
+      const bpIri = saved?.["@id"] ?? editingIri;
       if (bpIri) {
         await apiSend("PUT", `${bpIri}/boards`, { body: { boards: assigned } });
       }
-      setOpen(false);
+      closeSheet();
       await load();
     } catch (e) {
       setFormError(e instanceof ApiError ? e.message : "Could not save.");
@@ -196,10 +233,21 @@ const EngagementsPage = () => {
   const remove = async (bp: Engagement) => {
     try {
       await apiSend("DELETE", bp["@id"]);
+      closeSheet();
       await load();
     } catch {
       /* surfaced on next load */
     }
+  };
+
+  // Hydrate a freshly-uploaded MediaObject into the buffered attachment list so
+  // the panel can render it; the link is persisted on Save.
+  const onAttach = async (iri: string) => {
+    const att = await apiGet<Attachment>(iri, { errorMessage: "Failed to load the upload." });
+    setAttachments((prev) => [...prev, att]);
+  };
+  const onDetach = async (att: Attachment) => {
+    setAttachments((prev) => prev.filter((a) => a["@id"] !== att["@id"]));
   };
 
   const clientName = useMemo(() => {
@@ -221,23 +269,11 @@ const EngagementsPage = () => {
       <Head>
         <title>Engagements — Madori</title>
       </Head>
-      <main className="px-6 py-8 max-w-4xl mx-auto">
+      <main className="mx-auto max-w-4xl px-6 py-8">
         <PageHeader
           title="Engagements"
           icon={<Briefcase className="h-6 w-6 text-orange-600 dark:text-orange-400" />}
-          subtitle="A engagement has a client and a set of categories, each with an hourly rate. Time is tracked against a project + category."
-          count={projects.length}
-          actions={
-            <Button
-              size="sm"
-              className="gap-1.5 bg-emerald-600 hover:bg-emerald-500 text-white"
-              onClick={openCreate}
-              disabled={clients.length === 0}
-            >
-              <Plus className="h-3.5 w-3.5" />
-              New engagement
-            </Button>
-          }
+          subtitle="A engagement has a client and a set of categories, each with an hourly rate. Time is tracked against an engagement + category."
         />
 
         {loadError && (
@@ -247,74 +283,117 @@ const EngagementsPage = () => {
         )}
         {!loadError && clients.length === 0 && !loading && (
           <Alert className="mb-4">
-            <AlertDescription>
-              Add a client first — engagements bill to a client.
-            </AlertDescription>
+            <AlertDescription>Add a client first — engagements bill to a client.</AlertDescription>
           </Alert>
         )}
 
         {loading ? (
           <p className="text-muted-foreground">Loading…</p>
-        ) : projects.length === 0 ? (
-          <div className="rounded-lg border border-dashed p-10 text-center text-sm text-muted-foreground">
-            No engagements yet.
-          </div>
         ) : (
-          <ul className="space-y-3">
-            {projects.map((bp) => (
-              <li key={bp["@id"]} className="rounded-lg border p-4">
-                <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <div className="flex items-center gap-2">
-                      <p className="font-semibold">{bp.name}</p>
-                      {bp.archived && <Badge variant="secondary">Archived</Badge>}
-                    </div>
-                    <p className="text-xs text-muted-foreground">
-                      {clientName.get(bp.client) ?? "Client"} ·{" "}
-                      {bp.categories.length} categor{bp.categories.length === 1 ? "y" : "ies"}
-                      {bp.assignedProjectList.length > 0 &&
-                        ` · ${bp.assignedProjectList.length} project${bp.assignedProjectList.length === 1 ? "" : "s"}`}
-                    </p>
-                    {bp.categories.length > 0 && (
-                      <div className="mt-2 flex flex-wrap gap-1.5">
-                        {bp.categories.map((c) => (
-                          <Badge key={c.name} variant="outline" className="font-normal">
-                            {c.name} · {money(c.rateAmount, bp.currency)}
-                          </Badge>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                  <div className="flex shrink-0 items-center gap-1.5">
-                    <Button variant="outline" size="sm" onClick={() => openEdit(bp)}>
-                      Edit
-                    </Button>
-                    <Button variant="ghost" size="sm" onClick={() => void toggleArchive(bp)}>
-                      {bp.archived ? "Unarchive" : "Archive"}
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="text-muted-foreground hover:text-destructive"
-                      onClick={() => void remove(bp)}
-                      aria-label="Delete engagement"
-                    >
-                      <Trash2 className="h-3.5 w-3.5" />
-                    </Button>
-                  </div>
-                </div>
-              </li>
-            ))}
-          </ul>
+          <Card>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+                    <th className="px-4 py-2 font-medium">Name</th>
+                    <th className="px-4 py-2 font-medium">Client</th>
+                    <th className="px-4 py-2 font-medium">Categories</th>
+                    <th className="px-4 py-2 font-medium">Files</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {/* Inline "Add engagement" row, pinned to the top. */}
+                  <tr className="border-b">
+                    <td colSpan={COL_COUNT} className="px-4 py-2">
+                      <button
+                        type="button"
+                        onClick={openCreate}
+                        disabled={clients.length === 0}
+                        className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground disabled:opacity-50"
+                      >
+                        <Plus className="h-4 w-4" /> Add engagement
+                      </button>
+                    </td>
+                  </tr>
+
+                  {projects.length === 0 ? (
+                    <tr>
+                      <td colSpan={COL_COUNT} className="px-4 py-10 text-center text-muted-foreground">
+                        No engagements yet. Use “Add engagement” to create one.
+                      </td>
+                    </tr>
+                  ) : (
+                    projects.map((bp) => (
+                      <tr
+                        key={bp["@id"]}
+                        onClick={() => openEdit(bp)}
+                        className="cursor-pointer border-b align-middle last:border-0 hover:bg-accent/40"
+                      >
+                        <td className="px-4 py-3">
+                          <div className="flex items-center gap-2">
+                            <span className="font-medium">{bp.name}</span>
+                            {bp.archived && <Badge variant="secondary">Archived</Badge>}
+                          </div>
+                        </td>
+                        <td className="px-4 py-3 text-muted-foreground">
+                          {clientName.get(bp.client) ?? "Client"}
+                        </td>
+                        <td className="px-4 py-3">
+                          {bp.categories.length === 0 ? (
+                            <span className="text-muted-foreground">—</span>
+                          ) : (
+                            <div className="flex flex-wrap gap-1.5">
+                              {bp.categories.map((c) => (
+                                <Badge key={c.name} variant="outline" className="font-normal">
+                                  {c.name} · {money(c.rateAmount, bp.currency)}
+                                  {!c.billable && " · non-billable"}
+                                </Badge>
+                              ))}
+                            </div>
+                          )}
+                        </td>
+                        <td className="px-4 py-3 text-muted-foreground">
+                          {bp.attachments.length > 0 ? (
+                            <span className="inline-flex items-center gap-1">
+                              <Paperclip className="h-3.5 w-3.5" />
+                              {bp.attachments.length}
+                            </span>
+                          ) : (
+                            "—"
+                          )}
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </Card>
         )}
       </main>
 
-      <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="max-h-[90vh] overflow-y-auto">
-          <DialogHeader>
-            <DialogTitle>{editing ? "Edit engagement" : "New engagement"}</DialogTitle>
-          </DialogHeader>
-          <div className="space-y-4">
+      <Sheet open={sheetFor !== null} onOpenChange={(o) => !o && closeSheet()} modal={false}>
+        <SheetContent
+          side="right"
+          className="flex w-full flex-col gap-0 p-0 sm:max-w-lg"
+          onInteractOutside={(e) => {
+            const target = e.detail.originalEvent.target as HTMLElement | null;
+            if (
+              target?.closest(
+                '[data-slot="combobox-content"],[data-slot="popover-content"],[data-radix-popper-content-wrapper],.bn-container',
+              )
+            ) {
+              e.preventDefault();
+            }
+          }}
+        >
+          <SheetHeader className="border-b px-5 py-4">
+            <SheetTitle className="pr-9">
+              {sheetFor === NEW ? "New engagement" : name || "Engagement"}
+            </SheetTitle>
+          </SheetHeader>
+
+          <div className="flex-1 space-y-4 overflow-y-auto px-5 py-4">
             <div className="space-y-1.5">
               <Label htmlFor="bp-name">Name</Label>
               <Input id="bp-name" value={name} onChange={(e) => setName(e.target.value)} placeholder="Website redesign" />
@@ -350,8 +429,20 @@ const EngagementsPage = () => {
               </div>
             </div>
 
+            <div className="space-y-1.5">
+              <Label>
+                Description{" "}
+                <span className="font-normal text-muted-foreground">(optional, markdown)</span>
+              </Label>
+              <MarkdownEditor value={description} onChange={setDescription} ariaLabel="Engagement description" />
+            </div>
+
             <div className="space-y-2">
               <Label>Categories &amp; rates</Label>
+              <p className="text-xs text-muted-foreground">
+                Billability is set per category — time tracked on a non-billable category
+                is excluded from invoices.
+              </p>
               {cats.map((c, i) => (
                 <div key={i} className="flex items-center gap-2">
                   <Input
@@ -371,8 +462,18 @@ const EngagementsPage = () => {
                       setCats((prev) => prev.map((x, j) => (j === i ? { ...x, rate: e.target.value } : x)))
                     }
                     placeholder="Rate/hr"
-                    className="w-28"
+                    className="w-24"
                   />
+                  <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <Switch
+                      checked={c.billable}
+                      onCheckedChange={(v) =>
+                        setCats((prev) => prev.map((x, j) => (j === i ? { ...x, billable: v } : x)))
+                      }
+                      aria-label={`${c.name || "Category"} is billable`}
+                    />
+                    Billable
+                  </label>
                   <Button
                     type="button"
                     variant="ghost"
@@ -389,11 +490,22 @@ const EngagementsPage = () => {
                 variant="outline"
                 size="sm"
                 className="gap-1.5"
-                onClick={() => setCats((prev) => [...prev, { name: "", rate: "" }])}
+                onClick={() => setCats((prev) => [...prev, { name: "", rate: "", billable: true }])}
               >
                 <Plus className="h-3.5 w-3.5" />
                 Add category
               </Button>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Contract files</Label>
+              <AttachmentsPanel
+                taskTitle={name || "this engagement"}
+                attachments={attachments}
+                canDeleteAll
+                onAttach={onAttach}
+                onDetach={onDetach}
+              />
             </div>
 
             {taskBoards.length > 0 && (
@@ -423,16 +535,37 @@ const EngagementsPage = () => {
 
             {formError && <p className="text-sm text-destructive">{formError}</p>}
           </div>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setOpen(false)} disabled={saving}>
-              Cancel
-            </Button>
-            <Button onClick={() => void save()} disabled={saving}>
-              {saving ? "Saving…" : editing ? "Save changes" : "Create"}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+
+          <SheetFooter className="flex-row items-center justify-between border-t px-5 py-3">
+            <div className="flex items-center gap-1.5">
+              {editing && (
+                <>
+                  <Button variant="ghost" size="sm" onClick={() => void toggleArchive(editing)}>
+                    {editing.archived ? "Unarchive" : "Archive"}
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-muted-foreground hover:text-destructive"
+                    onClick={() => void remove(editing)}
+                    aria-label="Delete engagement"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </Button>
+                </>
+              )}
+            </div>
+            <div className="flex items-center gap-2">
+              <Button variant="ghost" size="sm" onClick={closeSheet} disabled={saving}>
+                Cancel
+              </Button>
+              <Button size="sm" onClick={() => void save()} disabled={saving}>
+                {saving ? "Saving…" : sheetFor === NEW ? "Create" : "Save changes"}
+              </Button>
+            </div>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
     </>
   );
 };

--- a/pwa/pages/invoices/index.tsx
+++ b/pwa/pages/invoices/index.tsx
@@ -3,22 +3,16 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { MoreHorizontal, Receipt } from "lucide-react";
+import { MoreHorizontal, Plus, Receipt } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
 import { apiGetCollection, apiSend } from "@/lib/apiClient";
 import { signinHrefForCurrent } from "@/lib/authRedirect";
-import {
-  Client,
-  Invoice,
-  STATUS_META,
-  clientName,
-  formatMoney,
-} from "@/lib/invoiceTypes";
+import { Invoice, STATUS_META, clientName, formatMoney } from "@/lib/invoiceTypes";
 import PageHeader from "@/components/common/PageHeader";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
+import { Card } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 import {
@@ -31,13 +25,20 @@ import {
 
 type InvoiceAction = "issue" | "send" | "mark-paid" | "void";
 
+/** Minimal engagement shape for the "generate from time" picker. */
+interface EngagementLite {
+  "@id": string;
+  name: string;
+}
+
 const InvoicesPage = () => {
   const { isAuthenticated, isLoading: authLoading } = useAuth();
   const { activeSpace, can } = useActiveSpace();
   const router = useRouter();
   const queryClient = useQueryClient();
 
-  const [genClient, setGenClient] = useState("");
+  const [showComposer, setShowComposer] = useState(false);
+  const [genEngagement, setGenEngagement] = useState("");
   const [notice, setNotice] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -58,17 +59,19 @@ const InvoicesPage = () => {
         { errorMessage: "Failed to load invoices." },
       ),
   });
-  const clientsQuery = useQuery({
-    queryKey: ["clients", spaceIri],
-    enabled: isAuthenticated,
+  // Invoices generate from an *engagement* (Harvest model): the engagement
+  // carries the client + currency and its unbilled time becomes line items.
+  const engagementsQuery = useQuery({
+    queryKey: ["engagements", spaceIri],
+    enabled: isAuthenticated && can("invoices", "create"),
     queryFn: () =>
-      apiGetCollection<Client>(
-        spaceIri ? `/clients?space=${encodeURIComponent(spaceIri)}` : "/clients",
-        { errorMessage: "Failed to load clients." },
+      apiGetCollection<EngagementLite>(
+        spaceIri ? `/engagements?space=${encodeURIComponent(spaceIri)}` : "/engagements",
+        { errorMessage: "Failed to load engagements." },
       ),
   });
   const invoices = invoicesQuery.data ?? [];
-  const clients = clientsQuery.data ?? [];
+  const engagements = engagementsQuery.data ?? [];
   const refresh = () => queryClient.invalidateQueries({ queryKey: ["invoices"] });
 
   const generate = useMutation({
@@ -76,12 +79,14 @@ const InvoicesPage = () => {
       apiSend<{ id: string; lineItemCount: number }>("POST", "/invoices/from-time-entries", {
         contentType: "application/json",
         errorMessage: "Failed to generate an invoice.",
-        body: { space: spaceIri, client: genClient },
+        body: { engagement: genEngagement },
       }),
     onSuccess: (res) => {
       setError(null);
-      setNotice(`Draft invoice created from ${res?.lineItemCount ?? 0} time entr${(res?.lineItemCount ?? 0) === 1 ? "y" : "ies"}.`);
-      setGenClient("");
+      const n = res?.lineItemCount ?? 0;
+      setNotice(`Draft invoice created from ${n} time entr${n === 1 ? "y" : "ies"}.`);
+      setGenEngagement("");
+      setShowComposer(false);
       void refresh();
     },
     onError: (e) => setError(e instanceof Error ? e.message : "Failed to generate an invoice."),
@@ -143,46 +148,7 @@ const InvoicesPage = () => {
           <PageHeader
             title="Invoices"
             icon={<Receipt className="size-6 text-blue-600 dark:text-blue-400" />}
-            count={invoicesQuery.isLoading ? undefined : invoices.length}
           />
-
-          {canManage && (
-            <Card className="mb-6">
-              <CardContent className="flex flex-wrap items-end gap-3 py-4">
-                <div className="space-y-1.5">
-                  <Label htmlFor="gen-client">Generate from tracked time</Label>
-                  <select
-                    id="gen-client"
-                    value={genClient}
-                    onChange={(e) => setGenClient(e.target.value)}
-                    className="h-9 w-64 max-w-full rounded-md border border-input bg-background px-3 text-sm"
-                  >
-                    <option value="">Select a client…</option>
-                    {clients.map((c) => (
-                      <option key={c["@id"]} value={c["@id"]}>
-                        {c.name}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-                <Button
-                  onClick={() => generate.mutate()}
-                  disabled={!genClient || generate.isPending}
-                >
-                  {generate.isPending ? "Generating…" : "Generate draft"}
-                </Button>
-                {clients.length === 0 && (
-                  <p className="text-sm text-muted-foreground">
-                    Add a{" "}
-                    <Link href="/clients" className="text-primary hover:underline">
-                      client
-                    </Link>{" "}
-                    first.
-                  </p>
-                )}
-              </CardContent>
-            </Card>
-          )}
 
           {notice && (
             <Alert className="mb-4">
@@ -197,84 +163,170 @@ const InvoicesPage = () => {
 
           {invoicesQuery.isLoading ? (
             <p className="text-muted-foreground">Loading…</p>
-          ) : invoices.length === 0 ? (
-            <Card>
-              <CardContent className="py-10 text-center text-muted-foreground">
-                No invoices yet. Generate one from tracked time above.
-              </CardContent>
-            </Card>
           ) : (
-            <ul className="divide-y rounded-md border">
-              {invoices.map((invoice) => {
-                const meta = STATUS_META[invoice.status];
-                return (
-                  <li key={invoice["@id"]} className="flex items-center justify-between gap-4 px-4 py-3">
-                    <Link href={`/invoices/${invoice.id}`} className="min-w-0 flex-1 hover:opacity-80">
-                      <p className="flex items-center gap-2 font-medium">
-                        {invoice.number ?? "Draft"}
-                        <span className={cn("rounded px-1.5 py-0.5 text-xs font-medium", meta.badgeClass)}>
-                          {meta.label}
-                        </span>
-                      </p>
-                      <p className="truncate text-xs text-muted-foreground">
-                        {clientName(invoice.client) || "—"}
-                      </p>
-                    </Link>
-                    <div className="flex shrink-0 items-center gap-3">
-                      <span className="font-medium tabular-nums">
-                        {formatMoney(invoice.total, invoice.currency)}
-                      </span>
-                      {canManage && (
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <Button variant="ghost" size="icon" aria-label="Invoice actions">
-                              <MoreHorizontal className="size-4" />
-                            </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="end">
-                            <DropdownMenuItem onClick={() => void openPdf(invoice)}>
-                              View PDF
-                            </DropdownMenuItem>
-                            {invoice.status === "draft" && (
-                              <DropdownMenuItem
-                                onClick={() => act.mutate({ invoice, action: "issue" })}
-                              >
-                                Issue
-                              </DropdownMenuItem>
-                            )}
-                            {invoice.status !== "void" && (
-                              <DropdownMenuItem
-                                onClick={() => act.mutate({ invoice, action: "send" })}
-                              >
-                                Send
-                              </DropdownMenuItem>
-                            )}
-                            {invoice.status !== "paid" && invoice.status !== "void" && (
-                              <DropdownMenuItem
-                                onClick={() => act.mutate({ invoice, action: "mark-paid" })}
-                              >
-                                Mark paid
-                              </DropdownMenuItem>
-                            )}
-                            {invoice.status !== "void" && (
-                              <>
-                                <DropdownMenuSeparator />
-                                <DropdownMenuItem
-                                  className="text-destructive"
-                                  onClick={() => act.mutate({ invoice, action: "void" })}
+            <Card>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+                      <th className="px-4 py-2 font-medium">Invoice</th>
+                      <th className="px-4 py-2 font-medium">Client</th>
+                      <th className="px-4 py-2 text-right font-medium">Total</th>
+                      <th className="px-4 py-2" />
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {/* Inline "Generate invoice" row, pinned to the top. */}
+                    {canManage &&
+                      (showComposer ? (
+                        <tr className="border-b bg-muted/10">
+                          <td colSpan={4} className="px-4 py-4">
+                            <div className="flex flex-wrap items-end gap-3">
+                              <div className="space-y-1.5">
+                                <Label htmlFor="gen-engagement">Generate from tracked time</Label>
+                                <select
+                                  id="gen-engagement"
+                                  value={genEngagement}
+                                  onChange={(e) => setGenEngagement(e.target.value)}
+                                  className="h-9 w-64 max-w-full rounded-md border border-input bg-background px-3 text-sm"
                                 >
-                                  Void
-                                </DropdownMenuItem>
-                              </>
-                            )}
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                      )}
-                    </div>
-                  </li>
-                );
-              })}
-            </ul>
+                                  <option value="">Select an engagement…</option>
+                                  {engagements.map((eng) => (
+                                    <option key={eng["@id"]} value={eng["@id"]}>
+                                      {eng.name}
+                                    </option>
+                                  ))}
+                                </select>
+                              </div>
+                              <Button
+                                size="sm"
+                                onClick={() => generate.mutate()}
+                                disabled={!genEngagement || generate.isPending}
+                              >
+                                {generate.isPending ? "Generating…" : "Generate draft"}
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => setShowComposer(false)}
+                              >
+                                Cancel
+                              </Button>
+                              {engagements.length === 0 && (
+                                <p className="text-sm text-muted-foreground">
+                                  Add an{" "}
+                                  <Link href="/engagements" className="text-primary hover:underline">
+                                    engagement
+                                  </Link>{" "}
+                                  first.
+                                </p>
+                              )}
+                            </div>
+                          </td>
+                        </tr>
+                      ) : (
+                        <tr className="border-b">
+                          <td colSpan={4} className="px-4 py-2">
+                            <button
+                              type="button"
+                              onClick={() => setShowComposer(true)}
+                              className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+                            >
+                              <Plus className="h-4 w-4" /> Generate invoice
+                            </button>
+                          </td>
+                        </tr>
+                      ))}
+
+                    {invoices.length === 0 ? (
+                      <tr>
+                        <td colSpan={4} className="px-4 py-10 text-center text-muted-foreground">
+                          No invoices yet. Use “Generate invoice” to bill tracked time.
+                        </td>
+                      </tr>
+                    ) : (
+                      invoices.map((invoice) => {
+                        const meta = STATUS_META[invoice.status];
+                        return (
+                          <tr key={invoice["@id"]} className="border-b align-middle last:border-0">
+                            <td className="px-4 py-3">
+                              <Link
+                                href={`/invoices/${invoice.id}`}
+                                className="flex items-center gap-2 font-medium hover:opacity-80"
+                              >
+                                {invoice.number ?? "Draft"}
+                                <span
+                                  className={cn(
+                                    "rounded px-1.5 py-0.5 text-xs font-medium",
+                                    meta.badgeClass,
+                                  )}
+                                >
+                                  {meta.label}
+                                </span>
+                              </Link>
+                            </td>
+                            <td className="px-4 py-3 text-muted-foreground">
+                              {clientName(invoice.client) || "—"}
+                            </td>
+                            <td className="px-4 py-3 text-right font-medium tabular-nums">
+                              {formatMoney(invoice.total, invoice.currency)}
+                            </td>
+                            <td className="px-4 py-3 text-right">
+                              {canManage && (
+                                <DropdownMenu>
+                                  <DropdownMenuTrigger asChild>
+                                    <Button variant="ghost" size="icon" aria-label="Invoice actions">
+                                      <MoreHorizontal className="size-4" />
+                                    </Button>
+                                  </DropdownMenuTrigger>
+                                  <DropdownMenuContent align="end">
+                                    <DropdownMenuItem onClick={() => void openPdf(invoice)}>
+                                      View PDF
+                                    </DropdownMenuItem>
+                                    {invoice.status === "draft" && (
+                                      <DropdownMenuItem
+                                        onClick={() => act.mutate({ invoice, action: "issue" })}
+                                      >
+                                        Issue
+                                      </DropdownMenuItem>
+                                    )}
+                                    {invoice.status !== "void" && (
+                                      <DropdownMenuItem
+                                        onClick={() => act.mutate({ invoice, action: "send" })}
+                                      >
+                                        Send
+                                      </DropdownMenuItem>
+                                    )}
+                                    {invoice.status !== "paid" && invoice.status !== "void" && (
+                                      <DropdownMenuItem
+                                        onClick={() => act.mutate({ invoice, action: "mark-paid" })}
+                                      >
+                                        Mark paid
+                                      </DropdownMenuItem>
+                                    )}
+                                    {invoice.status !== "void" && (
+                                      <>
+                                        <DropdownMenuSeparator />
+                                        <DropdownMenuItem
+                                          className="text-destructive"
+                                          onClick={() => act.mutate({ invoice, action: "void" })}
+                                        >
+                                          Void
+                                        </DropdownMenuItem>
+                                      </>
+                                    )}
+                                  </DropdownMenuContent>
+                                </DropdownMenu>
+                              )}
+                            </td>
+                          </tr>
+                        );
+                      })
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </Card>
           )}
         </div>
       </div>

--- a/pwa/pages/organizations/index.tsx
+++ b/pwa/pages/organizations/index.tsx
@@ -116,7 +116,6 @@ const OrganizationsIndex = () => {
           title="Organizations"
           icon={<Building2 className="h-6 w-6 text-cyan-600" />}
           subtitle="Team accounts that own shared spaces and a subscription. Members occupy seats; guests are free."
-          count={orgs.length}
           actions={
             <Button
               size="sm"

--- a/pwa/pages/pages/index.tsx
+++ b/pwa/pages/pages/index.tsx
@@ -139,7 +139,6 @@ const PagesIndex = () => {
           <PageHeader
             title="Pages"
             icon={<PagesIcon className={cn("h-6 w-6 shrink-0", pagesMeta.iconClass)} />}
-            count={isLoading ? null : pages.length}
             subtitle={
               activeSpace
                 ? `Long-form documents in ${activeSpace.name}.`

--- a/pwa/pages/time/index.tsx
+++ b/pwa/pages/time/index.tsx
@@ -1,9 +1,9 @@
 import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { FormEvent, useEffect, useMemo, useState } from "react";
+import { Fragment, FormEvent, useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Clock, Play, Square } from "lucide-react";
+import { Clock, Plus } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
 import { apiGet, apiGetCollection, apiSend } from "@/lib/apiClient";
@@ -12,20 +12,16 @@ import {
   EngagementOption,
   TimeEntry,
   elapsedSeconds,
-  formatClock,
   formatDuration,
-  isRunning,
 } from "@/lib/timeEntryTypes";
 import PageHeader from "@/components/common/PageHeader";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
+import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Switch } from "@/components/ui/switch";
-
-const MERGE_PATCH = "application/merge-patch+json";
+import { Textarea } from "@/components/ui/textarea";
 
 const SELECT_CLASS =
   "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50";
@@ -61,12 +57,10 @@ const TimePage = () => {
   const [description, setDescription] = useState("");
   const [workDate, setWorkDate] = useState(() => todayInput(new Date()));
   const [startTime, setStartTime] = useState(() => timeInput(new Date()));
-  const [endTime, setEndTime] = useState("");
-  const [billable, setBillable] = useState(true);
+  const [endTime, setEndTime] = useState(() => timeInput(new Date()));
   const [projectIri, setProjectIri] = useState("");
   const [categoryIri, setCategoryIri] = useState("");
   const [actionError, setActionError] = useState<string | null>(null);
-  const [nowTick, setNowTick] = useState(() => Date.now());
 
   useEffect(() => {
     if (!authLoading && !isAuthenticated) {
@@ -87,7 +81,6 @@ const TimePage = () => {
       ),
   });
   const entries = useMemo(() => entriesQuery.data ?? [], [entriesQuery.data]);
-  const running = entries.find(isRunning) ?? null;
   const refresh = () => queryClient.invalidateQueries({ queryKey: ["time_entries"] });
 
   // Engagements + categories the member may pick from.
@@ -109,6 +102,11 @@ const TimePage = () => {
     for (const p of projects) m.set(p["@id"], p.name);
     return m;
   }, [projects]);
+  const categoryName = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const p of projects) for (const c of p.categories) m.set(c["@id"], c.name);
+    return m;
+  }, [projects]);
 
   // Default the pickers once loaded / when the project changes.
   useEffect(() => {
@@ -120,40 +118,10 @@ const TimePage = () => {
     }
   }, [categories, categoryIri]);
 
-  useEffect(() => {
-    if (!running) return;
-    const t = setInterval(() => setNowTick(Date.now()), 1000);
-    return () => clearInterval(t);
-  }, [running]);
-
   const projectCategoryBody = () => ({
     engagement: projectIri,
     category: categoryIri,
     ...(spaceIri ? { space: spaceIri } : {}),
-  });
-
-  const startTimer = useMutation({
-    mutationFn: () =>
-      apiSend<TimeEntry>("POST", "/time_entries", {
-        errorMessage: "Failed to start the timer.",
-        body: { startedAt: new Date().toISOString(), billable: true, ...projectCategoryBody() },
-      }),
-    onSuccess: () => {
-      setActionError(null);
-      void refresh();
-    },
-    onError: (e) => setActionError(e instanceof Error ? e.message : "Failed to start the timer."),
-  });
-
-  const stopTimer = useMutation({
-    mutationFn: (entry: TimeEntry) =>
-      apiSend<TimeEntry>("PATCH", entry["@id"], {
-        contentType: MERGE_PATCH,
-        errorMessage: "Failed to stop the timer.",
-        body: { endedAt: new Date().toISOString() },
-      }),
-    onSuccess: () => void refresh(),
-    onError: (e) => setActionError(e instanceof Error ? e.message : "Failed to stop the timer."),
   });
 
   const logEntry = useMutation({
@@ -164,14 +132,13 @@ const TimePage = () => {
           description: description.trim() || null,
           startedAt: composeIso(workDate, startTime),
           endedAt: endTime ? composeIso(workDate, endTime) : null,
-          billable,
           ...projectCategoryBody(),
         },
       }),
     onSuccess: () => {
       setDescription("");
-      setEndTime("");
       setStartTime(timeInput(new Date()));
+      setEndTime(timeInput(new Date()));
       setWorkDate(todayInput(new Date()));
       setShowComposer(false);
       setActionError(null);
@@ -263,14 +230,6 @@ const TimePage = () => {
           <PageHeader
             title="Time"
             icon={<Clock className="size-6 text-orange-600 dark:text-orange-400" />}
-            count={entriesQuery.isLoading ? undefined : entries.length}
-            actions={
-              canCreate ? (
-                <Button variant="outline" size="sm" onClick={() => setShowComposer((v) => !v)}>
-                  {showComposer ? "Cancel" : "Log time"}
-                </Button>
-              ) : undefined
-            }
           />
 
           {canCreate && noProjects && (
@@ -285,114 +244,6 @@ const TimePage = () => {
             </Alert>
           )}
 
-          {canCreate && !noProjects && (
-            <Card className="mb-6">
-              <CardContent className="space-y-4 py-4">
-                {projectCategoryPickers}
-                <div className="flex items-center justify-between gap-4">
-                  {running ? (
-                    <>
-                      <div className="min-w-0">
-                        <p className="truncate text-sm font-medium">
-                          {running.description?.trim() || "Running timer"}
-                        </p>
-                        <p className="font-mono text-2xl tabular-nums">
-                          {formatClock(elapsedSeconds(running, nowTick))}
-                        </p>
-                      </div>
-                      <Button
-                        variant="destructive"
-                        onClick={() => stopTimer.mutate(running)}
-                        disabled={stopTimer.isPending}
-                      >
-                        <Square className="size-4" /> Stop
-                      </Button>
-                    </>
-                  ) : (
-                    <>
-                      <p className="text-sm text-muted-foreground">
-                        Start a timer, or log past time.
-                      </p>
-                      <Button
-                        onClick={() => startTimer.mutate()}
-                        disabled={startTimer.isPending || !canTrack}
-                      >
-                        <Play className="size-4" /> Start timer
-                      </Button>
-                    </>
-                  )}
-                </div>
-              </CardContent>
-            </Card>
-          )}
-
-          {showComposer && !noProjects && (
-            <Card className="mb-6">
-              <CardContent className="py-6">
-                <form onSubmit={handleLog} className="space-y-4">
-                  {projectCategoryPickers}
-                  <div className="space-y-1.5">
-                    <Label htmlFor="te-desc">
-                      Description{" "}
-                      <span className="font-normal text-muted-foreground">(optional)</span>
-                    </Label>
-                    <Input
-                      id="te-desc"
-                      value={description}
-                      onChange={(e) => setDescription(e.target.value)}
-                      maxLength={1000}
-                      placeholder="What did you work on?"
-                    />
-                  </div>
-                  <div className="grid gap-4 sm:grid-cols-3">
-                    <div className="space-y-1.5">
-                      <Label htmlFor="te-date">Date</Label>
-                      <Input
-                        id="te-date"
-                        type="date"
-                        value={workDate}
-                        onChange={(e) => setWorkDate(e.target.value)}
-                        required
-                      />
-                    </div>
-                    <div className="space-y-1.5">
-                      <Label htmlFor="te-start">Start</Label>
-                      <Input
-                        id="te-start"
-                        type="time"
-                        value={startTime}
-                        onChange={(e) => setStartTime(e.target.value)}
-                        required
-                      />
-                    </div>
-                    <div className="space-y-1.5">
-                      <Label htmlFor="te-end">
-                        End{" "}
-                        <span className="font-normal text-muted-foreground">(blank = running)</span>
-                      </Label>
-                      <Input
-                        id="te-end"
-                        type="time"
-                        value={endTime}
-                        onChange={(e) => setEndTime(e.target.value)}
-                      />
-                    </div>
-                  </div>
-                  <p className="text-xs text-muted-foreground">
-                    An entry can&apos;t span midnight — log separate entries per day.
-                  </p>
-                  <div className="flex items-center gap-2">
-                    <Switch id="te-billable" checked={billable} onCheckedChange={setBillable} />
-                    <Label htmlFor="te-billable">Billable</Label>
-                  </div>
-                  <Button type="submit" disabled={logEntry.isPending || !canTrack}>
-                    {logEntry.isPending ? "Logging…" : "Log time"}
-                  </Button>
-                </form>
-              </CardContent>
-            </Card>
-          )}
-
           {error && (
             <Alert variant="destructive" className="mb-4">
               <AlertDescription>{error}</AlertDescription>
@@ -401,53 +252,188 @@ const TimePage = () => {
 
           {entriesQuery.isLoading ? (
             <p className="text-muted-foreground">Loading…</p>
-          ) : entries.length === 0 ? (
-            <Card>
-              <CardContent className="py-10 text-center text-muted-foreground">
-                No time logged yet. Start a timer or log past time.
-              </CardContent>
-            </Card>
           ) : (
-            <div className="space-y-6">
-              {grouped.map(([day, dayEntries]) => (
-                <section key={day}>
-                  <h2 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                    {day}
-                  </h2>
-                  <ul className="divide-y rounded-md border">
-                    {dayEntries.map((entry) => (
-                      <li key={entry["@id"]} className="flex items-center justify-between gap-4 px-4 py-3">
-                        <div className="min-w-0">
-                          <p className="truncate text-sm">
-                            {entry.description?.trim() || (
-                              <span className="text-muted-foreground">No description</span>
-                            )}
-                          </p>
-                          <p className="text-xs text-muted-foreground">
-                            {new Date(entry.startedAt).toLocaleTimeString(undefined, {
+            <Card>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+                      <th className="px-4 py-2 font-medium">Description</th>
+                      <th className="px-4 py-2 font-medium">Engagement</th>
+                      <th className="px-4 py-2 font-medium">Category</th>
+                      <th className="px-4 py-2 font-medium">Time</th>
+                      <th className="px-4 py-2 font-medium">Billable</th>
+                      <th className="px-4 py-2 text-right font-medium">Duration</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {/* Inline "Add time" row, pinned to the top of the table. */}
+                    {canCreate && !noProjects &&
+                      (showComposer ? (
+                        <tr className="border-b bg-muted/10">
+                          <td colSpan={6} className="px-4 py-4">
+                            <form onSubmit={handleLog} className="space-y-4">
+                              {projectCategoryPickers}
+                              <div className="space-y-1.5">
+                                <Label htmlFor="te-desc">
+                                  Description{" "}
+                                  <span className="font-normal text-muted-foreground">
+                                    (optional)
+                                  </span>
+                                </Label>
+                                <Textarea
+                                  id="te-desc"
+                                  value={description}
+                                  onChange={(e) => setDescription(e.target.value)}
+                                  maxLength={1000}
+                                  rows={3}
+                                  placeholder="What did you work on?"
+                                />
+                              </div>
+                              <div className="grid gap-4 sm:grid-cols-3">
+                                <div className="space-y-1.5">
+                                  <Label htmlFor="te-date">Date</Label>
+                                  <Input
+                                    id="te-date"
+                                    type="date"
+                                    value={workDate}
+                                    onChange={(e) => setWorkDate(e.target.value)}
+                                    required
+                                  />
+                                </div>
+                                <div className="space-y-1.5">
+                                  <Label htmlFor="te-start">Start</Label>
+                                  <Input
+                                    id="te-start"
+                                    type="time"
+                                    value={startTime}
+                                    onChange={(e) => setStartTime(e.target.value)}
+                                    required
+                                  />
+                                </div>
+                                <div className="space-y-1.5">
+                                  <Label htmlFor="te-end">
+                                    End{" "}
+                                    <span className="font-normal text-muted-foreground">
+                                      (blank = running)
+                                    </span>
+                                  </Label>
+                                  <Input
+                                    id="te-end"
+                                    type="time"
+                                    value={endTime}
+                                    onChange={(e) => setEndTime(e.target.value)}
+                                  />
+                                </div>
+                              </div>
+                              <p className="text-xs text-muted-foreground">
+                                An entry can&apos;t span midnight — log separate entries per day.
+                              </p>
+                              <div className="flex items-center justify-end gap-2">
+                                <Button
+                                  type="button"
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => setShowComposer(false)}
+                                >
+                                  Cancel
+                                </Button>
+                                <Button
+                                  type="submit"
+                                  size="sm"
+                                  disabled={logEntry.isPending || !canTrack}
+                                >
+                                  {logEntry.isPending ? "Logging…" : "Log time"}
+                                </Button>
+                              </div>
+                            </form>
+                          </td>
+                        </tr>
+                      ) : (
+                        <tr className="border-b">
+                          <td colSpan={6} className="px-4 py-2">
+                            <button
+                              type="button"
+                              onClick={() => setShowComposer(true)}
+                              className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+                            >
+                              <Plus className="h-4 w-4" /> Add time
+                            </button>
+                          </td>
+                        </tr>
+                      ))}
+
+                    {entries.length === 0 ? (
+                      <tr>
+                        <td
+                          colSpan={6}
+                          className="px-4 py-10 text-center text-muted-foreground"
+                        >
+                          No time logged yet. Use “Add time” to log some.
+                        </td>
+                      </tr>
+                    ) : (
+                      grouped.map(([day, dayEntries]) => (
+                        <Fragment key={day}>
+                          <tr className="bg-muted/40">
+                            <td
+                              colSpan={6}
+                              className="px-4 py-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+                            >
+                              {day}
+                            </td>
+                          </tr>
+                          {dayEntries.map((entry) => {
+                            const startT = new Date(entry.startedAt).toLocaleTimeString(undefined, {
                               hour: "numeric",
                               minute: "2-digit",
-                            })}
-                            {entry.engagement && projectName.has(entry.engagement) && (
-                              <> · {projectName.get(entry.engagement)}</>
-                            )}
-                          </p>
-                        </div>
-                        <div className="flex shrink-0 items-center gap-2">
-                          {!entry.billable && <Badge variant="secondary">Non-billable</Badge>}
-                          {entry.billedAt && <Badge variant="secondary">Invoiced</Badge>}
-                          <span className="font-mono text-sm tabular-nums">
-                            {isRunning(entry)
-                              ? formatClock(elapsedSeconds(entry, nowTick))
-                              : formatDuration(entry.durationSeconds ?? 0)}
-                          </span>
-                        </div>
-                      </li>
-                    ))}
-                  </ul>
-                </section>
-              ))}
-            </div>
+                            });
+                            const endT = entry.endedAt
+                              ? new Date(entry.endedAt).toLocaleTimeString(undefined, {
+                                  hour: "numeric",
+                                  minute: "2-digit",
+                                })
+                              : null;
+                            return (
+                              <tr key={entry["@id"]} className="border-b last:border-0 align-middle">
+                                <td className="px-4 py-2.5">
+                                  {entry.description?.trim() || (
+                                    <span className="text-muted-foreground">No description</span>
+                                  )}
+                                </td>
+                                <td className="px-4 py-2.5 text-muted-foreground">
+                                  {entry.engagement
+                                    ? projectName.get(entry.engagement) ?? "—"
+                                    : "—"}
+                                </td>
+                                <td className="px-4 py-2.5 text-muted-foreground">
+                                  {entry.category ? categoryName.get(entry.category) ?? "—" : "—"}
+                                </td>
+                                <td className="whitespace-nowrap px-4 py-2.5 text-muted-foreground">
+                                  {startT}
+                                  {endT ? `–${endT}` : " · running"}
+                                </td>
+                                <td className="px-4 py-2.5">
+                                  <div className="flex items-center gap-1.5">
+                                    {!entry.billable && (
+                                      <Badge variant="secondary">Non-billable</Badge>
+                                    )}
+                                    {entry.billedAt && <Badge variant="secondary">Invoiced</Badge>}
+                                  </div>
+                                </td>
+                                <td className="whitespace-nowrap px-4 py-2.5 text-right font-mono tabular-nums">
+                                  {formatDuration(entry.durationSeconds ?? elapsedSeconds(entry))}
+                                </td>
+                              </tr>
+                            );
+                          })}
+                        </Fragment>
+                      ))
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </Card>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary

Iterative polish on the Harvest-style billing surfaces + a batch of UX fixes.

**Model**
- **Billability moves to the category.** `EngagementCategory.billable` (default true); a `TimeEntry` snapshots it (with the rate) on save. Invoicing still filters `billable = true`, so non-billable-category time is excluded.
- **Engagements gain a markdown `description` + contract-file attachments** (`engagement_attachment` join → `MediaObject`). `ValidEngagementAttachments` enforces uploader-is-member + kind. Download is gated: only a space admin or a member with an explicit `invoices.read` grant can pull a contract (404 otherwise).

**UI**
- Inline "add" rows at the **top** of `/time`, `/clients`, `/invoices` (header buttons removed). `/engagements` rows open a right-side **detail/create Sheet**; board-count column dropped.
- `/time`: description → textarea; billable toggle + start-timer removed; date/end default to now.
- Removed the count badge from `PageHeader` across all pages.

**Fixes**
- **Invoice generation** now POSTs `{ engagement }` (was `{ client }`) to `/invoices/from-time-entries` — fixes "Engagement not found".

**Fixtures**
- Admin demo spaces renamed **everything** / **nothing**; seeded a fake signed contract file on the Acme engagement.

## Migrations
- `Version20260706025536` — `engagement_category.billable`
- `Version20260706031202` — `engagement.description` + `engagement_attachment` join table

## Test plan
- Backend: `EngagementTest` (+2: description/attachment round-trip, contract download gating), `ClientInvoiceTest`, `TimeEntryTest`, plus Space/Task attachment + MediaObject download suites — green. PHPStan L10 + PHPCS clean; schema in sync.
- PWA: typecheck + lint clean.