### PR TITLE
feat(monitoring): forward app logs to Sentry (Structured Logs)

### DIFF
--- a/api/config/packages/monolog.yaml
+++ b/api/config/packages/monolog.yaml
@@ -60,3 +60,11 @@ when@prod:
                 channels: [deprecation]
                 path: php://stderr
                 formatter: monolog.formatter.json
+            # Fan app logs out to Sentry's Logs product alongside stderr. The
+            # handler bubbles (returns false), so every record still reaches the
+            # stream handlers above. Level (info+) lives on the service; noisy
+            # framework channels are excluded here. Inert without a SENTRY_DSN.
+            sentry_logs:
+                type: service
+                id: Sentry\SentryBundle\Monolog\LogsHandler
+                channels: ["!event", "!doctrine"]

--- a/api/config/packages/sentry.yaml
+++ b/api/config/packages/sentry.yaml
@@ -13,6 +13,10 @@ sentry:
         traces_sample_rate: '%env(float:SENTRY_TRACES_SAMPLE_RATE)%'
         # Don't attach IPs / cookies / request bodies by default.
         send_default_pii: false
+        # Turn on Sentry's Structured Logs product. This only opens the pipe;
+        # records reach it via the Monolog LogsHandler wired in monolog.yaml
+        # (when@prod). Inert without a DSN, so dev/test/CI never send.
+        enable_logs: true
 
 when@test:
     sentry:

--- a/api/config/services.yaml
+++ b/api/config/services.yaml
@@ -201,6 +201,18 @@ services:
             $localFactory: '@limiter.login_ip_email'
             $secret: '%kernel.secret%'
 
+    # Sentry Structured Logs bridge: a Monolog handler that forwards records to
+    # Sentry's Logs product (needs sentry.options.enable_logs). Registered as an
+    # *extra* Monolog handler in monolog.yaml (when@prod), so app logs keep going
+    # to stderr AND fan out to Sentry — Monolog already multiplexes to every
+    # handler, so this is the "composite" without a custom logger. info+ only, to
+    # respect the free-tier logs quota; records whose context carries an
+    # exception are skipped (they're reported as issues). Inert without a DSN.
+    Sentry\SentryBundle\Monolog\LogsHandler:
+        arguments:
+            $level: 'info'
+            $bubble: true
+
 when@dev:
     parameters:
         # Local dev: don't make the engineer think up a 12-char password

--- a/docs/developer/monitoring.md
+++ b/docs/developer/monitoring.md
@@ -17,6 +17,17 @@ the environment (exactly like the VAPID keys and the calendar-webhook URL).
   request bodies.
 - **Session Replay is off** (both PWA sample rates `0`) to conserve quota and
   keep the client bundle lean.
+- **Structured Logs** — application logs are mirrored into Sentry's Logs product
+  *in addition to* their normal destination (so nothing changes about existing
+  logging). On the API/worker, `enable_logs: true` plus the Monolog
+  `Sentry\SentryBundle\Monolog\LogsHandler` (wired as an extra `sentry_logs`
+  handler in `monolog.yaml` `when@prod`, `info`+, noisy `event`/`doctrine`
+  channels excluded) forward records — Monolog already fans each record out to
+  every handler, so it keeps hitting stderr too. Records whose context carries an
+  exception are skipped (they surface as issues instead). On the PWA, each
+  `Sentry.init` sets `enableLogs: true` + `consoleLoggingIntegration` so
+  `console.*` (log/info/warn/error) is mirrored while still printing normally.
+  Logs count against a separate free-tier quota from errors/traces.
 
 ## API + worker (Symfony)
 

--- a/pwa/instrumentation-client.ts
+++ b/pwa/instrumentation-client.ts
@@ -16,6 +16,12 @@ if (dsn) {
     replaysSessionSampleRate: 0,
     replaysOnErrorSampleRate: 0,
     sendDefaultPii: false,
+    // Structured Logs: mirror browser console.* into Sentry Logs. Additive —
+    // messages still print to the console as usual.
+    enableLogs: true,
+    integrations: [
+      Sentry.consoleLoggingIntegration({ levels: ["log", "info", "warn", "error"] }),
+    ],
   });
 }
 

--- a/pwa/sentry.edge.config.ts
+++ b/pwa/sentry.edge.config.ts
@@ -11,5 +11,10 @@ if (dsn) {
     release: process.env.NEXT_PUBLIC_SENTRY_RELEASE || undefined,
     tracesSampleRate: Number(process.env.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE ?? "0.1"),
     sendDefaultPii: false,
+    // Structured Logs: mirror edge-runtime console.* into Sentry Logs. Additive.
+    enableLogs: true,
+    integrations: [
+      Sentry.consoleLoggingIntegration({ levels: ["log", "info", "warn", "error"] }),
+    ],
   });
 }

--- a/pwa/sentry.server.config.ts
+++ b/pwa/sentry.server.config.ts
@@ -13,5 +13,10 @@ if (dsn) {
     release: process.env.NEXT_PUBLIC_SENTRY_RELEASE || undefined,
     tracesSampleRate: Number(process.env.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE ?? "0.1"),
     sendDefaultPii: false,
+    // Structured Logs: mirror server-side console.* into Sentry Logs. Additive.
+    enableLogs: true,
+    integrations: [
+      Sentry.consoleLoggingIntegration({ levels: ["log", "info", "warn", "error"] }),
+    ],
   });
 }


### PR DESCRIPTION
Sends our application logs to Sentry's **Logs** product, in addition to where they already go (no behavior change to existing logging).

## API / worker
- `sentry.yaml`: `options.enable_logs: true`.
- `services.yaml`: register `Sentry\SentryBundle\Monolog\LogsHandler` (`$level: info`).
- `monolog.yaml` (`when@prod`): add a `sentry_logs` handler (`type: service`, `event`/`doctrine` channels excluded).

Monolog already multiplexes each record to **every** handler, so this is the "composite logger" without a custom class — records keep hitting the stderr stream handler *and* now reach Sentry. The `LogsHandler` bubbles (returns false) and skips exception-context records (those remain issues). Self-flushes on handler `close()` at shutdown.

## PWA
- `enableLogs: true` + `Sentry.consoleLoggingIntegration({ levels: [log, info, warn, error] })` on all three inits (client / server / edge). `console.*` mirrors into Sentry Logs while still printing normally.

## Safety / activation
- **Inert without a DSN** — dev/test/CI never emit. `when@test` still forces `dsn: null`.
- API activation is env-only (the `SENTRY_DSN` on the server activates logs too on next deploy). The **PWA** still needs `NEXT_PUBLIC_SENTRY_DSN` committed to `pwa/.env.production` (separate Next.js project).
- Logs are a separate free-tier quota bucket.

## Verified
- Prod + test containers compile; `lint:container` clean; PWA typecheck clean; kernel-boot smoke test green.