### PR TITLE
feat(monitoring): Sentry releases + product-event metrics (free-tier)

### DIFF
--- a/docs/developer/monitoring.md
+++ b/docs/developer/monitoring.md
@@ -28,6 +28,22 @@ the environment (exactly like the VAPID keys and the calendar-webhook URL).
   `Sentry.init` sets `enableLogs: true` + `consoleLoggingIntegration` so
   `console.*` (log/info/warn/error) is mirrored while still printing normally.
   Logs count against a separate free-tier quota from errors/traces.
+- **Metrics** — the PWA's product-event catalog is mirrored into Sentry Metrics:
+  `trackEvent()` (`pwa/lib/analytics.ts`) emits one `Sentry.metrics.count(name, 1)`
+  per event alongside the Umami call, so the same coarse events (signup,
+  `task-create`, …) show up in Sentry dashboards/alerts. Application metrics are
+  included on all Sentry plans (free tier too); the call no-ops without a DSN.
+  Add more with `Sentry.metrics.count/gauge/distribution` (JS) or
+  `\Sentry\metrics()` (PHP) — there's no config flag, the SDK version is enough.
+- **Releases** — every event/log/trace is tagged with the deployed release (the
+  image tag = commit SHA). `scripts/deploy.sh` exports `SENTRY_RELEASE=$IMAGES_TAG`
+  so the `${SENTRY_RELEASE:-}` refs in `compose.yaml` pick it up; Sentry then
+  groups issues by release and flags regressions. Releases are free. (The PWA's
+  `NEXT_PUBLIC_SENTRY_RELEASE` is baked at build and is wired when its DSN lands.)
+- **Profiling is intentionally NOT enabled.** The free Developer plan has no
+  profile-hours quota (profiling is pay-as-you-go only), and the PHP profiler
+  additionally needs the `excimer` extension (not in our image). Revisit if we
+  ever move off the free tier.
 
 ## API + worker (Symfony)
 

--- a/pwa/lib/analytics.ts
+++ b/pwa/lib/analytics.ts
@@ -6,6 +6,11 @@
 // the script, including SPA route changes; call trackEvent() for product
 // events. Everything no-ops when the tracker is absent — dev without
 // analytics, tests, ad-blocked clients — so call sites never need to guard.
+//
+// Each event is also mirrored into Sentry Metrics (a counter per event name)
+// so the same coarse catalog shows up in Sentry dashboards/alerts. Metrics are
+// free on all Sentry plans; the call no-ops without a Sentry DSN.
+import * as Sentry from "@sentry/nextjs";
 
 type UmamiEventData = Record<string, string | number | boolean>;
 
@@ -32,5 +37,11 @@ export function trackEvent(name: string, data?: UmamiEventData): void {
     window.umami?.track(name, data);
   } catch {
     // Analytics must never break the app.
+  }
+  try {
+    // One counter per event name; no-ops without a Sentry DSN.
+    Sentry.metrics.count(name, 1);
+  } catch {
+    // Metrics must never break the app.
   }
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -56,6 +56,13 @@ if [ -z "${IMAGES_TAG:-}" ]; then
 fi
 export IMAGES_TAG
 
+# Tag every Sentry event / log / trace with the release being deployed (the
+# image tag = commit SHA), so Sentry can group issues by release and flag
+# regressions. Releases are free on all Sentry plans. Exported so the
+# `${SENTRY_RELEASE:-}` refs in compose.yaml (php + worker) pick it up; a
+# SENTRY_RELEASE already set in the environment wins.
+export SENTRY_RELEASE="${SENTRY_RELEASE:-$IMAGES_TAG}"
+
 log() {
   printf '[deploy %s] %s\n' "$(date -Iseconds 2>/dev/null || date)" "$*"
 }


### PR DESCRIPTION
Follow-up to the Sentry logs PR (#613). Wires the two Sentry features that **are** on the free tier; skips the one that isn't.

## Releases (free)
- `scripts/deploy.sh` exports `SENTRY_RELEASE=$IMAGES_TAG` (the deployed commit SHA). The existing `${SENTRY_RELEASE:-}` refs in `compose.yaml` (php + worker) pick it up, so every event/log/trace is tagged with the release → Sentry groups issues by release and flags regressions. No quota.
- PWA `NEXT_PUBLIC_SENTRY_RELEASE` (build-time) is deferred to the PWA-DSN change.

## Metrics (free — "application metrics", 5 GB on all plans)
- `trackEvent()` (`pwa/lib/analytics.ts`) now also emits `Sentry.metrics.count(name, 1)`, mirroring the existing Umami product-event catalog (signup, `task-create`, …) into Sentry Metrics from the single client-side chokepoint.
- No init flag needed — the new Metrics API is GA in `@sentry/nextjs` ≥ 10.25 (we're on 10.63) and `sentry/sentry` 4.29 (`\Sentry\metrics()`). No-ops without a DSN.

## Profiling — skipped (not free)
- The free **Developer** plan has **no profile-hours quota** (profiling is pay-as-you-go only), and PHP profiling additionally needs the `excimer` extension we don't build into the image. Documented; revisit off the free tier.

## Verified
- `bash -n scripts/deploy.sh` clean; PWA typecheck + eslint clean (`Sentry.metrics.count` valid at 10.63). No API code touched.

Sources for the free-tier determination: Sentry pricing/quotas docs (profile hours are PAYG-only; application metrics included on all plans; the old `Sentry.metrics` beta was replaced by a GA Metrics API in SDK v9+/10.25+).