### PR TITLE
feat(monitoring): inject PWA Sentry DSN via CI secret (keep it out of the public repo)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,6 +91,13 @@ jobs:
           context: pwa
           target: prod
           push: true
+          # Sentry: the DSN is public (it ships in the client bundle) but kept
+          # OUT of this public repo via a repo-level Actions secret; forks build
+          # with a blank DSN (Sentry off) since they can't read our secrets. The
+          # release is the commit SHA. Both are baked at build (NEXT_PUBLIC_*).
+          build-args: |
+            NEXT_PUBLIC_SENTRY_DSN=${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
+            NEXT_PUBLIC_SENTRY_RELEASE=${{ github.sha }}
           tags: |
             ghcr.io/${{ github.repository_owner }}/app-pwa:${{ github.sha }}
             ghcr.io/${{ github.repository_owner }}/app-pwa:latest

--- a/docs/developer/monitoring.md
+++ b/docs/developer/monitoring.md
@@ -77,14 +77,26 @@ are set at build time, so a normal build without them just skips the upload —
 no build-time Sentry account needed for the dark launch.
 
 The DSN is **public** (baked into the client bundle at build), so a single
-`NEXT_PUBLIC_SENTRY_DSN` serves client + server:
+`NEXT_PUBLIC_SENTRY_DSN` serves client + server. **It is NOT committed** — this
+is a public repo, and a committed DSN would be inherited by forks and invites
+quota abuse. Instead it's injected at CI build time from a **repo-level Actions
+secret** (`NEXT_PUBLIC_SENTRY_DSN`) via a Docker `build-arg` (see the
+`Build & push pwa image` step in `deploy.yml` + the `ARG`/`ENV` in `pwa/Dockerfile`).
+Forks and local builds get no secret → blank DSN → Sentry off.
 
 | Env var | Purpose |
 | --- | --- |
-| `NEXT_PUBLIC_SENTRY_DSN` | PWA project DSN. **Blank = disabled.** Committed in `pwa/.env.production` after first-run. |
-| `NEXT_PUBLIC_SENTRY_ENVIRONMENT` | e.g. `production`. |
+| `NEXT_PUBLIC_SENTRY_DSN` | PWA project DSN. **Blank = disabled.** Injected at build from the repo Actions secret (not committed). |
+| `NEXT_PUBLIC_SENTRY_ENVIRONMENT` | e.g. `production` (committed in `pwa/.env.production`). |
+| `NEXT_PUBLIC_SENTRY_RELEASE` | Commit SHA, passed as a build-arg from `${{ github.sha }}`. |
 | `NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE` | Trace sample rate (default `0.1`). |
 | `SENTRY_AUTH_TOKEN` / `SENTRY_ORG` / `SENTRY_PROJECT` | Build-time source-map upload (optional). |
+
+> **Even so, the DSN is visible in the deployed browser bundle** (unavoidable for
+> a browser SDK). Keeping it out of the repo only stops fork-inheritance and
+> casual grep. The real abuse mitigation is Sentry-side: in the PWA project's
+> settings, restrict **Allowed Domains / Inbound Filters** to `madori.app` and set
+> a **per-key rate limit / spike protection**.
 
 ## Going live
 
@@ -94,9 +106,11 @@ The DSN is **public** (baked into the client bundle at build), so a single
    optionally `SENTRY_RELEASE=<sha>`) to the server's `/opt/aura/.env`. The
    `compose.yaml` refs are already in place; a deploy recreates the containers
    with the value.
-3. **PWA:** commit the public DSN as `NEXT_PUBLIC_SENTRY_DSN` in
-   `pwa/.env.production` (it ships in the page source anyway) — it's baked into
-   the image at CI build.
+3. **PWA:** add the Next.js project DSN as a **repo-level Actions secret** named
+   `NEXT_PUBLIC_SENTRY_DSN` (repo → Settings → Secrets and variables → Actions).
+   The deploy build bakes it into the image; nothing to commit. Then, in the PWA
+   Sentry project, restrict Allowed Domains to `madori.app` + set a key rate
+   limit (the DSN is visible in the shipped bundle).
 4. *(Optional)* For readable stack traces, add `SENTRY_AUTH_TOKEN` / `SENTRY_ORG`
    / `SENTRY_PROJECT` to the CI build env so `withSentryConfig` uploads source
    maps.

--- a/pwa/.env.production
+++ b/pwa/.env.production
@@ -19,9 +19,12 @@ NEXT_PUBLIC_SITE_URL=https://madori.app
 NEXT_PUBLIC_BILLING_ENABLED=false
 
 # Sentry error + performance monitoring (see docs/developer/monitoring.md).
-# The DSN is public (baked into the client bundle) — commit the real value here
-# after creating the PWA project on sentry.io. Blank = Sentry fully off.
-NEXT_PUBLIC_SENTRY_DSN=
+# NEXT_PUBLIC_SENTRY_DSN is intentionally NOT set here. Even though the DSN is
+# public (it ships in the client bundle), this repo is public and forks would
+# inherit it — so it's injected at CI build time from a repo-level Actions
+# secret via a Docker build-arg (see .github/workflows/deploy.yml + pwa/Dockerfile).
+# NEXT_PUBLIC_SENTRY_RELEASE is likewise passed at build (the commit SHA).
+# Unset here → blank in forks/local builds → Sentry fully off.
 NEXT_PUBLIC_SENTRY_ENVIRONMENT=production
 # Performance-trace sample rate (0 = off, 1.0 = all). Low for the free tier.
 NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE=0.1

--- a/pwa/Dockerfile
+++ b/pwa/Dockerfile
@@ -45,6 +45,15 @@ RUN pnpm fetch --prod
 
 COPY --link . .
 
+# Sentry (PWA) is configured at build time via NEXT_PUBLIC_* baked into the
+# client bundle. The DSN is injected from a CI secret so it stays OUT of the
+# public repo; the release is the commit SHA. Both default empty, so forks and
+# local builds that don't pass them build with Sentry OFF.
+ARG NEXT_PUBLIC_SENTRY_DSN=""
+ARG NEXT_PUBLIC_SENTRY_RELEASE=""
+ENV NEXT_PUBLIC_SENTRY_DSN=$NEXT_PUBLIC_SENTRY_DSN
+ENV NEXT_PUBLIC_SENTRY_RELEASE=$NEXT_PUBLIC_SENTRY_RELEASE
+
 RUN	pnpm install --frozen-lockfile --offline --prod && \
 	pnpm run build
 


### PR DESCRIPTION
The PWA (Next.js) Sentry DSN is *public* (it ships in the browser bundle), but this is a **public repo** — committing it would let forks inherit it and invites quota abuse. So it's injected at build time from a repo-level Actions secret instead.

## Changes
- **`pwa/Dockerfile`** — builder stage accepts `ARG NEXT_PUBLIC_SENTRY_DSN` + `ARG NEXT_PUBLIC_SENTRY_RELEASE` and promotes them to `ENV` before `next build`. Both default empty → **forks/local builds get Sentry OFF**.
- **`deploy.yml`** — the `Build & push pwa image` step passes `build-args`: DSN from `${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}`, release from `${{ github.sha }}`.
- **`pwa/.env.production`** — the `NEXT_PUBLIC_SENTRY_DSN=` line is removed (documented); `NEXT_PUBLIC_SENTRY_ENVIRONMENT`/trace-rate stay committed (not secret).
- **docs** — the CI-secret flow + a note to restrict **Allowed Domains** / set a key **rate limit** in the PWA Sentry project (the DSN is still visible in the shipped bundle, so that's the real abuse mitigation).

## Action required to activate (you)
- Add a **repo-level** Actions secret `NEXT_PUBLIC_SENTRY_DSN` = the Next.js DSN (repo → Settings → Secrets and variables → Actions). The `build` job isn't environment-scoped, so it must be repo-level.
- In the PWA Sentry project: restrict Allowed Domains to `madori.app` + set a rate limit.

Safe to merge before the secret exists — an empty secret just builds Sentry-off. No app code touched; CI's image build validates the Dockerfile with empty args.