### PR TITLE
Promote main → production: Sentry logs, releases, metrics + PWA DSN

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,6 +91,13 @@ jobs:
           context: pwa
           target: prod
           push: true
+          # Sentry: the DSN is public (it ships in the client bundle) but kept
+          # OUT of this public repo via a repo-level Actions secret; forks build
+          # with a blank DSN (Sentry off) since they can't read our secrets. The
+          # release is the commit SHA. Both are baked at build (NEXT_PUBLIC_*).
+          build-args: |
+            NEXT_PUBLIC_SENTRY_DSN=${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
+            NEXT_PUBLIC_SENTRY_RELEASE=${{ github.sha }}
           tags: |
             ghcr.io/${{ github.repository_owner }}/app-pwa:${{ github.sha }}
             ghcr.io/${{ github.repository_owner }}/app-pwa:latest

--- a/api/config/packages/monolog.yaml
+++ b/api/config/packages/monolog.yaml
@@ -60,3 +60,11 @@ when@prod:
                 channels: [deprecation]
                 path: php://stderr
                 formatter: monolog.formatter.json
+            # Fan app logs out to Sentry's Logs product alongside stderr. The
+            # handler bubbles (returns false), so every record still reaches the
+            # stream handlers above. Level (info+) lives on the service; noisy
+            # framework channels are excluded here. Inert without a SENTRY_DSN.
+            sentry_logs:
+                type: service
+                id: Sentry\SentryBundle\Monolog\LogsHandler
+                channels: ["!event", "!doctrine"]

--- a/api/config/packages/sentry.yaml
+++ b/api/config/packages/sentry.yaml
@@ -13,6 +13,10 @@ sentry:
         traces_sample_rate: '%env(float:SENTRY_TRACES_SAMPLE_RATE)%'
         # Don't attach IPs / cookies / request bodies by default.
         send_default_pii: false
+        # Turn on Sentry's Structured Logs product. This only opens the pipe;
+        # records reach it via the Monolog LogsHandler wired in monolog.yaml
+        # (when@prod). Inert without a DSN, so dev/test/CI never send.
+        enable_logs: true
 
 when@test:
     sentry:

--- a/api/config/services.yaml
+++ b/api/config/services.yaml
@@ -201,6 +201,18 @@ services:
             $localFactory: '@limiter.login_ip_email'
             $secret: '%kernel.secret%'
 
+    # Sentry Structured Logs bridge: a Monolog handler that forwards records to
+    # Sentry's Logs product (needs sentry.options.enable_logs). Registered as an
+    # *extra* Monolog handler in monolog.yaml (when@prod), so app logs keep going
+    # to stderr AND fan out to Sentry — Monolog already multiplexes to every
+    # handler, so this is the "composite" without a custom logger. info+ only, to
+    # respect the free-tier logs quota; records whose context carries an
+    # exception are skipped (they're reported as issues). Inert without a DSN.
+    Sentry\SentryBundle\Monolog\LogsHandler:
+        arguments:
+            $level: 'info'
+            $bubble: true
+
 when@dev:
     parameters:
         # Local dev: don't make the engineer think up a 12-char password

--- a/docs/developer/monitoring.md
+++ b/docs/developer/monitoring.md
@@ -28,6 +28,22 @@ the environment (exactly like the VAPID keys and the calendar-webhook URL).
   `Sentry.init` sets `enableLogs: true` + `consoleLoggingIntegration` so
   `console.*` (log/info/warn/error) is mirrored while still printing normally.
   Logs count against a separate free-tier quota from errors/traces.
+- **Metrics** — the PWA's product-event catalog is mirrored into Sentry Metrics:
+  `trackEvent()` (`pwa/lib/analytics.ts`) emits one `Sentry.metrics.count(name, 1)`
+  per event alongside the Umami call, so the same coarse events (signup,
+  `task-create`, …) show up in Sentry dashboards/alerts. Application metrics are
+  included on all Sentry plans (free tier too); the call no-ops without a DSN.
+  Add more with `Sentry.metrics.count/gauge/distribution` (JS) or
+  `\Sentry\metrics()` (PHP) — there's no config flag, the SDK version is enough.
+- **Releases** — every event/log/trace is tagged with the deployed release (the
+  image tag = commit SHA). `scripts/deploy.sh` exports `SENTRY_RELEASE=$IMAGES_TAG`
+  so the `${SENTRY_RELEASE:-}` refs in `compose.yaml` pick it up; Sentry then
+  groups issues by release and flags regressions. Releases are free. (The PWA's
+  `NEXT_PUBLIC_SENTRY_RELEASE` is baked at build and is wired when its DSN lands.)
+- **Profiling is intentionally NOT enabled.** The free Developer plan has no
+  profile-hours quota (profiling is pay-as-you-go only), and the PHP profiler
+  additionally needs the `excimer` extension (not in our image). Revisit if we
+  ever move off the free tier.
 
 ## API + worker (Symfony)
 

--- a/docs/developer/monitoring.md
+++ b/docs/developer/monitoring.md
@@ -77,14 +77,26 @@ are set at build time, so a normal build without them just skips the upload —
 no build-time Sentry account needed for the dark launch.
 
 The DSN is **public** (baked into the client bundle at build), so a single
-`NEXT_PUBLIC_SENTRY_DSN` serves client + server:
+`NEXT_PUBLIC_SENTRY_DSN` serves client + server. **It is NOT committed** — this
+is a public repo, and a committed DSN would be inherited by forks and invites
+quota abuse. Instead it's injected at CI build time from a **repo-level Actions
+secret** (`NEXT_PUBLIC_SENTRY_DSN`) via a Docker `build-arg` (see the
+`Build & push pwa image` step in `deploy.yml` + the `ARG`/`ENV` in `pwa/Dockerfile`).
+Forks and local builds get no secret → blank DSN → Sentry off.
 
 | Env var | Purpose |
 | --- | --- |
-| `NEXT_PUBLIC_SENTRY_DSN` | PWA project DSN. **Blank = disabled.** Committed in `pwa/.env.production` after first-run. |
-| `NEXT_PUBLIC_SENTRY_ENVIRONMENT` | e.g. `production`. |
+| `NEXT_PUBLIC_SENTRY_DSN` | PWA project DSN. **Blank = disabled.** Injected at build from the repo Actions secret (not committed). |
+| `NEXT_PUBLIC_SENTRY_ENVIRONMENT` | e.g. `production` (committed in `pwa/.env.production`). |
+| `NEXT_PUBLIC_SENTRY_RELEASE` | Commit SHA, passed as a build-arg from `${{ github.sha }}`. |
 | `NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE` | Trace sample rate (default `0.1`). |
 | `SENTRY_AUTH_TOKEN` / `SENTRY_ORG` / `SENTRY_PROJECT` | Build-time source-map upload (optional). |
+
+> **Even so, the DSN is visible in the deployed browser bundle** (unavoidable for
+> a browser SDK). Keeping it out of the repo only stops fork-inheritance and
+> casual grep. The real abuse mitigation is Sentry-side: in the PWA project's
+> settings, restrict **Allowed Domains / Inbound Filters** to `madori.app` and set
+> a **per-key rate limit / spike protection**.
 
 ## Going live
 
@@ -94,9 +106,11 @@ The DSN is **public** (baked into the client bundle at build), so a single
    optionally `SENTRY_RELEASE=<sha>`) to the server's `/opt/aura/.env`. The
    `compose.yaml` refs are already in place; a deploy recreates the containers
    with the value.
-3. **PWA:** commit the public DSN as `NEXT_PUBLIC_SENTRY_DSN` in
-   `pwa/.env.production` (it ships in the page source anyway) — it's baked into
-   the image at CI build.
+3. **PWA:** add the Next.js project DSN as a **repo-level Actions secret** named
+   `NEXT_PUBLIC_SENTRY_DSN` (repo → Settings → Secrets and variables → Actions).
+   The deploy build bakes it into the image; nothing to commit. Then, in the PWA
+   Sentry project, restrict Allowed Domains to `madori.app` + set a key rate
+   limit (the DSN is visible in the shipped bundle).
 4. *(Optional)* For readable stack traces, add `SENTRY_AUTH_TOKEN` / `SENTRY_ORG`
    / `SENTRY_PROJECT` to the CI build env so `withSentryConfig` uploads source
    maps.

--- a/docs/developer/monitoring.md
+++ b/docs/developer/monitoring.md
@@ -17,6 +17,17 @@ the environment (exactly like the VAPID keys and the calendar-webhook URL).
   request bodies.
 - **Session Replay is off** (both PWA sample rates `0`) to conserve quota and
   keep the client bundle lean.
+- **Structured Logs** — application logs are mirrored into Sentry's Logs product
+  *in addition to* their normal destination (so nothing changes about existing
+  logging). On the API/worker, `enable_logs: true` plus the Monolog
+  `Sentry\SentryBundle\Monolog\LogsHandler` (wired as an extra `sentry_logs`
+  handler in `monolog.yaml` `when@prod`, `info`+, noisy `event`/`doctrine`
+  channels excluded) forward records — Monolog already fans each record out to
+  every handler, so it keeps hitting stderr too. Records whose context carries an
+  exception are skipped (they surface as issues instead). On the PWA, each
+  `Sentry.init` sets `enableLogs: true` + `consoleLoggingIntegration` so
+  `console.*` (log/info/warn/error) is mirrored while still printing normally.
+  Logs count against a separate free-tier quota from errors/traces.
 
 ## API + worker (Symfony)
 

--- a/pwa/.env.production
+++ b/pwa/.env.production
@@ -19,9 +19,12 @@ NEXT_PUBLIC_SITE_URL=https://madori.app
 NEXT_PUBLIC_BILLING_ENABLED=false
 
 # Sentry error + performance monitoring (see docs/developer/monitoring.md).
-# The DSN is public (baked into the client bundle) — commit the real value here
-# after creating the PWA project on sentry.io. Blank = Sentry fully off.
-NEXT_PUBLIC_SENTRY_DSN=
+# NEXT_PUBLIC_SENTRY_DSN is intentionally NOT set here. Even though the DSN is
+# public (it ships in the client bundle), this repo is public and forks would
+# inherit it — so it's injected at CI build time from a repo-level Actions
+# secret via a Docker build-arg (see .github/workflows/deploy.yml + pwa/Dockerfile).
+# NEXT_PUBLIC_SENTRY_RELEASE is likewise passed at build (the commit SHA).
+# Unset here → blank in forks/local builds → Sentry fully off.
 NEXT_PUBLIC_SENTRY_ENVIRONMENT=production
 # Performance-trace sample rate (0 = off, 1.0 = all). Low for the free tier.
 NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE=0.1

--- a/pwa/Dockerfile
+++ b/pwa/Dockerfile
@@ -45,6 +45,15 @@ RUN pnpm fetch --prod
 
 COPY --link . .
 
+# Sentry (PWA) is configured at build time via NEXT_PUBLIC_* baked into the
+# client bundle. The DSN is injected from a CI secret so it stays OUT of the
+# public repo; the release is the commit SHA. Both default empty, so forks and
+# local builds that don't pass them build with Sentry OFF.
+ARG NEXT_PUBLIC_SENTRY_DSN=""
+ARG NEXT_PUBLIC_SENTRY_RELEASE=""
+ENV NEXT_PUBLIC_SENTRY_DSN=$NEXT_PUBLIC_SENTRY_DSN
+ENV NEXT_PUBLIC_SENTRY_RELEASE=$NEXT_PUBLIC_SENTRY_RELEASE
+
 RUN	pnpm install --frozen-lockfile --offline --prod && \
 	pnpm run build
 

--- a/pwa/instrumentation-client.ts
+++ b/pwa/instrumentation-client.ts
@@ -16,6 +16,12 @@ if (dsn) {
     replaysSessionSampleRate: 0,
     replaysOnErrorSampleRate: 0,
     sendDefaultPii: false,
+    // Structured Logs: mirror browser console.* into Sentry Logs. Additive —
+    // messages still print to the console as usual.
+    enableLogs: true,
+    integrations: [
+      Sentry.consoleLoggingIntegration({ levels: ["log", "info", "warn", "error"] }),
+    ],
   });
 }
 

--- a/pwa/lib/analytics.ts
+++ b/pwa/lib/analytics.ts
@@ -6,6 +6,11 @@
 // the script, including SPA route changes; call trackEvent() for product
 // events. Everything no-ops when the tracker is absent — dev without
 // analytics, tests, ad-blocked clients — so call sites never need to guard.
+//
+// Each event is also mirrored into Sentry Metrics (a counter per event name)
+// so the same coarse catalog shows up in Sentry dashboards/alerts. Metrics are
+// free on all Sentry plans; the call no-ops without a Sentry DSN.
+import * as Sentry from "@sentry/nextjs";
 
 type UmamiEventData = Record<string, string | number | boolean>;
 
@@ -32,5 +37,11 @@ export function trackEvent(name: string, data?: UmamiEventData): void {
     window.umami?.track(name, data);
   } catch {
     // Analytics must never break the app.
+  }
+  try {
+    // One counter per event name; no-ops without a Sentry DSN.
+    Sentry.metrics.count(name, 1);
+  } catch {
+    // Metrics must never break the app.
   }
 }

--- a/pwa/sentry.edge.config.ts
+++ b/pwa/sentry.edge.config.ts
@@ -11,5 +11,10 @@ if (dsn) {
     release: process.env.NEXT_PUBLIC_SENTRY_RELEASE || undefined,
     tracesSampleRate: Number(process.env.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE ?? "0.1"),
     sendDefaultPii: false,
+    // Structured Logs: mirror edge-runtime console.* into Sentry Logs. Additive.
+    enableLogs: true,
+    integrations: [
+      Sentry.consoleLoggingIntegration({ levels: ["log", "info", "warn", "error"] }),
+    ],
   });
 }

--- a/pwa/sentry.server.config.ts
+++ b/pwa/sentry.server.config.ts
@@ -13,5 +13,10 @@ if (dsn) {
     release: process.env.NEXT_PUBLIC_SENTRY_RELEASE || undefined,
     tracesSampleRate: Number(process.env.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE ?? "0.1"),
     sendDefaultPii: false,
+    // Structured Logs: mirror server-side console.* into Sentry Logs. Additive.
+    enableLogs: true,
+    integrations: [
+      Sentry.consoleLoggingIntegration({ levels: ["log", "info", "warn", "error"] }),
+    ],
   });
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -56,6 +56,13 @@ if [ -z "${IMAGES_TAG:-}" ]; then
 fi
 export IMAGES_TAG
 
+# Tag every Sentry event / log / trace with the release being deployed (the
+# image tag = commit SHA), so Sentry can group issues by release and flag
+# regressions. Releases are free on all Sentry plans. Exported so the
+# `${SENTRY_RELEASE:-}` refs in compose.yaml (php + worker) pick it up; a
+# SENTRY_RELEASE already set in the environment wins.
+export SENTRY_RELEASE="${SENTRY_RELEASE:-$IMAGES_TAG}"
+
 log() {
   printf '[deploy %s] %s\n' "$(date -Iseconds 2>/dev/null || date)" "$*"
 }


### PR DESCRIPTION
Promotes 3 config-only PRs (no migrations, no schema changes) to activate the PWA side of Sentry.

- **#613** — forward application logs to Sentry (Structured Logs), API/worker + PWA.
- **#614** — Sentry releases (deploy SHA tag) + product-event metrics.
- **#615** — inject the PWA Sentry DSN via CI secret (kept out of the public repo).

## What activates on this deploy
- **PWA image** builds with `NEXT_PUBLIC_SENTRY_DSN` (from the repo Actions secret) + `NEXT_PUBLIC_SENTRY_RELEASE=<sha>` baked in → PWA errors/traces/logs/metrics come online.
- `deploy.sh` exports `SENTRY_RELEASE=$IMAGES_TAG` → API/worker events tagged with the release.
- API/worker `SENTRY_DSN` is already set on the server (verified: a PHP log reached Sentry), and the container swap keeps it.

## Risk
Low — config only. No DB migrations. `deploy.sh` still takes a pre-deploy backup.