### PR TITLE
feat(email): wire Resend as the production mail transport

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Ignored default folder with query files
+/queries/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/Aura.iml
+++ b/.idea/Aura.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/api/src" isTestSource="false" packagePrefix="App\" />
+      <sourceFolder url="file://$MODULE_DIR$/api/tests" isTestSource="true" packagePrefix="App\Tests\" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+  </profile>
+</component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/Aura.iml" filepath="$PROJECT_DIR$/.idea/Aura.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MessDetectorOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PHPCSFixerOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PHPCodeSnifferOptionsConfiguration">
+    <option name="highlightLevel" value="WARNING" />
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PhpProjectSharedConfiguration" php_language_level="8.4" />
+  <component name="PhpStanOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PhpUnit">
+    <phpunit_settings>
+      <PhpUnitSettings configuration_file_path="$PROJECT_DIR$/api/phpunit.xml.dist" custom_loader_path="$PROJECT_DIR$/api/vendor/autoload.php" use_configuration_file="true" />
+    </phpunit_settings>
+  </component>
+  <component name="PsalmOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
+</project>

--- a/.idea/phpunit.xml
+++ b/.idea/phpunit.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PHPUnit">
+    <option name="directories">
+      <list>
+        <option value="$PROJECT_DIR$/api/tests" />
+      </list>
+    </option>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/api/.env
+++ b/api/.env
@@ -120,8 +120,12 @@ STRIPE_PRICE_TEAM_YEARLY=
 # (Settings → Admin → SSO), stored encrypted in the DB — no env vars.
 
 ###> symfony/resend-mailer ###
+# Resend is the recommended PRODUCTION transport. Set MAILER_DSN in the server
+# env (compose: /opt/aura/.env; Helm: `mailer.dsn`) — never commit the API key.
 # MAILER_DSN=resend+api://API_KEY@default
 # MAILER_DSN=resend+smtp://resend:API_KEY@default
+# Also set MAILER_FROM to an address on your Resend-verified domain.
+# See docs/developer/email-delivery.md.
 ###< symfony/resend-mailer ###
 
 ###> sentry (error + performance monitoring) ###

--- a/docs/developer/email-delivery.md
+++ b/docs/developer/email-delivery.md
@@ -1,0 +1,98 @@
+# Email delivery (production)
+
+Madori sends transactional email for signup verification, password reset,
+space/group invites, email-change confirmation, waitlist access, and
+notification digests/reminders. All of it flows through **Symfony Mailer** and
+is dispatched **asynchronously** on the worker (the `SendEmailMessage` is routed
+to the `async` transport — see [`job-queue.md`](job-queue.md)), so a running
+worker is required for mail to actually leave the queue.
+
+## The transport is env-driven
+
+`config/packages/mailer.yaml` reads a single variable:
+
+```yaml
+framework:
+    mailer:
+        dsn: '%env(MAILER_DSN)%'
+```
+
+| `MAILER_DSN` value | Effect |
+| --- | --- |
+| _unset_ / `null://null` | **Mail is silently discarded.** This is the default in `api/.env` so a fresh checkout and the test suite never send. |
+| `smtp://mailpit:1025` | Local dev — caught by the Mailpit container (compose default). |
+| `resend+api://KEY@default` | **Production** — delivered via Resend. |
+
+> Leaving `MAILER_DSN` empty in production means password resets and invites go
+> nowhere. Setting a real transport is a launch prerequisite.
+
+## Recommended provider: Resend
+
+The `symfony/resend-mailer` bridge is already installed, so no code or
+dependency change is needed — production is purely configuration.
+
+1. Create a [Resend](https://resend.com) account and **verify your sending
+   domain** (add the SPF + DKIM DNS records Resend gives you). Deliverability
+   depends on this — unverified domains land in spam or are rejected.
+2. Create an **API key** (Sending access).
+3. Set two variables in the server environment:
+
+   ```dotenv
+   MAILER_DSN=resend+api://re_your_api_key@default
+   MAILER_FROM=no-reply@yourdomain.com   # must be on the verified domain
+   ```
+
+   `APP_FRONTEND_URL` must also point at the public PWA origin (e.g.
+   `https://app.yourdomain.com`) so links in the emails resolve correctly.
+
+`MAILER_FROM` is the default `From:` for every mailer (each service autowires
+`%env(default::MAILER_FROM)%` and falls back to a dev address when unset).
+
+## Where the env goes
+
+### Docker Compose (current production)
+
+`compose.yaml` already threads all three values through to both the `php` and
+`worker` services:
+
+```yaml
+MAILER_DSN: ${MAILER_DSN:-smtp://mailpit:1025}
+MAILER_FROM: ${MAILER_FROM:-no-reply@madori.test}
+APP_FRONTEND_URL: ${APP_FRONTEND_URL:-https://localhost}
+```
+
+Set the real values in the untracked `/opt/aura/.env` on the server (same
+pattern as `VAPID_*` and `STRIPE_*`). The deploy does `git reset --hard`, so
+this file must **not** be tracked in git.
+
+### Helm
+
+The chart injects the same variables into the web and worker Deployments:
+
+- `mailer.dsn` → the `mailer-dsn` **Secret** key (holds the API key).
+- `mailer.from` → the `mailer-from` ConfigMap key.
+- `app.frontendUrl` → the `app-frontend-url` ConfigMap key.
+
+```yaml
+# values.yaml (or a values override / secret manager)
+mailer:
+  dsn: "resend+api://re_your_api_key@default"
+  from: "no-reply@yourdomain.com"
+app:
+  frontendUrl: "https://app.yourdomain.com"
+```
+
+An empty `mailer.dsn` defaults to `null://null` so a chart install without mail
+configured still boots.
+
+## Verifying
+
+After setting the DSN, trigger a password reset from the sign-in page (or run
+`bin/console app:notifications:dispatch-digest` for a digest) and confirm the
+message arrives. In Resend, the **Logs** tab shows every send with its status.
+
+## Related
+
+- [`password-reset.md`](password-reset.md) — the reset token model + `MAILER_FROM` note.
+- [`job-queue.md`](job-queue.md) — why the worker must be running for mail to send.
+- [`deployment.md`](deployment.md) — server env + secrets layout.

--- a/helm/api-platform/templates/configmap.yaml
+++ b/helm/api-platform/templates/configmap.yaml
@@ -15,3 +15,5 @@ data:
   mercure-extra-directives: {{ .Values.mercure.extraDirectives | quote }}
   caddy-global-options: {{ .Values.php.caddyGlobalOptions | quote }}
   messenger-transport-dsn: {{ .Values.messenger.transportDsn | quote }}
+  mailer-from: {{ .Values.mailer.from | quote }}
+  app-frontend-url: {{ .Values.app.frontendUrl | quote }}

--- a/helm/api-platform/templates/deployment.yaml
+++ b/helm/api-platform/templates/deployment.yaml
@@ -90,6 +90,21 @@ spec:
                 configMapKeyRef:
                   name: {{ include "api-platform.fullname" . }}
                   key: messenger-transport-dsn
+            - name: MAILER_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "api-platform.fullname" . }}
+                  key: mailer-dsn
+            - name: MAILER_FROM
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "api-platform.fullname" . }}
+                  key: mailer-from
+            - name: APP_FRONTEND_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "api-platform.fullname" . }}
+                  key: app-frontend-url
             - name: CADDY_GLOBAL_OPTIONS
               valueFrom:
                 configMapKeyRef:

--- a/helm/api-platform/templates/secrets.yaml
+++ b/helm/api-platform/templates/secrets.yaml
@@ -13,3 +13,6 @@ data:
   {{- end }}
   php-app-secret: {{ .Values.php.appSecret | default (randAlphaNum 40) | b64enc | quote }}
   mercure-jwt-secret: {{ .Values.mercure.jwtSecret | default (randAlphaNum 40) | b64enc | quote }}
+  # Contains the provider API key (e.g. resend+api://KEY@default); empty falls
+  # back to null://null so a chart install without mail configured still boots.
+  mailer-dsn: {{ .Values.mailer.dsn | default "null://null" | b64enc | quote }}

--- a/helm/api-platform/templates/worker-deployment.yaml
+++ b/helm/api-platform/templates/worker-deployment.yaml
@@ -77,6 +77,23 @@ spec:
                 configMapKeyRef:
                   name: {{ include "api-platform.fullname" . }}
                   key: messenger-transport-dsn
+            # The worker sends digest/reminder/notification email, so it needs
+            # the same transport + link config as the web container.
+            - name: MAILER_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "api-platform.fullname" . }}
+                  key: mailer-dsn
+            - name: MAILER_FROM
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "api-platform.fullname" . }}
+                  key: mailer-from
+            - name: APP_FRONTEND_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "api-platform.fullname" . }}
+                  key: app-frontend-url
             - name: MERCURE_URL
               valueFrom:
                 configMapKeyRef:

--- a/helm/api-platform/values.yaml
+++ b/helm/api-platform/values.yaml
@@ -27,6 +27,21 @@ pwa:
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
 
+# Outbound email (Symfony Mailer). For production set a real transport —
+# Resend is the recommended provider: dsn: "resend+api://YOUR_API_KEY@default".
+# Leaving dsn empty falls back to null://null, which SILENTLY DISCARDS all mail
+# (password resets, invites, verification, notifications). `from` must be an
+# address on a domain you've verified with the provider.
+# See docs/developer/email-delivery.md.
+mailer:
+  dsn: ""
+  from: "no-reply@example.com"
+
+# Absolute base URL of the PWA, used to build links in outbound email
+# (verification, password reset, invites, digests).
+app:
+  frontendUrl: "https://chart-example.local"
+
 # Postgres-backed Symfony Messenger job queue. The Doctrine transport reuses
 # the app database; auto_setup is off because the messenger_messages table is
 # created by a migration.


### PR DESCRIPTION
## Why
Readiness review for public sign-ups found **no real outbound mail transport wired for production** — `MAILER_DSN=null://null` by default, and the Helm chart injected no mailer config at all. Password reset, invites, email verification, and notifications all silently fail without it.

## What
`symfony/resend-mailer` is already a dependency, so production is **config-only**. This PR closes the wiring + docs gap:

- **Helm parity**: inject `MAILER_DSN` (Secret), `MAILER_FROM` + `APP_FRONTEND_URL` (ConfigMap) into both the web and worker Deployments. New `mailer.{dsn,from}` + `app.frontendUrl` values; empty `mailer.dsn` falls back to `null://null` so a bare chart install still boots.
- **Docs**: new `docs/developer/email-delivery.md` — Resend setup, domain (SPF/DKIM) verification, compose (`/opt/aura/.env`) + Helm env, and how to verify delivery.
- `.env`: the resend-mailer block now points at the doc.

The **compose** production path already threaded `MAILER_DSN`/`MAILER_FROM`/`APP_FRONTEND_URL` through, so no change was needed there — the operator just sets them in `/opt/aura/.env`.

## Operator go-live (not code)
Set on the server: `MAILER_DSN=resend+api://re_KEY@default`, `MAILER_FROM=no-reply@<verified-domain>`, verify the sending domain in Resend. See the new doc.

## Test plan
- `helm template` renders `MAILER_DSN`/`MAILER_FROM`/`APP_FRONTEND_URL` into both deployments (CI Docker Lint).
- No app code changed; transport selection is entirely env-driven via existing `mailer.yaml`.