### PR TITLE
feat(billing): cancel Stripe sub on account deletion + subscription receipt emails

### DIFF
--- a/api/src/Billing/StripeGateway.php
+++ b/api/src/Billing/StripeGateway.php
@@ -145,6 +145,13 @@ final class StripeGateway implements StripeGatewayInterface
         ]);
     }
 
+    public function cancelSubscription(string $subscriptionId): void
+    {
+        // Immediate cancel: DELETE ends the subscription now (vs the POST
+        // cancel_at_period_end above which lets it ride out the period).
+        $this->request('DELETE', '/subscriptions/' . rawurlencode($subscriptionId), []);
+    }
+
     public function parseWebhookEvent(string $payload, string $signatureHeader): ?array
     {
         if ('' === $this->webhookSecret) {

--- a/api/src/Billing/StripeGatewayInterface.php
+++ b/api/src/Billing/StripeGatewayInterface.php
@@ -76,6 +76,17 @@ interface StripeGatewayInterface
     public function cancelSubscriptionAtPeriodEnd(string $subscriptionId): void;
 
     /**
+     * Cancel a subscription **immediately** (Stripe `DELETE /subscriptions/{id}`)
+     * — used when an account is deleted, so the customer's card can't keep
+     * being charged for an account that no longer exists. Unlike the
+     * at-period-end variant this ends billing now. The mirror row's terminal
+     * state still arrives via the `customer.subscription.deleted` webhook (a
+     * no-op if the row has already cascaded away with the account). Throws
+     * {@see BillingException} on a transport / API error.
+     */
+    public function cancelSubscription(string $subscriptionId): void;
+
+    /**
      * Verify the `Stripe-Signature` header against the raw request body and
      * return the decoded event, or null when the signature is missing /
      * invalid / outside the timestamp tolerance (caller answers 400).

--- a/api/src/Controller/BillingController.php
+++ b/api/src/Controller/BillingController.php
@@ -16,6 +16,7 @@ use App\Entity\Subscription;
 use App\Entity\User;
 use App\Repository\SubscriptionRepository;
 use App\Service\CancellationFeedbackRecorder;
+use App\Service\SubscriptionReceiptMailer;
 use App\Service\UsageLimiter;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -52,6 +53,7 @@ class BillingController extends AbstractController
         private UsageLimiter $usageLimiter,
         private CancellationFeedbackRecorder $feedback,
         private PlanGate $planGate,
+        private SubscriptionReceiptMailer $receiptMailer,
         private LoggerInterface $logger,
         #[Autowire('%env(string:default::STRIPE_PRICE_PRO_MONTHLY)%')]
         private string $proMonthly,
@@ -289,10 +291,65 @@ class BillingController extends AbstractController
             $this->syncSubscription($object, false);
         } elseif ('checkout.session.completed' === $type) {
             $this->markInvoicePaid($object);
+        } elseif ('invoice.payment_succeeded' === $type) {
+            $this->sendSubscriptionReceipt($object);
         }
         // Any other event type is acknowledged and ignored.
 
         return new Response('', Response::HTTP_OK);
+    }
+
+    /**
+     * Email a payment receipt off Stripe's `invoice.payment_succeeded` (fired
+     * for the first checkout charge and every renewal). Only subscription
+     * invoices — one-off client-invoice payments (#445) go through
+     * checkout.session.completed above. Best-effort: a mail failure is logged
+     * but still 200s so Stripe doesn't retry the whole event.
+     *
+     * @param array<mixed, mixed> $invoice
+     */
+    private function sendSubscriptionReceipt(array $invoice): void
+    {
+        $stripeSubId = $this->stringAt($invoice, ['subscription']);
+        if (null === $stripeSubId) {
+            return; // Not a subscription invoice.
+        }
+
+        $amountPaid = $this->dig($invoice, ['amount_paid']);
+        if (!is_int($amountPaid) || $amountPaid <= 0) {
+            return; // Nothing charged (100%-off coupon / trial) — no receipt.
+        }
+
+        $recipient = $this->stringAt($invoice, ['customer_email'])
+            ?? $this->receiptRecipientFor($stripeSubId);
+        if (null === $recipient) {
+            $this->logger->warning('Subscription receipt: no recipient email resolved.', ['subscription' => $stripeSubId]);
+            return;
+        }
+
+        try {
+            $this->receiptMailer->sendReceipt(
+                $recipient,
+                $amountPaid,
+                $this->stringAt($invoice, ['currency']) ?? 'usd',
+                $this->stringAt($invoice, ['number']),
+                $this->stringAt($invoice, ['hosted_invoice_url']),
+            );
+        } catch (\Throwable $e) {
+            $this->logger->warning('Failed to send subscription receipt: {error}', ['error' => $e->getMessage()]);
+        }
+    }
+
+    /**
+     * Resolve the billing account's email for a subscription id when the Stripe
+     * invoice didn't carry `customer_email`. Personal accounts only — org/space
+     * invoices reliably include customer_email, so a null here just skips.
+     */
+    private function receiptRecipientFor(string $stripeSubId): ?string
+    {
+        $owner = $this->subscriptions->findByStripeSubscriptionId($stripeSubId)?->getOwnerUser();
+
+        return $owner instanceof User ? $owner->getEmail() : null;
     }
 
     /**

--- a/api/src/Repository/SubscriptionRepository.php
+++ b/api/src/Repository/SubscriptionRepository.php
@@ -61,6 +61,29 @@ final class SubscriptionRepository extends ServiceEntityRepository
     }
 
     /**
+     * The user's own (personal-account) subscriptions that are still live at
+     * Stripe and so worth cancelling before the account is deleted — status is
+     * still entitling and a Stripe id is present. Org/space subscriptions are
+     * deliberately excluded: those belong to accounts that outlive the user.
+     *
+     * @return list<Subscription>
+     */
+    public function findCancelableForUser(User $user): array
+    {
+        /** @var list<Subscription> $result */
+        $result = $this->createQueryBuilder('s')
+            ->where('s.ownerUser = :user')
+            ->andWhere('s.status IN (:statuses)')
+            ->andWhere('s.stripeSubscriptionId IS NOT NULL')
+            ->setParameter('user', $user)
+            ->setParameter('statuses', Subscription::ENTITLING_STATUSES)
+            ->getQuery()
+            ->getResult();
+
+        return $result;
+    }
+
+    /**
      * True if the user is entitled through any account they belong to.
      */
     public function userHasActiveEntitlement(User $user): bool

--- a/api/src/Service/AccountDeletionService.php
+++ b/api/src/Service/AccountDeletionService.php
@@ -12,9 +12,13 @@ use App\Entity\Page;
 use App\Entity\Board;
 use App\Entity\Space;
 use App\Entity\SpaceMembership;
+use App\Billing\BillingException;
+use App\Billing\StripeGatewayInterface;
 use App\Entity\Task;
 use App\Entity\User;
+use App\Repository\SubscriptionRepository;
 use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 /**
@@ -36,6 +40,9 @@ final class AccountDeletionService
     public function __construct(
         private EntityManagerInterface $em,
         private UserPasswordHasherInterface $hasher,
+        private SubscriptionRepository $subscriptions,
+        private StripeGatewayInterface $stripe,
+        private LoggerInterface $logger,
     ) {
     }
 
@@ -44,6 +51,14 @@ final class AccountDeletionService
         if (self::SENTINEL_EMAIL === $user->getEmail()) {
             throw new \RuntimeException('The system sentinel account cannot be deleted.');
         }
+
+        // Stop billing the departing user's card BEFORE we delete the account.
+        // The personal Subscription rows are `onDelete: CASCADE` on ownerUser,
+        // so the transaction below would erase our mirror while leaving the
+        // Stripe subscription live and renewing. Cancel immediately at Stripe
+        // first; the resulting customer.subscription.deleted webhook is a
+        // harmless no-op once the row has cascaded away.
+        $this->cancelPersonalSubscriptions($user);
 
         $this->em->wrapInTransaction(function () use ($user): void {
             $userId = (string) $user->getId();
@@ -68,6 +83,34 @@ final class AccountDeletionService
                 $this->em->remove($managed);
             }
         });
+    }
+
+    /**
+     * Cancel every still-live personal subscription the user owns at Stripe.
+     * Best-effort and outside the delete transaction: a Stripe outage logs a
+     * warning but must never block a GDPR account deletion — worst case an
+     * operator cancels the stray subscription from the dashboard.
+     */
+    private function cancelPersonalSubscriptions(User $user): void
+    {
+        if (!$this->stripe->isConfigured()) {
+            return;
+        }
+
+        foreach ($this->subscriptions->findCancelableForUser($user) as $subscription) {
+            $stripeId = $subscription->getStripeSubscriptionId();
+            if (null === $stripeId || '' === $stripeId) {
+                continue;
+            }
+            try {
+                $this->stripe->cancelSubscription($stripeId);
+            } catch (BillingException $e) {
+                $this->logger->warning('Failed to cancel Stripe subscription {sub} on account deletion: {error}', [
+                    'sub' => $stripeId,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
     }
 
     private function reassign(string $entityClass, string $field, User $from, User $to): void

--- a/api/src/Service/SubscriptionReceiptMailer.php
+++ b/api/src/Service/SubscriptionReceiptMailer.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Service;
+
+use App\Service\Mail\MailDispatcher;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+
+/**
+ * Emails a payment receipt after a successful subscription charge, driven by
+ * Stripe's `invoice.payment_succeeded` webhook (see
+ * {@see \App\Controller\BillingController}). Purely a confirmation — the
+ * authoritative invoice + PDF live in Stripe, reachable via the linked hosted
+ * invoice page and the in-app Billing portal.
+ *
+ * Takes primitives (not entities) so the webhook can feed it straight from the
+ * decoded Stripe object without a lookup when `customer_email` is present.
+ * Sending is best-effort at the call site — a dead transport must not fail the
+ * webhook and trigger Stripe retries.
+ */
+final class SubscriptionReceiptMailer
+{
+    public function __construct(
+        private readonly MailDispatcher $mail,
+    ) {
+    }
+
+    public function sendReceipt(
+        string $toEmail,
+        int $amountMinorUnits,
+        string $currency,
+        ?string $invoiceNumber,
+        ?string $invoiceUrl,
+    ): void {
+        $email = (new TemplatedEmail())
+            ->to($toEmail)
+            ->subject('Your Madori payment receipt')
+            ->htmlTemplate('emails/subscription_receipt.html.twig')
+            ->textTemplate('emails/subscription_receipt.txt.twig')
+            ->context([
+                'amount' => $amountMinorUnits,
+                'currency' => strtoupper($currency),
+                'invoiceNumber' => $invoiceNumber,
+                'invoiceUrl' => $invoiceUrl,
+            ]);
+
+        $this->mail->send($email);
+    }
+}

--- a/api/templates/emails/subscription_receipt.html.twig
+++ b/api/templates/emails/subscription_receipt.html.twig
@@ -1,0 +1,20 @@
+<p>Hi,</p>
+
+<p>
+    Thanks for your Madori subscription. This confirms we received your payment
+    of <strong>{{ (amount / 100)|number_format(2) }} {{ currency }}</strong>{% if invoiceNumber %}
+    for invoice <strong>{{ invoiceNumber }}</strong>{% endif %}.
+</p>
+
+{% if invoiceUrl %}
+<p>
+    <a href="{{ invoiceUrl }}">View or download your receipt</a>
+</p>
+{% endif %}
+
+<p style="color: #9ca3af; font-size: 12px;">
+    You can review past invoices and manage your subscription anytime from
+    Billing in your Madori settings.
+</p>
+
+<p>— Madori</p>

--- a/api/templates/emails/subscription_receipt.txt.twig
+++ b/api/templates/emails/subscription_receipt.txt.twig
@@ -1,0 +1,9 @@
+Hi,
+
+Thanks for your Madori subscription. This confirms we received your payment of {{ (amount / 100)|number_format(2) }} {{ currency }}{% if invoiceNumber %} for invoice {{ invoiceNumber }}{% endif %}.
+{% if invoiceUrl %}
+View or download your receipt: {{ invoiceUrl }}
+{% endif %}
+You can review past invoices and manage your subscription anytime from Billing in your Madori settings.
+
+— Madori

--- a/api/tests/Api/BillingTest.php
+++ b/api/tests/Api/BillingTest.php
@@ -9,6 +9,7 @@ use App\Entity\SpaceMembership;
 use App\Entity\Subscription;
 use App\Entity\User;
 use App\Entity\UserGroup;
+use App\Service\AccountDeletionService;
 use App\Tests\Billing\InMemoryStripeGateway;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
@@ -456,6 +457,68 @@ class BillingTest extends ApiTestCase
         $this->assertTrue($features['sso']);
         $this->assertTrue($features['ai_assist']);
         $this->assertFalse($features['scim'], 'SCIM is Enterprise-only');
+    }
+
+    public function testInvoicePaymentSucceededEmailsReceipt(): void
+    {
+        static::createClient()->request('POST', '/billing/webhook', [
+            'headers' => ['Content-Type' => 'application/json', 'Stripe-Signature' => InMemoryStripeGateway::VALID_SIGNATURE],
+            'body' => json_encode([
+                'type' => 'invoice.payment_succeeded',
+                'data' => ['object' => [
+                    'subscription' => 'sub_receipt',
+                    'amount_paid' => 1200,
+                    'currency' => 'usd',
+                    'number' => 'INV-0001',
+                    'customer_email' => 'payer@example.com',
+                    'hosted_invoice_url' => 'https://invoice.stripe.test/i/1',
+                ]],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertEmailCount(1);
+        $email = $this->getMailerMessage();
+        self::assertNotNull($email);
+        $this->assertEmailAddressContains($email, 'To', 'payer@example.com');
+        $this->assertEmailHeaderSame($email, 'Subject', 'Your Madori payment receipt');
+    }
+
+    public function testInvoicePaymentSucceededSkipsNonSubscriptionInvoice(): void
+    {
+        static::createClient()->request('POST', '/billing/webhook', [
+            'headers' => ['Content-Type' => 'application/json', 'Stripe-Signature' => InMemoryStripeGateway::VALID_SIGNATURE],
+            'body' => json_encode([
+                'type' => 'invoice.payment_succeeded',
+                'data' => ['object' => ['amount_paid' => 500, 'currency' => 'usd', 'customer_email' => 'x@example.com']],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+
+        // No `subscription` on the invoice → a one-off payment, not our receipt.
+        $this->assertResponseIsSuccessful();
+        $this->assertEmailCount(0);
+    }
+
+    public function testAccountDeletionCancelsPersonalStripeSubscription(): void
+    {
+        $user = $this->createUser('leaver@example.com');
+        $subscription = (new Subscription())
+            ->setOwnerUser($user)
+            ->setStatus(Subscription::STATUS_ACTIVE)
+            ->setStripeCustomerId('cus_leaver')
+            ->setStripeSubscriptionId('sub_leaver');
+        $this->entityManager->persist($subscription);
+        $this->entityManager->flush();
+
+        // phpstan-symfony infers the concrete class from the class-string.
+        $gateway = static::getContainer()->get(InMemoryStripeGateway::class);
+        $service = static::getContainer()->get(AccountDeletionService::class);
+        $service->deleteAccount($user);
+
+        $this->assertContains('sub_leaver', $gateway->immediatelyCanceledSubscriptions);
+
+        $this->entityManager->clear();
+        $this->assertNull($this->entityManager->getRepository(User::class)->findOneBy(['email' => 'leaver@example.com']));
     }
 
     private function seedSubscription(

--- a/api/tests/Billing/InMemoryStripeGateway.php
+++ b/api/tests/Billing/InMemoryStripeGateway.php
@@ -31,6 +31,9 @@ final class InMemoryStripeGateway implements StripeGatewayInterface
     /** @var list<string> Stripe subscription ids asked to cancel at period end. */
     public array $canceledSubscriptions = [];
 
+    /** @var list<string> Stripe subscription ids asked to cancel immediately. */
+    public array $immediatelyCanceledSubscriptions = [];
+
     public bool $configured = true;
 
     public function isConfigured(): bool
@@ -89,6 +92,11 @@ final class InMemoryStripeGateway implements StripeGatewayInterface
         $this->canceledSubscriptions[] = $subscriptionId;
     }
 
+    public function cancelSubscription(string $subscriptionId): void
+    {
+        $this->immediatelyCanceledSubscriptions[] = $subscriptionId;
+    }
+
     public function parseWebhookEvent(string $payload, string $signatureHeader): ?array
     {
         if (self::VALID_SIGNATURE !== $signatureHeader) {
@@ -114,6 +122,7 @@ final class InMemoryStripeGateway implements StripeGatewayInterface
         $this->paymentSessions = [];
         $this->portalSessions = [];
         $this->canceledSubscriptions = [];
+        $this->immediatelyCanceledSubscriptions = [];
         $this->configured = true;
     }
 }

--- a/docs/developer/billing.md
+++ b/docs/developer/billing.md
@@ -63,7 +63,7 @@ back to our Space.
 | `POST /spaces/{id}/billing/portal` | space admin | Create a Customer Portal session → `{url}` |
 | `POST /spaces/{id}/billing/cancel` | space admin | Schedule cancel-at-period-end + record the churn survey (body `{reason, comment?}`) → `{ok, cancelAtPeriodEnd, currentPeriodEnd}` |
 | `GET /spaces/{id}/billing` | space member | Plan/status/seats/period + free limits |
-| `POST /billing/webhook` | Stripe (signed) | Upsert the Subscription from `customer.subscription.*` |
+| `POST /billing/webhook` | Stripe (signed) | Upsert the Subscription from `customer.subscription.*`; email a receipt on `invoice.payment_succeeded` |
 
 The **cancel** route is owned in-app (rather than punting to the Stripe portal)
 so we control the moment the "why are you leaving?" survey is asked. It validates
@@ -72,6 +72,15 @@ the required `reason`, calls `cancelSubscriptionAtPeriodEnd()` on the gateway
 further charge), records the survey only after Stripe accepts, then optimistically
 flags the mirror row's `cancelAtPeriodEnd` (the webhook confirms it). See the
 **Cancellation feedback** section below.
+
+**Account deletion cancels the card immediately.** A personal `Subscription` is
+`onDelete: CASCADE` on `ownerUser`, so deleting the account would erase our
+mirror while leaving the Stripe subscription live and renewing. `AccountDeletionService`
+therefore calls `cancelSubscription()` (Stripe `DELETE /subscriptions/{id}` —
+immediate, not period-end) on every still-entitling personal subscription
+*before* the delete transaction. It's best-effort and outside the transaction:
+a Stripe outage logs a warning but never blocks a GDPR deletion. Org/space
+subscriptions are left alone — those accounts outlive the departing member.
 
 The webhook is unauthenticated at the firewall (no Bearer, no cookie) — its
 authenticity is the `Stripe-Signature` HMAC, verified in `StripeGateway`
@@ -110,7 +119,10 @@ STRIPE_PRICE_TEAM_YEARLY=   # price_... (Team product, yearly)
    optional yearly one). Copy the `price_...` ids.
 3. Add a **webhook endpoint** → `https://<host>/billing/webhook`, subscribed to
    `customer.subscription.created`, `customer.subscription.updated`,
-   `customer.subscription.deleted`. Copy the signing secret (`whsec_...`).
+   `customer.subscription.deleted`, and `invoice.payment_succeeded` (the last
+   drives the receipt email — `SubscriptionReceiptMailer`; without it billing
+   still works, users just don't get an emailed receipt). Copy the signing
+   secret (`whsec_...`).
 4. Set the four `STRIPE_*` env vars on the server (and the price ids).
 5. Flip `app.billing_enforcement_enabled` to `true` and deploy.
 6. Smoke-test with a Stripe test card, then switch the keys to live mode.


### PR DESCRIPTION
## Why
Two readiness gaps flagged for taking money from the public:

1. **Account deletion never told Stripe to stop billing** (critical) — a deleted user kept getting charged.
2. **No receipt/confirmation email** on a subscription payment.

## 1. Deletion cancels the Stripe subscription (critical)
Personal `Subscription` rows are `onDelete: CASCADE` on `ownerUser`, so account deletion erased our mirror while leaving the Stripe subscription live and renewing.
- Added an **immediate** cancel to the gateway seam: `StripeGatewayInterface::cancelSubscription()` → `StripeGateway` `DELETE /subscriptions/{id}` (+ the in-memory double records it).
- `SubscriptionRepository::findCancelableForUser()` returns the user's still-entitling personal subs with a Stripe id.
- `AccountDeletionService` cancels each **before** the delete transaction — best-effort and outside the tx, so a Stripe outage logs a warning but never blocks a GDPR deletion. Org/space subs are left alone (those accounts outlive the departing member). The resulting `customer.subscription.deleted` webhook is a harmless no-op once the row has cascaded away.

## 2. Subscription receipt emails
- The webhook now handles `invoice.payment_succeeded` (first charge + every renewal) → `SubscriptionReceiptMailer` sends a receipt (amount + hosted invoice link) to the invoice's `customer_email`, falling back to the personal account's email. Only subscription invoices; one-off client invoices (#445) still go through `checkout.session.completed`.
- New `emails/subscription_receipt.{html,txt}.twig`.

## Not included (per decision)
Self-serve refund path — refunds stay manual via the Stripe dashboard.

## Tests / checks (green locally)
- `BillingTest` +3: receipt emailed on `invoice.payment_succeeded`, non-subscription invoice skipped, **account deletion cancels the personal Stripe sub**. Existing `BillingTest` (25) / `AccountLifecycleTest` / `WaitlistTest` still pass.
- PHPStan level 10 + strict clean, PHPCS clean, `lint:twig` valid.

## Operator note (go-live)
Subscribe the Stripe webhook to `invoice.payment_succeeded` in addition to the `customer.subscription.*` events (documented in `docs/developer/billing.md`). Without it, billing still works — users just don't get an emailed receipt.