### PR TITLE
feat(pwa): add public pricing and FAQ pages

### DIFF
--- a/pwa/components/common/Footer.tsx
+++ b/pwa/components/common/Footer.tsx
@@ -15,6 +15,16 @@ const Footer = () => (
               </Link>
             </li>
             <li>
+              <Link href="/pricing" className="text-foreground hover:underline">
+                Pricing
+              </Link>
+            </li>
+            <li>
+              <Link href="/faq" className="text-foreground hover:underline">
+                FAQ
+              </Link>
+            </li>
+            <li>
               <Link href="/blog" className="text-foreground hover:underline">
                 Blog
               </Link>

--- a/pwa/pages/faq.tsx
+++ b/pwa/pages/faq.tsx
@@ -1,0 +1,208 @@
+import Head from "next/head";
+import Link from "next/link";
+
+interface QA {
+  q: string;
+  a: React.ReactNode;
+}
+
+interface Section {
+  title: string;
+  items: QA[];
+}
+
+const SECTIONS: Section[] = [
+  {
+    title: "Getting started",
+    items: [
+      {
+        q: "What is Madori?",
+        a: "Madori is a collaborative workspace for tasks, projects, long-form pages, discussions, and a shared calendar — with programmatic API access for automation.",
+      },
+      {
+        q: "Is there a free plan?",
+        a: (
+          <>
+            Yes. The Free plan covers unlimited personal work and small shared
+            spaces at no cost, with no credit card required. See the{" "}
+            <Link href="/pricing" className="underline underline-offset-4 hover:text-foreground">
+              pricing page
+            </Link>{" "}
+            for the full breakdown.
+          </>
+        ),
+      },
+      {
+        q: "Do I need to verify my email?",
+        a: "Yes — after signing up you'll get a confirmation link by email. Clicking it activates your account. You can resend the link from the confirmation screen if it doesn't arrive.",
+      },
+    ],
+  },
+  {
+    title: "Plans & billing",
+    items: [
+      {
+        q: "What plans are available?",
+        a: "Free, Pro, Business, and Enterprise. Free and Pro suit individuals; Business is per-seat for teams that collaborate in shared spaces; Enterprise adds advanced controls and custom terms.",
+      },
+      {
+        q: "How does per-seat billing work?",
+        a: "Business is billed per member of your team. Payments are handled securely by Stripe — Madori never stores your card details.",
+      },
+      {
+        q: "Can I cancel anytime?",
+        a: "Yes. You can cancel from your billing settings at any time. Your plan stays active until the end of the current billing period, and you won't be charged again.",
+      },
+      {
+        q: "Do you offer refunds?",
+        a: (
+          <>
+            We handle refunds case by case — if something went wrong,{" "}
+            <Link href="/feedback" className="underline underline-offset-4 hover:text-foreground">
+              get in touch
+            </Link>{" "}
+            and we'll make it right.
+          </>
+        ),
+      },
+      {
+        q: "Where do I find my invoices and receipts?",
+        a: "We email a receipt after each payment, and you can view or download every invoice from the billing portal in your Madori settings.",
+      },
+    ],
+  },
+  {
+    title: "Your data & privacy",
+    items: [
+      {
+        q: "Can I export my data?",
+        a: "Yes. From Settings → Danger zone you can request a full export of your account data; we email you a secure download link when it's ready.",
+      },
+      {
+        q: "Can I delete my account?",
+        a: "Yes. Account deletion is self-service from Settings → Danger zone. It removes your personal data and cancels any active subscription.",
+      },
+      {
+        q: "Is my data private?",
+        a: (
+          <>
+            Content in a space is visible only to that space's members. See our{" "}
+            <Link href="/privacy" className="underline underline-offset-4 hover:text-foreground">
+              Privacy Policy
+            </Link>{" "}
+            for how we collect and protect your data.
+          </>
+        ),
+      },
+    ],
+  },
+  {
+    title: "Product & platform",
+    items: [
+      {
+        q: "What is the API / MCP access?",
+        a: "Madori exposes a Model Context Protocol (MCP) endpoint and a REST API so you can automate your workspace and connect AI tools. Usage is metered per plan.",
+      },
+      {
+        q: "Does it sync with my calendar?",
+        a: "Yes — you can connect Google or Microsoft calendars for two-way sync of your dated tasks (available on paid plans).",
+      },
+      {
+        q: "Is Madori open source?",
+        a: (
+          <>
+            Madori is source-available under the{" "}
+            <a
+              href="https://github.com/roboparker/Aura/blob/main/LICENSE"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline underline-offset-4 hover:text-foreground"
+            >
+              GNU AGPL-3.0
+            </a>
+            , with commercial licenses available. You're welcome to self-host.
+          </>
+        ),
+      },
+    ],
+  },
+  {
+    title: "Support",
+    items: [
+      {
+        q: "How do I get help?",
+        a: (
+          <>
+            Reach us through the{" "}
+            <Link href="/feedback" className="underline underline-offset-4 hover:text-foreground">
+              feedback form
+            </Link>
+            , browse the{" "}
+            <Link href="/guides" className="underline underline-offset-4 hover:text-foreground">
+              guides
+            </Link>
+            , or open an issue on{" "}
+            <a
+              href="https://github.com/roboparker/Aura"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline underline-offset-4 hover:text-foreground"
+            >
+              GitHub
+            </a>
+            .
+          </>
+        ),
+      },
+    ],
+  },
+];
+
+const Faq = () => (
+  <>
+    <Head>
+      <title>FAQ — Madori</title>
+      <meta
+        name="description"
+        content="Frequently asked questions about Madori — plans and billing, your data, the API, and support."
+      />
+    </Head>
+
+    <main className="bg-background">
+      <div className="max-w-3xl mx-auto px-4 py-12 md:py-16">
+        <header className="mb-10">
+          <h1 className="text-3xl md:text-4xl font-bold tracking-tight text-foreground mb-2">
+            Frequently asked questions
+          </h1>
+          <p className="text-muted-foreground">
+            Can&apos;t find what you&apos;re looking for?{" "}
+            <Link href="/feedback" className="underline underline-offset-4 hover:text-foreground">
+              Get in touch
+            </Link>
+            .
+          </p>
+        </header>
+
+        <div className="space-y-10">
+          {SECTIONS.map((section) => (
+            <section key={section.title}>
+              <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-4">
+                {section.title}
+              </h2>
+              <div className="space-y-6">
+                {section.items.map((item) => (
+                  <div key={item.q}>
+                    <h3 className="font-semibold text-foreground mb-1.5">{item.q}</h3>
+                    <p className="text-muted-foreground leading-relaxed">{item.a}</p>
+                  </div>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      </div>
+    </main>
+  </>
+);
+
+export default Faq;

--- a/pwa/pages/pricing.tsx
+++ b/pwa/pages/pricing.tsx
@@ -1,0 +1,217 @@
+import { useState } from "react";
+import Head from "next/head";
+import Link from "next/link";
+import { Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+/**
+ * Public pricing page.
+ *
+ * NOTE: the prices below are PLACEHOLDERS pending the final pricing decision —
+ * see https://github.com/roboparker/Aura/issues/617. When they're locked, update
+ * the amounts here and create the matching Stripe Prices
+ * (STRIPE_PRICE_{PRO,BUSINESS}_{MONTHLY,YEARLY}). Free-tier limits mirror the
+ * app.free_* backend defaults (member cap 5, 100 MCP calls/day).
+ */
+
+interface Tier {
+  name: string;
+  tagline: string;
+  /** Monthly price in whole currency units; null = custom / contact us. */
+  monthly: number | null;
+  /** Whether the price is charged per seat (vs a flat account price). */
+  perSeat?: boolean;
+  cta: { label: string; href: string };
+  highlighted?: boolean;
+  features: string[];
+}
+
+const TIERS: Tier[] = [
+  {
+    name: "Free",
+    tagline: "For individuals and trying things out.",
+    monthly: 0,
+    cta: { label: "Get started", href: "/signup" },
+    features: [
+      "Unlimited personal tasks, projects & pages",
+      "Up to 5 members per shared space",
+      "100 MCP (programmatic API) calls per day",
+      "Calendar, discussions & file attachments",
+    ],
+  },
+  {
+    name: "Pro",
+    tagline: "For power users who want more room.",
+    monthly: 8,
+    cta: { label: "Start Pro", href: "/signup" },
+    features: [
+      "Everything in Free",
+      "Higher MCP / API limits",
+      "Calendar sync (Google & Microsoft)",
+      "Priority email support",
+    ],
+  },
+  {
+    name: "Business",
+    tagline: "For teams that collaborate in shared spaces.",
+    monthly: 12,
+    perSeat: true,
+    highlighted: true,
+    cta: { label: "Start Business", href: "/signup" },
+    features: [
+      "Everything in Pro",
+      "Unlimited members & unlimited MCP usage",
+      "Custom roles & per-space permissions",
+      "SSO sign-in, automations & AI assist",
+    ],
+  },
+  {
+    name: "Enterprise",
+    tagline: "For organizations with advanced needs.",
+    monthly: null,
+    cta: { label: "Contact us", href: "/feedback" },
+    features: [
+      "Everything in Business",
+      "SCIM provisioning & advanced controls",
+      "Dedicated onboarding & support",
+      "Custom terms & invoicing",
+    ],
+  },
+];
+
+const Pricing = () => {
+  const [annual, setAnnual] = useState(false);
+
+  const priceLabel = (tier: Tier): { amount: string; period: string } => {
+    if (tier.monthly === null) return { amount: "Custom", period: "" };
+    if (tier.monthly === 0) return { amount: "$0", period: "forever" };
+    // Annual billed at 10× the monthly rate → two months free.
+    const amount = annual ? tier.monthly * 10 : tier.monthly;
+    const unit = tier.perSeat ? "/seat" : "";
+    return {
+      amount: `$${amount}${unit}`,
+      period: annual ? "per year" : "per month",
+    };
+  };
+
+  return (
+    <>
+      <Head>
+        <title>Pricing — Madori</title>
+        <meta
+          name="description"
+          content="Madori pricing — a free plan for individuals, plus Pro, Business, and Enterprise tiers for teams."
+        />
+      </Head>
+
+      <main className="bg-background">
+        <div className="max-w-6xl mx-auto px-4 py-12 md:py-16">
+          <header className="text-center mb-10">
+            <h1 className="text-3xl md:text-4xl font-bold tracking-tight text-foreground mb-3">
+              Simple, transparent pricing
+            </h1>
+            <p className="text-muted-foreground max-w-2xl mx-auto">
+              Start free and upgrade when your team grows. Every plan includes
+              the full Madori workspace — tasks, projects, pages, calendar, and
+              programmatic API access.
+            </p>
+          </header>
+
+          {/* Billing period toggle */}
+          <div className="flex items-center justify-center gap-1 mb-10">
+            <div className="inline-flex rounded-lg border border-input p-1 bg-card">
+              <button
+                type="button"
+                onClick={() => setAnnual(false)}
+                className={cn(
+                  "px-4 py-1.5 text-sm font-medium rounded-md transition-colors",
+                  !annual
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+                aria-pressed={!annual}
+              >
+                Monthly
+              </button>
+              <button
+                type="button"
+                onClick={() => setAnnual(true)}
+                className={cn(
+                  "px-4 py-1.5 text-sm font-medium rounded-md transition-colors",
+                  annual
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+                aria-pressed={annual}
+              >
+                Annual
+                <span className="ml-1.5 text-xs text-emerald-600">2 months free</span>
+              </button>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">
+            {TIERS.map((tier) => {
+              const { amount, period } = priceLabel(tier);
+              return (
+                <div
+                  key={tier.name}
+                  className={cn(
+                    "flex flex-col rounded-xl border bg-card p-6 shadow-sm",
+                    tier.highlighted
+                      ? "border-primary ring-1 ring-primary"
+                      : "border-border",
+                  )}
+                >
+                  {tier.highlighted ? (
+                    <span className="mb-3 inline-flex w-fit rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-medium text-primary">
+                      Most popular
+                    </span>
+                  ) : null}
+                  <h2 className="text-lg font-semibold text-foreground">{tier.name}</h2>
+                  <p className="mt-1 text-sm text-muted-foreground min-h-10">{tier.tagline}</p>
+                  <div className="mt-4 flex items-baseline gap-1">
+                    <span className="text-3xl font-bold text-foreground">{amount}</span>
+                    {period ? (
+                      <span className="text-sm text-muted-foreground">{period}</span>
+                    ) : null}
+                  </div>
+                  <Button
+                    asChild
+                    variant={tier.highlighted ? "default" : "outline"}
+                    className="mt-5 w-full"
+                  >
+                    <Link href={tier.cta.href}>{tier.cta.label}</Link>
+                  </Button>
+                  <ul className="mt-6 space-y-2.5 text-sm">
+                    {tier.features.map((feature) => (
+                      <li key={feature} className="flex items-start gap-2">
+                        <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600" />
+                        <span className="text-muted-foreground">{feature}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              );
+            })}
+          </div>
+
+          <p className="mt-10 text-center text-sm text-muted-foreground">
+            Prices in USD. Business is billed per seat. Questions?{" "}
+            <Link href="/faq" className="underline underline-offset-4 hover:text-foreground">
+              Read the FAQ
+            </Link>{" "}
+            or{" "}
+            <Link href="/feedback" className="underline underline-offset-4 hover:text-foreground">
+              get in touch
+            </Link>
+            .
+          </p>
+        </div>
+      </main>
+    </>
+  );
+};
+
+export default Pricing;


### PR DESCRIPTION
## Why
Readiness review found **no pricing page and no FAQ** — prospective public users had no way to see what they'd be buying or get common questions answered.

## What
- **`pages/pricing.tsx`** — Free / Pro / Business / Enterprise tier cards with a monthly/annual billing toggle (annual = 2 months free), per-tier feature lists, and CTAs (Free/Pro/Business → signup, Enterprise → contact).
- **`pages/faq.tsx`** — grouped Q&A: getting started (incl. email verification), plans & billing (cancel anytime, refunds, invoices/receipts), your data & privacy (export/delete), product & API (MCP, calendar sync, open source), and support.
- **Footer** links Pricing + FAQ under Product.

Both render in the standard layout like `/terms` and `/privacy`.

## ⚠️ Placeholder prices
The amounts are **placeholders** pending the final pricing decision — tracked in #617 (created from this readiness review; no agreed numbers existed in the repo/Notion). The Free-tier limits shown mirror the `app.free_*` backend defaults (5 members, 100 MCP calls/day). When prices are locked, update `pricing.tsx` and create the matching Stripe Prices.

## Checks
- `tsc --noEmit` + ESLint clean.
- Both pages render 200 from the PWA dev server.