### PR TITLE
fix(caddy): serve /favicon.svg + app icons (Accept-independent PWA routing)

### DIFF
--- a/api/frankenphp/Caddyfile
+++ b/api/frankenphp/Caddyfile
@@ -132,7 +132,7 @@
 					'*.json*', '*.html', '*.csv', '*.yml', '*.yaml', '*.xml'
 				)
 			)
-			|| path('/favicon.ico', '/manifest.json', '/robots.txt', '/sitemap*', '/_next*', '/__next*')
+			|| path('/favicon.ico', '/favicon.svg', '/apple-touch-icon.png', '/icon-*', '/manifest.json', '/robots.txt', '/sitemap*', '/_next*', '/__next*')
 			|| query({'_rsc': '*'})`
 
 		# Comment the following line if you don't want Next.js to catch requests for HTML documents.


### PR DESCRIPTION
The Caddy `@pwa` matcher force-routes only a fixed allowlist of static paths to the PWA when the request has no `text/html` Accept header. It included `/favicon.ico` but not `/favicon.svg`, `/apple-touch-icon.png`, or `/icon-*.png` — so browsers fetching those as image subresources missed the PWA and 404'd (SVG favicon fell back to the .ico; apple-touch/PWA icons failed).

Adds `/favicon.svg`, `/apple-touch-icon.png`, `/icon-*` to the allowlist. Caddy-only, no logic/migration.