### PR TITLE
Promote: Caddy static-icon routing fix

### DIFF
--- a/api/frankenphp/Caddyfile
+++ b/api/frankenphp/Caddyfile
@@ -132,7 +132,7 @@
 					'*.json*', '*.html', '*.csv', '*.yml', '*.yaml', '*.xml'
 				)
 			)
-			|| path('/favicon.ico', '/manifest.json', '/robots.txt', '/sitemap*', '/_next*', '/__next*')
+			|| path('/favicon.ico', '/favicon.svg', '/apple-touch-icon.png', '/icon-*', '/manifest.json', '/robots.txt', '/sitemap*', '/_next*', '/__next*')
 			|| query({'_rsc': '*'})`
 
 		# Comment the following line if you don't want Next.js to catch requests for HTML documents.


### PR DESCRIPTION
Promotes #629 — route `/favicon.svg`, `/apple-touch-icon.png`, `/icon-*` to the PWA regardless of Accept header, so the SVG favicon + app icons stop 404ing on image-subresource requests. Caddy-only, no migration.