### PR TITLE
fix(monitoring): stop reporting expected HTTP 4xx exceptions to Sentry

### DIFF
--- a/api/config/packages/sentry.yaml
+++ b/api/config/packages/sentry.yaml
@@ -17,6 +17,17 @@ sentry:
         # records reach it via the Monolog LogsHandler wired in monolog.yaml
         # (when@prod). Inert without a DSN, so dev/test/CI never send.
         enable_logs: true
+        # Don't report expected HTTP 4xx exceptions — they're normal responses,
+        # not errors, and bot/vuln scanners generate thousands of them
+        # (probing /api/config/services.yaml, .env.old, POST /, unauthenticated
+        # hits on protected routes). Reporting them floods the free-tier quota
+        # and buries real errors. 5xx and everything else still reports.
+        ignore_exceptions:
+            - Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+            - Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException
+            - Symfony\Component\HttpKernel\Exception\BadRequestHttpException
+            - Symfony\Component\Security\Core\Exception\AccessDeniedException
+            - Symfony\Component\Security\Core\Exception\AuthenticationException
 
 when@test:
     sentry:


### PR DESCRIPTION
The API Sentry project was flooded by scanner/expected-4xx noise: `/api/config/services.yaml` (918 events), `.env.old` (111), unauthenticated hits on protected routes (25), POST / (405), etc. All are normal HTTP responses, not bugs — but they burn the free-tier quota and bury real errors.

Adds `sentry.options.ignore_exceptions` for the 4xx/auth exception families (NotFound, MethodNotAllowed, BadRequest, AccessDenied, Authentication). 5xx + everything else still reports. No behavior change beyond what Sentry captures.