### PR TITLE
feat: add Sentry error tracking + performance tracing (API, worker, PWA)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,6 +255,7 @@ Developer docs:
 - `docs/developer/task-organization.md` - Task sections, the Kanban board view, and task relationships (entities, endpoints, validation, UI)
 - `docs/developer/billing.md` - Billing & the freemium gate: the Team plan, hybrid seat/usage caps, Stripe Checkout/Portal + webhook, enforcement flag, going-live setup
 - `docs/developer/blog.md` - Public file-based blog: markdown posts + frontmatter, SSG rendering, SEO meta, generated sitemap, drafts
+- `docs/developer/sentry.md` - Sentry error tracking + performance tracing across the API, worker, and PWA; DSN/env wiring, disabled-by-default posture, going-live checklist
 
 User docs:
 - `docs/user/two-factor-auth.md` - End-user guide for enabling, using, and recovering 2FA

--- a/api/.env
+++ b/api/.env
@@ -61,6 +61,20 @@ MAILER_DSN=null://null
 MESSENGER_TRANSPORT_DSN=doctrine://default?auto_setup=false
 ###< symfony/messenger ###
 
+###> sentry/sentry-symfony ###
+# Error tracking + performance tracing (see config/packages/sentry.yaml).
+# Leaving SENTRY_DSN empty disables the SDK entirely — no events are sent —
+# so a fresh checkout, the PHPUnit suite, and CI stay silent. Set the DSN of
+# your Sentry *PHP* project (shared by the API + worker) in .env.local or the
+# server env for staging/prod. Format: https://<key>@oNNN.ingest.sentry.io/NNN
+SENTRY_DSN=
+# Fraction of requests/jobs sampled for performance tracing, 0..1. 0 disables
+# tracing (errors are still captured); 0.1 = 10%. Lower it if quota is tight.
+SENTRY_TRACES_SAMPLE_RATE=0.1
+# Optional release marker shown on issues (e.g. the deploy image tag/SHA).
+SENTRY_RELEASE=
+###< sentry/sentry-symfony ###
+
 ###> app rate limits ###
 # Abuse throttles on the unauthenticated endpoints (see the rate_limiter
 # block in config/packages/framework.yaml). Prod-safe defaults here;

--- a/api/composer.json
+++ b/api/composer.json
@@ -25,6 +25,7 @@
         "scheb/2fa-backup-code": "^8.5",
         "scheb/2fa-bundle": "^8.5",
         "scheb/2fa-totp": "^8.5",
+        "sentry/sentry-symfony": "^5.10",
         "stof/doctrine-extensions-bundle": "^1.15",
         "symfony/asset": "7.4.*",
         "symfony/console": "7.4.*",

--- a/api/config/bundles.php
+++ b/api/config/bundles.php
@@ -17,4 +17,5 @@ return [
     League\FlysystemBundle\FlysystemBundle::class => ['all' => true],
     Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle::class => ['all' => true],
     Scheb\TwoFactorBundle\SchebTwoFactorBundle::class => ['all' => true],
+    Sentry\SentryBundle\SentryBundle::class => ['all' => true],
 ];

--- a/api/config/packages/messenger.yaml
+++ b/api/config/packages/messenger.yaml
@@ -43,6 +43,9 @@ framework:
             # Phase D) — async so the provider callback returns immediately (the
             # scheduled sweep reaches the same handler via scheduler_default).
             App\Message\PullCalendarChanges: async
+            # Admin-only Sentry verification: a job that fails on purpose so the
+            # worker→Sentry pipeline can be confirmed (SentryTestController).
+            App\Message\SentryTestFailure: async
 
 when@test:
     framework:

--- a/api/config/packages/security.yaml
+++ b/api/config/packages/security.yaml
@@ -122,6 +122,8 @@ security:
         - { path: ^/account-exports/, roles: IS_AUTHENTICATED_FULLY }
         # Waitlist mode toggle — platform admins only.
         - { path: ^/admin/waitlist, roles: ROLE_ADMIN }
+        # Sentry verification triggers (error/worker) — platform admins only.
+        - { path: ^/admin/sentry-test, roles: ROLE_ADMIN }
         # SSO admin config (enable toggle, allowed domains, button label).
         # Linking / unlinking a social account to the signed-in user (#267).
         - { path: ^/me/sso, roles: ROLE_USER }

--- a/api/config/packages/sentry.yaml
+++ b/api/config/packages/sentry.yaml
@@ -1,0 +1,38 @@
+# Sentry error tracking + performance tracing (sentry/sentry-symfony).
+#
+# The SDK is a no-op while SENTRY_DSN is empty (the committed default in
+# api/.env), so local dev, the PHPUnit suite, and CI never phone home. Set a
+# real DSN via the server env / .env.local — the SAME DSN is shared by the
+# `php` API and the `worker` (they run the same image; transactions are
+# distinguished by server_name), so one Sentry PHP project covers both.
+#
+# What's captured out of the box:
+#   * unhandled exceptions + HTTP 5xx (the bundle's error listener)
+#   * failed Messenger jobs — async queue, reminders, digests, calendar sync,
+#     backups (the `messenger` integration below)
+#   * performance traces at SENTRY_TRACES_SAMPLE_RATE (default 0.1 = 10%)
+#
+# We deliberately do NOT register a Monolog handler that turns every
+# logger->error() into a separate Sentry issue: Symfony already logs uncaught
+# exceptions through Monolog, so a broad error-level handler double-reports
+# what the error listener captured. Add `Sentry\Monolog\Handler` scoped to the
+# app channels later if standalone log-as-issue capture is wanted.
+sentry:
+    dsn: '%env(default::SENTRY_DSN)%'
+    # Uncaught exceptions/errors are captured by the bundle's error listener.
+    register_error_listener: true
+    register_error_handler: true
+    options:
+        environment: '%kernel.environment%'
+        # Optional build/release marker (e.g. the deploy image tag). Empty is fine.
+        release: '%env(default::SENTRY_RELEASE)%'
+        # Fraction of requests/jobs sampled for performance tracing (0..1).
+        traces_sample_rate: '%env(float:SENTRY_TRACES_SAMPLE_RATE)%'
+        # Never attach usernames/emails/IP/request bodies. Privacy-first posture,
+        # matching the rest of the app (cookieless analytics, no PII in events).
+        send_default_pii: false
+    messenger:
+        enabled: true
+        # Also report messages that fail but are retried (soft fails), so a job
+        # that only succeeds on retry still surfaces the underlying error.
+        capture_soft_fails: true

--- a/api/src/Controller/SentryTestController.php
+++ b/api/src/Controller/SentryTestController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Controller;
+
+use App\Message\SentryTestFailure;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Admin-only triggers for verifying the Sentry integration end-to-end once the
+ * DSNs are configured (see docs/developer/sentry.md). Each route deliberately
+ * produces an error so you can confirm the matching surface reaches Sentry:
+ *
+ *   - GET  /admin/sentry-test/error   throws in the request → tests API capture.
+ *   - POST /admin/sentry-test/worker  queues a job that fails → tests worker
+ *                                     capture (the failing job dead-letters into
+ *                                     the `failed` transport for inspection).
+ *
+ * These are non-destructive — they touch no data. Gated to ROLE_ADMIN in
+ * security.yaml (^/admin/sentry-test); the denyAccessUnlessGranted calls here
+ * are defense-in-depth so the routes stay locked even if that rule is loosened.
+ */
+class SentryTestController extends AbstractController
+{
+    #[Route('/admin/sentry-test/error', name: 'admin_sentry_test_error', methods: ['GET'])]
+    public function error(): never
+    {
+        $this->denyAccessUnlessGranted('ROLE_ADMIN');
+
+        throw new \RuntimeException('Sentry API test error — triggered from the admin verification page.');
+    }
+
+    #[Route('/admin/sentry-test/worker', name: 'admin_sentry_test_worker', methods: ['POST'])]
+    public function worker(MessageBusInterface $bus): JsonResponse
+    {
+        $this->denyAccessUnlessGranted('ROLE_ADMIN');
+
+        $bus->dispatch(new SentryTestFailure());
+
+        return $this->json([
+            'queued' => true,
+            'detail' => 'Dispatched a job that fails on purpose. Check the Sentry PHP project and the failed queue.',
+        ], 202);
+    }
+}

--- a/api/src/Message/SentryTestFailure.php
+++ b/api/src/Message/SentryTestFailure.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Message;
+
+/**
+ * Marker message dispatched by the admin Sentry verification surface
+ * (SentryTestController). Its handler throws on purpose so we can confirm that
+ * worker-side errors reach Sentry once a DSN is configured. Routed to `async`
+ * (messenger.yaml) so it runs on the worker process, not the request.
+ */
+final class SentryTestFailure
+{
+}

--- a/api/src/MessageHandler/SentryTestFailureHandler.php
+++ b/api/src/MessageHandler/SentryTestFailureHandler.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\MessageHandler;
+
+use App\Message\SentryTestFailure;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
+
+/**
+ * Fails on purpose so the admin verification surface can confirm that errors in
+ * a background job reach Sentry (via the bundle's Messenger integration).
+ *
+ * Throwing UnrecoverableMessageHandlingException means no retries: the job
+ * fails once, is captured a single time, and dead-letters into the `failed`
+ * transport (bin/console messenger:failed:show) instead of a 4× retry storm.
+ */
+#[AsMessageHandler]
+final class SentryTestFailureHandler
+{
+    public function __invoke(SentryTestFailure $message): never
+    {
+        throw new UnrecoverableMessageHandlingException(
+            'Sentry worker test error — triggered from the admin verification page.',
+        );
+    }
+}

--- a/api/tests/Api/SentryTestControllerTest.php
+++ b/api/tests/Api/SentryTestControllerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Covers the admin-only Sentry verification triggers (SentryTestController).
+ * These endpoints exist to confirm the Sentry pipeline once a DSN is set — the
+ * SDK itself is a no-op in the test env (blank SENTRY_DSN), so these assertions
+ * only exercise the routing, the admin gate, and the intentional failures.
+ */
+class SentryTestControllerTest extends ApiTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testEndpointsRequireAdmin(): void
+    {
+        $user = $this->createTestUser('plain@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        $client->request('GET', '/admin/sentry-test/error');
+        $this->assertResponseStatusCodeSame(403);
+
+        $client->request('POST', '/admin/sentry-test/worker');
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testAdminErrorEndpointRaisesAnException(): void
+    {
+        $admin = $this->createTestUser('admin@example.com', ['ROLE_ADMIN']);
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+
+        // The controller throws on purpose; the kernel catches it (the default
+        // for functional tests) and renders a 500 that Sentry's error listener
+        // would capture in a DSN-configured environment.
+        $client->request('GET', '/admin/sentry-test/error');
+        $this->assertResponseStatusCodeSame(500);
+    }
+
+    public function testAdminWorkerEndpointDispatchesFailingJob(): void
+    {
+        $admin = $this->createTestUser('admin@example.com', ['ROLE_ADMIN']);
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+
+        // In prod the async (Doctrine) transport returns 202 immediately and the
+        // worker fails the job later. In the test env the `async` transport is
+        // sync://, so the intentionally-failing handler surfaces synchronously
+        // as a 500 — which is exactly what exercises the handler code path.
+        $client->request('POST', '/admin/sentry-test/worker');
+        $this->assertResponseStatusCodeSame(500);
+    }
+
+    /**
+     * @param list<string> $roles
+     */
+    private function createTestUser(string $email, array $roles = []): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles($roles);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/compose.yaml
+++ b/compose.yaml
@@ -30,6 +30,12 @@ services:
       # POST change-notifications to. Blank = webhooks off (poll still syncs).
       CALENDAR_WEBHOOK_BASE_URL: ${CALENDAR_WEBHOOK_BASE_URL:-}
       MESSENGER_TRANSPORT_DSN: ${MESSENGER_TRANSPORT_DSN:-doctrine://default?auto_setup=false}
+      # Sentry error tracking + tracing. Blank DSN (the default) disables the
+      # SDK; set SENTRY_DSN in the server .env for staging/prod. Shared with the
+      # worker below — one Sentry PHP project covers both.
+      SENTRY_DSN: ${SENTRY_DSN:-}
+      SENTRY_TRACES_SAMPLE_RATE: ${SENTRY_TRACES_SAMPLE_RATE:-0.1}
+      SENTRY_RELEASE: ${SENTRY_RELEASE:-}
       # Hostname for the Umami dashboard site block in the Caddyfile.
       # Prod: analytics.<domain> (with a matching DNS A record).
       UMAMI_SERVER_NAME: ${UMAMI_SERVER_NAME:-analytics.localhost}
@@ -111,6 +117,11 @@ services:
       # provider subscriptions on the pull cron, so it needs the base URL too.
       CALENDAR_WEBHOOK_BASE_URL: ${CALENDAR_WEBHOOK_BASE_URL:-}
       MESSENGER_TRANSPORT_DSN: ${MESSENGER_TRANSPORT_DSN:-doctrine://default?auto_setup=false}
+      # Sentry — same PHP project/DSN as the php service; captures failures in
+      # async jobs, reminders, digests, calendar sync, and backups.
+      SENTRY_DSN: ${SENTRY_DSN:-}
+      SENTRY_TRACES_SAMPLE_RATE: ${SENTRY_TRACES_SAMPLE_RATE:-0.1}
+      SENTRY_RELEASE: ${SENTRY_RELEASE:-}
       MERCURE_URL: ${CADDY_MERCURE_URL:-http://php/.well-known/mercure}
       MERCURE_PUBLIC_URL: ${CADDY_MERCURE_PUBLIC_URL:-https://${SERVER_NAME:-localhost}:${HTTPS_PORT:-443}/.well-known/mercure}
       MERCURE_JWT_SECRET: ${CADDY_MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}

--- a/docs/developer/sentry.md
+++ b/docs/developer/sentry.md
@@ -1,0 +1,107 @@
+# Sentry (error tracking + performance tracing)
+
+Madori reports errors and a sampled slice of performance traces to
+[Sentry](https://sentry.io) from three surfaces:
+
+| Surface | SDK | Where it initialises |
+| --- | --- | --- |
+| API (Symfony, `php` container) | [`sentry/sentry-symfony`](https://docs.sentry.io/platforms/php/guides/symfony/) | `api/config/packages/sentry.yaml` |
+| Worker (Messenger, same image) | same bundle | same config; capture via the `messenger` integration |
+| PWA (Next.js) | [`@sentry/nextjs`](https://docs.sentry.io/platforms/javascript/guides/nextjs/) | `pwa/instrumentation-client.ts` · `pwa/instrumentation.ts` · `pwa/sentry.{server,edge}.config.ts` |
+
+**The whole thing is off until a DSN is set.** A blank DSN makes each SDK a
+no-op, so a fresh checkout, the PHPUnit/Vitest suites, and CI never phone home.
+Turning Sentry on is purely a matter of setting the DSN env vars in the
+deployment — no code change.
+
+## Sentry projects & DSNs
+
+Create **two projects** in the Sentry org:
+
+1. A **PHP** project — its DSN is shared by the API **and** the worker (they run
+   the same image; Sentry distinguishes them by `server_name`/transaction data).
+   This DSN is a **server secret** — set it via env, never commit it.
+2. A **Next.js** project — its DSN is **public** (it ships in the browser
+   bundle, exactly like the Umami website ID), so it can be committed in
+   `pwa/.env.production` once created.
+
+## Backend configuration
+
+Config lives in [`api/config/packages/sentry.yaml`](../../api/config/packages/sentry.yaml).
+Env vars (defaults committed blank/`0.1` in `api/.env`):
+
+| Var | Purpose |
+| --- | --- |
+| `SENTRY_DSN` | PHP project DSN. Blank = disabled. |
+| `SENTRY_TRACES_SAMPLE_RATE` | Tracing sample fraction `0..1` (default `0.1`). `0` = errors only. |
+| `SENTRY_RELEASE` | Optional release marker (e.g. deploy image tag). |
+
+What's captured automatically:
+
+- Unhandled exceptions and HTTP 5xx (the bundle's error listener).
+- Failed Messenger jobs — the async queue, task reminders, notification
+  digests, calendar sync, and backups (`messenger.enabled: true`,
+  `capture_soft_fails: true`).
+- Performance transactions at `SENTRY_TRACES_SAMPLE_RATE`.
+
+`send_default_pii` is **false** — no usernames, emails, IPs, cookies, or request
+bodies are attached, matching the app's privacy-first posture.
+
+> **Note — logged errors vs exceptions.** We intentionally do **not** register a
+> broad Monolog handler that turns every `logger->error()` into a separate Sentry
+> issue: Symfony already logs uncaught exceptions through Monolog, so such a
+> handler would double-report what the error listener already captures. If you
+> later want standalone log-as-issue capture, add `Sentry\Monolog\Handler`
+> scoped to the app channels (excluding `request`/`console`) in `when@prod`.
+
+## Frontend configuration
+
+`next.config.js` is wrapped with `withSentryConfig`. The SDK is gated on
+`NEXT_PUBLIC_SENTRY_DSN`, so the wrapper is inert until a DSN is set.
+
+| Var | Where | Purpose |
+| --- | --- | --- |
+| `NEXT_PUBLIC_SENTRY_DSN` | `pwa/.env.production` (public) | Next.js project DSN. Blank = disabled. |
+| `NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE` | `pwa/.env.production` | Tracing fraction `0..1` (default `0.1`). |
+| `NEXT_PUBLIC_SENTRY_ENVIRONMENT` | `pwa/.env.production` | Environment tag (default `production`). |
+
+These `NEXT_PUBLIC_*` vars are **baked in at build time**, so a change requires a
+rebuild of the PWA image.
+
+### Source maps (optional)
+
+Readable stack traces need source maps uploaded at build time. Upload only runs
+when `SENTRY_AUTH_TOKEN` is present, so the default build (no token) succeeds
+without it. To enable, pass these at PWA build time (CI build args / env):
+
+- `SENTRY_ORG` — your Sentry org slug
+- `SENTRY_PROJECT` — the Next.js project slug
+- `SENTRY_AUTH_TOKEN` — a Sentry auth token with `project:releases` scope (**secret**)
+
+## Going live checklist
+
+1. Create the two Sentry projects; copy their DSNs.
+2. **API + worker**: set `SENTRY_DSN` (and optionally `SENTRY_RELEASE`) in the
+   server's untracked `.env` (Compose) or the `sentry.dsn` Helm value
+   (lands in the chart Secret). `SENTRY_TRACES_SAMPLE_RATE` is already `0.1`.
+3. **PWA**: paste the Next.js DSN into `NEXT_PUBLIC_SENTRY_DSN` in
+   `pwa/.env.production`, commit, and rebuild the PWA image.
+4. (Optional) Wire `SENTRY_ORG` / `SENTRY_PROJECT` / `SENTRY_AUTH_TOKEN` into the
+   PWA build for source-map upload.
+5. Deploy, then verify. Sign in as an admin and open **`/admin/sentry-test`**
+   (sidebar → **Admin → Sentry test**). It has one button per surface:
+   throw a client error (Next.js project), trigger an API 500, and queue a
+   worker job that fails on purpose (both → the PHP project). Confirm each lands
+   in Sentry. The triggers are non-destructive; the worker job dead-letters into
+   the `failed` transport (`bin/console messenger:failed:show` to inspect/clear).
+
+The endpoints behind that page — `GET /admin/sentry-test/error` and
+`POST /admin/sentry-test/worker` (`App\Controller\SentryTestController`) — are
+gated to `ROLE_ADMIN`.
+
+## Tuning
+
+- **Quota tight?** Lower `SENTRY_TRACES_SAMPLE_RATE` /
+  `NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE` toward `0` (errors are still captured).
+- **Ad blockers dropping events?** Enable a same-origin tunnel by setting
+  `tunnelRoute` in `withSentryConfig` (see `pwa/next.config.js`).

--- a/helm/api-platform/templates/configmap.yaml
+++ b/helm/api-platform/templates/configmap.yaml
@@ -15,3 +15,5 @@ data:
   mercure-extra-directives: {{ .Values.mercure.extraDirectives | quote }}
   caddy-global-options: {{ .Values.php.caddyGlobalOptions | quote }}
   messenger-transport-dsn: {{ .Values.messenger.transportDsn | quote }}
+  sentry-traces-sample-rate: {{ .Values.sentry.tracesSampleRate | default "0.1" | quote }}
+  sentry-release: {{ .Values.sentry.release | default "" | quote }}

--- a/helm/api-platform/templates/deployment.yaml
+++ b/helm/api-platform/templates/deployment.yaml
@@ -115,6 +115,21 @@ spec:
                 secretKeyRef:
                   name: {{ include "api-platform.fullname" . }}
                   key: mercure-jwt-secret
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "api-platform.fullname" . }}
+                  key: sentry-dsn
+            - name: SENTRY_TRACES_SAMPLE_RATE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "api-platform.fullname" . }}
+                  key: sentry-traces-sample-rate
+            - name: SENTRY_RELEASE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "api-platform.fullname" . }}
+                  key: sentry-release
           ports:
             - name: http
               containerPort: 80

--- a/helm/api-platform/templates/secrets.yaml
+++ b/helm/api-platform/templates/secrets.yaml
@@ -13,3 +13,5 @@ data:
   {{- end }}
   php-app-secret: {{ .Values.php.appSecret | default (randAlphaNum 40) | b64enc | quote }}
   mercure-jwt-secret: {{ .Values.mercure.jwtSecret | default (randAlphaNum 40) | b64enc | quote }}
+  # Empty when Sentry is off; the SDK treats a blank DSN as disabled.
+  sentry-dsn: {{ .Values.sentry.dsn | default "" | b64enc | quote }}

--- a/helm/api-platform/templates/worker-deployment.yaml
+++ b/helm/api-platform/templates/worker-deployment.yaml
@@ -92,6 +92,21 @@ spec:
                 secretKeyRef:
                   name: {{ include "api-platform.fullname" . }}
                   key: mercure-jwt-secret
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "api-platform.fullname" . }}
+                  key: sentry-dsn
+            - name: SENTRY_TRACES_SAMPLE_RATE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "api-platform.fullname" . }}
+                  key: sentry-traces-sample-rate
+            - name: SENTRY_RELEASE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "api-platform.fullname" . }}
+                  key: sentry-release
           # Liveness via the consumer process: if messenger:consume dies the
           # container exits and the Deployment restarts it. The slim image has
           # no pgrep/ps, so check for the php process with pidof.

--- a/helm/api-platform/values.yaml
+++ b/helm/api-platform/values.yaml
@@ -33,6 +33,14 @@ pwa:
 messenger:
   transportDsn: "doctrine://default?auto_setup=false"
 
+# Sentry error tracking + performance tracing for the PHP API + worker (they
+# share one Sentry PHP project). Leave dsn empty to keep the SDK disabled;
+# set it to your project DSN to turn Sentry on. tracesSampleRate is 0..1.
+sentry:
+  dsn: ""
+  tracesSampleRate: "0.1"
+  release: ""
+
 # Long-running job runner (bin/console messenger:consume). Set enabled: false
 # to fall back to processing jobs inline / via cron only.
 worker:

--- a/pwa/.env.development
+++ b/pwa/.env.development
@@ -9,3 +9,7 @@ NEXT_PUBLIC_PASSWORD_MIN_STRENGTH=0
 # to disable the "enable browser notifications" prompts. Generate a pair with
 # `npx web-push generate-vapid-keys` and set the same public key here + in the API.
 NEXT_PUBLIC_VAPID_PUBLIC_KEY=
+
+# Sentry stays off in local dev (blank DSN = SDK disabled). Set your Next.js
+# project DSN here to exercise the integration locally.
+NEXT_PUBLIC_SENTRY_DSN=

--- a/pwa/.env.production
+++ b/pwa/.env.production
@@ -17,3 +17,14 @@ NEXT_PUBLIC_SITE_URL=https://madori.app
 # while false the space plan/upgrade card isn't rendered or fetched. Set to
 # "true" (and configure the Stripe env on the API) to turn billing on.
 NEXT_PUBLIC_BILLING_ENABLED=false
+
+# Sentry (frontend error tracking + performance tracing). The DSN is public —
+# it ships in the browser bundle like the Umami website ID above — so it is
+# safe to commit once you create the Next.js Sentry project. While blank the
+# SDK is disabled and no events are sent. This is the PWA's own DSN, distinct
+# from the API's SENTRY_DSN (a separate Sentry PHP project).
+NEXT_PUBLIC_SENTRY_DSN=
+# Fraction of transactions sampled for performance tracing (0..1). 0 = errors
+# only. Baked at build; keep in step with the API's SENTRY_TRACES_SAMPLE_RATE.
+NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE=0.1
+NEXT_PUBLIC_SENTRY_ENVIRONMENT=production

--- a/pwa/components/common/SidebarNav.tsx
+++ b/pwa/components/common/SidebarNav.tsx
@@ -296,6 +296,11 @@ const AdminSection = ({ wrap }: { wrap: (children: ReactNode) => ReactNode }) =>
       label: "Global custom fields",
       match: "/admin/global-custom-fields",
     },
+    {
+      href: "/admin/sentry-test",
+      label: "Sentry test",
+      match: "/admin/sentry-test",
+    },
     { href: "/feedback", label: "Feedback", match: "/feedback" },
     ...ADMIN_EXTERNAL_LINKS.map((l) => ({ ...l, match: l.href, external: true })),
   ];

--- a/pwa/instrumentation-client.ts
+++ b/pwa/instrumentation-client.ts
@@ -1,0 +1,23 @@
+// Browser-side Sentry init. Next.js auto-loads this file for the client
+// runtime (the successor to the old sentry.client.config.ts). No-op while the
+// DSN is unset — see @/lib/sentryConfig.
+import * as Sentry from "@sentry/nextjs"
+
+import {
+  sentryDsn,
+  sentryEnabled,
+  sentryEnvironment,
+  sentryTracesSampleRate,
+} from "@/lib/sentryConfig"
+
+Sentry.init({
+  dsn: sentryDsn,
+  enabled: sentryEnabled,
+  environment: sentryEnvironment,
+  tracesSampleRate: sentryTracesSampleRate,
+  // Privacy-first: never attach IP/cookies/user identity to events.
+  sendDefaultPii: false,
+})
+
+// Instruments client-side navigations for tracing.
+export const onRouterTransitionStart = Sentry.captureRouterTransitionStart

--- a/pwa/instrumentation.ts
+++ b/pwa/instrumentation.ts
@@ -1,0 +1,15 @@
+// Next.js instrumentation hook. register() runs once per server/edge runtime
+// boot and loads the matching Sentry init; onRequestError forwards server-side
+// errors (SSR, API routes, RSC) to Sentry. Both no-op while the DSN is unset.
+import * as Sentry from "@sentry/nextjs"
+
+export async function register() {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    await import("./sentry.server.config")
+  }
+  if (process.env.NEXT_RUNTIME === "edge") {
+    await import("./sentry.edge.config")
+  }
+}
+
+export const onRequestError = Sentry.captureRequestError

--- a/pwa/lib/sentryConfig.ts
+++ b/pwa/lib/sentryConfig.ts
@@ -1,0 +1,28 @@
+// Shared Sentry init values for the browser, server, and edge runtimes
+// (see docs/developer/sentry.md).
+//
+// DSN + sample rate come from NEXT_PUBLIC_* env vars baked in at build time
+// (pwa/.env.production for the prod image). The DSN is public — it ships in
+// the browser bundle just like the Umami website ID — so it is safe to commit.
+// A blank DSN disables the SDK, so local dev, tests, and any build without a
+// configured DSN send nothing.
+
+export const sentryDsn = process.env.NEXT_PUBLIC_SENTRY_DSN || undefined
+
+export const sentryEnabled = Boolean(sentryDsn)
+
+export const sentryEnvironment =
+  process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT || process.env.NODE_ENV || "production"
+
+function parseRate(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw === "") return fallback
+  const n = Number(raw)
+  return Number.isFinite(n) ? n : fallback
+}
+
+// Fraction of transactions sampled for performance tracing (0..1). Defaults to
+// 10%; set NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE=0 to capture errors only.
+export const sentryTracesSampleRate = parseRate(
+  process.env.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE,
+  0.1,
+)

--- a/pwa/next.config.js
+++ b/pwa/next.config.js
@@ -1,3 +1,5 @@
+const { withSentryConfig } = require('@sentry/nextjs')
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
@@ -18,4 +20,21 @@ const nextConfig = {
   },
 }
 
-module.exports = nextConfig
+// Wrap with Sentry. The SDK itself is gated on NEXT_PUBLIC_SENTRY_DSN (blank =
+// disabled), so this wrapper is inert at runtime until a DSN is configured.
+// Source-map upload only runs when SENTRY_AUTH_TOKEN is present at build time —
+// the committed default has no token, so builds succeed without one. To upload
+// maps, pass SENTRY_ORG / SENTRY_PROJECT / SENTRY_AUTH_TOKEN as build args/env.
+module.exports = withSentryConfig(nextConfig, {
+  org: process.env.SENTRY_ORG,
+  project: process.env.SENTRY_PROJECT,
+  authToken: process.env.SENTRY_AUTH_TOKEN,
+  // Quiet the plugin's build logs outside CI.
+  silent: !process.env.CI,
+  // Skip map upload unless an auth token is configured (keeps default builds green).
+  sourcemaps: { disable: !process.env.SENTRY_AUTH_TOKEN },
+  // Tree-shake Sentry's debug logger out of the client bundle.
+  disableLogger: true,
+  // Widen upload to catch client files hosted from a CDN sub-path, if enabled.
+  widenClientFileUpload: true,
+})

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -30,6 +30,7 @@
     "@radix-ui/react-label": "^2.1.11",
     "@radix-ui/react-separator": "^1.1.11",
     "@radix-ui/react-slot": "^1.3.0",
+    "@sentry/nextjs": "^10.63.0",
     "@tailwindcss/forms": "^0.5.11",
     "@tailwindcss/postcss": "^4.3.2",
     "@tanstack/react-query": "^5.101.2",

--- a/pwa/pages/admin/sentry-test.tsx
+++ b/pwa/pages/admin/sentry-test.tsx
@@ -1,0 +1,219 @@
+import type { NextPage } from "next";
+import Head from "next/head";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import { ENTRYPOINT } from "@/config/entrypoint";
+import { fetchWithTimeout } from "@/lib/fetchWithTimeout";
+import { signinHrefForCurrent } from "@/lib/authRedirect";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+// Admin-only page to verify Sentry captures errors on each surface once the
+// DSNs are configured (see docs/developer/sentry.md). Nothing here is
+// destructive — every action just produces a deliberate error.
+const AdminSentryTest: NextPage = () => {
+  const { user, isAuthenticated, isLoading } = useAuth();
+  const router = useRouter();
+  const isAdmin = user?.roles?.includes("ROLE_ADMIN");
+
+  const [notice, setNotice] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<"api" | "worker" | null>(null);
+
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated) {
+      router.replace(signinHrefForCurrent(router.asPath));
+    }
+  }, [isLoading, isAuthenticated, router]);
+
+  // Throw an uncaught client-side error. Deferred via setTimeout so it reaches
+  // the browser's global error handler (which Sentry hooks) rather than being
+  // swallowed by a surrounding try/catch.
+  const throwClientError = () => {
+    setError(null);
+    setNotice(
+      "Threw a client-side error. If a DSN is configured it should appear in the Next.js Sentry project shortly (also visible in the browser console).",
+    );
+    setTimeout(() => {
+      throw new Error("Sentry client test error — triggered from the admin verification page.");
+    }, 0);
+  };
+
+  const triggerApiError = async () => {
+    setBusy("api");
+    setError(null);
+    setNotice(null);
+    try {
+      const res = await fetchWithTimeout(`${ENTRYPOINT}/admin/sentry-test/error`, {
+        credentials: "include",
+      });
+      // The endpoint throws server-side, so a 500 is the expected, successful
+      // outcome of this test.
+      if (res.status === 500) {
+        setNotice(
+          "Triggered a server error (HTTP 500). If a DSN is configured it should appear in the Sentry PHP project shortly.",
+        );
+      } else {
+        setError(`Unexpected response from the API test endpoint (HTTP ${res.status}).`);
+      }
+    } catch {
+      setError("Couldn't reach the API test endpoint.");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const triggerWorkerError = async () => {
+    setBusy("worker");
+    setError(null);
+    setNotice(null);
+    try {
+      const res = await fetchWithTimeout(`${ENTRYPOINT}/admin/sentry-test/worker`, {
+        method: "POST",
+        credentials: "include",
+      });
+      if (res.status === 202) {
+        setNotice(
+          "Queued a job that fails on purpose. If a DSN is configured the failure should appear in the Sentry PHP project once the worker runs it (it also lands in the failed queue for inspection).",
+        );
+      } else {
+        setError(`Unexpected response from the worker test endpoint (HTTP ${res.status}).`);
+      }
+    } catch {
+      setError("Couldn't reach the worker test endpoint.");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-muted">
+        <p className="text-muted-foreground">Loading…</p>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return null;
+  }
+
+  if (!isAdmin) {
+    return (
+      <>
+        <Head>
+          <title>Access Denied - Madori</title>
+        </Head>
+        <div className="min-h-screen flex items-center justify-center bg-muted px-4">
+          <div className="text-center">
+            <h1 className="text-2xl font-bold text-foreground mb-2">Access Denied</h1>
+            <p className="text-muted-foreground">
+              You need administrator privileges to view this page.
+            </p>
+          </div>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Sentry test - Madori Admin</title>
+      </Head>
+      <div className="min-h-screen bg-background px-4 py-12">
+        <div className="max-w-3xl mx-auto space-y-6">
+          <header>
+            <h1 className="text-2xl font-bold">Sentry test</h1>
+            <p className="text-sm text-muted-foreground">
+              Verify that errors reach Sentry on each surface. These triggers are
+              safe — they touch no data. Nothing is sent until the corresponding
+              DSN is configured.
+            </p>
+          </header>
+
+          {error && (
+            <Alert variant="destructive" data-testid="sentry-test-error">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+          {notice && (
+            <Alert data-testid="sentry-test-notice">
+              <AlertDescription>{notice}</AlertDescription>
+            </Alert>
+          )}
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Frontend (PWA)</CardTitle>
+              <CardDescription>
+                Throws an uncaught error in the browser to test the Next.js
+                Sentry project.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button
+                variant="outline"
+                onClick={throwClientError}
+                data-testid="sentry-test-client"
+              >
+                Throw a client error
+              </Button>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>API (Symfony)</CardTitle>
+              <CardDescription>
+                Calls an endpoint that raises an exception (HTTP 500) to test the
+                Sentry PHP project.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button
+                variant="outline"
+                onClick={triggerApiError}
+                disabled={busy !== null}
+                data-testid="sentry-test-api"
+              >
+                {busy === "api" ? "Triggering…" : "Trigger an API error"}
+              </Button>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Worker (background job)</CardTitle>
+              <CardDescription>
+                Queues a job that fails on purpose to test worker-side capture
+                (same Sentry PHP project). The failed job dead-letters for
+                inspection.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button
+                variant="outline"
+                onClick={triggerWorkerError}
+                disabled={busy !== null}
+                data-testid="sentry-test-worker"
+              >
+                {busy === "worker" ? "Queuing…" : "Trigger a worker error"}
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default AdminSentryTest;

--- a/pwa/sentry.edge.config.ts
+++ b/pwa/sentry.edge.config.ts
@@ -1,0 +1,18 @@
+// Edge runtime Sentry init — loaded from instrumentation.ts. No-op while the
+// DSN is unset. See @/lib/sentryConfig.
+import * as Sentry from "@sentry/nextjs"
+
+import {
+  sentryDsn,
+  sentryEnabled,
+  sentryEnvironment,
+  sentryTracesSampleRate,
+} from "@/lib/sentryConfig"
+
+Sentry.init({
+  dsn: sentryDsn,
+  enabled: sentryEnabled,
+  environment: sentryEnvironment,
+  tracesSampleRate: sentryTracesSampleRate,
+  sendDefaultPii: false,
+})

--- a/pwa/sentry.server.config.ts
+++ b/pwa/sentry.server.config.ts
@@ -1,0 +1,18 @@
+// Node.js (server) runtime Sentry init — loaded from instrumentation.ts. No-op
+// while the DSN is unset. See @/lib/sentryConfig.
+import * as Sentry from "@sentry/nextjs"
+
+import {
+  sentryDsn,
+  sentryEnabled,
+  sentryEnvironment,
+  sentryTracesSampleRate,
+} from "@/lib/sentryConfig"
+
+Sentry.init({
+  dsn: sentryDsn,
+  enabled: sentryEnabled,
+  environment: sentryEnvironment,
+  tracesSampleRate: sentryTracesSampleRate,
+  sendDefaultPii: false,
+})


### PR DESCRIPTION
## Summary

Wires [Sentry](https://sentry.io) into all three surfaces — the Symfony API, the Messenger worker, and the Next.js PWA — for error tracking plus low-rate (10%) performance tracing. **Disabled by default**: a blank DSN makes every SDK a no-op, so local dev, the test suite, and CI stay silent until DSNs are configured. Turning it on is purely an env change, no code.

Decisions were confirmed with the requester: **hosted sentry.io**, all three surfaces, **errors + performance tracing** (no session replay), `send_default_pii: false` (privacy-first, matching the cookieless-analytics posture).

## What's included

**Backend (API + worker — one shared PHP Sentry project)**
- `sentry/sentry-symfony` bundle; config in `api/config/packages/sentry.yaml` (DSN, `environment`, `traces_sample_rate`, `send_default_pii: false`, Messenger job-failure capture).
- Captures unhandled exceptions + failed async jobs (reminders, digests, calendar sync, backups).
- Deliberately **no** broad Monolog error→issue handler (would double-report what the error listener already captures — rationale in the doc).

**Frontend (PWA — its own public DSN)**
- `@sentry/nextjs` via `instrumentation-client.ts` / `instrumentation.ts` / `sentry.{server,edge}.config.ts`; `next.config.js` wrapped with `withSentryConfig`.
- Source-map upload gated on `SENTRY_AUTH_TOKEN`, so default builds succeed without it.

**Deployment & config**
- Env through `api/.env`, `compose.yaml` (php + worker), and the Helm chart (Secret DSN + ConfigMap sample rate, both deployments).

**Admin-only verification**
- `/admin/sentry-test` (sidebar → Admin → Sentry test), one trigger per surface, backed by `SentryTestController` (ROLE_ADMIN) + a failing Messenger job. Non-destructive. Covered by `SentryTestControllerTest`.

**Docs** — `docs/developer/sentry.md` + CLAUDE.md pointer.

## ⚠️ Before merge — regenerate lockfiles

`composer.json` and `package.json` gained a dependency, but the lockfiles could **not** be regenerated in the authoring environment (no Docker/toolchain). CI will be red on the frozen-install checks until these run and are pushed to this branch:

```bash
docker compose exec php composer update sentry/sentry-symfony -w   # composer.lock
docker compose exec pwa  pnpm install                             # pnpm-lock.yaml
```

## Going live (after merge)
Create two Sentry projects (PHP + Next.js), set `SENTRY_DSN` on the server / Helm and `NEXT_PUBLIC_SENTRY_DSN` in `pwa/.env.production` (rebuild PWA), then verify via **Admin → Sentry test**. Full checklist in `docs/developer/sentry.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)