### PR TITLE
feat(billing): final prices ($10/$15) + enable Stripe billing UI

### DIFF
--- a/pwa/.env.production
+++ b/pwa/.env.production
@@ -13,10 +13,9 @@ NEXT_PUBLIC_VAPID_PUBLIC_KEY=BI0zaJu3pluxfEaKoSa2r1lnpwv_mlU1y7GTKPwNKGlsl8LgjlX
 # /sitemap.xml. Set this to the production domain.
 NEXT_PUBLIC_SITE_URL=https://madori.app
 
-# Billing (Stripe) UI gate. Off until a real payment system is wired up —
-# while false the space plan/upgrade card isn't rendered or fetched. Set to
-# "true" (and configure the Stripe env on the API) to turn billing on.
-NEXT_PUBLIC_BILLING_ENABLED=false
+# Billing (Stripe) UI gate. Renders the plan/upgrade cards + checkout.
+# Enabled now that the Stripe env is wired on the API (test mode → live).
+NEXT_PUBLIC_BILLING_ENABLED=true
 
 # Sentry error + performance monitoring (see docs/developer/monitoring.md).
 # NEXT_PUBLIC_SENTRY_DSN is intentionally NOT set here. Even though the DSN is

--- a/pwa/pages/pricing.tsx
+++ b/pwa/pages/pricing.tsx
@@ -8,11 +8,10 @@ import { cn } from "@/lib/utils";
 /**
  * Public pricing page.
  *
- * NOTE: the prices below are PLACEHOLDERS pending the final pricing decision —
- * see https://github.com/roboparker/Aura/issues/617. When they're locked, update
- * the amounts here and create the matching Stripe Prices
- * (STRIPE_PRICE_{PRO,BUSINESS}_{MONTHLY,YEARLY}). Free-tier limits mirror the
- * app.free_* backend defaults (member cap 5, 100 MCP calls/day).
+ * Prices: Pro $10/mo (flat), Business $15/mo per seat; annual = ×10 (2 months
+ * free). These must match the Stripe Prices
+ * (STRIPE_PRICE_{PRO,BUSINESS}_{MONTHLY,YEARLY}) — update both together. Free-tier
+ * limits mirror the app.free_* backend defaults (member cap 5, 100 MCP calls/day).
  */
 
 interface Tier {
@@ -43,7 +42,7 @@ const TIERS: Tier[] = [
   {
     name: "Pro",
     tagline: "For power users who want more room.",
-    monthly: 8,
+    monthly: 10,
     cta: { label: "Start Pro", href: "/signup" },
     features: [
       "Everything in Free",
@@ -55,7 +54,7 @@ const TIERS: Tier[] = [
   {
     name: "Business",
     tagline: "For teams that collaborate in shared spaces.",
-    monthly: 12,
+    monthly: 15,
     perSeat: true,
     highlighted: true,
     cta: { label: "Start Business", href: "/signup" },


### PR DESCRIPTION
Turns on the billing/upgrade UI now that the Stripe env is wired on the server (test mode).

- `pricing.tsx`: Pro $10/mo, Business $15/seat (annual ×10 → $100/$150), matching the Stripe Prices.
- `NEXT_PUBLIC_BILLING_ENABLED=true` — renders the upgrade/checkout cards.

Enforcement (`app.billing_enforcement_enabled`) stays OFF — this only exposes the upgrade path; free users aren't capped yet. Instance is waitlist-gated, so exposure is limited while we smoke-test with a Stripe test card, then swap test→live keys.