### PR TITLE
test(billing): make Stripe price config deterministic (fix flaky BillingTest)

### DIFF
--- a/api/config/services.yaml
+++ b/api/config/services.yaml
@@ -8,6 +8,17 @@ parameters:
     # env var is unset — see app.calendar_webhook_base_url below (#582 Phase D).
     env(CALENDAR_WEBHOOK_BASE_URL): ''
 
+    # Stripe self-serve price-id fallbacks. The billing controllers resolve each
+    # price from its STRIPE_PRICE_* env var, defaulting to these params when the
+    # env is empty/unset. Blank here → prod correctly reports "plan not
+    # configured" until the real ids are set. Pinned in when@test below so the
+    # billing suite is deterministic regardless of env-resolution order (see
+    # RateLimitTest, which mutates $_ENV and reboots kernels).
+    app.stripe_price_pro_monthly: ''
+    app.stripe_price_pro_yearly: ''
+    app.stripe_price_business_monthly: ''
+    app.stripe_price_business_yearly: ''
+
     # Whether a new open signup (waitlist off) must confirm its email before
     # the account is usable. Env-driven (like the RATE_LIMIT_* knobs) so the
     # test suite can toggle it per case: prod/staging ship it ON via .env,
@@ -243,6 +254,15 @@ when@test:
         # registering plain users; WaitlistTest flips the toggle on
         # explicitly to exercise the gated path.
         app.waitlist_enabled_default: false
+        # Pin the Stripe price ids so the billing suite always sees the plans as
+        # configured — the STRIPE_PRICE_* env in .env.test can resolve empty in
+        # an unlucky test order (RateLimitTest mutates $_ENV + reboots kernels),
+        # which intermittently 503'd checkout with "plan not configured". These
+        # match the .env.test values so assertions on the price id still hold.
+        app.stripe_price_pro_monthly: 'price_test_pro_monthly'
+        app.stripe_price_pro_yearly: 'price_test_pro_yearly'
+        app.stripe_price_business_monthly: 'price_test_biz_monthly'
+        app.stripe_price_business_yearly: 'price_test_biz_yearly'
     services:
         App\Tests\Push\InMemoryPushSender:
             public: true

--- a/api/src/Controller/BillingController.php
+++ b/api/src/Controller/BillingController.php
@@ -55,13 +55,13 @@ class BillingController extends AbstractController
         private PlanGate $planGate,
         private SubscriptionReceiptMailer $receiptMailer,
         private LoggerInterface $logger,
-        #[Autowire('%env(string:default::STRIPE_PRICE_PRO_MONTHLY)%')]
+        #[Autowire('%env(string:default:app.stripe_price_pro_monthly:STRIPE_PRICE_PRO_MONTHLY)%')]
         private string $proMonthly,
-        #[Autowire('%env(string:default::STRIPE_PRICE_PRO_YEARLY)%')]
+        #[Autowire('%env(string:default:app.stripe_price_pro_yearly:STRIPE_PRICE_PRO_YEARLY)%')]
         private string $proYearly,
-        #[Autowire('%env(string:default::STRIPE_PRICE_BUSINESS_MONTHLY)%')]
+        #[Autowire('%env(string:default:app.stripe_price_business_monthly:STRIPE_PRICE_BUSINESS_MONTHLY)%')]
         private string $businessMonthly,
-        #[Autowire('%env(string:default::STRIPE_PRICE_BUSINESS_YEARLY)%')]
+        #[Autowire('%env(string:default:app.stripe_price_business_yearly:STRIPE_PRICE_BUSINESS_YEARLY)%')]
         private string $businessYearly,
         #[Autowire('%env(APP_FRONTEND_URL)%')]
         private string $frontendUrl,

--- a/api/src/Controller/MeBillingController.php
+++ b/api/src/Controller/MeBillingController.php
@@ -37,9 +37,9 @@ class MeBillingController extends AbstractController
         private PlanGate $planGate,
         private CancellationFeedbackRecorder $feedback,
         private LoggerInterface $logger,
-        #[Autowire('%env(string:default::STRIPE_PRICE_PRO_MONTHLY)%')]
+        #[Autowire('%env(string:default:app.stripe_price_pro_monthly:STRIPE_PRICE_PRO_MONTHLY)%')]
         private string $proMonthly,
-        #[Autowire('%env(string:default::STRIPE_PRICE_PRO_YEARLY)%')]
+        #[Autowire('%env(string:default:app.stripe_price_pro_yearly:STRIPE_PRICE_PRO_YEARLY)%')]
         private string $proYearly,
         #[Autowire('%env(APP_FRONTEND_URL)%')]
         private string $frontendUrl,

--- a/api/src/Controller/OrganizationBillingController.php
+++ b/api/src/Controller/OrganizationBillingController.php
@@ -38,9 +38,9 @@ class OrganizationBillingController extends AbstractController
         private PlanGate $planGate,
         private CancellationFeedbackRecorder $feedback,
         private LoggerInterface $logger,
-        #[Autowire('%env(string:default::STRIPE_PRICE_BUSINESS_MONTHLY)%')]
+        #[Autowire('%env(string:default:app.stripe_price_business_monthly:STRIPE_PRICE_BUSINESS_MONTHLY)%')]
         private string $businessMonthly,
-        #[Autowire('%env(string:default::STRIPE_PRICE_BUSINESS_YEARLY)%')]
+        #[Autowire('%env(string:default:app.stripe_price_business_yearly:STRIPE_PRICE_BUSINESS_YEARLY)%')]
         private string $businessYearly,
         #[Autowire('%env(APP_FRONTEND_URL)%')]
         private string $frontendUrl,


### PR DESCRIPTION
`BillingTest` intermittently failed with 'The Pro/Business plan is not configured' (503 on checkout). Root cause: the billing controllers resolve prices via `%env(string:default::STRIPE_PRICE_*)%` (empty fallback), and `RateLimitTest` mutates `$_ENV`/`$_SERVER` + reboots kernels, so in an unlucky test order the price env resolves empty → 'not configured'.

Fix: give each price a **parameter fallback** (`app.stripe_price_*`) — blank in prod (unchanged: still 'not configured' until real ids are set), pinned to the `.env.test` values in `when@test`. Plans are now always configured in tests regardless of $_ENV order.

No prod behavior change; no migration.