### PR TITLE
feat(time): edit/delete entries + optional timer on /time (#643, #646)

### DIFF
--- a/api/src/Entity/TimeEntry.php
+++ b/api/src/Entity/TimeEntry.php
@@ -16,6 +16,7 @@ use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
 use App\Repository\TimeEntryRepository;
+use App\State\TimeEntryDeleteProcessor;
 use App\State\TimeEntryUserProcessor;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Attribute\Groups;
@@ -58,6 +59,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
         ),
         new Delete(
             security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getUser() == user or object.getSpace().isAdmin(user) or (object.getSpace().hasMember(user) and is_granted('space.time_entries.delete', object)))",
+            processor: TimeEntryDeleteProcessor::class,
         ),
     ],
     normalizationContext: ['groups' => ['time_entry:read']],

--- a/api/src/State/TimeEntryDeleteProcessor.php
+++ b/api/src/State/TimeEntryDeleteProcessor.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\Entity\TimeEntry;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+
+/**
+ * Guards deletion of billed time entries. Once an entry has been pulled onto
+ * an invoice ({@see TimeEntry::$billedAt}) it is part of a financial document —
+ * deleting it would silently desync the invoice from the time that backs it.
+ * The PWA hides the delete affordance for billed rows; this enforces the same
+ * rule server-side (422, mirroring the edit guard in TimeEntryUserProcessor).
+ *
+ * @implements ProcessorInterface<TimeEntry, void>
+ */
+final class TimeEntryDeleteProcessor implements ProcessorInterface
+{
+    /**
+     * @param ProcessorInterface<TimeEntry, void> $removeProcessor
+     */
+    public function __construct(
+        #[Autowire(service: 'api_platform.doctrine.orm.state.remove_processor')]
+        private ProcessorInterface $removeProcessor,
+    ) {
+    }
+
+    /**
+     * @param TimeEntry $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): void
+    {
+        if (null !== $data->getBilledAt()) {
+            throw new UnprocessableEntityHttpException(
+                'This entry is on an invoice and can no longer be deleted.',
+            );
+        }
+
+        $this->removeProcessor->process($data, $operation, $uriVariables, $context);
+    }
+}

--- a/api/src/State/TimeEntryUserProcessor.php
+++ b/api/src/State/TimeEntryUserProcessor.php
@@ -9,6 +9,7 @@ use App\Repository\TimeEntryRepository;
 use App\Security\AuthenticatedUserResolver;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
 /**
  * Stamps the current user as the time entry's tracker on create, mirroring the
@@ -47,6 +48,16 @@ final class TimeEntryUserProcessor implements ProcessorInterface
         $user = $this->auth->requireUser('track time');
 
         $isCreate = null === $data->getUser();
+
+        // Billed entries are frozen: they back an invoice line, so editing them
+        // would desync the financial document from the time behind it. billedAt
+        // is never client-writable, so non-null here means "already invoiced".
+        if (!$isCreate && null !== $data->getBilledAt()) {
+            throw new UnprocessableEntityHttpException(
+                'This entry is on an invoice and can no longer be edited.',
+            );
+        }
+
         if ($isCreate) {
             $data->setUser($user);
 

--- a/api/tests/Api/TimeEntryTest.php
+++ b/api/tests/Api/TimeEntryTest.php
@@ -204,6 +204,76 @@ class TimeEntryTest extends ApiTestCase
         $this->assertSame(1, $running['totalItems'] ?? null);
     }
 
+    public function testBilledEntryCannotBeEditedOrDeleted(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $board = $this->createProject($alice, 'Backend');
+        $spaceIri = $this->spaceIri($board);
+        [$bpIri, $catIri] = $this->createBilling($board, 'Website', 'Development', 12000);
+
+        $client = static::createClient();
+        $client->loginUser($alice);
+
+        $entry = $client->request('POST', '/time_entries', [
+            'json' => [
+                'space' => $spaceIri,
+                'engagement' => $bpIri,
+                'category' => $catIri,
+                'description' => 'Soon to be billed',
+                'startedAt' => '2026-07-03T09:00:00+00:00',
+                'endedAt' => '2026-07-03T10:00:00+00:00',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $iri = $entry['@id'];
+        $this->assertIsString($iri);
+
+        // Simulate the invoice pull stamping billedAt (server-side only —
+        // billedAt is never client-writable).
+        $row = $this->entityManager->getRepository(TimeEntry::class)
+            ->findOneBy(['description' => 'Soon to be billed']);
+        $this->assertNotNull($row);
+        $row->setBilledAt(new \DateTimeImmutable());
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        // A billed entry is frozen: no edits…
+        $client->request('PATCH', $iri, [
+            'json' => ['description' => 'rewritten history'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+
+        // …and no deletion.
+        $client->request('DELETE', $iri);
+        $this->assertResponseStatusCodeSame(422);
+
+        // Control: an unbilled entry still edits and deletes normally.
+        $other = $client->request('POST', '/time_entries', [
+            'json' => [
+                'space' => $spaceIri,
+                'engagement' => $bpIri,
+                'category' => $catIri,
+                'description' => 'Still editable',
+                'startedAt' => '2026-07-03T11:00:00+00:00',
+                'endedAt' => '2026-07-03T11:30:00+00:00',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $otherIri = $other['@id'];
+        $this->assertIsString($otherIri);
+
+        $client->request('PATCH', $otherIri, [
+            'json' => ['description' => 'Edited'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(200);
+
+        $client->request('DELETE', $otherIri);
+        $this->assertResponseStatusCodeSame(204);
+    }
+
     public function testMemberCanListEngagementOptions(): void
     {
         $alice = $this->createUser('alice@example.com');

--- a/api/tests/Api/TimeEntryTest.php
+++ b/api/tests/Api/TimeEntryTest.php
@@ -230,13 +230,16 @@ class TimeEntryTest extends ApiTestCase
         $this->assertIsString($iri);
 
         // Simulate the invoice pull stamping billedAt (server-side only —
-        // billedAt is never client-writable).
-        $row = $this->entityManager->getRepository(TimeEntry::class)
+        // billedAt is never client-writable). Use the CLIENT kernel's manager:
+        // requests share its identity map, so a write through the stale setUp
+        // manager would be invisible to the next request's item lookup.
+        $em = static::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $row = $em->getRepository(TimeEntry::class)
             ->findOneBy(['description' => 'Soon to be billed']);
         $this->assertNotNull($row);
         $row->setBilledAt(new \DateTimeImmutable());
-        $this->entityManager->flush();
-        $this->entityManager->clear();
+        $em->flush();
 
         // A billed entry is frozen: no edits…
         $client->request('PATCH', $iri, [

--- a/pwa/pages/time/index.tsx
+++ b/pwa/pages/time/index.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { Fragment, FormEvent, useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Clock, Plus } from "lucide-react";
+import { Clock, Pencil, Play, Plus, Square, Trash2 } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
 import { apiGet, apiGetCollection, apiSend } from "@/lib/apiClient";
@@ -12,7 +12,9 @@ import {
   EngagementOption,
   TimeEntry,
   elapsedSeconds,
+  formatClock,
   formatDuration,
+  isRunning,
 } from "@/lib/timeEntryTypes";
 import PageHeader from "@/components/common/PageHeader";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -23,11 +25,13 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 
+const MERGE_PATCH = "application/merge-patch+json";
+
 const SELECT_CLASS =
   "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50";
 
 /** "YYYY-MM-DD" for a date input (local). */
-const todayInput = (d: Date): string => {
+const dateInput = (d: Date): string => {
   const pad = (n: number) => n.toString().padStart(2, "0");
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
 };
@@ -47,20 +51,25 @@ const dayLabel = (iso: string): string =>
     day: "numeric",
   });
 
+const clockLabel = (iso: string): string =>
+  new Date(iso).toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+
 const TimePage = () => {
-  const { isAuthenticated, isLoading: authLoading } = useAuth();
+  const { isAuthenticated, isLoading: authLoading, user } = useAuth();
   const { activeSpace, can } = useActiveSpace();
   const router = useRouter();
   const queryClient = useQueryClient();
 
   const [showComposer, setShowComposer] = useState(false);
   const [description, setDescription] = useState("");
-  const [workDate, setWorkDate] = useState(() => todayInput(new Date()));
+  const [workDate, setWorkDate] = useState(() => dateInput(new Date()));
   const [startTime, setStartTime] = useState(() => timeInput(new Date()));
   const [endTime, setEndTime] = useState(() => timeInput(new Date()));
   const [projectIri, setProjectIri] = useState("");
   const [categoryIri, setCategoryIri] = useState("");
+  const [editingIri, setEditingIri] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [nowTick, setNowTick] = useState(() => Date.now());
 
   useEffect(() => {
     if (!authLoading && !isAuthenticated) {
@@ -70,6 +79,7 @@ const TimePage = () => {
 
   const spaceIri = activeSpace?.["@id"] ?? null;
   const spaceId = activeSpace?.id ?? null;
+  const currentUserIri = user ? `/users/${user.id}` : null;
 
   const entriesQuery = useQuery({
     queryKey: ["time_entries", spaceIri],
@@ -118,6 +128,15 @@ const TimePage = () => {
     }
   }, [categories, categoryIri]);
 
+  // The (at most one) running timer, pinned above the day groups.
+  const running = useMemo(() => entries.find(isRunning) ?? null, [entries]);
+  const runningIri = running?.["@id"] ?? null;
+  useEffect(() => {
+    if (!runningIri) return;
+    const t = setInterval(() => setNowTick(Date.now()), 1000);
+    return () => clearInterval(t);
+  }, [runningIri]);
+
   const projectCategoryBody = () => ({
     engagement: projectIri,
     category: categoryIri,
@@ -139,7 +158,7 @@ const TimePage = () => {
       setDescription("");
       setStartTime(timeInput(new Date()));
       setEndTime(timeInput(new Date()));
-      setWorkDate(todayInput(new Date()));
+      setWorkDate(dateInput(new Date()));
       setShowComposer(false);
       setActionError(null);
       void refresh();
@@ -147,14 +166,86 @@ const TimePage = () => {
     onError: (e) => setActionError(e instanceof Error ? e.message : "Failed to log time."),
   });
 
+  const startTimer = useMutation({
+    mutationFn: () =>
+      apiSend<TimeEntry>("POST", "/time_entries", {
+        errorMessage: "Failed to start the timer.",
+        body: { startedAt: new Date().toISOString(), ...projectCategoryBody() },
+      }),
+    onSuccess: () => {
+      setActionError(null);
+      void refresh();
+    },
+    onError: (e) =>
+      setActionError(e instanceof Error ? e.message : "Failed to start the timer."),
+  });
+
+  const stopTimer = useMutation({
+    mutationFn: (entry: TimeEntry) => {
+      // Entries can't span midnight — a timer left running overnight is
+      // capped at the end of its start day (matching the server rule).
+      const start = new Date(entry.startedAt);
+      let end = new Date();
+      if (end.toDateString() !== start.toDateString()) {
+        end = new Date(start);
+        end.setHours(23, 59, 59, 0);
+      }
+      return apiSend<TimeEntry>("PATCH", entry["@id"], {
+        contentType: MERGE_PATCH,
+        errorMessage: "Failed to stop the timer.",
+        body: { endedAt: end.toISOString() },
+      });
+    },
+    onSuccess: () => {
+      setActionError(null);
+      void refresh();
+    },
+    onError: (e) =>
+      setActionError(e instanceof Error ? e.message : "Failed to stop the timer."),
+  });
+
+  const updateEntry = useMutation({
+    mutationFn: ({ iri, body }: { iri: string; body: Record<string, unknown> }) =>
+      apiSend<TimeEntry>("PATCH", iri, {
+        contentType: MERGE_PATCH,
+        errorMessage: "Failed to update the entry.",
+        body,
+      }),
+    onSuccess: () => {
+      setEditingIri(null);
+      setActionError(null);
+      void refresh();
+    },
+    onError: (e) =>
+      setActionError(e instanceof Error ? e.message : "Failed to update the entry."),
+  });
+
+  const deleteEntry = useMutation({
+    mutationFn: (iri: string) =>
+      apiSend("DELETE", iri, { errorMessage: "Failed to delete the entry." }),
+    onSuccess: () => {
+      setActionError(null);
+      void refresh();
+    },
+    onError: (e) =>
+      setActionError(e instanceof Error ? e.message : "Failed to delete the entry."),
+  });
+
   const handleLog = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     logEntry.mutate();
   };
 
+  const handleDelete = (entry: TimeEntry) => {
+    if (!window.confirm("Delete this time entry?")) return;
+    deleteEntry.mutate(entry["@id"]);
+  };
+
+  // Completed entries only — the running timer renders as its own pinned row.
   const grouped = useMemo(() => {
     const byDay = new Map<string, TimeEntry[]>();
     for (const entry of entries) {
+      if (isRunning(entry)) continue;
       const key = dayLabel(entry.startedAt);
       const list = byDay.get(key) ?? [];
       list.push(entry);
@@ -162,9 +253,14 @@ const TimePage = () => {
     }
     return Array.from(byDay.entries());
   }, [entries]);
+  const hasCompleted = grouped.length > 0;
 
   const canCreate = can("time_entries", "create");
   const canTrack = !!projectIri && !!categoryIri;
+  const isOwn = (entry: TimeEntry) =>
+    !!currentUserIri && entry.user === currentUserIri;
+  const canModify = (entry: TimeEntry) =>
+    !entry.billedAt && (isOwn(entry) || can("time_entries", "update"));
   const error = actionError || (entriesQuery.isError ? "Failed to load time entries." : null);
 
   if (authLoading || !isAuthenticated) {
@@ -226,7 +322,7 @@ const TimePage = () => {
         <title>Time — Madori</title>
       </Head>
       <div className="min-h-screen bg-background px-4 py-12">
-        <div className="mx-auto max-w-4xl">
+        <div className="mx-auto max-w-5xl">
           <PageHeader
             title="Time"
             icon={<Clock className="size-6 text-orange-600 dark:text-orange-400" />}
@@ -264,6 +360,7 @@ const TimePage = () => {
                       <th className="px-4 py-2 font-medium">Time</th>
                       <th className="px-4 py-2 font-medium">Billable</th>
                       <th className="px-4 py-2 text-right font-medium">Duration</th>
+                      <th className="px-2 py-2" aria-label="Actions" />
                     </tr>
                   </thead>
                   <tbody>
@@ -271,7 +368,7 @@ const TimePage = () => {
                     {canCreate && !noProjects &&
                       (showComposer ? (
                         <tr className="border-b bg-muted/10">
-                          <td colSpan={6} className="px-4 py-4">
+                          <td colSpan={7} className="px-4 py-4">
                             <form onSubmit={handleLog} className="space-y-4">
                               {projectCategoryPickers}
                               <div className="space-y-1.5">
@@ -351,22 +448,81 @@ const TimePage = () => {
                         </tr>
                       ) : (
                         <tr className="border-b">
-                          <td colSpan={6} className="px-4 py-2">
-                            <button
-                              type="button"
-                              onClick={() => setShowComposer(true)}
-                              className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
-                            >
-                              <Plus className="h-4 w-4" /> Add time
-                            </button>
+                          <td colSpan={7} className="px-4 py-2">
+                            <div className="flex items-center gap-4">
+                              <button
+                                type="button"
+                                onClick={() => setShowComposer(true)}
+                                className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+                              >
+                                <Plus className="h-4 w-4" /> Add time
+                              </button>
+                              {!running && (
+                                <button
+                                  type="button"
+                                  onClick={() => startTimer.mutate()}
+                                  disabled={!canTrack || startTimer.isPending}
+                                  title={
+                                    canTrack
+                                      ? `Start a timer on ${projectName.get(projectIri) ?? "…"} · ${categoryName.get(categoryIri) ?? "…"} (change via Add time)`
+                                      : "Pick an engagement first"
+                                  }
+                                  className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                                >
+                                  <Play className="h-4 w-4" /> Start timer
+                                </button>
+                              )}
+                            </div>
                           </td>
                         </tr>
                       ))}
 
-                    {entries.length === 0 ? (
+                    {/* Running timer, pinned above the day groups. */}
+                    {running && (
+                      <tr className="border-b bg-emerald-500/5" data-testid="running-entry">
+                        <td className="px-4 py-2.5">
+                          <span className="inline-flex items-center gap-2">
+                            <span className="relative flex h-2 w-2 shrink-0">
+                              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-500 opacity-60" />
+                              <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500" />
+                            </span>
+                            {running.description?.trim() || (
+                              <span className="text-muted-foreground">Running timer</span>
+                            )}
+                          </span>
+                        </td>
+                        <td className="px-4 py-2.5 text-muted-foreground">
+                          {running.engagement
+                            ? projectName.get(running.engagement) ?? "—"
+                            : "—"}
+                        </td>
+                        <td className="px-4 py-2.5 text-muted-foreground">
+                          {running.category ? categoryName.get(running.category) ?? "—" : "—"}
+                        </td>
+                        <td className="whitespace-nowrap px-4 py-2.5 text-muted-foreground">
+                          {clockLabel(running.startedAt)} · running
+                        </td>
+                        <td className="px-4 py-2.5" />
+                        <td className="whitespace-nowrap px-4 py-2.5 text-right font-mono tabular-nums">
+                          {formatClock(elapsedSeconds(running, nowTick))}
+                        </td>
+                        <td className="px-2 py-2.5 text-right">
+                          <Button
+                            size="sm"
+                            variant="destructive"
+                            onClick={() => stopTimer.mutate(running)}
+                            disabled={stopTimer.isPending}
+                          >
+                            <Square className="h-3.5 w-3.5" /> Stop
+                          </Button>
+                        </td>
+                      </tr>
+                    )}
+
+                    {!hasCompleted && !running ? (
                       <tr>
                         <td
-                          colSpan={6}
+                          colSpan={7}
                           className="px-4 py-10 text-center text-muted-foreground"
                         >
                           No time logged yet. Use “Add time” to log some.
@@ -377,25 +533,29 @@ const TimePage = () => {
                         <Fragment key={day}>
                           <tr className="bg-muted/40">
                             <td
-                              colSpan={6}
+                              colSpan={7}
                               className="px-4 py-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground"
                             >
                               {day}
                             </td>
                           </tr>
-                          {dayEntries.map((entry) => {
-                            const startT = new Date(entry.startedAt).toLocaleTimeString(undefined, {
-                              hour: "numeric",
-                              minute: "2-digit",
-                            });
-                            const endT = entry.endedAt
-                              ? new Date(entry.endedAt).toLocaleTimeString(undefined, {
-                                  hour: "numeric",
-                                  minute: "2-digit",
-                                })
-                              : null;
-                            return (
-                              <tr key={entry["@id"]} className="border-b last:border-0 align-middle">
+                          {dayEntries.map((entry) =>
+                            editingIri === entry["@id"] ? (
+                              <EditEntryRow
+                                key={entry["@id"]}
+                                entry={entry}
+                                projects={projects}
+                                pending={updateEntry.isPending}
+                                onCancel={() => setEditingIri(null)}
+                                onSave={(body) =>
+                                  updateEntry.mutate({ iri: entry["@id"], body })
+                                }
+                              />
+                            ) : (
+                              <tr
+                                key={entry["@id"]}
+                                className="group border-b last:border-0 align-middle"
+                              >
                                 <td className="px-4 py-2.5">
                                   {entry.description?.trim() || (
                                     <span className="text-muted-foreground">No description</span>
@@ -407,26 +567,52 @@ const TimePage = () => {
                                     : "—"}
                                 </td>
                                 <td className="px-4 py-2.5 text-muted-foreground">
-                                  {entry.category ? categoryName.get(entry.category) ?? "—" : "—"}
+                                  {entry.category
+                                    ? categoryName.get(entry.category) ?? "—"
+                                    : "—"}
                                 </td>
                                 <td className="whitespace-nowrap px-4 py-2.5 text-muted-foreground">
-                                  {startT}
-                                  {endT ? `–${endT}` : " · running"}
+                                  {clockLabel(entry.startedAt)}
+                                  {entry.endedAt ? `–${clockLabel(entry.endedAt)}` : ""}
                                 </td>
                                 <td className="px-4 py-2.5">
                                   <div className="flex items-center gap-1.5">
                                     {!entry.billable && (
                                       <Badge variant="secondary">Non-billable</Badge>
                                     )}
-                                    {entry.billedAt && <Badge variant="secondary">Invoiced</Badge>}
+                                    {entry.billedAt && (
+                                      <Badge variant="secondary">Invoiced</Badge>
+                                    )}
                                   </div>
                                 </td>
                                 <td className="whitespace-nowrap px-4 py-2.5 text-right font-mono tabular-nums">
                                   {formatDuration(entry.durationSeconds ?? elapsedSeconds(entry))}
                                 </td>
+                                <td className="whitespace-nowrap px-2 py-2.5 text-right">
+                                  {canModify(entry) && (
+                                    <span className="inline-flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
+                                      <button
+                                        type="button"
+                                        onClick={() => setEditingIri(entry["@id"])}
+                                        aria-label="Edit entry"
+                                        className="rounded p-1 text-muted-foreground hover:text-foreground"
+                                      >
+                                        <Pencil className="h-3.5 w-3.5" />
+                                      </button>
+                                      <button
+                                        type="button"
+                                        onClick={() => handleDelete(entry)}
+                                        aria-label="Delete entry"
+                                        className="rounded p-1 text-muted-foreground hover:text-destructive"
+                                      >
+                                        <Trash2 className="h-3.5 w-3.5" />
+                                      </button>
+                                    </span>
+                                  )}
+                                </td>
                               </tr>
-                            );
-                          })}
+                            ),
+                          )}
                         </Fragment>
                       ))
                     )}
@@ -438,6 +624,145 @@ const TimePage = () => {
         </div>
       </div>
     </>
+  );
+};
+
+/**
+ * Inline editor for one completed entry — mirrors the add-row form but with
+ * its own local state (keyed by the entry, so switching rows remounts it).
+ * Billed entries never reach this (the actions are hidden + the server 422s).
+ */
+const EditEntryRow = ({
+  entry,
+  projects,
+  pending,
+  onSave,
+  onCancel,
+}: {
+  entry: TimeEntry;
+  projects: EngagementOption[];
+  pending: boolean;
+  onSave: (body: Record<string, unknown>) => void;
+  onCancel: () => void;
+}) => {
+  const [eDescription, setEDescription] = useState(entry.description ?? "");
+  const [eDate, setEDate] = useState(() => dateInput(new Date(entry.startedAt)));
+  const [eStart, setEStart] = useState(() => timeInput(new Date(entry.startedAt)));
+  const [eEnd, setEEnd] = useState(() =>
+    entry.endedAt ? timeInput(new Date(entry.endedAt)) : "",
+  );
+  const [eProject, setEProject] = useState(entry.engagement ?? "");
+  const [eCategory, setECategory] = useState(entry.category ?? "");
+
+  const cats = projects.find((p) => p["@id"] === eProject)?.categories ?? [];
+
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    onSave({
+      description: eDescription.trim() || null,
+      startedAt: composeIso(eDate, eStart),
+      endedAt: eEnd ? composeIso(eDate, eEnd) : null,
+      engagement: eProject,
+      category: eCategory,
+    });
+  };
+
+  return (
+    <tr className="border-b bg-muted/10">
+      <td colSpan={7} className="px-4 py-4">
+        <form onSubmit={submit} className="space-y-4">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="tee-project">Engagement</Label>
+              <select
+                id="tee-project"
+                value={eProject}
+                onChange={(e) => {
+                  const next = e.target.value;
+                  setEProject(next);
+                  const nextCats =
+                    projects.find((p) => p["@id"] === next)?.categories ?? [];
+                  setECategory(nextCats[0]?.["@id"] ?? "");
+                }}
+                className={SELECT_CLASS}
+              >
+                {projects.map((p) => (
+                  <option key={p["@id"]} value={p["@id"]}>
+                    {p.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="tee-category">Category</Label>
+              <select
+                id="tee-category"
+                value={eCategory}
+                onChange={(e) => setECategory(e.target.value)}
+                className={SELECT_CLASS}
+              >
+                {cats.map((c) => (
+                  <option key={c["@id"]} value={c["@id"]}>
+                    {c.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="tee-desc">
+              Description <span className="font-normal text-muted-foreground">(optional)</span>
+            </Label>
+            <Textarea
+              id="tee-desc"
+              value={eDescription}
+              onChange={(e) => setEDescription(e.target.value)}
+              maxLength={1000}
+              rows={3}
+            />
+          </div>
+          <div className="grid gap-4 sm:grid-cols-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="tee-date">Date</Label>
+              <Input
+                id="tee-date"
+                type="date"
+                value={eDate}
+                onChange={(e) => setEDate(e.target.value)}
+                required
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="tee-start">Start</Label>
+              <Input
+                id="tee-start"
+                type="time"
+                value={eStart}
+                onChange={(e) => setEStart(e.target.value)}
+                required
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="tee-end">End</Label>
+              <Input
+                id="tee-end"
+                type="time"
+                value={eEnd}
+                onChange={(e) => setEEnd(e.target.value)}
+              />
+            </div>
+          </div>
+          <div className="flex items-center justify-end gap-2">
+            <Button type="button" variant="ghost" size="sm" onClick={onCancel}>
+              Cancel
+            </Button>
+            <Button type="submit" size="sm" disabled={pending || !eProject || !eCategory}>
+              {pending ? "Saving…" : "Save changes"}
+            </Button>
+          </div>
+        </form>
+      </td>
+    </tr>
   );
 };
 


### PR DESCRIPTION
First P0 slice of the Harvest gap plan. Closes #643, closes #646.

## Edit + delete (#643)
- Hover actions on each /time row: **edit** opens an inline form (engagement/category/description/date/start/end — mirrors the add row, own state keyed per entry) → PATCH; **delete** confirms → DELETE.
- Visible only to the entry owner or `time_entries.update` grantees, and never on billed rows.
- **Server-side billed-lock**: PATCH (`TimeEntryUserProcessor`) and DELETE (new `TimeEntryDeleteProcessor`) return **422** once `billedAt` is set — invoiced time is frozen. `billedAt` is never client-writable, so non-null ⇒ already invoiced.

## Timer (#646)
- Compact **Start timer** beside "Add time" (uses the shared engagement/category selection; tooltip explains how to change it). Backend already enforces one-running-per-user and auto-stops the previous timer.
- Running entry pins above the day groups with a pulsing dot + live clock + **Stop**.
- Midnight rule: stopping on a later calendar day caps `endedAt` at the start day's 23:59:59 (server would 422 otherwise).

## Tests
`TimeEntryTest::testBilledEntryCannotBeEditedOrDeleted` — billed entry 422s on PATCH + DELETE; control entry edits (200) and deletes (204) normally (covers both processor branches).