### PR TITLE
feat(invoices): date range + entry selection with preview when generating from time

### DIFF
--- a/api/src/Controller/InvoiceFromTimeController.php
+++ b/api/src/Controller/InvoiceFromTimeController.php
@@ -25,9 +25,17 @@ use Symfony\Component\Uid\Uuid;
  * snapshotted category rate), each back-linking its source entry, and every
  * pulled entry stamped `billedAt` so the same time can't be billed twice.
  *
- * Body: `{ engagement }` (IRI or UUID). Auth: creating invoices is
- * admin-reserved — the caller must be a space admin or hold an explicit
- * invoicing role.
+ * Body: `{ engagement }` (IRI or UUID), plus optional scoping (#644):
+ *  - `from` / `to` — inclusive `Y-m-d` dates on the entry's startedAt, so
+ *    "invoice just October" is possible;
+ *  - `entries` — an explicit list of entry IRIs/UUIDs to pull; every selected
+ *    entry must be in the invoiceable pool (unbilled, billable, completed, on
+ *    this engagement, inside the range) or the whole request 422s;
+ *  - `preview: true` — return the candidate rows + totals WITHOUT creating an
+ *    invoice or stamping billedAt, so the UI can offer per-entry unticks.
+ *
+ * Auth: creating invoices is admin-reserved — the caller must be a space admin
+ * or hold an explicit invoicing role.
  */
 class InvoiceFromTimeController extends AbstractController
 {
@@ -66,13 +74,56 @@ class InvoiceFromTimeController extends AbstractController
             return $this->json(['error' => 'This engagement has no client.'], 422);
         }
 
-        $entries = $this->timeEntries->findInvoiceableForEngagement($engagement);
+        $from = $this->parseDate($payload['from'] ?? null);
+        $to = $this->parseDate($payload['to'] ?? null);
+        if (false === $from || false === $to) {
+            return $this->json(['error' => 'Dates must be formatted YYYY-MM-DD.'], 422);
+        }
+        if (null !== $from && null !== $to && $to < $from) {
+            return $this->json(['error' => 'The end of the range is before its start.'], 422);
+        }
+
+        $entries = $this->timeEntries->findInvoiceableForEngagement(
+            $engagement,
+            $from,
+            $to?->modify('+1 day'),
+        );
+
+        // Optional explicit selection — must be a subset of the pool, so a
+        // stale/foreign/billed reference fails loudly instead of silently
+        // shrinking the invoice.
+        $selection = $payload['entries'] ?? null;
+        if (is_array($selection)) {
+            $wanted = [];
+            foreach ($selection as $ref) {
+                $id = $this->entryId($ref);
+                if (null === $id) {
+                    return $this->json(['error' => 'Invalid entry reference in the selection.'], 422);
+                }
+                $wanted[$id] = true;
+            }
+            $entries = array_values(array_filter(
+                $entries,
+                static fn (TimeEntry $t): bool => isset($wanted[(string) $t->getId()]),
+            ));
+            if (count($entries) !== count($wanted)) {
+                return $this->json([
+                    'error' => 'One or more selected entries are not invoiceable for this engagement.',
+                ], 422);
+            }
+        }
+
+        $currency = $engagement->getCurrency() ?? $client->getCurrency() ?? 'USD';
+
+        if (true === ($payload['preview'] ?? false)) {
+            return $this->preview($entries, $client->getDefaultRateAmount(), $currency);
+        }
+
         if (0 === count($entries)) {
             return $this->json(['error' => 'No unbilled billable time to invoice.'], 422);
         }
 
         $now = new \DateTimeImmutable();
-        $currency = $engagement->getCurrency() ?? $client->getCurrency() ?? 'USD';
         $invoice = (new Invoice())
             ->setSpace($space)
             ->setClient($client)
@@ -115,6 +166,68 @@ class InvoiceFromTimeController extends AbstractController
             'total' => $invoice->getTotal(),
             'lineItemCount' => count($entries),
         ], 201);
+    }
+
+    /**
+     * The candidate rows + totals for the UI's untick list — same math as the
+     * generation loop, but read-only: nothing is created, nothing is stamped.
+     *
+     * @param list<TimeEntry> $entries
+     */
+    private function preview(array $entries, ?int $clientDefaultRate, string $currency): JsonResponse
+    {
+        $rows = [];
+        $subtotal = 0;
+        foreach ($entries as $entry) {
+            $hours = round(($entry->getDurationSeconds() ?? 0) / self::SECONDS_PER_HOUR, 2);
+            $unitAmount = $entry->getRateAmount() ?? $clientDefaultRate ?? 0;
+            $amount = (int) round($hours * $unitAmount);
+            $subtotal += $amount;
+
+            $rows[] = [
+                '@id' => '/time_entries/' . $entry->getId(),
+                'id' => (string) $entry->getId(),
+                'description' => $entry->getDescription(),
+                'categoryName' => $entry->getCategory()?->getName(),
+                'startedAt' => $entry->getStartedAt()?->format(\DateTimeInterface::ATOM),
+                'durationSeconds' => $entry->getDurationSeconds(),
+                'hours' => $hours,
+                'unitAmount' => $unitAmount,
+                'amount' => $amount,
+            ];
+        }
+
+        return $this->json([
+            'entries' => $rows,
+            'count' => count($rows),
+            'subtotal' => $subtotal,
+            'currency' => $currency,
+        ]);
+    }
+
+    /** A `Y-m-d` payload date → midnight UTC; null when absent, false when malformed. */
+    private function parseDate(mixed $value): \DateTimeImmutable|false|null
+    {
+        if (null === $value || '' === $value) {
+            return null;
+        }
+        if (!is_string($value)) {
+            return false;
+        }
+
+        return \DateTimeImmutable::createFromFormat('!Y-m-d', trim($value), new \DateTimeZone('UTC'));
+    }
+
+    /** Normalise an entry reference (IRI or bare UUID) to a UUID string, or null. */
+    private function entryId(mixed $ref): ?string
+    {
+        if (!is_string($ref) || '' === trim($ref)) {
+            return null;
+        }
+        $trimmed = trim($ref);
+        $id = Uuid::isValid($trimmed) ? $trimmed : substr($trimmed, (int) strrpos($trimmed, '/') + 1);
+
+        return Uuid::isValid($id) ? $id : null;
     }
 
     /** "Category — description" (either part optional), capped to the column length. */

--- a/api/src/Repository/TimeEntryRepository.php
+++ b/api/src/Repository/TimeEntryRepository.php
@@ -40,12 +40,18 @@ class TimeEntryRepository extends ServiceEntityRepository
     /**
      * Completed, billable, not-yet-billed entries on a engagement — the pool
      * an invoice draws from. Ordered by category then start so line items group.
+     * An optional [$from, $toExclusive) window filters on the entry's startedAt
+     * (callers pass the day AFTER the last wanted date as $toExclusive, so a
+     * user-facing inclusive date range maps cleanly onto timestamps).
      *
      * @return list<TimeEntry>
      */
-    public function findInvoiceableForEngagement(Engagement $engagement): array
-    {
-        return $this->createQueryBuilder('t')
+    public function findInvoiceableForEngagement(
+        Engagement $engagement,
+        ?\DateTimeImmutable $from = null,
+        ?\DateTimeImmutable $toExclusive = null,
+    ): array {
+        $qb = $this->createQueryBuilder('t')
             ->andWhere('t.engagement = :bp')
             ->andWhere('t.billable = true')
             ->andWhere('t.endedAt IS NOT NULL')
@@ -53,8 +59,16 @@ class TimeEntryRepository extends ServiceEntityRepository
             ->setParameter('bp', $engagement)
             ->leftJoin('t.category', 'c')
             ->orderBy('c.position', 'ASC')
-            ->addOrderBy('t.startedAt', 'ASC')
-            ->getQuery()
-            ->getResult();
+            ->addOrderBy('t.startedAt', 'ASC');
+
+        if (null !== $from) {
+            $qb->andWhere('t.startedAt >= :from')->setParameter('from', $from);
+        }
+        if (null !== $toExclusive) {
+            $qb->andWhere('t.startedAt < :toExclusive')->setParameter('toExclusive', $toExclusive);
+        }
+
+        /** @var list<TimeEntry> */
+        return $qb->getQuery()->getResult();
     }
 }

--- a/api/tests/Api/ClientInvoiceTest.php
+++ b/api/tests/Api/ClientInvoiceTest.php
@@ -169,6 +169,146 @@ class ClientInvoiceTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(422);
     }
 
+    public function testInvoicePreviewListsCandidatesWithoutBilling(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $space = $this->createSharedSpace($admin);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        [$bpIri, $devCat] = $this->createEngagement($client, $spaceIri, $this->iri($clientRow));
+
+        $this->trackTime($client, $spaceIri, $bpIri, $devCat, '2026-07-03T09:00:00+00:00', '2026-07-03T10:00:00+00:00');
+        $this->trackTime($client, $spaceIri, $bpIri, $devCat, '2026-07-04T09:00:00+00:00', '2026-07-04T09:30:00+00:00');
+
+        $preview = $client->request('POST', '/invoices/from-time-entries', [
+            'json' => ['engagement' => $bpIri, 'preview' => true],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(2, $preview['count'] ?? null);
+        // 1h × 6000 + 0.5h × 6000 = 9000.
+        $this->assertSame(9000, $preview['subtotal'] ?? null);
+
+        // Preview stamped nothing — a real generation afterwards still pulls both.
+        $result = $client->request('POST', '/invoices/from-time-entries', [
+            'json' => ['engagement' => $bpIri],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertSame(2, $result['lineItemCount'] ?? null);
+    }
+
+    public function testInvoiceGenerationHonoursRangeAndSelection(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $space = $this->createSharedSpace($admin);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        [$bpIri, $devCat] = $this->createEngagement($client, $spaceIri, $this->iri($clientRow));
+
+        // One hour on each of July 1, 2 and 3.
+        foreach (['01', '02', '03'] as $day) {
+            $this->trackTime(
+                $client,
+                $spaceIri,
+                $bpIri,
+                $devCat,
+                sprintf('2026-07-%sT09:00:00+00:00', $day),
+                sprintf('2026-07-%sT10:00:00+00:00', $day),
+            );
+        }
+
+        // A range preview scopes the pool (July 2 only) and yields the entry id.
+        $preview = $client->request('POST', '/invoices/from-time-entries', [
+            'json' => ['engagement' => $bpIri, 'from' => '2026-07-02', 'to' => '2026-07-02', 'preview' => true],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(1, $preview['count'] ?? null);
+        $rows = $preview['entries'];
+        $this->assertIsArray($rows);
+        $first = $rows[0];
+        $this->assertIsArray($first);
+        $july2Iri = $first['@id'];
+        $this->assertIsString($july2Iri);
+
+        // Generate July 1–2 but explicitly select only the July 2 entry.
+        $result = $client->request('POST', '/invoices/from-time-entries', [
+            'json' => [
+                'engagement' => $bpIri,
+                'from' => '2026-07-01',
+                'to' => '2026-07-02',
+                'entries' => [$july2Iri],
+            ],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertSame(1, $result['lineItemCount'] ?? null);
+        $this->assertSame(6000, $result['subtotal'] ?? null);
+
+        // July 1 and July 3 stay invoiceable for a later invoice.
+        $rest = $client->request('POST', '/invoices/from-time-entries', [
+            'json' => ['engagement' => $bpIri, 'preview' => true],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $this->assertSame(2, $rest['count'] ?? null);
+    }
+
+    public function testInvoiceSelectionRejectsNonInvoiceableEntry(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $space = $this->createSharedSpace($admin);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $clientIri = $this->iri($clientRow);
+        [$bpA] = $this->createEngagement($client, $spaceIri, $clientIri);
+        [$bpB, $devB] = $this->createEngagement($client, $spaceIri, $clientIri);
+
+        $this->trackTime($client, $spaceIri, $bpB, $devB, '2026-07-03T09:00:00+00:00', '2026-07-03T10:00:00+00:00');
+        $previewB = $client->request('POST', '/invoices/from-time-entries', [
+            'json' => ['engagement' => $bpB, 'preview' => true],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $rowsB = $previewB['entries'];
+        $this->assertIsArray($rowsB);
+        $firstB = $rowsB[0];
+        $this->assertIsArray($firstB);
+        $entryBIri = $firstB['@id'];
+        $this->assertIsString($entryBIri);
+
+        // Selecting engagement B's entry while invoicing engagement A → 422.
+        $client->request('POST', '/invoices/from-time-entries', [
+            'json' => ['engagement' => $bpA, 'entries' => [$entryBIri]],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+
+        // Malformed dates are rejected too.
+        $client->request('POST', '/invoices/from-time-entries', [
+            'json' => ['engagement' => $bpB, 'from' => 'not-a-date'],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+    }
+
     public function testIssueAssignsNumberThenMarkPaid(): void
     {
         $admin = $this->createUser('admin@example.com');

--- a/pwa/pages/invoices/index.tsx
+++ b/pwa/pages/invoices/index.tsx
@@ -31,6 +31,25 @@ interface EngagementLite {
   name: string;
 }
 
+/** One candidate row from the from-time preview endpoint (#644). */
+interface PreviewEntry {
+  "@id": string;
+  id: string;
+  description: string | null;
+  categoryName: string | null;
+  startedAt: string | null;
+  hours: number;
+  unitAmount: number;
+  amount: number;
+}
+
+interface GenPreview {
+  entries: PreviewEntry[];
+  count: number;
+  subtotal: number;
+  currency: string;
+}
+
 const InvoicesPage = () => {
   const { isAuthenticated, isLoading: authLoading } = useAuth();
   const { activeSpace, can } = useActiveSpace();
@@ -39,6 +58,10 @@ const InvoicesPage = () => {
 
   const [showComposer, setShowComposer] = useState(false);
   const [genEngagement, setGenEngagement] = useState("");
+  const [genFrom, setGenFrom] = useState("");
+  const [genTo, setGenTo] = useState("");
+  const [preview, setPreview] = useState<GenPreview | null>(null);
+  const [checked, setChecked] = useState<Set<string>>(new Set());
   const [notice, setNotice] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -74,23 +97,72 @@ const InvoicesPage = () => {
   const engagements = engagementsQuery.data ?? [];
   const refresh = () => queryClient.invalidateQueries({ queryKey: ["invoices"] });
 
+  // Engagement + optional inclusive date range — shared by preview and generate.
+  const rangeBody = () => ({
+    engagement: genEngagement,
+    ...(genFrom ? { from: genFrom } : {}),
+    ...(genTo ? { to: genTo } : {}),
+  });
+
+  const resetComposer = () => {
+    setGenEngagement("");
+    setGenFrom("");
+    setGenTo("");
+    setPreview(null);
+    setChecked(new Set());
+    setShowComposer(false);
+  };
+
+  // Any change to the scope invalidates a previously-loaded preview.
+  const clearPreview = () => {
+    setPreview(null);
+    setChecked(new Set());
+  };
+
+  const loadPreview = useMutation({
+    mutationFn: () =>
+      apiSend<GenPreview>("POST", "/invoices/from-time-entries", {
+        contentType: "application/json",
+        errorMessage: "Failed to load unbilled time.",
+        body: { ...rangeBody(), preview: true },
+      }),
+    onSuccess: (res) => {
+      setError(null);
+      setPreview(res);
+      // Everything ticked by default — the list is for *un*ticking.
+      setChecked(new Set((res?.entries ?? []).map((e) => e["@id"])));
+    },
+    onError: (e) => setError(e instanceof Error ? e.message : "Failed to load unbilled time."),
+  });
+
   const generate = useMutation({
     mutationFn: () =>
       apiSend<{ id: string; lineItemCount: number }>("POST", "/invoices/from-time-entries", {
         contentType: "application/json",
         errorMessage: "Failed to generate an invoice.",
-        body: { engagement: genEngagement },
+        body: { ...rangeBody(), entries: Array.from(checked) },
       }),
     onSuccess: (res) => {
       setError(null);
       const n = res?.lineItemCount ?? 0;
       setNotice(`Draft invoice created from ${n} time entr${n === 1 ? "y" : "ies"}.`);
-      setGenEngagement("");
-      setShowComposer(false);
+      resetComposer();
       void refresh();
     },
     onError: (e) => setError(e instanceof Error ? e.message : "Failed to generate an invoice."),
   });
+
+  const toggleChecked = (iri: string) => {
+    setChecked((prev) => {
+      const next = new Set(prev);
+      if (next.has(iri)) {
+        next.delete(iri);
+      } else {
+        next.add(iri);
+      }
+      return next;
+    });
+  };
 
   const act = useMutation({
     mutationFn: ({ invoice, action }: { invoice: Invoice; action: InvoiceAction }) =>
@@ -187,7 +259,10 @@ const InvoicesPage = () => {
                                 <select
                                   id="gen-engagement"
                                   value={genEngagement}
-                                  onChange={(e) => setGenEngagement(e.target.value)}
+                                  onChange={(e) => {
+                                    setGenEngagement(e.target.value);
+                                    clearPreview();
+                                  }}
                                   className="h-9 w-64 max-w-full rounded-md border border-input bg-background px-3 text-sm"
                                 >
                                   <option value="">Select an engagement…</option>
@@ -198,18 +273,40 @@ const InvoicesPage = () => {
                                   ))}
                                 </select>
                               </div>
+                              <div className="space-y-1.5">
+                                <Label htmlFor="gen-from">From</Label>
+                                <input
+                                  id="gen-from"
+                                  type="date"
+                                  value={genFrom}
+                                  onChange={(e) => {
+                                    setGenFrom(e.target.value);
+                                    clearPreview();
+                                  }}
+                                  className="h-9 rounded-md border border-input bg-background px-3 text-sm"
+                                />
+                              </div>
+                              <div className="space-y-1.5">
+                                <Label htmlFor="gen-to">To</Label>
+                                <input
+                                  id="gen-to"
+                                  type="date"
+                                  value={genTo}
+                                  onChange={(e) => {
+                                    setGenTo(e.target.value);
+                                    clearPreview();
+                                  }}
+                                  className="h-9 rounded-md border border-input bg-background px-3 text-sm"
+                                />
+                              </div>
                               <Button
                                 size="sm"
-                                onClick={() => generate.mutate()}
-                                disabled={!genEngagement || generate.isPending}
+                                onClick={() => loadPreview.mutate()}
+                                disabled={!genEngagement || loadPreview.isPending}
                               >
-                                {generate.isPending ? "Generating…" : "Generate draft"}
+                                {loadPreview.isPending ? "Loading…" : "Preview"}
                               </Button>
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => setShowComposer(false)}
-                              >
+                              <Button variant="ghost" size="sm" onClick={resetComposer}>
                                 Cancel
                               </Button>
                               {engagements.length === 0 && (
@@ -222,6 +319,89 @@ const InvoicesPage = () => {
                                 </p>
                               )}
                             </div>
+
+                            {preview && preview.entries.length === 0 && (
+                              <p className="mt-3 text-sm text-muted-foreground">
+                                No unbilled billable time
+                                {genFrom || genTo ? " in this range" : ""} for this engagement.
+                              </p>
+                            )}
+
+                            {preview && preview.entries.length > 0 && (
+                              <div className="mt-3 space-y-2">
+                                <div className="max-h-64 overflow-y-auto rounded-md border">
+                                  <table className="w-full text-sm">
+                                    <thead>
+                                      <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+                                        <th className="w-8 px-3 py-1.5" />
+                                        <th className="px-3 py-1.5 font-medium">Date</th>
+                                        <th className="px-3 py-1.5 font-medium">Description</th>
+                                        <th className="px-3 py-1.5 text-right font-medium">Hours</th>
+                                        <th className="px-3 py-1.5 text-right font-medium">Amount</th>
+                                      </tr>
+                                    </thead>
+                                    <tbody>
+                                      {preview.entries.map((entry) => (
+                                        <tr
+                                          key={entry["@id"]}
+                                          className={cn(
+                                            "border-b last:border-b-0",
+                                            !checked.has(entry["@id"]) && "opacity-50",
+                                          )}
+                                        >
+                                          <td className="px-3 py-1.5">
+                                            <input
+                                              type="checkbox"
+                                              checked={checked.has(entry["@id"])}
+                                              onChange={() => toggleChecked(entry["@id"])}
+                                              aria-label="Include this entry"
+                                            />
+                                          </td>
+                                          <td className="whitespace-nowrap px-3 py-1.5">
+                                            {entry.startedAt
+                                              ? new Date(entry.startedAt).toLocaleDateString()
+                                              : "—"}
+                                          </td>
+                                          <td className="px-3 py-1.5">
+                                            {entry.description || "Tracked time"}
+                                            {entry.categoryName && (
+                                              <span className="ml-1.5 text-xs text-muted-foreground">
+                                                {entry.categoryName}
+                                              </span>
+                                            )}
+                                          </td>
+                                          <td className="px-3 py-1.5 text-right tabular-nums">
+                                            {entry.hours.toFixed(2)}
+                                          </td>
+                                          <td className="px-3 py-1.5 text-right tabular-nums">
+                                            {formatMoney(entry.amount, preview.currency)}
+                                          </td>
+                                        </tr>
+                                      ))}
+                                    </tbody>
+                                  </table>
+                                </div>
+                                <div className="flex flex-wrap items-center justify-between gap-3">
+                                  <p className="text-sm text-muted-foreground">
+                                    {checked.size} of {preview.entries.length} entr
+                                    {preview.entries.length === 1 ? "y" : "ies"} selected ·{" "}
+                                    {formatMoney(
+                                      preview.entries
+                                        .filter((e) => checked.has(e["@id"]))
+                                        .reduce((sum, e) => sum + e.amount, 0),
+                                      preview.currency,
+                                    )}
+                                  </p>
+                                  <Button
+                                    size="sm"
+                                    onClick={() => generate.mutate()}
+                                    disabled={checked.size === 0 || generate.isPending}
+                                  >
+                                    {generate.isPending ? "Generating…" : "Generate draft"}
+                                  </Button>
+                                </div>
+                              </div>
+                            )}
                           </td>
                         </tr>
                       ) : (


### PR DESCRIPTION
Closes #644

## What
Reworks "generate invoice from tracked time" so the admin controls exactly what gets billed:

**API — `POST /invoices/from-time-entries` now accepts:**
- `from` / `to` — inclusive `Y-m-d` dates filtering on the entry's `startedAt` (so "invoice just October" works). Malformed dates and `to < from` 422.
- `entries` — explicit list of entry IRIs/UUIDs to pull. Must be a subset of the invoiceable pool (unbilled, billable, completed, on this engagement, inside the range) or the whole request 422s — a stale/foreign/billed reference fails loudly instead of silently shrinking the invoice.
- `preview: true` — returns candidate rows + totals (`{entries, count, subtotal, currency}`) **without** creating an invoice or stamping `billedAt`.

`TimeEntryRepository::findInvoiceableForEngagement` gains an optional `[from, toExclusive)` window.

**PWA — `/invoices` generate flow** becomes: engagement → optional From/To dates → **Preview** (checkbox list of candidates, all ticked by default, with date/description/category/hours/amount + live selected-subtotal) → **Generate draft** posts the checked set. Changing the scope invalidates the loaded preview.

## Tests
- `testInvoicePreviewListsCandidatesWithoutBilling` — preview lists + totals, nothing stamped, generate afterwards still pulls everything
- `testInvoiceGenerationHonoursRangeAndSelection` — range narrows the pool; generate with a sub-selection bills only that entry; the rest remain invoiceable
- `testInvoiceSelectionRejectsNonInvoiceableEntry` — foreign entry in selection 422s; malformed `from` 422s