### PR TITLE
feat(time): week timesheet grid + copy last week

### DIFF
--- a/api/src/Entity/TimeEntry.php
+++ b/api/src/Entity/TimeEntry.php
@@ -44,6 +44,9 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
     operations: [
         new GetCollection(
             security: "is_granted('ROLE_USER')",
+            // The week timesheet grid fetches a whole week in one request —
+            // let clients raise the page size (capped globally at 100).
+            paginationClientItemsPerPage: true,
         ),
         new Post(
             security: "is_granted('ROLE_USER')",

--- a/pwa/components/time/WeekTimesheet.tsx
+++ b/pwa/components/time/WeekTimesheet.tsx
@@ -1,0 +1,545 @@
+import { useMemo, useRef, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ChevronLeft, ChevronRight, CopyPlus, Lock, Plus } from "lucide-react";
+import { apiGetCollection, apiSend } from "@/lib/apiClient";
+import {
+  EngagementOption,
+  TimeEntry,
+  formatCellDuration,
+  parseDurationInput,
+} from "@/lib/timeEntryTypes";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+const MERGE_PATCH = "application/merge-patch+json";
+
+const SELECT_CLASS =
+  "h-8 rounded-md border border-input bg-transparent px-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
+
+/** Monday 00:00 (local) of the week containing `d`. */
+const mondayOf = (d: Date): Date => {
+  const monday = new Date(d.getFullYear(), d.getMonth(), d.getDate());
+  const dow = (monday.getDay() + 6) % 7; // Mon=0 … Sun=6
+  monday.setDate(monday.getDate() - dow);
+  return monday;
+};
+
+const addDays = (d: Date, days: number): Date => {
+  const next = new Date(d);
+  next.setDate(next.getDate() + days);
+  return next;
+};
+
+/** "YYYY-MM-DD" in local time — the grid's day-bucket key. */
+const localDateKey = (d: Date): string => {
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+};
+
+const rowKeyOf = (engagement: string | null, category: string | null): string =>
+  `${engagement ?? ""}|${category ?? ""}`;
+
+interface CellData {
+  entries: TimeEntry[];
+  total: number;
+}
+
+interface RowData {
+  key: string;
+  engagement: string | null;
+  category: string | null;
+  cells: Map<string, CellData>;
+  total: number;
+}
+
+/**
+ * Harvest-style week grid (#645): rows = engagement+category pairs with time
+ * this week (plus any rows added via "Add row" / "Copy last week"), columns =
+ * Mon–Sun, cells = editable durations. A cell edit creates/updates/deletes the
+ * underlying entry: one duration-anchored entry per cell keeps the same-day
+ * rule happy. Cells backed by multiple entries (or billed/foreign entries)
+ * render read-only — the list view is the place to untangle those.
+ */
+const WeekTimesheet = ({
+  spaceIri,
+  projects,
+  canCreate,
+  canModify,
+  onError,
+}: {
+  spaceIri: string | null;
+  projects: EngagementOption[];
+  canCreate: boolean;
+  canModify: (entry: TimeEntry) => boolean;
+  onError: (message: string | null) => void;
+}) => {
+  const queryClient = useQueryClient();
+  const [weekStart, setWeekStart] = useState(() => mondayOf(new Date()));
+  // Pairs surfaced without entries yet (added by hand or copied from last week).
+  const [extraRows, setExtraRows] = useState<Set<string>>(new Set());
+  const [draft, setDraft] = useState<{ cell: string; value: string } | null>(null);
+  const [addingRow, setAddingRow] = useState(false);
+  const [addEngagement, setAddEngagement] = useState("");
+  const [addCategory, setAddCategory] = useState("");
+  // Escape sets this so the blur it triggers discards instead of committing.
+  const cancelEditRef = useRef(false);
+
+  const weekKey = localDateKey(weekStart);
+  const days = useMemo(
+    () => Array.from({ length: 7 }, (_, i) => addDays(weekStart, i)),
+    [weekStart],
+  );
+  const todayKey = localDateKey(new Date());
+
+  const weekQueryPath = (start: Date): string => {
+    const params = new URLSearchParams();
+    if (spaceIri) params.set("space", spaceIri);
+    // Widen by a day each side (the filter compares in UTC; buckets are local).
+    params.set("startedAt[after]", localDateKey(addDays(start, -1)));
+    params.set("startedAt[before]", localDateKey(addDays(start, 8)));
+    params.set("itemsPerPage", "100");
+    return `/time_entries?${params.toString()}`;
+  };
+
+  const entriesQuery = useQuery({
+    queryKey: ["time_entries", "week", spaceIri, weekKey],
+    queryFn: () =>
+      apiGetCollection<TimeEntry>(weekQueryPath(weekStart), {
+        errorMessage: "Failed to load the week.",
+      }),
+  });
+  const refresh = () => queryClient.invalidateQueries({ queryKey: ["time_entries"] });
+
+  // Completed entries bucketed by (pair, local day) inside the shown week.
+  const rows = useMemo((): RowData[] => {
+    const weekEnd = addDays(weekStart, 7);
+    const byKey = new Map<string, RowData>();
+    const ensureRow = (engagement: string | null, category: string | null): RowData => {
+      const key = rowKeyOf(engagement, category);
+      let row = byKey.get(key);
+      if (!row) {
+        row = { key, engagement, category, cells: new Map(), total: 0 };
+        byKey.set(key, row);
+      }
+      return row;
+    };
+
+    for (const entry of entriesQuery.data ?? []) {
+      if (entry.endedAt === null) continue; // running timer lives in list view
+      const started = new Date(entry.startedAt);
+      if (started < weekStart || started >= weekEnd) continue;
+      const row = ensureRow(entry.engagement, entry.category);
+      const dayKey = localDateKey(started);
+      const cell = row.cells.get(dayKey) ?? { entries: [], total: 0 };
+      cell.entries.push(entry);
+      cell.total += entry.durationSeconds ?? 0;
+      row.cells.set(dayKey, cell);
+      row.total += entry.durationSeconds ?? 0;
+    }
+    for (const key of extraRows) {
+      const [engagement, category] = key.split("|");
+      ensureRow(engagement || null, category || null);
+    }
+
+    const nameOf = (row: RowData): string => {
+      const p = projects.find((x) => x["@id"] === row.engagement);
+      const c = p?.categories.find((x) => x["@id"] === row.category);
+      return `${p?.name ?? "zzz"} ${c?.name ?? ""}`;
+    };
+    return Array.from(byKey.values()).sort((a, b) => nameOf(a).localeCompare(nameOf(b)));
+  }, [entriesQuery.data, weekStart, extraRows, projects]);
+
+  const dayTotals = useMemo(() => {
+    const totals = new Map<string, number>();
+    for (const row of rows) {
+      for (const [dayKey, cell] of row.cells) {
+        totals.set(dayKey, (totals.get(dayKey) ?? 0) + cell.total);
+      }
+    }
+    return totals;
+  }, [rows]);
+  const grandTotal = rows.reduce((sum, row) => sum + row.total, 0);
+
+  const labelFor = (row: RowData): { engagement: string; category: string } => {
+    const p = projects.find((x) => x["@id"] === row.engagement);
+    const c = p?.categories.find((x) => x["@id"] === row.category);
+    return {
+      engagement: p?.name ?? "Unknown engagement",
+      category: c?.name ?? "—",
+    };
+  };
+
+  const saveCell = useMutation({
+    mutationFn: async ({
+      row,
+      day,
+      cell,
+      seconds,
+    }: {
+      row: RowData;
+      day: Date;
+      cell: CellData | undefined;
+      seconds: number;
+    }) => {
+      const single = cell && cell.entries.length === 1 ? cell.entries[0] : null;
+      if (single) {
+        if (seconds === 0) {
+          return apiSend("DELETE", single["@id"], {
+            errorMessage: "Failed to delete the entry.",
+          });
+        }
+        // Keep the entry's start time unless the new duration would cross
+        // midnight — then re-anchor at the start of the day.
+        let start = new Date(single.startedAt);
+        const secondsIntoDay =
+          start.getHours() * 3600 + start.getMinutes() * 60 + start.getSeconds();
+        if (secondsIntoDay + seconds >= 24 * 3600) {
+          start = new Date(day);
+        }
+        return apiSend("PATCH", single["@id"], {
+          contentType: MERGE_PATCH,
+          errorMessage: "Failed to update the entry.",
+          body: {
+            startedAt: start.toISOString(),
+            endedAt: new Date(start.getTime() + seconds * 1000).toISOString(),
+          },
+        });
+      }
+      if (seconds === 0) return null;
+      // New duration entry — noon-anchored so it reads naturally in the list
+      // view, falling back to midnight when noon + duration would cross days.
+      const noonFits = 12 * 3600 + seconds < 24 * 3600;
+      const start = new Date(day.getTime() + (noonFits ? 12 * 3600 * 1000 : 0));
+      return apiSend("POST", "/time_entries", {
+        errorMessage: "Failed to log time.",
+        body: {
+          engagement: row.engagement,
+          category: row.category,
+          startedAt: start.toISOString(),
+          endedAt: new Date(start.getTime() + seconds * 1000).toISOString(),
+          ...(spaceIri ? { space: spaceIri } : {}),
+        },
+      });
+    },
+    onSuccess: () => {
+      onError(null);
+      void refresh();
+    },
+    onError: (e) => onError(e instanceof Error ? e.message : "Failed to save the cell."),
+  });
+
+  const commitCell = (row: RowData, day: Date, raw: string) => {
+    setDraft(null);
+    if (cancelEditRef.current) {
+      cancelEditRef.current = false;
+      return;
+    }
+    const cell = row.cells.get(localDateKey(day));
+    const seconds = parseDurationInput(raw);
+    if (seconds === null) {
+      onError('Enter a duration like "1:30" or "1.5".');
+      return;
+    }
+    if (seconds === (cell?.total ?? 0)) return;
+    if (seconds > 0 && !cell?.entries.length && (!row.engagement || !row.category)) {
+      onError("This row has no engagement/category — edit it in the list view.");
+      return;
+    }
+    saveCell.mutate({ row, day, cell, seconds });
+  };
+
+  const copyLastWeek = useMutation({
+    mutationFn: () =>
+      apiGetCollection<TimeEntry>(weekQueryPath(addDays(weekStart, -7)), {
+        errorMessage: "Failed to load last week.",
+      }),
+    onSuccess: (lastWeek) => {
+      onError(null);
+      const prevStart = addDays(weekStart, -7);
+      const keys = new Set(extraRows);
+      let added = 0;
+      for (const entry of lastWeek ?? []) {
+        if (entry.endedAt === null) continue;
+        const started = new Date(entry.startedAt);
+        if (started < prevStart || started >= weekStart) continue;
+        if (!entry.engagement || !entry.category) continue;
+        const key = rowKeyOf(entry.engagement, entry.category);
+        if (!keys.has(key) && !rows.some((r) => r.key === key)) {
+          keys.add(key);
+          added += 1;
+        }
+      }
+      setExtraRows(keys);
+      if (added === 0) onError("Nothing new to copy from last week.");
+    },
+    onError: (e) => onError(e instanceof Error ? e.message : "Failed to load last week."),
+  });
+
+  const goToWeek = (start: Date) => {
+    setWeekStart(start);
+    setExtraRows(new Set());
+    setDraft(null);
+  };
+
+  const addCats = projects.find((p) => p["@id"] === addEngagement)?.categories ?? [];
+  const rangeLabel = `${weekStart.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  })} – ${addDays(weekStart, 6).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })}`;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-1.5">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => goToWeek(addDays(weekStart, -7))}
+            aria-label="Previous week"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => goToWeek(addDays(weekStart, 7))}
+            aria-label="Next week"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => goToWeek(mondayOf(new Date()))}>
+            Today
+          </Button>
+          <span className="ml-2 text-sm font-medium">{rangeLabel}</span>
+        </div>
+        {canCreate && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => copyLastWeek.mutate()}
+            disabled={copyLastWeek.isPending}
+          >
+            <CopyPlus className="h-4 w-4" />
+            {copyLastWeek.isPending ? "Copying…" : "Copy last week"}
+          </Button>
+        )}
+      </div>
+
+      <Card>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+                <th className="min-w-48 px-4 py-2 font-medium">Engagement / category</th>
+                {days.map((day) => (
+                  <th
+                    key={localDateKey(day)}
+                    className={cn(
+                      "w-20 px-2 py-2 text-center font-medium",
+                      localDateKey(day) === todayKey && "text-foreground",
+                    )}
+                  >
+                    {day.toLocaleDateString(undefined, { weekday: "short" })}
+                    <span className="block font-normal">
+                      {day.toLocaleDateString(undefined, { day: "numeric" })}
+                    </span>
+                  </th>
+                ))}
+                <th className="w-20 px-3 py-2 text-right font-medium">Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entriesQuery.isLoading ? (
+                <tr>
+                  <td colSpan={9} className="px-4 py-10 text-center text-muted-foreground">
+                    Loading…
+                  </td>
+                </tr>
+              ) : rows.length === 0 ? (
+                <tr>
+                  <td colSpan={9} className="px-4 py-10 text-center text-muted-foreground">
+                    No time this week. Add a row below or copy last week&apos;s rows.
+                  </td>
+                </tr>
+              ) : (
+                rows.map((row) => {
+                  const label = labelFor(row);
+                  return (
+                    <tr key={row.key} className="border-b align-middle">
+                      <td className="px-4 py-2">
+                        <span className="font-medium">{label.engagement}</span>
+                        <span className="block text-xs text-muted-foreground">
+                          {label.category}
+                        </span>
+                      </td>
+                      {days.map((day) => {
+                        const dayKey = localDateKey(day);
+                        const cell = row.cells.get(dayKey);
+                        const cellId = `${row.key}@${dayKey}`;
+                        const editable =
+                          canCreate &&
+                          (!cell ||
+                            (cell.entries.length === 1 && canModify(cell.entries[0])));
+                        const display =
+                          draft?.cell === cellId
+                            ? draft.value
+                            : formatCellDuration(cell?.total ?? 0);
+                        if (!editable) {
+                          return (
+                            <td
+                              key={dayKey}
+                              className="px-2 py-2 text-center tabular-nums text-muted-foreground"
+                              title={
+                                cell && cell.entries.length > 1
+                                  ? "Multiple entries — edit in the list view"
+                                  : cell?.entries.some((e) => !!e.billedAt)
+                                    ? "Invoiced — locked"
+                                    : undefined
+                              }
+                            >
+                              <span className="inline-flex items-center gap-1">
+                                {formatCellDuration(cell?.total ?? 0) || "—"}
+                                {cell?.entries.some((e) => !!e.billedAt) && (
+                                  <Lock className="h-3 w-3" />
+                                )}
+                              </span>
+                            </td>
+                          );
+                        }
+                        return (
+                          <td key={dayKey} className="px-1 py-1.5 text-center">
+                            <input
+                              type="text"
+                              inputMode="decimal"
+                              value={display}
+                              placeholder="0:00"
+                              aria-label={`${label.engagement} ${label.category} on ${dayKey}`}
+                              onFocus={() => setDraft({ cell: cellId, value: display })}
+                              onChange={(e) =>
+                                setDraft({ cell: cellId, value: e.target.value })
+                              }
+                              onBlur={(e) => commitCell(row, day, e.target.value)}
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter") e.currentTarget.blur();
+                                if (e.key === "Escape") {
+                                  cancelEditRef.current = true;
+                                  e.currentTarget.blur();
+                                }
+                              }}
+                              className={cn(
+                                "h-8 w-16 rounded-md border border-transparent bg-transparent text-center text-sm tabular-nums",
+                                "hover:border-input focus-visible:border-input focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                                dayKey === todayKey && "bg-muted/40",
+                              )}
+                            />
+                          </td>
+                        );
+                      })}
+                      <td className="px-3 py-2 text-right font-mono tabular-nums">
+                        {formatCellDuration(row.total) || "—"}
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+
+              {/* Add-row control */}
+              {canCreate && (
+                <tr className="border-b">
+                  <td colSpan={9} className="px-4 py-2">
+                    {addingRow ? (
+                      <div className="flex flex-wrap items-center gap-2">
+                        <select
+                          value={addEngagement}
+                          onChange={(e) => {
+                            setAddEngagement(e.target.value);
+                            const cats =
+                              projects.find((p) => p["@id"] === e.target.value)
+                                ?.categories ?? [];
+                            setAddCategory(cats[0]?.["@id"] ?? "");
+                          }}
+                          className={SELECT_CLASS}
+                          aria-label="Engagement"
+                        >
+                          <option value="">Engagement…</option>
+                          {projects.map((p) => (
+                            <option key={p["@id"]} value={p["@id"]}>
+                              {p.name}
+                            </option>
+                          ))}
+                        </select>
+                        <select
+                          value={addCategory}
+                          onChange={(e) => setAddCategory(e.target.value)}
+                          className={SELECT_CLASS}
+                          disabled={addCats.length === 0}
+                          aria-label="Category"
+                        >
+                          {addCats.length === 0 ? (
+                            <option value="">Category…</option>
+                          ) : (
+                            addCats.map((c) => (
+                              <option key={c["@id"]} value={c["@id"]}>
+                                {c.name}
+                              </option>
+                            ))
+                          )}
+                        </select>
+                        <Button
+                          size="sm"
+                          disabled={!addEngagement || !addCategory}
+                          onClick={() => {
+                            setExtraRows((prev) =>
+                              new Set(prev).add(rowKeyOf(addEngagement, addCategory)),
+                            );
+                            setAddingRow(false);
+                          }}
+                        >
+                          Add
+                        </Button>
+                        <Button variant="ghost" size="sm" onClick={() => setAddingRow(false)}>
+                          Cancel
+                        </Button>
+                      </div>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => setAddingRow(true)}
+                        className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+                      >
+                        <Plus className="h-4 w-4" /> Add row
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              )}
+            </tbody>
+            <tfoot>
+              <tr className="bg-muted/40 text-sm font-medium">
+                <td className="px-4 py-2">Total</td>
+                {days.map((day) => (
+                  <td
+                    key={localDateKey(day)}
+                    className="px-2 py-2 text-center font-mono tabular-nums"
+                  >
+                    {formatCellDuration(dayTotals.get(localDateKey(day)) ?? 0) || "—"}
+                  </td>
+                ))}
+                <td className="px-3 py-2 text-right font-mono tabular-nums">
+                  {formatCellDuration(grandTotal) || "—"}
+                </td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      </Card>
+    </div>
+  );
+};
+
+export default WeekTimesheet;

--- a/pwa/lib/timeEntryTypes.ts
+++ b/pwa/lib/timeEntryTypes.ts
@@ -71,6 +71,39 @@ export const formatDuration = (totalSeconds: number): string => {
   return `${seconds}s`;
 };
 
+/**
+ * Format a duration as a timesheet cell value — "1:30" (h:mm). Empty string
+ * for zero so an untouched grid cell stays blank.
+ */
+export const formatCellDuration = (totalSeconds: number): string => {
+  const s = Math.max(0, Math.round(totalSeconds));
+  if (s === 0) return "";
+  const hours = Math.floor(s / 3600);
+  const minutes = Math.round((s % 3600) / 60);
+  return `${hours}:${minutes.toString().padStart(2, "0")}`;
+};
+
+/**
+ * Parse a timesheet cell input into seconds. Accepts "1:30" (h:mm), "1.5"
+ * (decimal hours), and "" / "0" (zero). Returns null for anything malformed
+ * or out of range (an entry can't span midnight, so < 24h).
+ */
+export const parseDurationInput = (raw: string): number | null => {
+  const value = raw.trim();
+  if (value === "" || value === "0") return 0;
+  let seconds: number;
+  const colon = /^(\d{1,2}):([0-5]?\d)$/.exec(value);
+  if (colon) {
+    seconds = parseInt(colon[1], 10) * 3600 + parseInt(colon[2], 10) * 60;
+  } else if (/^\d+([.,]\d+)?$/.test(value)) {
+    seconds = Math.round(parseFloat(value.replace(",", ".")) * 3600);
+  } else {
+    return null;
+  }
+  if (seconds <= 0 || seconds >= 24 * 3600) return null;
+  return seconds;
+};
+
 /** A stopwatch-style "1:30:05" clock for a live running timer. */
 export const formatClock = (totalSeconds: number): string => {
   const s = Math.max(0, Math.floor(totalSeconds));

--- a/pwa/pages/time/index.tsx
+++ b/pwa/pages/time/index.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { Fragment, FormEvent, useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Clock, Pencil, Play, Plus, Square, Trash2 } from "lucide-react";
+import { CalendarRange, Clock, List, Pencil, Play, Plus, Square, Trash2 } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
 import { apiGet, apiGetCollection, apiSend } from "@/lib/apiClient";
@@ -17,6 +17,7 @@ import {
   isRunning,
 } from "@/lib/timeEntryTypes";
 import PageHeader from "@/components/common/PageHeader";
+import WeekTimesheet from "@/components/time/WeekTimesheet";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -60,6 +61,7 @@ const TimePage = () => {
   const router = useRouter();
   const queryClient = useQueryClient();
 
+  const [view, setView] = useState<"list" | "week">("list");
   const [showComposer, setShowComposer] = useState(false);
   const [description, setDescription] = useState("");
   const [workDate, setWorkDate] = useState(() => dateInput(new Date()));
@@ -346,7 +348,36 @@ const TimePage = () => {
             </Alert>
           )}
 
-          {entriesQuery.isLoading ? (
+          <div className="mb-3 inline-flex rounded-md border p-0.5" role="tablist">
+            <Button
+              variant={view === "list" ? "secondary" : "ghost"}
+              size="sm"
+              role="tab"
+              aria-selected={view === "list"}
+              onClick={() => setView("list")}
+            >
+              <List className="h-4 w-4" /> List
+            </Button>
+            <Button
+              variant={view === "week" ? "secondary" : "ghost"}
+              size="sm"
+              role="tab"
+              aria-selected={view === "week"}
+              onClick={() => setView("week")}
+            >
+              <CalendarRange className="h-4 w-4" /> Week
+            </Button>
+          </div>
+
+          {view === "week" ? (
+            <WeekTimesheet
+              spaceIri={spaceIri}
+              projects={projects}
+              canCreate={canCreate && !noProjects}
+              canModify={canModify}
+              onError={setActionError}
+            />
+          ) : entriesQuery.isLoading ? (
             <p className="text-muted-foreground">Loading…</p>
           ) : (
             <Card>


### PR DESCRIPTION
Closes #645

## What
Adds Harvest's fastest bulk-entry surface: a **week grid** on `/time` behind a List | Week toggle.

- **Grid**: rows = engagement+category pairs with time that week (plus rows added by hand), columns = Mon–Sun, cells = editable durations accepting `1:30` (h:mm) or `1.5` (decimal hours). Week navigation (‹ › / Today) + per-row, per-day, and grand totals. Today's column is highlighted.
- **Cell edits create/update/delete the underlying entries** (same-day rule respected):
  - empty → value: POST a noon-anchored duration entry (midnight-anchored when noon + duration would cross days)
  - single-entry cell → PATCH the entry's duration, keeping its start time (re-anchored to midnight only if the new duration would cross midnight)
  - value → empty/0: DELETE the entry
  - Cells backed by **multiple entries** or **invoiced (billed-locked) entries** render read-only with a tooltip/lock — the list view is the place to untangle those.
- **Copy last week**: clones last week's engagement+category row set into the current week as empty rows.
- **Add row**: engagement + category picker to surface a pair before typing time into it.
- Escape cancels a cell edit; Enter commits.

## API
`TimeEntry` `GetCollection` now allows client-controlled `itemsPerPage` (global cap 100 still applies) so the grid fetches a whole week in one request (`startedAt[after/before]` window ±1 day, bucketed client-side by local date).

## Notes
- A week with >100 completed entries would truncate at the page cap — far beyond realistic weekly volume for one space, noted for a future server-side week endpoint if it ever matters.
- The running timer stays a list-view concern (grid shows completed entries only).