### PR TITLE
feat(billing): automatic late-payment reminder emails

### DIFF
--- a/api/migrations/Version20260716120000.php
+++ b/api/migrations/Version20260716120000.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Late-payment reminders (#649): invoice.reminders_enabled (per-invoice
+ * opt-out, on by default) + invoice.reminders_sent_at (JSON log of reminders
+ * already emailed — the sweep's idempotency ledger).
+ */
+final class Version20260716120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Invoice late-payment reminders: reminders_enabled toggle + reminders_sent_at log.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE invoice ADD reminders_enabled BOOLEAN DEFAULT true NOT NULL');
+        $this->addSql('ALTER TABLE invoice ADD reminders_sent_at JSON DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE invoice DROP reminders_enabled');
+        $this->addSql('ALTER TABLE invoice DROP reminders_sent_at');
+    }
+}

--- a/api/src/Entity/Invoice.php
+++ b/api/src/Entity/Invoice.php
@@ -201,6 +201,25 @@ class Invoice
     #[ORM\Column(length: 64, nullable: true, unique: true)]
     private ?string $publicToken = null;
 
+    /**
+     * Per-invoice opt-out for the automatic late-payment reminder emails
+     * (#649) — on by default; a space admin can pause them per invoice.
+     */
+    #[ORM\Column(type: 'boolean', options: ['default' => true])]
+    #[Groups(['invoice:read', 'invoice:write'])]
+    private bool $remindersEnabled = true;
+
+    /**
+     * ISO-8601 timestamps of each late-payment reminder actually emailed —
+     * the idempotency log the daily sweep checks before sending the next one
+     * (max 3: on overdue, +7d, +14d).
+     *
+     * @var list<string>|null
+     */
+    #[ORM\Column(type: 'json', nullable: true)]
+    #[Groups(['invoice:read'])]
+    private ?array $remindersSentAt = null;
+
     #[ORM\Column(type: 'datetime_immutable', nullable: true)]
     #[Groups(['invoice:read'])]
     private ?\DateTimeImmutable $sentAt = null;
@@ -507,6 +526,33 @@ class Invoice
     public function setPublicToken(?string $publicToken): self
     {
         $this->publicToken = $publicToken;
+
+        return $this;
+    }
+
+    public function isRemindersEnabled(): bool
+    {
+        return $this->remindersEnabled;
+    }
+
+    public function setRemindersEnabled(bool $remindersEnabled): self
+    {
+        $this->remindersEnabled = $remindersEnabled;
+
+        return $this;
+    }
+
+    /** @return list<string> */
+    public function getRemindersSentAt(): array
+    {
+        return $this->remindersSentAt ?? [];
+    }
+
+    public function addReminderSentAt(\DateTimeImmutable $when): self
+    {
+        $log = $this->getRemindersSentAt();
+        $log[] = $when->format(\DateTimeInterface::ATOM);
+        $this->remindersSentAt = $log;
 
         return $this;
     }

--- a/api/src/MessageHandler/MarkOverdueInvoicesHandler.php
+++ b/api/src/MessageHandler/MarkOverdueInvoicesHandler.php
@@ -4,19 +4,23 @@ namespace App\MessageHandler;
 
 use App\Message\MarkOverdueInvoices;
 use App\Repository\InvoiceRepository;
+use App\Service\InvoiceReminderDispatcher;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 /**
  * Marks past-due sent invoices overdue when the scheduler fires
- * App\Message\MarkOverdueInvoices (daily). Idempotent — a re-run just finds
- * fewer (or no) still-sent past-due invoices.
+ * App\Message\MarkOverdueInvoices (daily), then runs the late-payment
+ * reminder sweep (#649) over the overdue set. Idempotent — a re-run just
+ * finds fewer (or no) still-sent past-due invoices, and the reminder ledger
+ * on each invoice stops duplicate emails.
  */
 #[AsMessageHandler]
 final class MarkOverdueInvoicesHandler
 {
     public function __construct(
         private InvoiceRepository $invoices,
+        private InvoiceReminderDispatcher $reminders,
         private LoggerInterface $logger,
     ) {
     }
@@ -29,5 +33,7 @@ final class MarkOverdueInvoicesHandler
         if ($count > 0) {
             $this->logger->info(sprintf('Marked %d invoice(s) overdue.', $count));
         }
+
+        $this->reminders->dispatchDue($today);
     }
 }

--- a/api/src/Repository/InvoiceRepository.php
+++ b/api/src/Repository/InvoiceRepository.php
@@ -57,6 +57,25 @@ class InvoiceRepository extends ServiceEntityRepository
     }
 
     /**
+     * Overdue invoices that may still need a late-payment reminder (#649):
+     * reminders on, a due date to schedule from. The caller checks the
+     * per-invoice reminder ledger — this just narrows the pool.
+     *
+     * @return list<Invoice>
+     */
+    public function findOverdueForReminders(): array
+    {
+        /** @var list<Invoice> */
+        return $this->createQueryBuilder('i')
+            ->andWhere('i.status = :overdue')
+            ->andWhere('i.remindersEnabled = true')
+            ->andWhere('i.dueDate IS NOT NULL')
+            ->setParameter('overdue', Invoice::STATUS_OVERDUE)
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
      * Flip every sent invoice whose due date has passed to overdue, in one bulk
      * UPDATE. Returns how many were changed. Paid/void/draft are left alone.
      */

--- a/api/src/Service/InvoiceReminderDispatcher.php
+++ b/api/src/Service/InvoiceReminderDispatcher.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Invoice;
+use App\Repository\InvoiceRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * The late-payment reminder sweep (#649), run daily right after the overdue
+ * flip: for every overdue invoice with reminders enabled, sends the next
+ * reminder in the schedule (on overdue, +7d, +14d after the due date) if its
+ * day has arrived. The {@see Invoice::$remindersSentAt} log is the idempotency
+ * ledger — a re-run on the same day finds the reminder already logged and
+ * sends nothing, and a missed day self-heals on the next run (at most one
+ * reminder per invoice per run).
+ *
+ * Each reminder rotates the invoice's public token (the plaintext is
+ * unrecoverable by design, sha256 at rest) so the freshest email always
+ * carries a working link — same pattern as invite resends.
+ */
+final class InvoiceReminderDispatcher
+{
+    /** Days after the due date each reminder fires (index = reminders already sent). */
+    private const OFFSETS_DAYS = [0, 7, 14];
+
+    public function __construct(
+        private readonly InvoiceRepository $invoices,
+        private readonly InvoiceReminderMailer $mailer,
+        private readonly EntityManagerInterface $em,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    /** Returns how many reminders were sent. */
+    public function dispatchDue(\DateTimeImmutable $today): int
+    {
+        $sent = 0;
+        foreach ($this->invoices->findOverdueForReminders() as $invoice) {
+            if ($this->sendNextIfDue($invoice, $today)) {
+                ++$sent;
+            }
+        }
+        if ($sent > 0) {
+            $this->em->flush();
+            $this->logger->info(sprintf('Sent %d late-payment reminder(s).', $sent));
+        }
+
+        return $sent;
+    }
+
+    private function sendNextIfDue(Invoice $invoice, \DateTimeImmutable $today): bool
+    {
+        $dueDate = $invoice->getDueDate();
+        $email = $invoice->getClient()?->getEmail();
+        if (null === $dueDate || null === $email || '' === trim($email)) {
+            return false;
+        }
+
+        $alreadySent = count($invoice->getRemindersSentAt());
+        if ($alreadySent >= count(self::OFFSETS_DAYS)) {
+            return false;
+        }
+        $fireDate = $dueDate->modify(sprintf('+%d days', self::OFFSETS_DAYS[$alreadySent]));
+        if ($today < $fireDate) {
+            return false;
+        }
+
+        // Rotate the public token so the reminder link always works.
+        $plain = bin2hex(random_bytes(32));
+        $invoice->setPublicToken(hash('sha256', $plain));
+        $invoice->addReminderSentAt(new \DateTimeImmutable());
+
+        $this->mailer->sendReminder($invoice, $plain, $alreadySent + 1);
+
+        return true;
+    }
+}

--- a/api/src/Service/InvoiceReminderMailer.php
+++ b/api/src/Service/InvoiceReminderMailer.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Invoice;
+use App\Service\Mail\MailDispatcher;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+
+/**
+ * Emails the client a late-payment reminder for an overdue invoice (#649),
+ * carrying a fresh public link (the plaintext token is minted by the caller —
+ * only its sha256 lives at rest). Copy escalates with the reminder sequence
+ * (1 = just went overdue, 2 = +7 days, 3 = final at +14 days).
+ * No-ops when the client has no email on file.
+ */
+final class InvoiceReminderMailer
+{
+    public function __construct(
+        private readonly MailDispatcher $mail,
+    ) {
+    }
+
+    public function sendReminder(Invoice $invoice, string $plainToken, int $sequence): void
+    {
+        $to = $invoice->getClient()?->getEmail();
+        if (null === $to || '' === trim($to)) {
+            return;
+        }
+
+        $from = $invoice->getSpace()?->getName() ?? 'Madori';
+        $number = $invoice->getNumber() ?? 'invoice';
+        $subject = 3 === $sequence
+            ? sprintf('Final reminder: %s from %s is overdue', ucfirst($number), $from)
+            : sprintf('Reminder: %s from %s is overdue', ucfirst($number), $from);
+
+        $email = (new TemplatedEmail())
+            ->to($to)
+            ->subject($subject)
+            ->htmlTemplate('emails/invoice_reminder.html.twig')
+            ->textTemplate('emails/invoice_reminder.txt.twig')
+            ->context([
+                'invoice' => $invoice,
+                'client' => $invoice->getClient(),
+                'fromName' => $from,
+                'sequence' => $sequence,
+                'viewUrl' => $this->mail->frontendLink('/i/' . $plainToken),
+            ]);
+
+        $this->mail->send($email);
+    }
+}

--- a/api/templates/emails/invoice_reminder.html.twig
+++ b/api/templates/emails/invoice_reminder.html.twig
@@ -1,0 +1,27 @@
+{# @var invoice \App\Entity\Invoice #}
+{# @var client \App\Entity\Client #}
+{# @var sequence int 1 = just overdue, 2 = +7 days, 3 = final (+14 days) #}
+<p>Hi {{ client.name }},</p>
+
+<p>
+    {% if sequence == 1 %}
+        This is a friendly reminder that
+    {% elseif sequence == 2 %}
+        Just following up —
+    {% else %}
+        This is a final reminder —
+    {% endif %}
+    {% if invoice.number %}invoice <strong>{{ invoice.number }}</strong>{% else %}an invoice{% endif %}
+    from {{ fromName }}
+    for <strong>{{ (invoice.total / 100)|number_format(2) }} {{ invoice.currency }}</strong>
+    {% if invoice.dueDate %}was due {{ invoice.dueDate|date('F j, Y') }} and {% endif %}is still awaiting payment.
+</p>
+
+<p>
+    <a href="{{ viewUrl }}">View and pay your invoice</a>
+</p>
+
+<p style="color: #9ca3af; font-size: 12px;">
+    You can review the line items, download a PDF, and pay online from that page.
+    If you've already paid, please disregard this message.
+</p>

--- a/api/templates/emails/invoice_reminder.txt.twig
+++ b/api/templates/emails/invoice_reminder.txt.twig
@@ -1,0 +1,11 @@
+{# @var invoice \App\Entity\Invoice #}
+{# @var client \App\Entity\Client #}
+{# @var sequence int 1 = just overdue, 2 = +7 days, 3 = final (+14 days) #}
+Hi {{ client.name }},
+
+{% if sequence == 1 %}This is a friendly reminder that {% elseif sequence == 2 %}Just following up — {% else %}This is a final reminder — {% endif %}{% if invoice.number %}invoice {{ invoice.number }}{% else %}an invoice{% endif %} from {{ fromName }} for {{ (invoice.total / 100)|number_format(2) }} {{ invoice.currency }}{% if invoice.dueDate %} was due {{ invoice.dueDate|date('F j, Y') }} and{% endif %} is still awaiting payment.
+
+View and pay your invoice: {{ viewUrl }}
+
+You can review the line items, download a PDF, and pay online from that page.
+If you've already paid, please disregard this message.

--- a/api/tests/Api/ClientInvoiceTest.php
+++ b/api/tests/Api/ClientInvoiceTest.php
@@ -505,6 +505,93 @@ class ClientInvoiceTest extends ApiTestCase
         $this->assertSame('overdue', $refreshed['status'] ?? null);
     }
 
+    public function testLatePaymentRemindersFollowScheduleAndOptOut(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $space = $this->createSharedSpace($admin);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'email' => 'billing@acme.test', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+
+        $yesterday = (new \DateTimeImmutable('today'))->modify('-1 day')->format('Y-m-d');
+        $makeInvoice = function (string $description) use ($client, $spaceIri, $clientRow, $yesterday): array {
+            $row = $client->request('POST', '/invoices', [
+                'json' => [
+                    'space' => $spaceIri,
+                    'client' => $clientRow['@id'],
+                    'currency' => 'USD',
+                    'dueDate' => $yesterday,
+                    'lineItems' => [['description' => $description, 'quantity' => 1, 'unitAmount' => 5000]],
+                ],
+                'headers' => ['Content-Type' => 'application/ld+json'],
+            ])->toArray();
+            $this->assertResponseStatusCodeSame(201);
+            $client->request('POST', $this->iri($row) . '/send', [
+                'json' => [],
+                'headers' => ['Content-Type' => 'application/json'],
+            ]);
+            $this->assertResponseStatusCodeSame(201);
+
+            return $row;
+        };
+
+        // A: reminders on (default). B: paused via the per-invoice opt-out.
+        $a = $makeInvoice('Work A');
+        $b = $makeInvoice('Work B');
+        $client->request('PATCH', $this->iri($b), [
+            'json' => ['remindersEnabled' => false],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(200);
+        // Two "here's your invoice" emails from the sends.
+        $this->assertEmailCount(2);
+
+        // The daily sweep flips both overdue and sends A's first reminder only.
+        $handler = static::getContainer()->get(\App\MessageHandler\MarkOverdueInvoicesHandler::class);
+        $this->assertInstanceOf(\App\MessageHandler\MarkOverdueInvoicesHandler::class, $handler);
+        $handler(new \App\Message\MarkOverdueInvoices());
+        $this->assertEmailCount(3);
+        $message = $this->getMailerMessage(2);
+        $this->assertNotNull($message);
+        $this->assertEmailAddressContains($message, 'To', 'billing@acme.test');
+
+        $aFresh = $client->request('GET', $this->iri($a))->toArray();
+        $this->assertSame('overdue', $aFresh['status'] ?? null);
+        $aLog = $aFresh['remindersSentAt'] ?? null;
+        $this->assertIsArray($aLog);
+        $this->assertCount(1, $aLog);
+        $bFresh = $client->request('GET', $this->iri($b))->toArray();
+        $this->assertSame('overdue', $bFresh['status'] ?? null);
+        $this->assertSame([], $bFresh['remindersSentAt'] ?? []);
+
+        // Re-run the same day: reminder 2 isn't due yet (+7d), nothing new sent.
+        $handler(new \App\Message\MarkOverdueInvoices());
+        $this->assertEmailCount(3);
+
+        // A missed week self-heals: back-date A's due date so +7d has passed —
+        // the next run sends exactly one more (reminder 2 of 3).
+        $em = static::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $aId = $a['id'];
+        $this->assertIsString($aId);
+        $aEntity = $em->getRepository(Invoice::class)->find($aId);
+        $this->assertInstanceOf(Invoice::class, $aEntity);
+        $aEntity->setDueDate(new \DateTimeImmutable('-8 days'));
+        $em->flush();
+
+        $handler(new \App\Message\MarkOverdueInvoices());
+        $this->assertEmailCount(4);
+        $aFresh = $client->request('GET', $this->iri($a))->toArray();
+        $aLog = $aFresh['remindersSentAt'] ?? null;
+        $this->assertIsArray($aLog);
+        $this->assertCount(2, $aLog);
+    }
+
     public function testRecurringInvoiceSpawnsAFreshDraft(): void
     {
         $admin = $this->createUser('admin@example.com');

--- a/api/tests/Api/ClientInvoiceTest.php
+++ b/api/tests/Api/ClientInvoiceTest.php
@@ -548,48 +548,45 @@ class ClientInvoiceTest extends ApiTestCase
             'headers' => ['Content-Type' => 'application/merge-patch+json'],
         ]);
         $this->assertResponseStatusCodeSame(200);
-        // Two "here's your invoice" emails from the sends.
-        $this->assertEmailCount(2);
 
-        // The daily sweep flips both overdue and sends A's first reminder only.
+        // No more HTTP requests from here — each client request reboots the
+        // kernel and resets the mailer message logger, so the counts below see
+        // only what the in-process sweep sends.
+        $em = static::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
         $handler = static::getContainer()->get(\App\MessageHandler\MarkOverdueInvoicesHandler::class);
-        $this->assertInstanceOf(\App\MessageHandler\MarkOverdueInvoicesHandler::class, $handler);
+
+        // The daily sweep flips both overdue and sends A's first reminder only
+        // (B is paused).
         $handler(new \App\Message\MarkOverdueInvoices());
-        $this->assertEmailCount(3);
-        $message = $this->getMailerMessage(2);
+        $this->assertEmailCount(1);
+        $message = $this->getMailerMessage();
         $this->assertNotNull($message);
         $this->assertEmailAddressContains($message, 'To', 'billing@acme.test');
 
-        $aFresh = $client->request('GET', $this->iri($a))->toArray();
-        $this->assertSame('overdue', $aFresh['status'] ?? null);
-        $aLog = $aFresh['remindersSentAt'] ?? null;
-        $this->assertIsArray($aLog);
-        $this->assertCount(1, $aLog);
-        $bFresh = $client->request('GET', $this->iri($b))->toArray();
-        $this->assertSame('overdue', $bFresh['status'] ?? null);
-        $this->assertSame([], $bFresh['remindersSentAt'] ?? []);
-
         // Re-run the same day: reminder 2 isn't due yet (+7d), nothing new sent.
         $handler(new \App\Message\MarkOverdueInvoices());
-        $this->assertEmailCount(3);
+        $this->assertEmailCount(1);
 
-        // A missed week self-heals: back-date A's due date so +7d has passed —
-        // the next run sends exactly one more (reminder 2 of 3).
-        $em = static::getContainer()->get('doctrine')->getManager();
-        assert($em instanceof EntityManagerInterface);
         $aId = $a['id'];
         $this->assertIsString($aId);
         $aEntity = $em->getRepository(Invoice::class)->find($aId);
         $this->assertInstanceOf(Invoice::class, $aEntity);
+        $this->assertCount(1, $aEntity->getRemindersSentAt());
+        $bId = $b['id'];
+        $this->assertIsString($bId);
+        $bEntity = $em->getRepository(Invoice::class)->find($bId);
+        $this->assertInstanceOf(Invoice::class, $bEntity);
+        $this->assertSame([], $bEntity->getRemindersSentAt());
+
+        // A missed week self-heals: back-date A's due date so +7d has passed —
+        // the next run sends exactly one more (reminder 2 of 3).
         $aEntity->setDueDate(new \DateTimeImmutable('-8 days'));
         $em->flush();
 
         $handler(new \App\Message\MarkOverdueInvoices());
-        $this->assertEmailCount(4);
-        $aFresh = $client->request('GET', $this->iri($a))->toArray();
-        $aLog = $aFresh['remindersSentAt'] ?? null;
-        $this->assertIsArray($aLog);
-        $this->assertCount(2, $aLog);
+        $this->assertEmailCount(2);
+        $this->assertCount(2, $aEntity->getRemindersSentAt());
     }
 
     public function testRecurringInvoiceSpawnsAFreshDraft(): void

--- a/api/tests/Api/ClientInvoiceTest.php
+++ b/api/tests/Api/ClientInvoiceTest.php
@@ -586,6 +586,7 @@ class ClientInvoiceTest extends ApiTestCase
 
         $handler(new \App\Message\MarkOverdueInvoices());
         $this->assertEmailCount(2);
+        $em->refresh($aEntity);
         $this->assertCount(2, $aEntity->getRemindersSentAt());
     }
 

--- a/pwa/lib/invoiceTypes.ts
+++ b/pwa/lib/invoiceTypes.ts
@@ -54,6 +54,8 @@ export interface Invoice {
   recurrenceFrequency: "weekly" | "monthly" | "yearly" | null;
   recurrenceInterval: number | null;
   nextIssueDate: string | null;
+  remindersEnabled: boolean;
+  remindersSentAt: string[] | null;
   sentAt: string | null;
   paidAt: string | null;
   createdAt: string;

--- a/pwa/pages/invoices/index.tsx
+++ b/pwa/pages/invoices/index.tsx
@@ -183,6 +183,22 @@ const InvoicesPage = () => {
     onError: (e) => setError(e instanceof Error ? e.message : "Action failed."),
   });
 
+  // Per-invoice opt-out for the automatic late-payment reminder emails (#649).
+  const toggleReminders = useMutation({
+    mutationFn: ({ invoice, enabled }: { invoice: Invoice; enabled: boolean }) =>
+      apiSend<Invoice>("PATCH", invoice["@id"], {
+        contentType: "application/merge-patch+json",
+        errorMessage: "Failed to update reminders.",
+        body: { remindersEnabled: enabled },
+      }),
+    onSuccess: (_res, { enabled }) => {
+      setError(null);
+      setNotice(enabled ? "Late-payment reminders resumed." : "Late-payment reminders paused.");
+      void refresh();
+    },
+    onError: (e) => setError(e instanceof Error ? e.message : "Failed to update reminders."),
+  });
+
   const openPdf = async (invoice: Invoice) => {
     try {
       const res = await fetch(`${invoice["@id"]}/pdf`, {
@@ -482,6 +498,21 @@ const InvoicesPage = () => {
                                         onClick={() => act.mutate({ invoice, action: "mark-paid" })}
                                       >
                                         Mark paid
+                                      </DropdownMenuItem>
+                                    )}
+                                    {(invoice.status === "sent" ||
+                                      invoice.status === "overdue") && (
+                                      <DropdownMenuItem
+                                        onClick={() =>
+                                          toggleReminders.mutate({
+                                            invoice,
+                                            enabled: !invoice.remindersEnabled,
+                                          })
+                                        }
+                                      >
+                                        {invoice.remindersEnabled
+                                          ? "Pause reminders"
+                                          : "Resume reminders"}
                                       </DropdownMenuItem>
                                     )}
                                     {invoice.status !== "void" && (


### PR DESCRIPTION
Closes #649

## What
We flip invoices to overdue nightly (`MarkOverdueInvoices`, 03:50 UTC) but never told anyone. Now the same sweep emails the client.

**Schedule**: a reminder when the invoice goes overdue, then **+7d** and **+14d** after the due date while still unpaid (3 max, final one labeled as such).

**Idempotency**: each send is logged to `Invoice.remindersSentAt` (JSON ledger). The next reminder's fire date = `dueDate + [0,7,14][count]` — so a same-day re-run sends nothing, and a missed cron day self-heals on the next run (at most one reminder per invoice per run).

**Opt-out**: `Invoice.remindersEnabled` (default on), PATCHable — surfaced as **Pause/Resume reminders** in the invoice row menu for sent/overdue invoices.

**Link freshness**: each reminder rotates the public token (plaintext is unrecoverable by design, sha256 at rest) — same pattern as invite resends, so the newest email is always the authoritative link.

## Pieces
- `InvoiceReminderDispatcher` (sweep logic) + `InvoiceReminderMailer` + `emails/invoice_reminder.{html,txt}.twig` (escalating copy: friendly → follow-up → final)
- `MarkOverdueInvoicesHandler` runs the sweep right after the overdue flip — piggybacks the existing cron, no new schedule entry
- `InvoiceRepository::findOverdueForReminders()` narrows the pool (overdue + reminders on + has due date); the ledger check is per-invoice
- Migration `Version20260716120000`: `reminders_enabled` + `reminders_sent_at` on `invoice`

## Tests
`testLatePaymentRemindersFollowScheduleAndOptOut`: first reminder fires on overdue + logs to the ledger, the paused invoice is skipped, a same-day re-run sends nothing, and a back-dated due date (missed week) triggers exactly one catch-up reminder.