### PR TITLE
feat(billing): invoice discounts + partial payments

### DIFF
--- a/api/migrations/Version20260716140000.php
+++ b/api/migrations/Version20260716140000.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Invoice discounts + partial payments (#648): discount columns on invoice
+ * (percent-or-fixed, applied between subtotal and tax) and the invoice_payment
+ * table (balance due = total − Σ payments; paid only when the balance is 0).
+ */
+final class Version20260716140000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Invoice discounts (type/value/amount) + invoice_payment table for partial payments.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE invoice_payment (id UUID NOT NULL, amount INT NOT NULL, paid_on DATE NOT NULL, method VARCHAR(40) DEFAULT NULL, note VARCHAR(255) DEFAULT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, invoice_id UUID NOT NULL, created_by_id UUID DEFAULT NULL, PRIMARY KEY (id))');
+        $this->addSql('CREATE INDEX idx_invoice_payment_invoice ON invoice_payment (invoice_id)');
+        $this->addSql('CREATE INDEX IDX_9FF1B2DEB03A8386 ON invoice_payment (created_by_id)');
+        $this->addSql('ALTER TABLE invoice_payment ADD CONSTRAINT FK_9FF1B2DE2989F1FD FOREIGN KEY (invoice_id) REFERENCES invoice (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE invoice_payment ADD CONSTRAINT FK_9FF1B2DEB03A8386 FOREIGN KEY (created_by_id) REFERENCES "user" (id) ON DELETE SET NULL NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE invoice ADD discount_type VARCHAR(10) DEFAULT NULL');
+        $this->addSql('ALTER TABLE invoice ADD discount_value INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE invoice ADD discount_amount INT DEFAULT 0 NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE invoice_payment DROP CONSTRAINT FK_9FF1B2DE2989F1FD');
+        $this->addSql('ALTER TABLE invoice_payment DROP CONSTRAINT FK_9FF1B2DEB03A8386');
+        $this->addSql('DROP TABLE invoice_payment');
+        $this->addSql('ALTER TABLE invoice DROP discount_type');
+        $this->addSql('ALTER TABLE invoice DROP discount_value');
+        $this->addSql('ALTER TABLE invoice DROP discount_amount');
+    }
+}

--- a/api/src/Billing/Payment/StripePaymentGateway.php
+++ b/api/src/Billing/Payment/StripePaymentGateway.php
@@ -37,8 +37,10 @@ final class StripePaymentGateway implements PaymentGatewayInterface
         $label = $invoice->getNumber();
         $description = 'Invoice ' . (null !== $label && '' !== $label ? $label : (string) $invoice->getId());
 
+        // Charge the balance due, not the full total — partial payments (#648)
+        // may already cover part of the invoice.
         return $this->stripe->createPaymentCheckout(
-            $invoice->getTotal(),
+            $invoice->getBalanceDue(),
             $invoice->getCurrency(),
             $description,
             $successUrl,

--- a/api/src/Controller/BillingController.php
+++ b/api/src/Controller/BillingController.php
@@ -12,6 +12,7 @@ use App\Entity\Organization;
 use App\Entity\Space;
 use App\Entity\CancellationFeedback;
 use App\Entity\Invoice;
+use App\Entity\InvoicePayment;
 use App\Entity\Subscription;
 use App\Entity\User;
 use App\Repository\SubscriptionRepository;
@@ -377,8 +378,23 @@ class BillingController extends AbstractController
         if (Invoice::STATUS_PAID === $invoice->getStatus() || Invoice::STATUS_VOID === $invoice->getStatus()) {
             return;
         }
-        $invoice->setStatus(Invoice::STATUS_PAID);
-        $invoice->setPaidAt(new \DateTimeImmutable());
+
+        // Record the payment on the ledger (#648): the session charged the
+        // balance due at checkout time; fall back to the current balance if
+        // Stripe's amount_total is missing. Paid only when the balance clears.
+        $amountTotal = $this->dig($session, ['amount_total']);
+        $amount = is_int($amountTotal) && $amountTotal > 0 ? $amountTotal : $invoice->getBalanceDue();
+        if ($amount > 0) {
+            $invoice->addPayment(
+                (new InvoicePayment())
+                    ->setAmount(min($amount, $invoice->getBalanceDue()))
+                    ->setMethod(InvoicePayment::METHOD_STRIPE),
+            );
+        }
+        if (0 === $invoice->getBalanceDue()) {
+            $invoice->setStatus(Invoice::STATUS_PAID);
+            $invoice->setPaidAt(new \DateTimeImmutable());
+        }
         $this->em->flush();
     }
 

--- a/api/src/Controller/InvoiceActionController.php
+++ b/api/src/Controller/InvoiceActionController.php
@@ -3,6 +3,7 @@
 namespace App\Controller;
 
 use App\Entity\Invoice;
+use App\Entity\InvoicePayment;
 use App\Entity\User;
 use App\Repository\InvoiceRepository;
 use App\Security\Permission\SpacePermission;
@@ -11,6 +12,7 @@ use App\Service\InvoiceMailer;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
 use Symfony\Component\Uid\Uuid;
@@ -76,11 +78,115 @@ class InvoiceActionController extends AbstractController
             return $this->json(['error' => 'A void invoice cannot be marked paid.'], 409);
         }
 
+        // Record the remaining balance as a payment (#648) so the ledger and
+        // the status agree — a fully-paid-by-parts invoice records nothing new.
+        $balance = $invoice->getBalanceDue();
+        if ($balance > 0) {
+            $invoice->addPayment(
+                (new InvoicePayment())
+                    ->setAmount($balance)
+                    ->setMethod(InvoicePayment::METHOD_MANUAL)
+                    ->setCreatedBy($user instanceof User ? $user : null),
+            );
+        }
         $invoice->setStatus(Invoice::STATUS_PAID);
         $invoice->setPaidAt(new \DateTimeImmutable());
         $this->em->flush();
 
         return $this->summary($invoice);
+    }
+
+    /**
+     * Record a (possibly partial) payment (#648). Balance due = total − Σ
+     * payments; the status flips to paid only when the balance hits zero and
+     * stays sent/overdue while anything is outstanding.
+     */
+    #[Route('/invoices/{id}/payments', name: 'invoice_payment_add', methods: ['POST'])]
+    public function addPayment(string $id, Request $request, #[CurrentUser] ?User $user): JsonResponse
+    {
+        $invoice = $this->authorize($id, $user);
+        if ($invoice instanceof JsonResponse) {
+            return $invoice;
+        }
+        if (in_array($invoice->getStatus(), [Invoice::STATUS_DRAFT, Invoice::STATUS_VOID], true)) {
+            return $this->json(['error' => 'Payments can only be recorded on an issued invoice.'], 409);
+        }
+
+        $payload = $request->toArray();
+        $amount = $payload['amount'] ?? null;
+        if (!is_int($amount) || $amount <= 0) {
+            return $this->json(['error' => 'A positive amount (minor units) is required.'], 422);
+        }
+        if ($amount > $invoice->getBalanceDue()) {
+            return $this->json(['error' => 'The payment exceeds the balance due.'], 422);
+        }
+
+        $paidOn = new \DateTimeImmutable('today');
+        $paidOnRaw = $payload['paidOn'] ?? null;
+        if (is_string($paidOnRaw) && '' !== trim($paidOnRaw)) {
+            $parsed = \DateTimeImmutable::createFromFormat('!Y-m-d', trim($paidOnRaw), new \DateTimeZone('UTC'));
+            if (false === $parsed) {
+                return $this->json(['error' => 'paidOn must be formatted YYYY-MM-DD.'], 422);
+            }
+            $paidOn = $parsed;
+        }
+
+        $method = $payload['method'] ?? null;
+        $note = $payload['note'] ?? null;
+        $payment = (new InvoicePayment())
+            ->setAmount($amount)
+            ->setPaidOn($paidOn)
+            ->setMethod(is_string($method) && '' !== trim($method) ? mb_substr(trim($method), 0, 40) : InvoicePayment::METHOD_MANUAL)
+            ->setNote(is_string($note) && '' !== trim($note) ? mb_substr(trim($note), 0, 255) : null)
+            ->setCreatedBy($user instanceof User ? $user : null);
+        $invoice->addPayment($payment);
+
+        if (0 === $invoice->getBalanceDue()) {
+            $invoice->setStatus(Invoice::STATUS_PAID);
+            $invoice->setPaidAt(new \DateTimeImmutable());
+        }
+        $this->em->flush();
+
+        return $this->paymentSummary($invoice);
+    }
+
+    /**
+     * Remove a recorded payment (a typo'd amount, a bounced check). If the
+     * invoice was paid and the balance reopens, the status reverts to
+     * sent/overdue (past-due picks overdue).
+     */
+    #[Route('/invoices/{id}/payments/{paymentId}', name: 'invoice_payment_remove', methods: ['DELETE'])]
+    public function removePayment(string $id, string $paymentId, #[CurrentUser] ?User $user): JsonResponse
+    {
+        $invoice = $this->authorize($id, $user);
+        if ($invoice instanceof JsonResponse) {
+            return $invoice;
+        }
+
+        if (!Uuid::isValid($paymentId)) {
+            return $this->json(['error' => 'Payment not found.'], 404);
+        }
+        $payment = null;
+        foreach ($invoice->getPayments() as $candidate) {
+            if ($candidate->getId()?->toRfc4122() === strtolower($paymentId)) {
+                $payment = $candidate;
+                break;
+            }
+        }
+        if (null === $payment) {
+            return $this->json(['error' => 'Payment not found.'], 404);
+        }
+
+        $invoice->removePayment($payment);
+
+        if (Invoice::STATUS_PAID === $invoice->getStatus() && $invoice->getBalanceDue() > 0) {
+            $pastDue = null !== $invoice->getDueDate() && $invoice->getDueDate() < new \DateTimeImmutable('today');
+            $invoice->setStatus($pastDue ? Invoice::STATUS_OVERDUE : Invoice::STATUS_SENT);
+            $invoice->setPaidAt(null);
+        }
+        $this->em->flush();
+
+        return $this->paymentSummary($invoice);
     }
 
     #[Route('/invoices/{id}/send', name: 'invoice_send', methods: ['POST'])]
@@ -172,6 +278,31 @@ class InvoiceActionController extends AbstractController
         }
 
         return $invoice;
+    }
+
+    /** The payment ledger + balance the PWA re-renders after a payment write. */
+    private function paymentSummary(Invoice $invoice): JsonResponse
+    {
+        $payments = [];
+        foreach ($invoice->getPayments() as $payment) {
+            $payments[] = [
+                'id' => (string) $payment->getId(),
+                'amount' => $payment->getAmount(),
+                'paidOn' => $payment->getPaidOn()->format('Y-m-d'),
+                'method' => $payment->getMethod(),
+                'note' => $payment->getNote(),
+            ];
+        }
+
+        return $this->json([
+            '@id' => '/invoices/' . $invoice->getId(),
+            'id' => (string) $invoice->getId(),
+            'status' => $invoice->getStatus(),
+            'total' => $invoice->getTotal(),
+            'amountPaid' => $invoice->getAmountPaid(),
+            'balanceDue' => $invoice->getBalanceDue(),
+            'payments' => $payments,
+        ]);
     }
 
     private function summary(Invoice $invoice): JsonResponse

--- a/api/src/Controller/PublicInvoiceController.php
+++ b/api/src/Controller/PublicInvoiceController.php
@@ -48,6 +48,15 @@ class PublicInvoiceController extends AbstractController
             ];
         }
 
+        $payments = [];
+        foreach ($invoice->getPayments() as $payment) {
+            $payments[] = [
+                'amount' => $payment->getAmount(),
+                'paidOn' => $payment->getPaidOn()->format('Y-m-d'),
+                'method' => $payment->getMethod(),
+            ];
+        }
+
         return $this->json([
             'number' => $invoice->getNumber(),
             'status' => $invoice->getStatus(),
@@ -58,8 +67,12 @@ class PublicInvoiceController extends AbstractController
             'billTo' => $invoice->getClient()?->getName(),
             'lineItems' => $lines,
             'subtotal' => $invoice->getSubtotal(),
+            'discountAmount' => $invoice->getDiscountAmount(),
             'taxAmount' => $invoice->getTaxAmount(),
             'total' => $invoice->getTotal(),
+            'amountPaid' => $invoice->getAmountPaid(),
+            'balanceDue' => $invoice->getBalanceDue(),
+            'payments' => $payments,
             'pdfUrl' => '/public/invoices/' . $token . '/pdf',
         ]);
     }
@@ -88,7 +101,7 @@ class PublicInvoiceController extends AbstractController
         if (Invoice::STATUS_PAID === $invoice->getStatus()) {
             return $this->json(['error' => 'This invoice is already paid.'], 409);
         }
-        if ($invoice->getTotal() <= 0) {
+        if ($invoice->getBalanceDue() <= 0) {
             return $this->json(['error' => 'Nothing to pay on this invoice.'], 409);
         }
 

--- a/api/src/Entity/Invoice.php
+++ b/api/src/Entity/Invoice.php
@@ -87,6 +87,12 @@ class Invoice
         self::STATUS_VOID,
     ];
 
+    public const DISCOUNT_PERCENT = 'percent';
+    public const DISCOUNT_FIXED = 'fixed';
+
+    /** @var list<string> */
+    public const DISCOUNT_TYPES = [self::DISCOUNT_PERCENT, self::DISCOUNT_FIXED];
+
     public const FREQ_WEEKLY = 'weekly';
     public const FREQ_MONTHLY = 'monthly';
     public const FREQ_YEARLY = 'yearly';
@@ -149,6 +155,25 @@ class Invoice
     private ?string $notes = null;
 
     /**
+     * Discount applied between subtotal and tax (#648): percent-of-subtotal or
+     * a fixed amount. Null = no discount.
+     */
+    #[ORM\Column(length: 10, nullable: true)]
+    #[Assert\Choice(choices: self::DISCOUNT_TYPES, message: 'Invalid discount type.')]
+    #[Groups(['invoice:read', 'invoice:write'])]
+    private ?string $discountType = null;
+
+    /** Basis points for percent (1000 = 10%), minor units for fixed. */
+    #[ORM\Column(type: 'integer', nullable: true)]
+    #[Groups(['invoice:read', 'invoice:write'])]
+    private ?int $discountValue = null;
+
+    /** The discount actually subtracted, minor units. Derived. */
+    #[ORM\Column(type: 'integer', options: ['default' => 0])]
+    #[Groups(['invoice:read'])]
+    private int $discountAmount = 0;
+
+    /**
      * When set, this invoice is a recurring template: the sweep clones it into a
      * fresh draft each time {@see $nextIssueDate} arrives. One of weekly / monthly
      * / yearly, repeated every {@see $recurrenceInterval}.
@@ -175,6 +200,19 @@ class Invoice
     #[Assert\Valid]
     #[Groups(['invoice:read', 'invoice:write'])]
     private Collection $lineItems;
+
+    /**
+     * Payments recorded against this invoice (#648) — server-written only
+     * (payments endpoint, mark-paid, Stripe webhook), read-embedded so the
+     * client sees the ledger + balance without another fetch.
+     *
+     * @var Collection<int, InvoicePayment>
+     */
+    #[ApiProperty(readableLink: true, writableLink: false)]
+    #[ORM\OneToMany(mappedBy: 'invoice', targetEntity: InvoicePayment::class, cascade: ['persist'], orphanRemoval: true)]
+    #[ORM\OrderBy(['paidOn' => 'ASC', 'createdAt' => 'ASC'])]
+    #[Groups(['invoice:read'])]
+    private Collection $payments;
 
     /** Sum of line amounts, minor units. Derived. */
     #[ORM\Column(type: 'integer')]
@@ -240,6 +278,7 @@ class Invoice
     {
         $this->createdAt = new \DateTimeImmutable();
         $this->lineItems = new ArrayCollection();
+        $this->payments = new ArrayCollection();
     }
 
     #[ORM\PreUpdate]
@@ -257,6 +296,27 @@ class Invoice
             $context->buildViolation('Client must belong to the same space.')
                 ->atPath('client')
                 ->addViolation();
+        }
+
+        if (null !== $this->discountType && null === $this->discountValue) {
+            $context->buildViolation('A discount needs a value.')
+                ->atPath('discountValue')
+                ->addViolation();
+        }
+        if (null !== $this->discountValue) {
+            if (null === $this->discountType) {
+                $context->buildViolation('A discount value needs a type (percent or fixed).')
+                    ->atPath('discountType')
+                    ->addViolation();
+            } elseif ($this->discountValue < 0) {
+                $context->buildViolation('A discount cannot be negative.')
+                    ->atPath('discountValue')
+                    ->addViolation();
+            } elseif (self::DISCOUNT_PERCENT === $this->discountType && $this->discountValue > 10000) {
+                $context->buildViolation('A percent discount cannot exceed 100%.')
+                    ->atPath('discountValue')
+                    ->addViolation();
+            }
         }
 
         if (null !== $this->recurrenceFrequency) {
@@ -468,6 +528,88 @@ class Invoice
         }
 
         return $this;
+    }
+
+    public function getDiscountType(): ?string
+    {
+        return $this->discountType;
+    }
+
+    public function setDiscountType(?string $discountType): self
+    {
+        $this->discountType = $discountType;
+
+        return $this;
+    }
+
+    public function getDiscountValue(): ?int
+    {
+        return $this->discountValue;
+    }
+
+    public function setDiscountValue(?int $discountValue): self
+    {
+        $this->discountValue = $discountValue;
+
+        return $this;
+    }
+
+    public function getDiscountAmount(): int
+    {
+        return $this->discountAmount;
+    }
+
+    public function setDiscountAmount(int $discountAmount): self
+    {
+        $this->discountAmount = $discountAmount;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, InvoicePayment>
+     */
+    public function getPayments(): Collection
+    {
+        return $this->payments;
+    }
+
+    public function addPayment(InvoicePayment $payment): self
+    {
+        if (!$this->payments->contains($payment)) {
+            $this->payments->add($payment);
+            $payment->setInvoice($this);
+        }
+
+        return $this;
+    }
+
+    public function removePayment(InvoicePayment $payment): self
+    {
+        if ($this->payments->removeElement($payment) && $payment->getInvoice() === $this) {
+            $payment->setInvoice(null);
+        }
+
+        return $this;
+    }
+
+    /** Σ recorded payments, minor units. */
+    #[Groups(['invoice:read'])]
+    public function getAmountPaid(): int
+    {
+        $sum = 0;
+        foreach ($this->payments as $payment) {
+            $sum += $payment->getAmount();
+        }
+
+        return $sum;
+    }
+
+    /** total − Σ payments, floored at zero. */
+    #[Groups(['invoice:read'])]
+    public function getBalanceDue(): int
+    {
+        return max(0, $this->total - $this->getAmountPaid());
     }
 
     public function getSubtotal(): int

--- a/api/src/Entity/Invoice.php
+++ b/api/src/Entity/Invoice.php
@@ -574,6 +574,13 @@ class Invoice
         return $this->payments;
     }
 
+    /**
+     * Mutates the ledger — marked impure so PHPStan forgets remembered
+     * getBalanceDue()/getStatus() values after a call (the fluent return
+     * otherwise makes it look side-effect-free).
+     *
+     * @phpstan-impure
+     */
     public function addPayment(InvoicePayment $payment): self
     {
         if (!$this->payments->contains($payment)) {
@@ -584,6 +591,7 @@ class Invoice
         return $this;
     }
 
+    /** @phpstan-impure */
     public function removePayment(InvoicePayment $payment): self
     {
         if ($this->payments->removeElement($payment) && $payment->getInvoice() === $this) {

--- a/api/src/Entity/InvoicePayment.php
+++ b/api/src/Entity/InvoicePayment.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * One payment recorded against an {@see Invoice} (#648) — Harvest-style
+ * partial payments: the invoice's balance due = total − Σ payments, and the
+ * status only flips to paid when the balance hits zero. Rows are written
+ * through `POST /invoices/{id}/payments` (manual entry), the mark-paid action
+ * (records the remaining balance), and the Stripe webhook (online payment) —
+ * never directly by clients, so amounts are always server-controlled.
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'invoice_payment')]
+#[ORM\Index(columns: ['invoice_id'], name: 'idx_invoice_payment_invoice')]
+class InvoicePayment
+{
+    public const METHOD_MANUAL = 'manual';
+    public const METHOD_STRIPE = 'stripe';
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
+    #[Groups(['invoice:read'])]
+    private ?Uuid $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Invoice::class, inversedBy: 'payments')]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private ?Invoice $invoice = null;
+
+    /** Minor units of the invoice's currency. Always positive. */
+    #[ORM\Column(type: 'integer')]
+    #[Groups(['invoice:read'])]
+    private int $amount = 0;
+
+    #[ORM\Column(type: 'date_immutable')]
+    #[Groups(['invoice:read'])]
+    private \DateTimeImmutable $paidOn;
+
+    /** e.g. "manual", "stripe", "bank transfer", "check". */
+    #[ORM\Column(length: 40, nullable: true)]
+    #[Groups(['invoice:read'])]
+    private ?string $method = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    #[Groups(['invoice:read'])]
+    private ?string $note = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    private ?User $createdBy = null;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    #[Groups(['invoice:read'])]
+    private \DateTimeImmutable $createdAt;
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTimeImmutable();
+        $this->paidOn = new \DateTimeImmutable('today');
+    }
+
+    public function getId(): ?Uuid
+    {
+        return $this->id;
+    }
+
+    public function getInvoice(): ?Invoice
+    {
+        return $this->invoice;
+    }
+
+    public function setInvoice(?Invoice $invoice): self
+    {
+        $this->invoice = $invoice;
+
+        return $this;
+    }
+
+    public function getAmount(): int
+    {
+        return $this->amount;
+    }
+
+    public function setAmount(int $amount): self
+    {
+        $this->amount = $amount;
+
+        return $this;
+    }
+
+    public function getPaidOn(): \DateTimeImmutable
+    {
+        return $this->paidOn;
+    }
+
+    public function setPaidOn(\DateTimeImmutable $paidOn): self
+    {
+        $this->paidOn = $paidOn;
+
+        return $this;
+    }
+
+    public function getMethod(): ?string
+    {
+        return $this->method;
+    }
+
+    public function setMethod(?string $method): self
+    {
+        $this->method = $method;
+
+        return $this;
+    }
+
+    public function getNote(): ?string
+    {
+        return $this->note;
+    }
+
+    public function setNote(?string $note): self
+    {
+        $this->note = $note;
+
+        return $this;
+    }
+
+    public function getCreatedBy(): ?User
+    {
+        return $this->createdBy;
+    }
+
+    public function setCreatedBy(?User $createdBy): self
+    {
+        $this->createdBy = $createdBy;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+}

--- a/api/src/State/InvoiceProcessor.php
+++ b/api/src/State/InvoiceProcessor.php
@@ -57,9 +57,22 @@ final class InvoiceProcessor implements ProcessorInterface
             $subtotal += $amount;
         }
 
-        $taxAmount = (int) round($subtotal * $invoice->getTaxRate() / self::BASIS_POINTS);
+        // Discount (#648) applies between subtotal and tax: percent of the
+        // subtotal or a fixed amount, never more than the subtotal itself.
+        $discountValue = $invoice->getDiscountValue();
+        $discountAmount = 0;
+        if (null !== $invoice->getDiscountType() && null !== $discountValue) {
+            $discountAmount = Invoice::DISCOUNT_PERCENT === $invoice->getDiscountType()
+                ? (int) round($subtotal * $discountValue / self::BASIS_POINTS)
+                : $discountValue;
+            $discountAmount = max(0, min($discountAmount, $subtotal));
+        }
+
+        $taxable = $subtotal - $discountAmount;
+        $taxAmount = (int) round($taxable * $invoice->getTaxRate() / self::BASIS_POINTS);
         $invoice->setSubtotal($subtotal);
+        $invoice->setDiscountAmount($discountAmount);
         $invoice->setTaxAmount($taxAmount);
-        $invoice->setTotal($subtotal + $taxAmount);
+        $invoice->setTotal($taxable + $taxAmount);
     }
 }

--- a/api/templates/invoice/pdf.html.twig
+++ b/api/templates/invoice/pdf.html.twig
@@ -90,6 +90,12 @@
         <td>Subtotal</td>
         <td class="num">{{ fmt.money(invoice.subtotal, c) }}</td>
     </tr>
+    {% if invoice.discountAmount > 0 %}
+    <tr>
+        <td>Discount{% if invoice.discountType == 'percent' and invoice.discountValue %} ({{ (invoice.discountValue / 100)|number_format(2) }}%){% endif %}</td>
+        <td class="num">−{{ fmt.money(invoice.discountAmount, c) }}</td>
+    </tr>
+    {% endif %}
     {% if invoice.taxAmount > 0 %}
     <tr>
         <td>Tax ({{ (invoice.taxRate / 100)|number_format(2) }}%)</td>
@@ -100,7 +106,38 @@
         <td>Total</td>
         <td class="num">{{ fmt.money(invoice.total, c) }}</td>
     </tr>
+    {% if invoice.amountPaid > 0 %}
+    <tr>
+        <td>Amount paid</td>
+        <td class="num">−{{ fmt.money(invoice.amountPaid, c) }}</td>
+    </tr>
+    <tr class="grand">
+        <td>Balance due</td>
+        <td class="num">{{ fmt.money(invoice.balanceDue, c) }}</td>
+    </tr>
+    {% endif %}
 </table>
+
+{% if invoice.payments|length > 0 %}
+<table class="lines" style="margin-top: 20px;">
+    <thead>
+        <tr>
+            <th>Payment</th>
+            <th class="num">Date</th>
+            <th class="num">Amount</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for payment in invoice.payments %}
+        <tr>
+            <td>{{ payment.method ?? 'payment' }}</td>
+            <td class="num">{{ payment.paidOn|date('M j, Y') }}</td>
+            <td class="num">{{ fmt.money(payment.amount, c) }}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% endif %}
 
 {% if invoice.notes %}
 <div class="notes">{{ invoice.notes }}</div>

--- a/api/tests/Api/ClientInvoiceTest.php
+++ b/api/tests/Api/ClientInvoiceTest.php
@@ -719,6 +719,152 @@ class ClientInvoiceTest extends ApiTestCase
         $this->assertNotNull($refreshed['paidAt'] ?? null);
     }
 
+    public function testDiscountAppliesBetweenSubtotalAndTax(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $space = $this->createSharedSpace($admin);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+
+        // 25% off 20000 = 5000; tax 10% on the discounted 15000 = 1500.
+        $invoice = $client->request('POST', '/invoices', [
+            'json' => [
+                'space' => $spaceIri,
+                'client' => $clientRow['@id'],
+                'currency' => 'USD',
+                'taxRate' => 1000,
+                'discountType' => 'percent',
+                'discountValue' => 2500,
+                'lineItems' => [['description' => 'Work', 'quantity' => 4, 'unitAmount' => 5000]],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertSame(20000, $invoice['subtotal'] ?? null);
+        $this->assertSame(5000, $invoice['discountAmount'] ?? null);
+        $this->assertSame(1500, $invoice['taxAmount'] ?? null);
+        $this->assertSame(16500, $invoice['total'] ?? null);
+
+        // Switch to a fixed 30.00 discount: tax 10% on 17000 = 1700.
+        $patched = $client->request('PATCH', $this->iri($invoice), [
+            'json' => ['discountType' => 'fixed', 'discountValue' => 3000],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertSame(3000, $patched['discountAmount'] ?? null);
+        $this->assertSame(1700, $patched['taxAmount'] ?? null);
+        $this->assertSame(18700, $patched['total'] ?? null);
+
+        // A percent discount over 100% is rejected.
+        $client->request('PATCH', $this->iri($invoice), [
+            'json' => ['discountType' => 'percent', 'discountValue' => 10001],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testPartialPaymentsTrackBalanceAndFlipStatus(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $space = $this->createSharedSpace($admin);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $yesterday = (new \DateTimeImmutable('today'))->modify('-1 day')->format('Y-m-d');
+        $invoice = $client->request('POST', '/invoices', [
+            'json' => [
+                'space' => $spaceIri,
+                'client' => $clientRow['@id'],
+                'currency' => 'USD',
+                'dueDate' => $yesterday,
+                'lineItems' => [['description' => 'Work', 'quantity' => 1, 'unitAmount' => 10000]],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $invoiceIri = $invoice['@id'];
+        $this->assertIsString($invoiceIri);
+
+        // Payments can't be recorded on a draft.
+        $client->request('POST', $invoiceIri . '/payments', [
+            'json' => ['amount' => 1000],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(409);
+
+        $client->request('POST', $invoiceIri . '/send', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+
+        // Partial payment: status stays sent, balance shrinks.
+        $partial = $client->request('POST', $invoiceIri . '/payments', [
+            'json' => ['amount' => 4000, 'method' => 'bank transfer', 'note' => 'first half'],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertSame('sent', $partial['status'] ?? null);
+        $this->assertSame(4000, $partial['amountPaid'] ?? null);
+        $this->assertSame(6000, $partial['balanceDue'] ?? null);
+
+        // Overpaying is rejected.
+        $client->request('POST', $invoiceIri . '/payments', [
+            'json' => ['amount' => 7000],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+
+        // Paying the rest flips the invoice to paid.
+        $final = $client->request('POST', $invoiceIri . '/payments', [
+            'json' => ['amount' => 6000],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $this->assertSame('paid', $final['status'] ?? null);
+        $this->assertSame(0, $final['balanceDue'] ?? null);
+        $payments = $final['payments'] ?? null;
+        $this->assertIsArray($payments);
+        $this->assertCount(2, $payments);
+        // Same-day payments share a paidOn — pick the 6000 row by amount.
+        $lastId = null;
+        foreach ($payments as $row) {
+            $this->assertIsArray($row);
+            if (6000 === ($row['amount'] ?? null)) {
+                $lastId = $row['id'];
+            }
+        }
+        $this->assertIsString($lastId);
+
+        // Removing the final payment reopens the balance — past due, so overdue.
+        $reopened = $client->request('DELETE', $invoiceIri . '/payments/' . $lastId)->toArray();
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertSame('overdue', $reopened['status'] ?? null);
+        $this->assertSame(6000, $reopened['balanceDue'] ?? null);
+
+        // mark-paid records the remaining balance as a manual payment.
+        $client->request('POST', $invoiceIri . '/mark-paid', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(200);
+        $refreshed = $client->request('GET', $invoiceIri)->toArray();
+        $this->assertSame('paid', $refreshed['status'] ?? null);
+        $this->assertSame(10000, $refreshed['amountPaid'] ?? null);
+        $paymentRows = $refreshed['payments'] ?? null;
+        $this->assertIsArray($paymentRows);
+        $this->assertCount(2, $paymentRows);
+    }
+
     private function trackTime(
         \ApiPlatform\Symfony\Bundle\Test\Client $client,
         string $spaceIri,

--- a/pwa/lib/invoiceTypes.ts
+++ b/pwa/lib/invoiceTypes.ts
@@ -35,6 +35,17 @@ export interface InvoiceLineItem {
 
 export type InvoiceStatus = "draft" | "sent" | "paid" | "overdue" | "void";
 
+export type DiscountType = "percent" | "fixed";
+
+export interface InvoicePayment {
+  id: string;
+  amount: number;
+  paidOn: string;
+  method: string | null;
+  note: string | null;
+  createdAt: string;
+}
+
 export interface Invoice {
   "@id": string;
   id: string;
@@ -47,7 +58,13 @@ export interface Invoice {
   currency: string;
   taxRate: number;
   notes: string | null;
+  discountType: DiscountType | null;
+  discountValue: number | null;
+  discountAmount: number;
   lineItems: InvoiceLineItem[];
+  payments: InvoicePayment[];
+  amountPaid: number;
+  balanceDue: number;
   subtotal: number;
   taxAmount: number;
   total: number;

--- a/pwa/pages/i/[token].tsx
+++ b/pwa/pages/i/[token].tsx
@@ -25,8 +25,12 @@ interface PublicInvoice {
   billTo: string | null;
   lineItems: PublicLine[];
   subtotal: number;
+  discountAmount: number;
   taxAmount: number;
   total: number;
+  amountPaid: number;
+  balanceDue: number;
+  payments: { amount: number; paidOn: string; method: string | null }[];
 }
 
 const fmtDate = (iso: string | null): string =>
@@ -192,6 +196,14 @@ const PublicInvoicePage = () => {
             <span className="text-muted-foreground">Subtotal</span>
             <span className="tabular-nums">{formatMoney(invoice.subtotal, invoice.currency)}</span>
           </div>
+          {invoice.discountAmount > 0 && (
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Discount</span>
+              <span className="tabular-nums">
+                −{formatMoney(invoice.discountAmount, invoice.currency)}
+              </span>
+            </div>
+          )}
           {invoice.taxAmount > 0 && (
             <div className="flex justify-between">
               <span className="text-muted-foreground">Tax</span>
@@ -202,7 +214,38 @@ const PublicInvoicePage = () => {
             <span>Total</span>
             <span className="tabular-nums">{formatMoney(invoice.total, invoice.currency)}</span>
           </div>
+          {invoice.amountPaid > 0 && (
+            <>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Amount paid</span>
+                <span className="tabular-nums">
+                  −{formatMoney(invoice.amountPaid, invoice.currency)}
+                </span>
+              </div>
+              <div className="flex justify-between border-t pt-1 text-base font-semibold">
+                <span>Balance due</span>
+                <span className="tabular-nums">
+                  {formatMoney(invoice.balanceDue, invoice.currency)}
+                </span>
+              </div>
+            </>
+          )}
         </div>
+
+        {invoice.payments.length > 0 && (
+          <div className="text-sm">
+            <p className="mb-1 text-xs uppercase tracking-wide text-muted-foreground">Payments</p>
+            {invoice.payments.map((p, i) => (
+              <div key={i} className="flex justify-between border-b py-1 last:border-0">
+                <span className="text-muted-foreground">
+                  {fmtDate(p.paidOn)}
+                  {p.method ? ` · ${p.method}` : ""}
+                </span>
+                <span className="tabular-nums">{formatMoney(p.amount, invoice.currency)}</span>
+              </div>
+            ))}
+          </div>
+        )}
 
         {error && <p className="text-center text-sm text-destructive">{error}</p>}
 
@@ -210,9 +253,13 @@ const PublicInvoicePage = () => {
           <Button variant="outline" onClick={() => void downloadPdf()} className="gap-1.5">
             <Download className="h-4 w-4" aria-hidden /> PDF
           </Button>
-          {invoice.status !== "paid" && invoice.status !== "void" && invoice.total > 0 && (
+          {invoice.status !== "paid" && invoice.status !== "void" && invoice.balanceDue > 0 && (
             <Button onClick={() => void payOnline()} disabled={paying}>
-              {paying ? "Starting…" : "Pay online"}
+              {paying
+                ? "Starting…"
+                : invoice.amountPaid > 0
+                  ? `Pay ${formatMoney(invoice.balanceDue, invoice.currency)}`
+                  : "Pay online"}
             </Button>
           )}
           {invoice.status === "paid" && (

--- a/pwa/pages/invoices/[id].tsx
+++ b/pwa/pages/invoices/[id].tsx
@@ -41,6 +41,13 @@ const InvoiceDetailPage = () => {
   const [dueDate, setDueDate] = useState("");
   const [notes, setNotes] = useState("");
   const [taxPercent, setTaxPercent] = useState("0");
+  const [discType, setDiscType] = useState("");
+  const [discValue, setDiscValue] = useState("");
+  const [payAmount, setPayAmount] = useState("");
+  const [payDate, setPayDate] = useState("");
+  const [payMethod, setPayMethod] = useState("");
+  const [payNote, setPayNote] = useState("");
+  const [payBusy, setPayBusy] = useState(false);
   const [freq, setFreq] = useState("");
   const [interval, setInterval] = useState("1");
   const [nextIssue, setNextIssue] = useState("");
@@ -78,6 +85,14 @@ const InvoiceDetailPage = () => {
     setDueDate(invoice.dueDate ?? "");
     setNotes(invoice.notes ?? "");
     setTaxPercent(String(invoice.taxRate / 100));
+    setDiscType(invoice.discountType ?? "");
+    setDiscValue(
+      invoice.discountValue === null
+        ? ""
+        : invoice.discountType === "percent"
+          ? String(invoice.discountValue / 100)
+          : (invoice.discountValue / 100).toFixed(2),
+    );
     setFreq(invoice.recurrenceFrequency ?? "");
     setInterval(String(invoice.recurrenceInterval ?? 1));
     setNextIssue(invoice.nextIssueDate ?? "");
@@ -89,9 +104,18 @@ const InvoiceDetailPage = () => {
       const unitMinor = Math.round((parseFloat(l.unit) || 0) * 100);
       return sum + Math.round(qty * unitMinor);
     }, 0);
-    const tax = Math.round((subtotal * (parseFloat(taxPercent) || 0) * 100) / 10000);
-    return { subtotal, tax, total: subtotal + tax };
-  }, [lines, taxPercent]);
+    // Discount between subtotal and tax, mirroring InvoiceProcessor.
+    let discount = 0;
+    if (discType === "percent") {
+      discount = Math.round((subtotal * (parseFloat(discValue) || 0) * 100) / 10000);
+    } else if (discType === "fixed") {
+      discount = Math.round((parseFloat(discValue) || 0) * 100);
+    }
+    discount = Math.max(0, Math.min(discount, subtotal));
+    const taxable = subtotal - discount;
+    const tax = Math.round((taxable * (parseFloat(taxPercent) || 0) * 100) / 10000);
+    return { subtotal, discount, tax, total: taxable + tax };
+  }, [lines, taxPercent, discType, discValue]);
 
   const addLine = () =>
     setLines((prev) => [
@@ -115,6 +139,11 @@ const InvoiceDetailPage = () => {
           dueDate: dueDate || null,
           notes: notes.trim() || null,
           taxRate: Math.round((parseFloat(taxPercent) || 0) * 100),
+          discountType: discType || null,
+          discountValue:
+            discType === ""
+              ? null
+              : Math.round((parseFloat(discValue) || 0) * 100),
           lineItems: lines.map((l, i) => ({
             description: l.description.trim() || "—",
             quantity: parseFloat(l.quantity) || 0,
@@ -150,6 +179,54 @@ const InvoiceDetailPage = () => {
       void invoiceQuery.refetch();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Action failed.");
+    }
+  };
+
+  // Partial payments (#648): record against / remove from the ledger.
+  const recordPayment = async () => {
+    if (!invoice) return;
+    const amountMinor = Math.round((parseFloat(payAmount) || 0) * 100);
+    if (amountMinor <= 0) {
+      setError("Enter a payment amount.");
+      return;
+    }
+    setPayBusy(true);
+    setError(null);
+    try {
+      await apiSend("POST", `${invoice["@id"]}/payments`, {
+        contentType: "application/json",
+        errorMessage: "Failed to record the payment.",
+        body: {
+          amount: amountMinor,
+          ...(payDate ? { paidOn: payDate } : {}),
+          ...(payMethod.trim() ? { method: payMethod.trim() } : {}),
+          ...(payNote.trim() ? { note: payNote.trim() } : {}),
+        },
+      });
+      setPayAmount("");
+      setPayDate("");
+      setPayMethod("");
+      setPayNote("");
+      setNotice("Payment recorded.");
+      void invoiceQuery.refetch();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to record the payment.");
+    } finally {
+      setPayBusy(false);
+    }
+  };
+
+  const deletePayment = async (paymentId: string) => {
+    if (!invoice) return;
+    if (!window.confirm("Remove this payment?")) return;
+    setError(null);
+    try {
+      await apiSend("DELETE", `${invoice["@id"]}/payments/${paymentId}`, {
+        errorMessage: "Failed to remove the payment.",
+      });
+      void invoiceQuery.refetch();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to remove the payment.");
     }
   };
 
@@ -314,6 +391,14 @@ const InvoiceDetailPage = () => {
                       <span className="text-muted-foreground">Subtotal</span>
                       <span className="tabular-nums">{formatMoney(preview.subtotal, currency)}</span>
                     </div>
+                    {preview.discount > 0 && (
+                      <div className="flex justify-between">
+                        <span className="text-muted-foreground">Discount</span>
+                        <span className="tabular-nums">
+                          −{formatMoney(preview.discount, currency)}
+                        </span>
+                      </div>
+                    )}
                     {preview.tax > 0 && (
                       <div className="flex justify-between">
                         <span className="text-muted-foreground">Tax</span>
@@ -324,6 +409,22 @@ const InvoiceDetailPage = () => {
                       <span>Total</span>
                       <span className="tabular-nums">{formatMoney(preview.total, currency)}</span>
                     </div>
+                    {invoice.amountPaid > 0 && (
+                      <>
+                        <div className="flex justify-between">
+                          <span className="text-muted-foreground">Paid</span>
+                          <span className="tabular-nums">
+                            −{formatMoney(invoice.amountPaid, currency)}
+                          </span>
+                        </div>
+                        <div className="flex justify-between border-t pt-1 font-semibold">
+                          <span>Balance due</span>
+                          <span className="tabular-nums">
+                            {formatMoney(invoice.balanceDue, currency)}
+                          </span>
+                        </div>
+                      </>
+                    )}
                   </div>
                 </CardContent>
               </Card>
@@ -352,6 +453,36 @@ const InvoiceDetailPage = () => {
                           onChange={(e) => setTaxPercent(e.target.value)}
                         />
                       </div>
+                    </div>
+                    <div className="grid gap-4 sm:grid-cols-2">
+                      <div className="space-y-1.5">
+                        <Label htmlFor="inv-disc-type">Discount</Label>
+                        <select
+                          id="inv-disc-type"
+                          value={discType}
+                          onChange={(e) => setDiscType(e.target.value)}
+                          className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
+                        >
+                          <option value="">None</option>
+                          <option value="percent">Percent</option>
+                          <option value="fixed">Fixed amount</option>
+                        </select>
+                      </div>
+                      {discType !== "" && (
+                        <div className="space-y-1.5">
+                          <Label htmlFor="inv-disc-value">
+                            {discType === "percent" ? "Discount %" : "Discount amount"}
+                          </Label>
+                          <Input
+                            id="inv-disc-value"
+                            type="number"
+                            step="0.01"
+                            min="0"
+                            value={discValue}
+                            onChange={(e) => setDiscValue(e.target.value)}
+                          />
+                        </div>
+                      )}
                     </div>
                     <div className="space-y-1.5">
                       <Label htmlFor="inv-notes">Notes</Label>
@@ -404,6 +535,109 @@ const InvoiceDetailPage = () => {
                     <Button onClick={() => void save()} disabled={saving}>
                       {saving ? "Saving…" : "Save"}
                     </Button>
+                  </CardContent>
+                </Card>
+              )}
+
+              {(status === "sent" || status === "overdue" || status === "paid") && (
+                <Card className="mb-6">
+                  <CardContent className="space-y-4 py-6">
+                    <div className="flex items-center justify-between">
+                      <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                        Payments
+                      </h2>
+                      <span className="text-sm text-muted-foreground">
+                        Balance due:{" "}
+                        <span className="font-semibold text-foreground tabular-nums">
+                          {formatMoney(invoice.balanceDue, currency)}
+                        </span>
+                      </span>
+                    </div>
+
+                    {invoice.payments.length === 0 ? (
+                      <p className="text-sm text-muted-foreground">No payments recorded yet.</p>
+                    ) : (
+                      <table className="w-full text-sm">
+                        <tbody>
+                          {invoice.payments.map((p) => (
+                            <tr key={p.id} className="border-b last:border-0">
+                              <td className="py-1.5 text-muted-foreground">
+                                {new Date(p.paidOn).toLocaleDateString(undefined, {
+                                  dateStyle: "medium",
+                                })}
+                              </td>
+                              <td className="py-1.5">{p.method ?? "payment"}</td>
+                              <td className="py-1.5 text-muted-foreground">{p.note}</td>
+                              <td className="py-1.5 text-right tabular-nums">
+                                {formatMoney(p.amount, currency)}
+                              </td>
+                              <td className="w-8 py-1.5 text-right">
+                                <Button
+                                  variant="ghost"
+                                  size="icon"
+                                  onClick={() => void deletePayment(p.id)}
+                                  aria-label="Remove payment"
+                                >
+                                  <Trash2 className="size-4 text-muted-foreground" />
+                                </Button>
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    )}
+
+                    {invoice.balanceDue > 0 && (
+                      <div className="flex flex-wrap items-end gap-3">
+                        <div className="space-y-1.5">
+                          <Label htmlFor="pay-amount">Amount</Label>
+                          <Input
+                            id="pay-amount"
+                            type="number"
+                            step="0.01"
+                            min="0"
+                            value={payAmount}
+                            onChange={(e) => setPayAmount(e.target.value)}
+                            className="w-32"
+                          />
+                        </div>
+                        <div className="space-y-1.5">
+                          <Label htmlFor="pay-date">Date</Label>
+                          <Input
+                            id="pay-date"
+                            type="date"
+                            value={payDate}
+                            onChange={(e) => setPayDate(e.target.value)}
+                            className="w-40"
+                          />
+                        </div>
+                        <div className="space-y-1.5">
+                          <Label htmlFor="pay-method">Method</Label>
+                          <Input
+                            id="pay-method"
+                            placeholder="bank transfer"
+                            value={payMethod}
+                            onChange={(e) => setPayMethod(e.target.value)}
+                            className="w-40"
+                          />
+                        </div>
+                        <div className="min-w-40 flex-1 space-y-1.5">
+                          <Label htmlFor="pay-note">Note</Label>
+                          <Input
+                            id="pay-note"
+                            value={payNote}
+                            onChange={(e) => setPayNote(e.target.value)}
+                          />
+                        </div>
+                        <Button
+                          size="sm"
+                          onClick={() => void recordPayment()}
+                          disabled={payBusy}
+                        >
+                          {payBusy ? "Recording…" : "Record payment"}
+                        </Button>
+                      </div>
+                    )}
                   </CardContent>
                 </Card>
               )}


### PR DESCRIPTION
Closes #648

## Discount
- `discountType` (`percent` | `fixed`) + `discountValue` (basis points / minor units) on Invoice; `discountAmount` derived server-side by `InvoiceProcessor`, applied **between subtotal and tax** (tax computes on the discounted base), capped at the subtotal.
- Validation: value needs a type and vice-versa; percent ≤ 100%.
- Shown on the invoice detail editor (live preview mirrors server math), public page, and PDF.

## Partial payments
- New `InvoicePayment` ledger (`invoice_payment` table) — server-written only: the payments endpoint, mark-paid, and the Stripe webhook. **Balance due = total − Σ payments**; the invoice flips to `paid` only when the balance hits zero and stays `sent`/`overdue` while anything is outstanding.
- `POST /invoices/{id}/payments` — `{amount, paidOn?, method?, note?}`; 409 on draft/void, 422 on non-positive or over-balance amounts.
- `DELETE /invoices/{id}/payments/{paymentId}` — removing a payment that reopens a paid invoice reverts it to `sent` (or `overdue` when past due) and clears `paidAt`.
- `mark-paid` records the remaining balance as a `manual` payment so ledger and status always agree.
- **Stripe**: the checkout charges the **balance due** (not the total) and the webhook records the payment on the ledger before flipping status.
- Surfaces: invoice detail payments card (record/remove + balance), public page (payments + balance + "Pay $X" button), PDF (discount row, amount paid, balance due, payments table).

## Tests
- `testDiscountAppliesBetweenSubtotalAndTax` — percent + fixed derivations, >100% rejected
- `testPartialPaymentsTrackBalanceAndFlipStatus` — draft 409, partial keeps `sent`, over-balance 422, final payment flips paid, delete reverts to overdue, mark-paid records the remainder
- Webhook test extended: payment recorded on the ledger (`amountPaid`/`balanceDue` asserted)