### PR TITLE
feat(reports): time summary + uninvoiced reports with CSV export

### DIFF
--- a/api/src/Controller/ReportController.php
+++ b/api/src/Controller/ReportController.php
@@ -1,0 +1,340 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\Space;
+use App\Entity\TimeEntry;
+use App\Entity\User;
+use App\Repository\TimeEntryRepository;
+use App\Security\Permission\SpacePermission;
+use App\Security\Permission\SpacePermissionResolver;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Billing reports (#647) — the Harvest-parity read side of time tracking:
+ *
+ *  - time-summary: period + group-by (client / engagement / category /
+ *    person) with hours, billable hours, and billable amount per group;
+ *  - uninvoiced: per-engagement unbilled billable hours + amount — the
+ *    "what can I bill right now" view feeding the invoice generator (#644).
+ *
+ * Both accept `?format=csv` for a server-generated export with the same
+ * filters. Amount math mirrors invoice generation exactly (hours rounded to
+ * 2 decimals × the entry's snapshotted rate, falling back to the client
+ * default) so a report never disagrees with the invoice it predicts.
+ *
+ * Access: the admin-reserved `invoices` category (space admins or explicit
+ * grantees), space-scoped; outsiders get the usual existence-hiding 404.
+ */
+class ReportController extends AbstractController
+{
+    private const GROUP_BYS = ['client', 'engagement', 'category', 'person'];
+
+    public function __construct(
+        private EntityManagerInterface $em,
+        private TimeEntryRepository $timeEntries,
+        private SpacePermissionResolver $permissions,
+    ) {
+    }
+
+    #[Route('/spaces/{id}/reports/time-summary', name: 'report_time_summary', methods: ['GET'])]
+    public function timeSummary(string $id, Request $request, #[CurrentUser] ?User $user): Response
+    {
+        $space = $this->authorize($id, $user);
+        if ($space instanceof JsonResponse) {
+            return $space;
+        }
+
+        $groupBy = $request->query->get('groupBy', 'engagement');
+        if (!in_array($groupBy, self::GROUP_BYS, true)) {
+            return $this->json(['error' => 'groupBy must be one of: ' . implode(', ', self::GROUP_BYS) . '.'], 422);
+        }
+        $from = $this->parseDate($request->query->get('from'));
+        $to = $this->parseDate($request->query->get('to'));
+        if (false === $from || false === $to) {
+            return $this->json(['error' => 'Dates must be formatted YYYY-MM-DD.'], 422);
+        }
+        if (null !== $from && null !== $to && $to < $from) {
+            return $this->json(['error' => 'The end of the range is before its start.'], 422);
+        }
+
+        $entries = $this->timeEntries->findCompletedForSpace($space, $from, $to?->modify('+1 day'));
+
+        /** @var array<string, array{label: string, seconds: int, billableSeconds: int, amounts: array<string, int>}> $rows */
+        $rows = [];
+        foreach ($entries as $entry) {
+            [$key, $label] = $this->groupKey($entry, $groupBy);
+            $row = $rows[$key] ?? ['label' => $label, 'seconds' => 0, 'billableSeconds' => 0, 'amounts' => []];
+
+            $seconds = $entry->getDurationSeconds() ?? 0;
+            $row['seconds'] += $seconds;
+            if ($entry->isBillable()) {
+                $row['billableSeconds'] += $seconds;
+                $amount = $this->entryAmount($entry, $seconds);
+                if ($amount > 0) {
+                    $currency = $this->entryCurrency($entry);
+                    $row['amounts'][$currency] = ($row['amounts'][$currency] ?? 0) + $amount;
+                }
+            }
+            $rows[$key] = $row;
+        }
+
+        uasort($rows, static fn (array $a, array $b): int => strcasecmp($a['label'], $b['label']));
+
+        $totals = ['seconds' => 0, 'billableSeconds' => 0, 'amounts' => []];
+        $list = [];
+        foreach ($rows as $key => $row) {
+            $totals['seconds'] += $row['seconds'];
+            $totals['billableSeconds'] += $row['billableSeconds'];
+            foreach ($row['amounts'] as $currency => $amount) {
+                $totals['amounts'][$currency] = ($totals['amounts'][$currency] ?? 0) + $amount;
+            }
+            $list[] = [
+                'key' => $key,
+                'label' => $row['label'],
+                'seconds' => $row['seconds'],
+                'hours' => round($row['seconds'] / 3600, 2),
+                'billableSeconds' => $row['billableSeconds'],
+                'billableHours' => round($row['billableSeconds'] / 3600, 2),
+                'amounts' => $row['amounts'],
+            ];
+        }
+
+        if ('csv' === $request->query->get('format')) {
+            $csvRows = [];
+            foreach ($list as $row) {
+                $csvRows[] = [
+                    $row['label'],
+                    number_format($row['hours'], 2, '.', ''),
+                    number_format($row['billableHours'], 2, '.', ''),
+                    $this->amountsLabel($row['amounts']),
+                ];
+            }
+
+            return $this->csv(
+                sprintf('time-summary-by-%s.csv', $groupBy),
+                [ucfirst($groupBy), 'Hours', 'Billable hours', 'Billable amount'],
+                $csvRows,
+            );
+        }
+
+        return $this->json([
+            'groupBy' => $groupBy,
+            'from' => $from?->format('Y-m-d'),
+            'to' => $to?->format('Y-m-d'),
+            'rows' => $list,
+            'totals' => [
+                'seconds' => $totals['seconds'],
+                'hours' => round($totals['seconds'] / 3600, 2),
+                'billableSeconds' => $totals['billableSeconds'],
+                'billableHours' => round($totals['billableSeconds'] / 3600, 2),
+                'amounts' => $totals['amounts'],
+            ],
+        ]);
+    }
+
+    #[Route('/spaces/{id}/reports/uninvoiced', name: 'report_uninvoiced', methods: ['GET'])]
+    public function uninvoiced(string $id, Request $request, #[CurrentUser] ?User $user): Response
+    {
+        $space = $this->authorize($id, $user);
+        if ($space instanceof JsonResponse) {
+            return $space;
+        }
+
+        /** @var array<string, array{engagement: string, client: string|null, currency: string, entryCount: int, seconds: int, amount: int}> $rows */
+        $rows = [];
+        foreach ($this->timeEntries->findUninvoicedForSpace($space) as $entry) {
+            $engagement = $entry->getEngagement();
+            if (null === $engagement) {
+                continue;
+            }
+            $key = (string) $engagement->getId();
+            $row = $rows[$key] ?? [
+                'engagement' => $engagement->getName(),
+                'client' => $engagement->getClient()?->getName(),
+                'currency' => $this->entryCurrency($entry),
+                'entryCount' => 0,
+                'seconds' => 0,
+                'amount' => 0,
+            ];
+            $seconds = $entry->getDurationSeconds() ?? 0;
+            ++$row['entryCount'];
+            $row['seconds'] += $seconds;
+            $row['amount'] += $this->entryAmount($entry, $seconds);
+            $rows[$key] = $row;
+        }
+
+        uasort($rows, static fn (array $a, array $b): int => strcasecmp($a['engagement'], $b['engagement']));
+
+        $list = [];
+        foreach ($rows as $key => $row) {
+            $list[] = [
+                'engagementId' => $key,
+                'engagement' => $row['engagement'],
+                'client' => $row['client'],
+                'entryCount' => $row['entryCount'],
+                'seconds' => $row['seconds'],
+                'hours' => round($row['seconds'] / 3600, 2),
+                'amount' => $row['amount'],
+                'currency' => $row['currency'],
+            ];
+        }
+
+        if ('csv' === $request->query->get('format')) {
+            $csvRows = [];
+            foreach ($list as $row) {
+                $csvRows[] = [
+                    $row['engagement'],
+                    $row['client'] ?? '',
+                    (string) $row['entryCount'],
+                    number_format($row['hours'], 2, '.', ''),
+                    number_format($row['amount'] / 100, 2, '.', '') . ' ' . $row['currency'],
+                ];
+            }
+
+            return $this->csv(
+                'uninvoiced.csv',
+                ['Engagement', 'Client', 'Entries', 'Hours', 'Amount'],
+                $csvRows,
+            );
+        }
+
+        return $this->json(['rows' => $list]);
+    }
+
+    /** Same per-entry math as invoice generation: round(hours, 2) × rate. */
+    private function entryAmount(TimeEntry $entry, int $seconds): int
+    {
+        $rate = $entry->getRateAmount()
+            ?? $entry->getEngagement()?->getClient()?->getDefaultRateAmount()
+            ?? 0;
+
+        return (int) round(round($seconds / 3600, 2) * $rate);
+    }
+
+    private function entryCurrency(TimeEntry $entry): string
+    {
+        $engagement = $entry->getEngagement();
+
+        return $entry->getRateCurrency()
+            ?? $engagement?->getCurrency()
+            ?? $engagement?->getClient()?->getCurrency()
+            ?? 'USD';
+    }
+
+    /** @return array{string, string} [stable key, display label] */
+    private function groupKey(TimeEntry $entry, string $groupBy): array
+    {
+        switch ($groupBy) {
+            case 'client':
+                $client = $entry->getEngagement()?->getClient();
+
+                return null === $client
+                    ? ['none', 'No client']
+                    : ['client:' . $client->getId(), $client->getName()];
+            case 'category':
+                $category = $entry->getCategory();
+
+                return null === $category
+                    ? ['none', 'No category']
+                    : ['category:' . $category->getId(), $category->getName()];
+            case 'person':
+                $person = $entry->getUser();
+                if (null === $person) {
+                    return ['none', 'Unknown'];
+                }
+                $name = trim($person->getGivenName() . ' ' . $person->getFamilyName());
+
+                return ['person:' . $person->getId(), '' !== $name ? $name : $person->getEmail()];
+            default:
+                $engagement = $entry->getEngagement();
+
+                return null === $engagement
+                    ? ['none', 'No engagement']
+                    : ['engagement:' . $engagement->getId(), $engagement->getName()];
+        }
+    }
+
+    /**
+     * "12.34 USD" / "12.34 USD; 5.00 EUR" for the CSV amount cell.
+     *
+     * @param array<string, int> $amounts
+     */
+    private function amountsLabel(array $amounts): string
+    {
+        $parts = [];
+        foreach ($amounts as $currency => $amount) {
+            $parts[] = number_format($amount / 100, 2, '.', '') . ' ' . $currency;
+        }
+
+        return implode('; ', $parts);
+    }
+
+    /**
+     * @param list<string>       $headers
+     * @param list<list<string>> $rows
+     */
+    private function csv(string $filename, array $headers, array $rows): Response
+    {
+        $handle = fopen('php://temp', 'r+');
+        if (false === $handle) {
+            return $this->json(['error' => 'Could not build the export.'], 500);
+        }
+        fputcsv($handle, $headers, ',', '"', '\\');
+        foreach ($rows as $row) {
+            fputcsv($handle, $row, ',', '"', '\\');
+        }
+        rewind($handle);
+        $csv = stream_get_contents($handle);
+        fclose($handle);
+
+        return new Response(false === $csv ? '' : $csv, Response::HTTP_OK, [
+            'Content-Type' => 'text/csv; charset=UTF-8',
+            'Content-Disposition' => sprintf('attachment; filename="%s"', $filename),
+        ]);
+    }
+
+    /** A `Y-m-d` query date → midnight UTC; null when absent, false when malformed. */
+    private function parseDate(?string $value): \DateTimeImmutable|false|null
+    {
+        if (null === $value || '' === trim($value)) {
+            return null;
+        }
+
+        return \DateTimeImmutable::createFromFormat('!Y-m-d', trim($value), new \DateTimeZone('UTC'));
+    }
+
+    /**
+     * Load the space and confirm the caller may read billing reports, or
+     * return the error response to short-circuit with.
+     */
+    private function authorize(string $id, ?User $user): Space|JsonResponse
+    {
+        if (null === $user) {
+            return $this->json(['error' => 'Not authenticated.'], 401);
+        }
+        if (!Uuid::isValid($id)) {
+            return $this->json(['error' => 'Space not found.'], 404);
+        }
+        $space = $this->em->getRepository(Space::class)->find($id);
+        if (null === $space || (!$this->isGranted('ROLE_ADMIN') && !$space->hasMember($user))) {
+            return $this->json(['error' => 'Space not found.'], 404);
+        }
+        if (
+            !$this->isGranted('ROLE_ADMIN')
+            && !$space->isAdmin($user)
+            && !$this->permissions->canByExplicitGrant($user, $space, SpacePermission::INVOICES, SpacePermission::READ)
+        ) {
+            return $this->json(['error' => 'You cannot view billing reports in this space.'], 403);
+        }
+
+        return $space;
+    }
+}

--- a/api/src/Repository/TimeEntryRepository.php
+++ b/api/src/Repository/TimeEntryRepository.php
@@ -3,6 +3,7 @@
 namespace App\Repository;
 
 use App\Entity\Engagement;
+use App\Entity\Space;
 use App\Entity\TimeEntry;
 use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
@@ -35,6 +36,65 @@ class TimeEntryRepository extends ServiceEntityRepository
         assert(null === $result || $result instanceof TimeEntry);
 
         return $result;
+    }
+
+    /**
+     * Completed entries in a space for the reports (#647), relations
+     * fetch-joined so per-row label lookups don't N+1. Optional
+     * [$from, $toExclusive) window on startedAt.
+     *
+     * @return list<TimeEntry>
+     */
+    public function findCompletedForSpace(
+        Space $space,
+        ?\DateTimeImmutable $from = null,
+        ?\DateTimeImmutable $toExclusive = null,
+    ): array {
+        $qb = $this->createQueryBuilder('t')
+            ->addSelect('e', 'c', 'cl', 'u')
+            ->leftJoin('t.engagement', 'e')
+            ->leftJoin('t.category', 'c')
+            ->leftJoin('e.client', 'cl')
+            ->leftJoin('t.user', 'u')
+            ->andWhere('t.space = :space')
+            ->andWhere('t.endedAt IS NOT NULL')
+            ->setParameter('space', $space)
+            ->orderBy('t.startedAt', 'ASC');
+
+        if (null !== $from) {
+            $qb->andWhere('t.startedAt >= :from')->setParameter('from', $from);
+        }
+        if (null !== $toExclusive) {
+            $qb->andWhere('t.startedAt < :toExclusive')->setParameter('toExclusive', $toExclusive);
+        }
+
+        /** @var list<TimeEntry> */
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * Unbilled billable completed entries across a whole space — the
+     * "what can I bill right now" pool the uninvoiced report (#647) groups
+     * per engagement. Entries without an engagement can't be invoiced, so
+     * they're excluded.
+     *
+     * @return list<TimeEntry>
+     */
+    public function findUninvoicedForSpace(Space $space): array
+    {
+        /** @var list<TimeEntry> */
+        return $this->createQueryBuilder('t')
+            ->addSelect('e', 'cl')
+            ->join('t.engagement', 'e')
+            ->leftJoin('e.client', 'cl')
+            ->andWhere('t.space = :space')
+            ->andWhere('t.billable = true')
+            ->andWhere('t.endedAt IS NOT NULL')
+            ->andWhere('t.billedAt IS NULL')
+            ->setParameter('space', $space)
+            ->orderBy('t.startedAt', 'ASC')
+            ->getQuery()
+            ->getResult();
     }
 
     /**

--- a/api/tests/Api/ReportTest.php
+++ b/api/tests/Api/ReportTest.php
@@ -1,0 +1,272 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\Space;
+use App\Entity\SpaceMembership;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Billing reports (#647): the time summary (period + group-by) and the
+ * per-engagement uninvoiced pool, both gated on the admin-reserved `invoices`
+ * category and exportable as CSV.
+ */
+class ReportTest extends ApiTestCase
+{
+    use SpaceMembershipFixture;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = static::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Invoice')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\TimeEntry')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\EngagementCategory')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Engagement')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Client')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\SpaceMembership')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Space')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testTimeSummaryGroupsTotalsAndExportsCsv(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $member = $this->createUser('member@example.com');
+        $space = $this->createSharedSpace($admin, $member);
+        $spaceId = (string) $space->getId();
+        $spaceIri = '/spaces/' . $spaceId;
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        [$bpIri, $devCat, $buildCat, $internalCat] = $this->createEngagement($client, $spaceIri, $this->iri($clientRow));
+
+        // 1h Dev @6000 + 30m Build @8000 (billable) + 2h Internal (non-billable).
+        $this->trackTime($client, $spaceIri, $bpIri, $devCat, '2026-07-03T09:00:00+00:00', '2026-07-03T10:00:00+00:00');
+        $this->trackTime($client, $spaceIri, $bpIri, $buildCat, '2026-07-03T11:00:00+00:00', '2026-07-03T11:30:00+00:00');
+        $this->trackTime($client, $spaceIri, $bpIri, $internalCat, '2026-07-04T09:00:00+00:00', '2026-07-04T11:00:00+00:00');
+
+        $report = $client->request('GET', '/spaces/' . $spaceId . '/reports/time-summary?groupBy=category')->toArray();
+        $this->assertResponseStatusCodeSame(200);
+        $rows = $report['rows'];
+        $this->assertIsArray($rows);
+        $this->assertCount(3, $rows);
+        $byLabel = [];
+        foreach ($rows as $row) {
+            $this->assertIsArray($row);
+            $label = $row['label'];
+            $this->assertIsString($label);
+            $byLabel[$label] = $row;
+        }
+        $this->assertSame(1.0, $byLabel['Dev']['hours'] ?? null);
+        $this->assertSame(['USD' => 6000], $byLabel['Dev']['amounts'] ?? null);
+        $this->assertSame(0.5, $byLabel['Build']['billableHours'] ?? null);
+        $this->assertSame(['USD' => 4000], $byLabel['Build']['amounts'] ?? null);
+        $this->assertSame(2.0, $byLabel['Internal']['hours'] ?? null);
+        $this->assertSame(0.0, $byLabel['Internal']['billableHours'] ?? null);
+        $this->assertSame([], $byLabel['Internal']['amounts'] ?? null);
+        $totals = $report['totals'];
+        $this->assertIsArray($totals);
+        $this->assertSame(3.5, $totals['hours'] ?? null);
+        $this->assertSame(1.5, $totals['billableHours'] ?? null);
+        $this->assertSame(['USD' => 10000], $totals['amounts'] ?? null);
+
+        // A range that misses everything comes back empty.
+        $empty = $client->request('GET', '/spaces/' . $spaceId . '/reports/time-summary?from=2030-01-01')->toArray();
+        $this->assertSame([], $empty['rows'] ?? null);
+
+        // Unknown groupBy is rejected.
+        $client->request('GET', '/spaces/' . $spaceId . '/reports/time-summary?groupBy=bogus');
+        $this->assertResponseStatusCodeSame(422);
+
+        // CSV export mirrors the same data.
+        $csv = $client->request('GET', '/spaces/' . $spaceId . '/reports/time-summary?groupBy=category&format=csv');
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertResponseHeaderSame('content-type', 'text/csv; charset=UTF-8');
+        $this->assertStringContainsString('Dev', $csv->getContent());
+        $this->assertStringContainsString('60.00 USD', $csv->getContent());
+
+        // A plain member (no invoicing grant) is refused; an outsider gets 404.
+        $client->loginUser($member);
+        $client->request('GET', '/spaces/' . $spaceId . '/reports/time-summary');
+        $this->assertResponseStatusCodeSame(403);
+        $outsider = $this->createUser('outsider@example.com');
+        $client->loginUser($outsider);
+        $client->request('GET', '/spaces/' . $spaceId . '/reports/time-summary');
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testUninvoicedReportShowsThePoolAndEmptiesAfterInvoicing(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $space = $this->createSharedSpace($admin);
+        $spaceId = (string) $space->getId();
+        $spaceIri = '/spaces/' . $spaceId;
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        [$bpIri, $devCat, $buildCat, $internalCat] = $this->createEngagement($client, $spaceIri, $this->iri($clientRow));
+
+        $this->trackTime($client, $spaceIri, $bpIri, $devCat, '2026-07-03T09:00:00+00:00', '2026-07-03T10:00:00+00:00');
+        $this->trackTime($client, $spaceIri, $bpIri, $buildCat, '2026-07-03T11:00:00+00:00', '2026-07-03T11:30:00+00:00');
+        // Non-billable time never enters the pool.
+        $this->trackTime($client, $spaceIri, $bpIri, $internalCat, '2026-07-04T09:00:00+00:00', '2026-07-04T11:00:00+00:00');
+
+        $report = $client->request('GET', '/spaces/' . $spaceId . '/reports/uninvoiced')->toArray();
+        $this->assertResponseStatusCodeSame(200);
+        $rows = $report['rows'];
+        $this->assertIsArray($rows);
+        $this->assertCount(1, $rows);
+        $row = $rows[0];
+        $this->assertIsArray($row);
+        $this->assertSame('Acme Website', $row['engagement'] ?? null);
+        $this->assertSame('Acme Co', $row['client'] ?? null);
+        $this->assertSame(2, $row['entryCount'] ?? null);
+        $this->assertSame(1.5, $row['hours'] ?? null);
+        $this->assertSame(10000, $row['amount'] ?? null);
+        $this->assertSame('USD', $row['currency'] ?? null);
+
+        // Invoicing the engagement drains the pool.
+        $client->request('POST', '/invoices/from-time-entries', [
+            'json' => ['engagement' => $bpIri],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+        $after = $client->request('GET', '/spaces/' . $spaceId . '/reports/uninvoiced')->toArray();
+        $this->assertSame([], $after['rows'] ?? null);
+    }
+
+    /**
+     * Admin creates a engagement (for $clientIri) with two billable categories
+     * ("Dev" @ 6000, "Build" @ 8000) and one non-billable ("Internal" @ 0).
+     * Returns [engagementIri, devCategoryIri, buildCategoryIri, internalCategoryIri].
+     *
+     * @return array{0: string, 1: string, 2: string, 3: string}
+     */
+    private function createEngagement(
+        \ApiPlatform\Symfony\Bundle\Test\Client $client,
+        string $spaceIri,
+        string $clientIri,
+    ): array {
+        $row = $client->request('POST', '/engagements', [
+            'json' => [
+                'space' => $spaceIri,
+                'client' => $clientIri,
+                'name' => 'Acme Website',
+                'currency' => 'USD',
+                'categories' => [
+                    ['name' => 'Dev', 'rateAmount' => 6000, 'position' => 0],
+                    ['name' => 'Build', 'rateAmount' => 8000, 'position' => 1],
+                    ['name' => 'Internal', 'rateAmount' => 0, 'position' => 2, 'billable' => false],
+                ],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+
+        $bpIri = $this->iri($row);
+        $categories = $row['categories'] ?? [];
+        $this->assertIsArray($categories);
+        $byName = [];
+        foreach ($categories as $category) {
+            $this->assertIsArray($category);
+            $name = $category['name'] ?? null;
+            $iri = $category['@id'] ?? null;
+            if (is_string($name) && is_string($iri)) {
+                $byName[$name] = $iri;
+            }
+        }
+        $this->assertArrayHasKey('Dev', $byName);
+        $this->assertArrayHasKey('Build', $byName);
+        $this->assertArrayHasKey('Internal', $byName);
+
+        return [$bpIri, $byName['Dev'], $byName['Build'], $byName['Internal']];
+    }
+
+    private function trackTime(
+        \ApiPlatform\Symfony\Bundle\Test\Client $client,
+        string $spaceIri,
+        string $engagementIri,
+        string $categoryIri,
+        string $startedAt,
+        string $endedAt,
+    ): void {
+        $client->request('POST', '/time_entries', [
+            'json' => [
+                'space' => $spaceIri,
+                'engagement' => $engagementIri,
+                'category' => $categoryIri,
+                'startedAt' => $startedAt,
+                'endedAt' => $endedAt,
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+    }
+
+    /**
+     * The `@id` of a decoded resource, narrowed to string for concatenation.
+     *
+     * @param array<int|string, mixed> $row
+     */
+    private function iri(array $row): string
+    {
+        $iri = $row['@id'] ?? null;
+        $this->assertIsString($iri);
+
+        return $iri;
+    }
+
+    private function createSharedSpace(User $admin, ?User $member = null): Space
+    {
+        $space = (new Space())->setName('Studio')->setCreatedBy($admin);
+        $this->entityManager->persist($space);
+        $adminMembership = (new SpaceMembership())
+            ->setUser($admin)
+            ->setRole(Space::ROLE_ADMIN);
+        $space->addUserMembership($adminMembership);
+        $this->entityManager->persist($adminMembership);
+        if (null !== $member) {
+            $memberMembership = (new SpaceMembership())
+                ->setUser($member)
+                ->setRole(Space::ROLE_MEMBER);
+            $space->addUserMembership($memberMembership);
+            $this->entityManager->persist($memberMembership);
+        }
+        $this->entityManager->flush();
+
+        return $space;
+    }
+
+    private function createUser(string $email): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/api/tests/Api/ReportTest.php
+++ b/api/tests/Api/ReportTest.php
@@ -70,17 +70,19 @@ class ReportTest extends ApiTestCase
             $this->assertIsString($label);
             $byLabel[$label] = $row;
         }
-        $this->assertSame(1.0, $byLabel['Dev']['hours'] ?? null);
+        // json_encode drops zero fractions (1.0 → 1), so numeric fields use
+        // assertEquals rather than assertSame.
+        $this->assertEquals(1.0, $byLabel['Dev']['hours'] ?? null);
         $this->assertSame(['USD' => 6000], $byLabel['Dev']['amounts'] ?? null);
-        $this->assertSame(0.5, $byLabel['Build']['billableHours'] ?? null);
+        $this->assertEquals(0.5, $byLabel['Build']['billableHours'] ?? null);
         $this->assertSame(['USD' => 4000], $byLabel['Build']['amounts'] ?? null);
-        $this->assertSame(2.0, $byLabel['Internal']['hours'] ?? null);
-        $this->assertSame(0.0, $byLabel['Internal']['billableHours'] ?? null);
+        $this->assertEquals(2.0, $byLabel['Internal']['hours'] ?? null);
+        $this->assertEquals(0.0, $byLabel['Internal']['billableHours'] ?? null);
         $this->assertSame([], $byLabel['Internal']['amounts'] ?? null);
         $totals = $report['totals'];
         $this->assertIsArray($totals);
-        $this->assertSame(3.5, $totals['hours'] ?? null);
-        $this->assertSame(1.5, $totals['billableHours'] ?? null);
+        $this->assertEquals(3.5, $totals['hours'] ?? null);
+        $this->assertEquals(1.5, $totals['billableHours'] ?? null);
         $this->assertSame(['USD' => 10000], $totals['amounts'] ?? null);
 
         // A range that misses everything comes back empty.

--- a/pwa/components/common/SidebarNav.tsx
+++ b/pwa/components/common/SidebarNav.tsx
@@ -577,6 +577,7 @@ const BillingSection = ({
     { href: "/engagements", label: "Engagements", match: "/engagements", show: canInvoices },
     { href: "/clients", label: "Clients", match: "/clients", show: canInvoices },
     { href: "/invoices", label: "Invoices", match: "/invoices", show: canInvoices },
+    { href: "/reports", label: "Reports", match: "/reports", show: canInvoices },
   ].filter((l) => l.show);
 
   if (links.length === 0) return null;

--- a/pwa/pages/reports/index.tsx
+++ b/pwa/pages/reports/index.tsx
@@ -1,0 +1,389 @@
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { BarChart3, Download } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
+import { apiGet } from "@/lib/apiClient";
+import { signinHrefForCurrent } from "@/lib/authRedirect";
+import { formatMoney } from "@/lib/invoiceTypes";
+import PageHeader from "@/components/common/PageHeader";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+const GROUP_BYS = [
+  { value: "engagement", label: "Engagement" },
+  { value: "client", label: "Client" },
+  { value: "category", label: "Category" },
+  { value: "person", label: "Person" },
+] as const;
+
+interface SummaryRow {
+  key: string;
+  label: string;
+  seconds: number;
+  hours: number;
+  billableSeconds: number;
+  billableHours: number;
+  amounts: Record<string, number>;
+}
+
+interface SummaryReport {
+  groupBy: string;
+  from: string | null;
+  to: string | null;
+  rows: SummaryRow[];
+  totals: {
+    seconds: number;
+    hours: number;
+    billableSeconds: number;
+    billableHours: number;
+    amounts: Record<string, number>;
+  };
+}
+
+interface UninvoicedRow {
+  engagementId: string;
+  engagement: string;
+  client: string | null;
+  entryCount: number;
+  seconds: number;
+  hours: number;
+  amount: number;
+  currency: string;
+}
+
+/** "$123.45" / "$123.45 · €50.00" for a per-currency amount map. */
+const amountsLabel = (amounts: Record<string, number>): string => {
+  const parts = Object.entries(amounts).map(([currency, minor]) =>
+    formatMoney(minor, currency),
+  );
+  return parts.length > 0 ? parts.join(" · ") : "—";
+};
+
+/** First day of the current month, as a date-input value. */
+const monthStart = (): string => {
+  const now = new Date();
+  return `${now.getFullYear()}-${(now.getMonth() + 1).toString().padStart(2, "0")}-01`;
+};
+
+const todayInput = (): string => {
+  const now = new Date();
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+};
+
+/**
+ * Billing reports (#647): a time summary (period + group-by) and the
+ * per-engagement uninvoiced pool, each with a CSV export mirroring the same
+ * filters server-side.
+ */
+const ReportsPage = () => {
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
+  const { activeSpace, can } = useActiveSpace();
+  const router = useRouter();
+
+  const [tab, setTab] = useState<"summary" | "uninvoiced">("summary");
+  const [from, setFrom] = useState(monthStart);
+  const [to, setTo] = useState(todayInput);
+  const [groupBy, setGroupBy] = useState("engagement");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) {
+      router.replace(signinHrefForCurrent(router.asPath));
+    }
+  }, [authLoading, isAuthenticated, router]);
+
+  const spaceId = activeSpace?.id ?? null;
+  const canView = can("invoices", "read");
+
+  const summaryParams = new URLSearchParams({
+    ...(from ? { from } : {}),
+    ...(to ? { to } : {}),
+    groupBy,
+  });
+  const summaryQuery = useQuery({
+    queryKey: ["report_summary", spaceId, from, to, groupBy],
+    enabled: isAuthenticated && !!spaceId && canView && tab === "summary",
+    queryFn: () =>
+      apiGet<SummaryReport>(
+        `/spaces/${spaceId}/reports/time-summary?${summaryParams.toString()}`,
+        { errorMessage: "Failed to load the report." },
+      ),
+  });
+
+  const uninvoicedQuery = useQuery({
+    queryKey: ["report_uninvoiced", spaceId],
+    enabled: isAuthenticated && !!spaceId && canView && tab === "uninvoiced",
+    queryFn: () =>
+      apiGet<{ rows: UninvoicedRow[] }>(`/spaces/${spaceId}/reports/uninvoiced`, {
+        errorMessage: "Failed to load the report.",
+      }),
+  });
+
+  const downloadCsv = async () => {
+    if (!spaceId) return;
+    const path =
+      tab === "summary"
+        ? `/spaces/${spaceId}/reports/time-summary?${summaryParams.toString()}&format=csv`
+        : `/spaces/${spaceId}/reports/uninvoiced?format=csv`;
+    try {
+      const res = await fetch(path, { credentials: "include", headers: { Accept: "text/csv" } });
+      if (!res.ok) {
+        setError("Could not build the export.");
+        return;
+      }
+      const blob = await res.blob();
+      const a = document.createElement("a");
+      a.href = URL.createObjectURL(blob);
+      a.download = tab === "summary" ? `time-summary-by-${groupBy}.csv` : "uninvoiced.csv";
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+    } catch {
+      setError("Could not build the export.");
+    }
+  };
+
+  if (authLoading || !isAuthenticated) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-muted">
+        <p className="text-muted-foreground">Loading…</p>
+      </div>
+    );
+  }
+
+  const summary = summaryQuery.data ?? null;
+  const uninvoiced = uninvoicedQuery.data?.rows ?? [];
+
+  return (
+    <>
+      <Head>
+        <title>Reports — Madori</title>
+      </Head>
+      <div className="min-h-screen bg-background px-4 py-12">
+        <div className="mx-auto max-w-4xl">
+          <PageHeader
+            title="Reports"
+            icon={<BarChart3 className="size-6 text-violet-600 dark:text-violet-400" />}
+          />
+
+          {!canView ? (
+            <Alert>
+              <AlertDescription>
+                Reports are limited to members with invoicing access.
+              </AlertDescription>
+            </Alert>
+          ) : (
+            <>
+              {error && (
+                <Alert variant="destructive" className="mb-4">
+                  <AlertDescription>{error}</AlertDescription>
+                </Alert>
+              )}
+
+              <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+                <div className="inline-flex rounded-md border p-0.5" role="tablist">
+                  <Button
+                    variant={tab === "summary" ? "secondary" : "ghost"}
+                    size="sm"
+                    role="tab"
+                    aria-selected={tab === "summary"}
+                    onClick={() => setTab("summary")}
+                  >
+                    Time summary
+                  </Button>
+                  <Button
+                    variant={tab === "uninvoiced" ? "secondary" : "ghost"}
+                    size="sm"
+                    role="tab"
+                    aria-selected={tab === "uninvoiced"}
+                    onClick={() => setTab("uninvoiced")}
+                  >
+                    Uninvoiced
+                  </Button>
+                </div>
+                <Button variant="outline" size="sm" onClick={() => void downloadCsv()}>
+                  <Download className="h-4 w-4" /> Export CSV
+                </Button>
+              </div>
+
+              {tab === "summary" && (
+                <>
+                  <div className="mb-4 flex flex-wrap items-end gap-3">
+                    <div className="space-y-1.5">
+                      <Label htmlFor="rep-from">From</Label>
+                      <Input
+                        id="rep-from"
+                        type="date"
+                        value={from}
+                        onChange={(e) => setFrom(e.target.value)}
+                        className="w-40"
+                      />
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="rep-to">To</Label>
+                      <Input
+                        id="rep-to"
+                        type="date"
+                        value={to}
+                        onChange={(e) => setTo(e.target.value)}
+                        className="w-40"
+                      />
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="rep-group">Group by</Label>
+                      <select
+                        id="rep-group"
+                        value={groupBy}
+                        onChange={(e) => setGroupBy(e.target.value)}
+                        className="h-9 w-40 rounded-md border border-input bg-background px-3 text-sm"
+                      >
+                        {GROUP_BYS.map((g) => (
+                          <option key={g.value} value={g.value}>
+                            {g.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  </div>
+
+                  <Card>
+                    <div className="overflow-x-auto">
+                      <table className="w-full text-sm">
+                        <thead>
+                          <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+                            <th className="px-4 py-2 font-medium">
+                              {GROUP_BYS.find((g) => g.value === groupBy)?.label}
+                            </th>
+                            <th className="px-4 py-2 text-right font-medium">Hours</th>
+                            <th className="px-4 py-2 text-right font-medium">Billable hours</th>
+                            <th className="px-4 py-2 text-right font-medium">Billable amount</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {summaryQuery.isLoading ? (
+                            <tr>
+                              <td colSpan={4} className="px-4 py-10 text-center text-muted-foreground">
+                                Loading…
+                              </td>
+                            </tr>
+                          ) : !summary || summary.rows.length === 0 ? (
+                            <tr>
+                              <td colSpan={4} className="px-4 py-10 text-center text-muted-foreground">
+                                No tracked time in this period.
+                              </td>
+                            </tr>
+                          ) : (
+                            summary.rows.map((row) => (
+                              <tr key={row.key} className="border-b last:border-0">
+                                <td className="px-4 py-2.5">{row.label}</td>
+                                <td className="px-4 py-2.5 text-right tabular-nums">
+                                  {row.hours.toFixed(2)}
+                                </td>
+                                <td className="px-4 py-2.5 text-right tabular-nums">
+                                  {row.billableHours.toFixed(2)}
+                                </td>
+                                <td className="px-4 py-2.5 text-right tabular-nums">
+                                  {amountsLabel(row.amounts)}
+                                </td>
+                              </tr>
+                            ))
+                          )}
+                        </tbody>
+                        {summary && summary.rows.length > 0 && (
+                          <tfoot>
+                            <tr className="bg-muted/40 font-medium">
+                              <td className="px-4 py-2">Total</td>
+                              <td className="px-4 py-2 text-right tabular-nums">
+                                {summary.totals.hours.toFixed(2)}
+                              </td>
+                              <td className="px-4 py-2 text-right tabular-nums">
+                                {summary.totals.billableHours.toFixed(2)}
+                              </td>
+                              <td className="px-4 py-2 text-right tabular-nums">
+                                {amountsLabel(summary.totals.amounts)}
+                              </td>
+                            </tr>
+                          </tfoot>
+                        )}
+                      </table>
+                    </div>
+                  </Card>
+                </>
+              )}
+
+              {tab === "uninvoiced" && (
+                <Card>
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+                          <th className="px-4 py-2 font-medium">Engagement</th>
+                          <th className="px-4 py-2 font-medium">Client</th>
+                          <th className="px-4 py-2 text-right font-medium">Entries</th>
+                          <th className="px-4 py-2 text-right font-medium">Hours</th>
+                          <th className="px-4 py-2 text-right font-medium">Amount</th>
+                          <th className="px-4 py-2" />
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {uninvoicedQuery.isLoading ? (
+                          <tr>
+                            <td colSpan={6} className="px-4 py-10 text-center text-muted-foreground">
+                              Loading…
+                            </td>
+                          </tr>
+                        ) : uninvoiced.length === 0 ? (
+                          <tr>
+                            <td colSpan={6} className="px-4 py-10 text-center text-muted-foreground">
+                              Nothing to bill — every billable hour is invoiced.
+                            </td>
+                          </tr>
+                        ) : (
+                          uninvoiced.map((row) => (
+                            <tr key={row.engagementId} className="border-b last:border-0">
+                              <td className="px-4 py-2.5 font-medium">{row.engagement}</td>
+                              <td className="px-4 py-2.5 text-muted-foreground">
+                                {row.client ?? "—"}
+                              </td>
+                              <td className="px-4 py-2.5 text-right tabular-nums">
+                                {row.entryCount}
+                              </td>
+                              <td className="px-4 py-2.5 text-right tabular-nums">
+                                {row.hours.toFixed(2)}
+                              </td>
+                              <td className="px-4 py-2.5 text-right tabular-nums">
+                                {formatMoney(row.amount, row.currency)}
+                              </td>
+                              <td className="px-4 py-2.5 text-right">
+                                <Link
+                                  href="/invoices"
+                                  className="text-sm text-primary hover:underline"
+                                >
+                                  Create invoice
+                                </Link>
+                              </td>
+                            </tr>
+                          ))
+                        )}
+                      </tbody>
+                    </table>
+                  </div>
+                </Card>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ReportsPage;


### PR DESCRIPTION
Closes #647

## What
First reporting surface (the biggest Harvest gap — we had zero reports). Two reports v1, both space-scoped and gated on the admin-reserved `invoices` category (space admins or explicit grantees; outsiders 404):

**Time summary** — `GET /spaces/{id}/reports/time-summary?from&to&groupBy`
- Group by **client / engagement / category / person**; per group: hours, billable hours, billable amount.
- Amounts are **per-currency maps** (`{USD: 12345}`) so mixed-currency spaces never silently sum apples and oranges; totals aggregate the same way.
- The per-entry amount math mirrors invoice generation exactly (`round(hours, 2) × snapshotted rate`, client-default fallback) so a report never disagrees with the invoice it predicts.

**Uninvoiced** — `GET /spaces/{id}/reports/uninvoiced`
- Per engagement: unbilled billable entry count, hours, amount, currency — the "what can I bill right now" view; rows link into the invoice generator (#644).

**CSV** — both accept `?format=csv` (server-generated, same filters, `text/csv` attachment).

## PWA
`/reports` page under the Billing sidebar group: Time summary / Uninvoiced tabs, period + group-by pickers (defaults to the current month), totals row, per-row amounts, Export CSV button (auth-credentialed fetch → blob download).

## Tests
`ReportTest`:
- summary grouping by category (billable vs non-billable, per-currency amounts, totals), empty range, bogus groupBy 422, CSV content-type + payload, member-without-grant 403, outsider 404
- uninvoiced pool (non-billable excluded, hours/amount/count) and that generating an invoice drains it