### PR TITLE
feat(expenses): billable expenses that flow onto invoices

### DIFF
--- a/api/migrations/Version20260716150000.php
+++ b/api/migrations/Version20260716150000.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Expenses (#650): the expense table (engagement-scoped costs with a billed
+ * lock + optional receipt MediaObject) and invoice_line_item.source_expense_id
+ * so invoice lines back-link the expense they bill (mirroring
+ * source_time_entry_id, used by void to release the expense).
+ */
+final class Version20260716150000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Expense table + invoice_line_item.source_expense_id back-link.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE expense (id UUID NOT NULL, spent_on DATE NOT NULL, category VARCHAR(80) DEFAULT NULL, amount INT NOT NULL, currency VARCHAR(3) DEFAULT NULL, description TEXT DEFAULT NULL, billable BOOLEAN NOT NULL, billed_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL, space_id UUID NOT NULL, engagement_id UUID DEFAULT NULL, user_id UUID NOT NULL, receipt_id UUID DEFAULT NULL, PRIMARY KEY (id))');
+        $this->addSql('CREATE INDEX idx_expense_space_spent ON expense (space_id, spent_on)');
+        $this->addSql('CREATE INDEX idx_expense_engagement ON expense (engagement_id)');
+        $this->addSql('CREATE INDEX idx_expense_user ON expense (user_id)');
+        $this->addSql('CREATE INDEX IDX_2D3A8DA62B5CA896 ON expense (receipt_id)');
+        $this->addSql('ALTER TABLE expense ADD CONSTRAINT FK_2D3A8DA623575340 FOREIGN KEY (space_id) REFERENCES space (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE expense ADD CONSTRAINT FK_2D3A8DA6D30F6F97 FOREIGN KEY (engagement_id) REFERENCES engagement (id) ON DELETE SET NULL NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE expense ADD CONSTRAINT FK_2D3A8DA6A76ED395 FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE expense ADD CONSTRAINT FK_2D3A8DA62B5CA896 FOREIGN KEY (receipt_id) REFERENCES media_object (id) ON DELETE SET NULL NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE invoice_line_item ADD source_expense_id UUID DEFAULT NULL');
+        $this->addSql('CREATE INDEX IDX_F1F9275B8F21AA5F ON invoice_line_item (source_expense_id)');
+        $this->addSql('ALTER TABLE invoice_line_item ADD CONSTRAINT FK_F1F9275B8F21AA5F FOREIGN KEY (source_expense_id) REFERENCES expense (id) ON DELETE SET NULL NOT DEFERRABLE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE invoice_line_item DROP CONSTRAINT FK_F1F9275B8F21AA5F');
+        $this->addSql('ALTER TABLE invoice_line_item DROP source_expense_id');
+        $this->addSql('ALTER TABLE expense DROP CONSTRAINT FK_2D3A8DA623575340');
+        $this->addSql('ALTER TABLE expense DROP CONSTRAINT FK_2D3A8DA6D30F6F97');
+        $this->addSql('ALTER TABLE expense DROP CONSTRAINT FK_2D3A8DA6A76ED395');
+        $this->addSql('ALTER TABLE expense DROP CONSTRAINT FK_2D3A8DA62B5CA896');
+        $this->addSql('DROP TABLE expense');
+    }
+}

--- a/api/src/Controller/InvoiceActionController.php
+++ b/api/src/Controller/InvoiceActionController.php
@@ -240,9 +240,10 @@ class InvoiceActionController extends AbstractController
             return $invoice;
         }
 
-        // Release the billed time entries so the hours can be re-invoiced.
+        // Release the billed time entries + expenses so they can be re-invoiced.
         foreach ($invoice->getLineItems() as $line) {
             $line->getSourceTimeEntry()?->setBilledAt(null);
+            $line->getSourceExpense()?->setBilledAt(null);
         }
         $invoice->setStatus(Invoice::STATUS_VOID);
         $this->em->flush();

--- a/api/src/Controller/InvoiceFromTimeController.php
+++ b/api/src/Controller/InvoiceFromTimeController.php
@@ -3,10 +3,12 @@
 namespace App\Controller;
 
 use App\Entity\Engagement;
+use App\Entity\Expense;
 use App\Entity\Invoice;
 use App\Entity\InvoiceLineItem;
 use App\Entity\TimeEntry;
 use App\Entity\User;
+use App\Repository\ExpenseRepository;
 use App\Repository\TimeEntryRepository;
 use App\Security\Permission\SpacePermission;
 use App\Security\Permission\SpacePermissionResolver;
@@ -44,6 +46,7 @@ class InvoiceFromTimeController extends AbstractController
     public function __construct(
         private EntityManagerInterface $em,
         private TimeEntryRepository $timeEntries,
+        private ExpenseRepository $expenses,
         private SpacePermissionResolver $permissions,
     ) {
     }
@@ -115,12 +118,42 @@ class InvoiceFromTimeController extends AbstractController
 
         $currency = $engagement->getCurrency() ?? $client->getCurrency() ?? 'USD';
 
-        if (true === ($payload['preview'] ?? false)) {
-            return $this->preview($entries, $client->getDefaultRateAmount(), $currency);
+        // Unbilled billable expenses ride along (#650) unless opted out.
+        // Only same-currency expenses join — an invoice pins one currency.
+        $expenses = [];
+        if (false !== ($payload['includeExpenses'] ?? true)) {
+            $expenses = array_values(array_filter(
+                $this->expenses->findInvoiceableForEngagement($engagement, $from, $to?->modify('+1 day')),
+                static fn (Expense $x): bool => null === $x->getCurrency() || $x->getCurrency() === $currency,
+            ));
+        }
+        $expenseSelection = $payload['expenses'] ?? null;
+        if (is_array($expenseSelection)) {
+            $wantedExpenses = [];
+            foreach ($expenseSelection as $ref) {
+                $xid = $this->entryId($ref);
+                if (null === $xid) {
+                    return $this->json(['error' => 'Invalid expense reference in the selection.'], 422);
+                }
+                $wantedExpenses[$xid] = true;
+            }
+            $expenses = array_values(array_filter(
+                $expenses,
+                static fn (Expense $x): bool => isset($wantedExpenses[(string) $x->getId()]),
+            ));
+            if (count($expenses) !== count($wantedExpenses)) {
+                return $this->json([
+                    'error' => 'One or more selected expenses are not invoiceable for this engagement.',
+                ], 422);
+            }
         }
 
-        if (0 === count($entries)) {
-            return $this->json(['error' => 'No unbilled billable time to invoice.'], 422);
+        if (true === ($payload['preview'] ?? false)) {
+            return $this->preview($entries, $expenses, $client->getDefaultRateAmount(), $currency);
+        }
+
+        if (0 === count($entries) && 0 === count($expenses)) {
+            return $this->json(['error' => 'No unbilled billable time or expenses to invoice.'], 422);
         }
 
         $now = new \DateTimeImmutable();
@@ -150,6 +183,23 @@ class InvoiceFromTimeController extends AbstractController
             $entry->setBilledAt($now);
         }
 
+        // Expenses follow the time lines, grouped as their own section (#650).
+        foreach ($expenses as $expense) {
+            $amount = $expense->getAmount();
+            $subtotal += $amount;
+
+            $line = (new InvoiceLineItem())
+                ->setDescription($this->expenseLabel($expense))
+                ->setQuantity(1.0)
+                ->setUnitAmount($amount)
+                ->setAmount($amount)
+                ->setPosition($position++)
+                ->setSourceExpense($expense);
+            $invoice->addLineItem($line);
+
+            $expense->setBilledAt($now);
+        }
+
         $invoice->setSubtotal($subtotal);
         $invoice->setTaxAmount(0);
         $invoice->setTotal($subtotal);
@@ -164,7 +214,7 @@ class InvoiceFromTimeController extends AbstractController
             'currency' => $invoice->getCurrency(),
             'subtotal' => $invoice->getSubtotal(),
             'total' => $invoice->getTotal(),
-            'lineItemCount' => count($entries),
+            'lineItemCount' => count($entries) + count($expenses),
         ], 201);
     }
 
@@ -173,8 +223,9 @@ class InvoiceFromTimeController extends AbstractController
      * generation loop, but read-only: nothing is created, nothing is stamped.
      *
      * @param list<TimeEntry> $entries
+     * @param list<Expense>   $expenses
      */
-    private function preview(array $entries, ?int $clientDefaultRate, string $currency): JsonResponse
+    private function preview(array $entries, array $expenses, ?int $clientDefaultRate, string $currency): JsonResponse
     {
         $rows = [];
         $subtotal = 0;
@@ -197,12 +248,43 @@ class InvoiceFromTimeController extends AbstractController
             ];
         }
 
+        $expenseRows = [];
+        foreach ($expenses as $expense) {
+            $subtotal += $expense->getAmount();
+            $expenseRows[] = [
+                '@id' => '/expenses/' . $expense->getId(),
+                'id' => (string) $expense->getId(),
+                'description' => $expense->getDescription(),
+                'category' => $expense->getCategory(),
+                'spentOn' => $expense->getSpentOn()?->format('Y-m-d'),
+                'amount' => $expense->getAmount(),
+            ];
+        }
+
         return $this->json([
             'entries' => $rows,
-            'count' => count($rows),
+            'expenses' => $expenseRows,
+            'count' => count($rows) + count($expenseRows),
             'subtotal' => $subtotal,
             'currency' => $currency,
         ]);
+    }
+
+    /** "Expense — Category: description" (parts optional), capped to the column length. */
+    private function expenseLabel(Expense $expense): string
+    {
+        $parts = [];
+        $category = $expense->getCategory();
+        if (null !== $category && '' !== trim($category)) {
+            $parts[] = trim($category);
+        }
+        $description = $expense->getDescription();
+        if (null !== $description && '' !== trim($description)) {
+            $parts[] = trim($description);
+        }
+        $label = 'Expense — ' . ([] === $parts ? 'other' : implode(': ', $parts));
+
+        return mb_substr($label, 0, InvoiceLineItem::MAX_DESCRIPTION_LENGTH);
     }
 
     /** A `Y-m-d` payload date → midnight UTC; null when absent, false when malformed. */

--- a/api/src/Controller/MediaObjectDownloadController.php
+++ b/api/src/Controller/MediaObjectDownloadController.php
@@ -3,6 +3,7 @@
 namespace App\Controller;
 
 use App\Entity\Engagement;
+use App\Entity\Expense;
 use App\Entity\MediaObject;
 use App\Entity\Space;
 use App\Entity\Task;
@@ -123,11 +124,13 @@ class MediaObjectDownloadController extends AbstractController
         if ($this->isGranted('ROLE_ADMIN')) {
             return $this->mediaIsAttachedToAnyTask($media)
                 || $this->mediaIsAttachedToAnySpace($media)
-                || $this->mediaIsAttachedToAnyEngagement($media);
+                || $this->mediaIsAttachedToAnyEngagement($media)
+                || $this->mediaIsAReceiptOnAnyExpense($media);
         }
         return $this->mediaIsAttachedToReadableTask($media, $user)
             || $this->mediaIsAttachedToReadableSpace($media, $user)
-            || $this->mediaIsAttachedToReadableEngagement($media, $user);
+            || $this->mediaIsAttachedToReadableEngagement($media, $user)
+            || $this->mediaIsAReceiptOnReadableExpense($media, $user);
     }
 
     private function mediaIsAttachedToAnyTask(MediaObject $media): bool
@@ -221,6 +224,53 @@ class MediaObjectDownloadController extends AbstractController
             ->getQuery()
             ->getSingleScalarResult();
         return $count > 0;
+    }
+
+    private function mediaIsAReceiptOnAnyExpense(MediaObject $media): bool
+    {
+        $count = (int) $this->em->getRepository(Expense::class)
+            ->createQueryBuilder('x')
+            ->select('COUNT(x.id)')
+            ->where('x.receipt = :media')
+            ->setParameter('media', $media)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getSingleScalarResult();
+        return $count > 0;
+    }
+
+    /**
+     * Expense receipts (#650) are readable by the expense's own spender, a
+     * space admin, or a member holding an explicit `time_entries.read` grant
+     * — the same bar as the Expense GET security expression. A media backs at
+     * most a handful of expenses, so the per-row check is cheap.
+     */
+    private function mediaIsAReceiptOnReadableExpense(MediaObject $media, User $user): bool
+    {
+        $expenses = $this->em->getRepository(Expense::class)
+            ->createQueryBuilder('x')
+            ->where('x.receipt = :media')
+            ->setParameter('media', $media)
+            ->getQuery()
+            ->getResult();
+
+        foreach ($expenses as $expense) {
+            if (true === $expense->getUser()?->getId()?->equals($user->getId())) {
+                return true;
+            }
+            $space = $expense->getSpace();
+            if (null === $space || !$space->hasMember($user)) {
+                continue;
+            }
+            if (
+                $space->isAdmin($user)
+                || $this->permissions->can($user, $space, SpacePermission::TIME_ENTRIES, SpacePermission::READ)
+            ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/api/src/Doctrine/ExpenseAccessExtension.php
+++ b/api/src/Doctrine/ExpenseAccessExtension.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Doctrine;
+
+use App\Entity\Expense;
+use App\Security\Permission\SpacePermission;
+
+/**
+ * Scopes Expense queries to the spaces the current user belongs to (#650),
+ * via the denormalised `expense.space` FK — the exact shape of
+ * {@see TimeEntryAccessExtension} (expenses ride the same `time_entries`
+ * permission category as the rest of the billing inputs).
+ */
+final class ExpenseAccessExtension extends AbstractSpaceAccessExtension
+{
+    protected function getResourceClass(): string
+    {
+        return Expense::class;
+    }
+
+    protected function getAliasPrefix(): string
+    {
+        return 'expense_access';
+    }
+
+    protected function getImpersonationItemType(): ?string
+    {
+        return null;
+    }
+
+    protected function getPermissionCategory(): string
+    {
+        return SpacePermission::TIME_ENTRIES;
+    }
+}

--- a/api/src/Entity/Expense.php
+++ b/api/src/Entity/Expense.php
@@ -1,0 +1,347 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Doctrine\Orm\Filter\BooleanFilter;
+use ApiPlatform\Doctrine\Orm\Filter\DateFilter;
+use ApiPlatform\Doctrine\Orm\Filter\OrderFilter;
+use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
+use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use App\Repository\ExpenseRepository;
+use App\State\ExpenseDeleteProcessor;
+use App\State\ExpenseUserProcessor;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+
+/**
+ * A billable (or internal) expense tracked against an {@see Engagement}
+ * (#650) — the sibling of {@see TimeEntry} on the cost side: members log
+ * their own, invoice generation pulls the unbilled billable ones onto the
+ * invoice as line items and stamps {@see $billedAt} so an expense can't be
+ * billed twice. An optional {@see $receipt} MediaObject rides the gated
+ * download endpoint.
+ *
+ * Access mirrors time entries: any space member creates (their own), the
+ * author / space admin / `time_entries.update|delete` grantees edit and
+ * delete, and the collection is scoped by ExpenseAccessExtension.
+ */
+#[ApiResource(
+    shortName: 'Expense',
+    operations: [
+        new GetCollection(
+            security: "is_granted('ROLE_USER')",
+        ),
+        new Post(
+            security: "is_granted('ROLE_USER')",
+            securityPostDenormalize: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or (object.getSpace() !== null and object.getSpace().hasMember(user) and is_granted('space.time_entries.create', object)))",
+            processor: ExpenseUserProcessor::class,
+        ),
+        new Get(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or (object.getSpace().hasMember(user) and is_granted('space.time_entries.read', object)))",
+        ),
+        new Patch(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getUser() == user or object.getSpace().isAdmin(user) or (object.getSpace().hasMember(user) and is_granted('space.time_entries.update', object)))",
+            processor: ExpenseUserProcessor::class,
+        ),
+        new Delete(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getUser() == user or object.getSpace().isAdmin(user) or (object.getSpace().hasMember(user) and is_granted('space.time_entries.delete', object)))",
+            processor: ExpenseDeleteProcessor::class,
+        ),
+    ],
+    normalizationContext: ['groups' => ['expense:read']],
+    denormalizationContext: ['groups' => ['expense:write']],
+    order: ['spentOn' => 'DESC'],
+)]
+#[ApiFilter(SearchFilter::class, properties: ['space' => 'exact', 'engagement' => 'exact', 'user' => 'exact'])]
+#[ApiFilter(BooleanFilter::class, properties: ['billable'])]
+#[ApiFilter(DateFilter::class, properties: ['spentOn'])]
+#[ApiFilter(OrderFilter::class, properties: ['spentOn', 'createdAt'])]
+#[ORM\Entity(repositoryClass: ExpenseRepository::class)]
+#[ORM\Table(name: 'expense')]
+#[ORM\Index(columns: ['space_id', 'spent_on'], name: 'idx_expense_space_spent')]
+#[ORM\Index(columns: ['engagement_id'], name: 'idx_expense_engagement')]
+#[ORM\Index(columns: ['user_id'], name: 'idx_expense_user')]
+#[ORM\HasLifecycleCallbacks]
+#[Assert\Callback('validateConsistency')]
+class Expense
+{
+    public const MAX_DESCRIPTION_LENGTH = 1000;
+    public const MAX_CATEGORY_LENGTH = 80;
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
+    #[Groups(['expense:read'])]
+    private ?Uuid $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Space::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    #[Assert\NotNull(message: 'Space is required.')]
+    #[Groups(['expense:read', 'expense:write'])]
+    private ?Space $space = null;
+
+    /** The engagement this expense bills against. Required. */
+    #[ApiProperty(readableLink: false)]
+    #[ORM\ManyToOne(targetEntity: Engagement::class)]
+    #[ORM\JoinColumn(name: 'engagement_id', nullable: true, onDelete: 'SET NULL')]
+    #[Assert\NotNull(message: 'A engagement is required.')]
+    #[Groups(['expense:read', 'expense:write'])]
+    private ?Engagement $engagement = null;
+
+    /** Who spent it. Stamped server-side, never from the payload. */
+    #[ApiProperty(readableLink: false)]
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    #[Groups(['expense:read'])]
+    private ?User $user = null;
+
+    #[ORM\Column(type: 'date_immutable')]
+    #[Assert\NotNull(message: 'A date is required.')]
+    #[Groups(['expense:read', 'expense:write'])]
+    private ?\DateTimeImmutable $spentOn = null;
+
+    /** Free-text category ("Travel", "Software", …). */
+    #[ORM\Column(length: self::MAX_CATEGORY_LENGTH, nullable: true)]
+    #[Assert\Length(max: self::MAX_CATEGORY_LENGTH)]
+    #[Groups(['expense:read', 'expense:write'])]
+    private ?string $category = null;
+
+    /** Cost in minor units of {@see $currency}. */
+    #[ORM\Column(type: 'integer')]
+    #[Assert\Positive(message: 'The amount must be positive.')]
+    #[Groups(['expense:read', 'expense:write'])]
+    private int $amount = 0;
+
+    /** Defaults to the engagement's (then client's) currency on save. */
+    #[ORM\Column(type: 'string', length: 3, nullable: true)]
+    #[Assert\Currency]
+    #[Groups(['expense:read', 'expense:write'])]
+    private ?string $currency = null;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    #[Assert\Length(max: self::MAX_DESCRIPTION_LENGTH)]
+    #[Groups(['expense:read', 'expense:write'])]
+    private ?string $description = null;
+
+    #[ORM\Column(type: 'boolean')]
+    #[Groups(['expense:read', 'expense:write'])]
+    private bool $billable = true;
+
+    /** Receipt image/PDF — bytes stream through the gated media download. */
+    #[ORM\ManyToOne(targetEntity: MediaObject::class)]
+    #[ORM\JoinColumn(name: 'receipt_id', nullable: true, onDelete: 'SET NULL')]
+    #[Groups(['expense:read', 'expense:write'])]
+    private ?MediaObject $receipt = null;
+
+    /** Set when the expense is pulled onto an invoice; locks it against re-billing. */
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    #[Groups(['expense:read'])]
+    private ?\DateTimeImmutable $billedAt = null;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    #[Groups(['expense:read'])]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    #[Groups(['expense:read'])]
+    private ?\DateTimeImmutable $updatedAt = null;
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    /**
+     * Denormalise the space + currency from the engagement so the access
+     * extension can scope by `space` alone and amounts always carry a currency.
+     */
+    #[ORM\PrePersist]
+    #[ORM\PreUpdate]
+    public function syncDerived(): void
+    {
+        if (null === $this->space && null !== $this->engagement) {
+            $this->space = $this->engagement->getSpace();
+        }
+        if (null === $this->currency) {
+            $this->currency = $this->engagement?->getCurrency()
+                ?? $this->engagement?->getClient()?->getCurrency()
+                ?? 'USD';
+        }
+    }
+
+    #[ORM\PreUpdate]
+    public function onPreUpdate(): void
+    {
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function validateConsistency(ExecutionContextInterface $context): void
+    {
+        if (
+            null !== $this->engagement && null !== $this->space
+            && true !== $this->engagement->getSpace()?->getId()?->equals($this->space->getId())
+        ) {
+            $context->buildViolation('Engagement must belong to the same space.')
+                ->atPath('engagement')
+                ->addViolation();
+        }
+    }
+
+    public function getId(): ?Uuid
+    {
+        return $this->id;
+    }
+
+    public function getSpace(): ?Space
+    {
+        return $this->space;
+    }
+
+    public function setSpace(?Space $space): self
+    {
+        $this->space = $space;
+
+        return $this;
+    }
+
+    public function getEngagement(): ?Engagement
+    {
+        return $this->engagement;
+    }
+
+    public function setEngagement(?Engagement $engagement): self
+    {
+        $this->engagement = $engagement;
+
+        return $this;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(?User $user): self
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    public function getSpentOn(): ?\DateTimeImmutable
+    {
+        return $this->spentOn;
+    }
+
+    public function setSpentOn(?\DateTimeImmutable $spentOn): self
+    {
+        $this->spentOn = $spentOn;
+
+        return $this;
+    }
+
+    public function getCategory(): ?string
+    {
+        return $this->category;
+    }
+
+    public function setCategory(?string $category): self
+    {
+        $this->category = $category;
+
+        return $this;
+    }
+
+    public function getAmount(): int
+    {
+        return $this->amount;
+    }
+
+    public function setAmount(int $amount): self
+    {
+        $this->amount = $amount;
+
+        return $this;
+    }
+
+    public function getCurrency(): ?string
+    {
+        return $this->currency;
+    }
+
+    public function setCurrency(?string $currency): self
+    {
+        $this->currency = $currency;
+
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(?string $description): self
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function isBillable(): bool
+    {
+        return $this->billable;
+    }
+
+    public function setBillable(bool $billable): self
+    {
+        $this->billable = $billable;
+
+        return $this;
+    }
+
+    public function getReceipt(): ?MediaObject
+    {
+        return $this->receipt;
+    }
+
+    public function setReceipt(?MediaObject $receipt): self
+    {
+        $this->receipt = $receipt;
+
+        return $this;
+    }
+
+    public function getBilledAt(): ?\DateTimeImmutable
+    {
+        return $this->billedAt;
+    }
+
+    public function setBilledAt(?\DateTimeImmutable $billedAt): self
+    {
+        $this->billedAt = $billedAt;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): ?\DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+}

--- a/api/src/Entity/InvoiceLineItem.php
+++ b/api/src/Entity/InvoiceLineItem.php
@@ -67,6 +67,13 @@ class InvoiceLineItem
     #[Groups(['invoice:read', 'invoice:write'])]
     private ?TimeEntry $sourceTimeEntry = null;
 
+    /** Back-link for a line generated from an expense (#650) — lets void release it. */
+    #[ApiProperty(readableLink: false)]
+    #[ORM\ManyToOne(targetEntity: Expense::class)]
+    #[ORM\JoinColumn(name: 'source_expense_id', nullable: true, onDelete: 'SET NULL')]
+    #[Groups(['invoice:read'])]
+    private ?Expense $sourceExpense = null;
+
     public function getId(): ?Uuid
     {
         return $this->id;
@@ -152,6 +159,18 @@ class InvoiceLineItem
     public function setSourceTimeEntry(?TimeEntry $sourceTimeEntry): self
     {
         $this->sourceTimeEntry = $sourceTimeEntry;
+
+        return $this;
+    }
+
+    public function getSourceExpense(): ?Expense
+    {
+        return $this->sourceExpense;
+    }
+
+    public function setSourceExpense(?Expense $sourceExpense): self
+    {
+        $this->sourceExpense = $sourceExpense;
 
         return $this;
     }

--- a/api/src/Repository/ExpenseRepository.php
+++ b/api/src/Repository/ExpenseRepository.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Engagement;
+use App\Entity\Expense;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Expense>
+ */
+class ExpenseRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Expense::class);
+    }
+
+    /**
+     * Billable, not-yet-billed expenses on an engagement — the pool invoice
+     * generation (#644/#650) pulls onto the invoice. An optional
+     * [$from, $toExclusive) window filters on spentOn, mirroring the
+     * time-entry pool's startedAt window.
+     *
+     * @return list<Expense>
+     */
+    public function findInvoiceableForEngagement(
+        Engagement $engagement,
+        ?\DateTimeImmutable $from = null,
+        ?\DateTimeImmutable $toExclusive = null,
+    ): array {
+        $qb = $this->createQueryBuilder('x')
+            ->andWhere('x.engagement = :bp')
+            ->andWhere('x.billable = true')
+            ->andWhere('x.billedAt IS NULL')
+            ->setParameter('bp', $engagement)
+            ->orderBy('x.spentOn', 'ASC')
+            ->addOrderBy('x.createdAt', 'ASC');
+
+        if (null !== $from) {
+            $qb->andWhere('x.spentOn >= :from')->setParameter('from', $from);
+        }
+        if (null !== $toExclusive) {
+            $qb->andWhere('x.spentOn < :toExclusive')->setParameter('toExclusive', $toExclusive);
+        }
+
+        /** @var list<Expense> */
+        return $qb->getQuery()->getResult();
+    }
+}

--- a/api/src/State/ExpenseDeleteProcessor.php
+++ b/api/src/State/ExpenseDeleteProcessor.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\Entity\Expense;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+
+/**
+ * Blocks deleting an expense that already backs an invoice line (#650) —
+ * same billed-lock as TimeEntryDeleteProcessor. Voiding the invoice releases
+ * the expense first.
+ *
+ * @implements ProcessorInterface<Expense, void>
+ */
+final class ExpenseDeleteProcessor implements ProcessorInterface
+{
+    /**
+     * @param ProcessorInterface<Expense, void> $removeProcessor
+     */
+    public function __construct(
+        #[Autowire(service: 'api_platform.doctrine.orm.state.remove_processor')]
+        private ProcessorInterface $removeProcessor,
+    ) {
+    }
+
+    /**
+     * @param Expense $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): void
+    {
+        if (null !== $data->getBilledAt()) {
+            throw new UnprocessableEntityHttpException(
+                'This expense is on an invoice and can no longer be deleted.',
+            );
+        }
+
+        $this->removeProcessor->process($data, $operation, $uriVariables, $context);
+    }
+}

--- a/api/src/State/ExpenseUserProcessor.php
+++ b/api/src/State/ExpenseUserProcessor.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\Entity\Expense;
+use App\Security\AuthenticatedUserResolver;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+
+/**
+ * Stamps the current user as the expense's spender on create (server-side,
+ * never from the payload — same trust model as TimeEntryUserProcessor) and
+ * freezes billed expenses: once an expense backs an invoice line, editing it
+ * would desync the financial document from the cost behind it.
+ *
+ * @implements ProcessorInterface<Expense, Expense>
+ */
+final class ExpenseUserProcessor implements ProcessorInterface
+{
+    /**
+     * @param ProcessorInterface<Expense, Expense> $persistProcessor
+     */
+    public function __construct(
+        #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
+        private ProcessorInterface $persistProcessor,
+        private AuthenticatedUserResolver $auth,
+    ) {
+    }
+
+    /**
+     * @param Expense $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Expense
+    {
+        $user = $this->auth->requireUser('track expenses');
+
+        $isCreate = null === $data->getUser();
+        if (!$isCreate && null !== $data->getBilledAt()) {
+            throw new UnprocessableEntityHttpException(
+                'This expense is on an invoice and can no longer be edited.',
+            );
+        }
+        if ($isCreate) {
+            $data->setUser($user);
+        }
+
+        return $this->persistProcessor->process($data, $operation, $uriVariables, $context);
+    }
+}

--- a/api/tests/Api/ExpenseTest.php
+++ b/api/tests/Api/ExpenseTest.php
@@ -1,0 +1,264 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\Expense;
+use App\Entity\Space;
+use App\Entity\SpaceMembership;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Expenses (#650): members log their own engagement-scoped costs, billed
+ * expenses are frozen, and invoice generation pulls the unbilled billable
+ * pool (stamping billedAt; void releases it again).
+ */
+class ExpenseTest extends ApiTestCase
+{
+    use SpaceMembershipFixture;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = static::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Invoice')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Expense')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\TimeEntry')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\EngagementCategory')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Engagement')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Client')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\SpaceMembership')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Space')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testMemberLogsOwnExpenseAndBilledLockFreezesIt(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $member = $this->createUser('member@example.com');
+        $space = $this->createSharedSpace($admin, $member);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $bpIri = $this->createEngagement($client, $spaceIri, $this->iri($clientRow));
+
+        // A plain member logs their own expense; the spender is stamped
+        // server-side and the currency defaults from the engagement.
+        $client->loginUser($member);
+        $expense = $client->request('POST', '/expenses', [
+            'json' => [
+                'space' => $spaceIri,
+                'engagement' => $bpIri,
+                'spentOn' => '2026-07-10',
+                'category' => 'Travel',
+                'description' => 'Taxi to the site',
+                'amount' => 2500,
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertSame('/users/' . $member->getId(), $expense['user'] ?? null);
+        $this->assertSame('USD', $expense['currency'] ?? null);
+        $this->assertTrue($expense['billable'] ?? null);
+        $expenseIri = $this->iri($expense);
+
+        // The member can edit their own expense while unbilled.
+        $client->request('PATCH', $expenseIri, [
+            'json' => ['amount' => 3000],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(200);
+
+        // Billed = frozen: editing or deleting 422s. (Stamp through the client
+        // kernel's EM so the request sees the change.)
+        $em = static::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $expenseId = $expense['id'];
+        $this->assertIsString($expenseId);
+        $entity = $em->getRepository(Expense::class)->find($expenseId);
+        $this->assertInstanceOf(Expense::class, $entity);
+        $entity->setBilledAt(new \DateTimeImmutable());
+        $em->flush();
+
+        $client->request('PATCH', $expenseIri, [
+            'json' => ['amount' => 9999],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+        $client->request('DELETE', $expenseIri);
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testBillableExpensesFlowOntoInvoicesAndVoidReleasesThem(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $space = $this->createSharedSpace($admin);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $bpIri = $this->createEngagement($client, $spaceIri, $this->iri($clientRow));
+
+        $makeExpense = function (int $amount, bool $billable, string $description) use ($client, $spaceIri, $bpIri): array {
+            $row = $client->request('POST', '/expenses', [
+                'json' => [
+                    'space' => $spaceIri,
+                    'engagement' => $bpIri,
+                    'spentOn' => '2026-07-10',
+                    'category' => 'Travel',
+                    'description' => $description,
+                    'amount' => $amount,
+                    'billable' => $billable,
+                ],
+                'headers' => ['Content-Type' => 'application/ld+json'],
+            ])->toArray();
+            $this->assertResponseStatusCodeSame(201);
+
+            return $row;
+        };
+        $billableExpense = $makeExpense(2500, true, 'Taxi to the site');
+        $makeExpense(1000, false, 'Team lunch'); // never invoiced
+
+        // Preview lists the billable expense in its own section.
+        $previewed = $client->request('POST', '/invoices/from-time-entries', [
+            'json' => ['engagement' => $bpIri, 'preview' => true],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(200);
+        $previewExpenses = $previewed['expenses'] ?? null;
+        $this->assertIsArray($previewExpenses);
+        $this->assertCount(1, $previewExpenses);
+        $this->assertSame(2500, $previewed['subtotal'] ?? null);
+
+        // Generation (no tracked time — an expense-only invoice is fine)
+        // pulls the expense as a line item and stamps billedAt.
+        $invoice = $client->request('POST', '/invoices/from-time-entries', [
+            'json' => ['engagement' => $bpIri],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertSame(1, $invoice['lineItemCount'] ?? null);
+        $this->assertSame(2500, $invoice['subtotal'] ?? null);
+        $invoiceIri = $invoice['@id'];
+        $this->assertIsString($invoiceIri);
+
+        $full = $client->request('GET', $invoiceIri)->toArray();
+        $lines = $full['lineItems'] ?? null;
+        $this->assertIsArray($lines);
+        $this->assertCount(1, $lines);
+        $line = $lines[0];
+        $this->assertIsArray($line);
+        $this->assertSame('Expense — Travel: Taxi to the site', $line['description'] ?? null);
+
+        $billedExpense = $client->request('GET', $this->iri($billableExpense))->toArray();
+        $this->assertNotNull($billedExpense['billedAt'] ?? null);
+
+        // Nothing left to bill: a second generation 422s.
+        $client->request('POST', '/invoices/from-time-entries', [
+            'json' => ['engagement' => $bpIri],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+
+        // Voiding the invoice releases the expense for re-billing.
+        $client->request('POST', $invoiceIri . '/void', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(200);
+        $released = $client->request('GET', $this->iri($billableExpense))->toArray();
+        $this->assertNull($released['billedAt'] ?? null);
+    }
+
+    /**
+     * Admin creates an engagement (for $clientIri) with one billable "Dev"
+     * category — expenses only need the engagement itself.
+     */
+    private function createEngagement(
+        \ApiPlatform\Symfony\Bundle\Test\Client $client,
+        string $spaceIri,
+        string $clientIri,
+    ): string {
+        $row = $client->request('POST', '/engagements', [
+            'json' => [
+                'space' => $spaceIri,
+                'client' => $clientIri,
+                'name' => 'Acme Website',
+                'currency' => 'USD',
+                'categories' => [
+                    ['name' => 'Dev', 'rateAmount' => 6000, 'position' => 0],
+                ],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+
+        return $this->iri($row);
+    }
+
+    /**
+     * The `@id` of a decoded resource, narrowed to string for concatenation.
+     *
+     * @param array<int|string, mixed> $row
+     */
+    private function iri(array $row): string
+    {
+        $iri = $row['@id'] ?? null;
+        $this->assertIsString($iri);
+
+        return $iri;
+    }
+
+    private function createSharedSpace(User $admin, ?User $member = null): Space
+    {
+        $space = (new Space())->setName('Studio')->setCreatedBy($admin);
+        $this->entityManager->persist($space);
+        $adminMembership = (new SpaceMembership())
+            ->setUser($admin)
+            ->setRole(Space::ROLE_ADMIN);
+        $space->addUserMembership($adminMembership);
+        $this->entityManager->persist($adminMembership);
+        if (null !== $member) {
+            $memberMembership = (new SpaceMembership())
+                ->setUser($member)
+                ->setRole(Space::ROLE_MEMBER);
+            $space->addUserMembership($memberMembership);
+            $this->entityManager->persist($memberMembership);
+        }
+        $this->entityManager->flush();
+
+        return $space;
+    }
+
+    private function createUser(string $email): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/pwa/components/common/SidebarNav.tsx
+++ b/pwa/components/common/SidebarNav.tsx
@@ -574,6 +574,7 @@ const BillingSection = ({
 
   const links = [
     { href: "/time", label: "Time", match: "/time", show: true },
+    { href: "/expenses", label: "Expenses", match: "/expenses", show: true },
     { href: "/engagements", label: "Engagements", match: "/engagements", show: canInvoices },
     { href: "/clients", label: "Clients", match: "/clients", show: canInvoices },
     { href: "/invoices", label: "Invoices", match: "/invoices", show: canInvoices },

--- a/pwa/lib/expenseTypes.ts
+++ b/pwa/lib/expenseTypes.ts
@@ -1,0 +1,18 @@
+/** Wire shape for `/expenses` (#650). */
+export interface Expense {
+  "@id": string;
+  id: string;
+  space: string;
+  engagement: string | null;
+  user: string;
+  spentOn: string;
+  category: string | null;
+  amount: number;
+  currency: string | null;
+  description: string | null;
+  billable: boolean;
+  receipt: string | null;
+  billedAt: string | null;
+  createdAt: string;
+  updatedAt: string | null;
+}

--- a/pwa/pages/expenses/index.tsx
+++ b/pwa/pages/expenses/index.tsx
@@ -1,0 +1,599 @@
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Paperclip, Pencil, Plus, ReceiptText, Trash2 } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
+import { apiGet, apiGetCollection, apiSend } from "@/lib/apiClient";
+import { signinHrefForCurrent } from "@/lib/authRedirect";
+import { uploadAttachmentFile } from "@/lib/attachments";
+import { Expense } from "@/lib/expenseTypes";
+import { EngagementOption } from "@/lib/timeEntryTypes";
+import { formatMoney } from "@/lib/invoiceTypes";
+import PageHeader from "@/components/common/PageHeader";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+const MERGE_PATCH = "application/merge-patch+json";
+
+const SELECT_CLASS =
+  "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50";
+
+const todayInput = (): string => {
+  const now = new Date();
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+};
+
+/** Download a gated receipt via the authenticated media endpoint. */
+const openReceipt = async (receiptIri: string, onError: (m: string) => void) => {
+  const id = receiptIri.slice(receiptIri.lastIndexOf("/") + 1);
+  try {
+    const res = await fetch(`/media-objects/${id}/download`, { credentials: "include" });
+    if (!res.ok) {
+      onError("Could not open the receipt.");
+      return;
+    }
+    window.open(URL.createObjectURL(await res.blob()), "_blank");
+  } catch {
+    onError("Could not open the receipt.");
+  }
+};
+
+/**
+ * Expense tracking (#650): inline-add list like /time — members log their
+ * own expenses against an engagement, optionally attach a receipt, and
+ * invoice generation pulls the unbilled billable ones (billed = locked).
+ */
+const ExpensesPage = () => {
+  const { isAuthenticated, isLoading: authLoading, user } = useAuth();
+  const { activeSpace, can } = useActiveSpace();
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const [showComposer, setShowComposer] = useState(false);
+  const [spentOn, setSpentOn] = useState(todayInput);
+  const [engagementIri, setEngagementIri] = useState("");
+  const [category, setCategory] = useState("");
+  const [description, setDescription] = useState("");
+  const [amount, setAmount] = useState("");
+  const [billable, setBillable] = useState(true);
+  const [receiptFile, setReceiptFile] = useState<File | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) {
+      router.replace(signinHrefForCurrent(router.asPath));
+    }
+  }, [authLoading, isAuthenticated, router]);
+
+  const spaceIri = activeSpace?.["@id"] ?? null;
+  const spaceId = activeSpace?.id ?? null;
+  const currentUserIri = user ? `/users/${user.id}` : null;
+
+  const expensesQuery = useQuery({
+    queryKey: ["expenses", spaceIri],
+    enabled: isAuthenticated,
+    queryFn: () =>
+      apiGetCollection<Expense>(
+        spaceIri ? `/expenses?space=${encodeURIComponent(spaceIri)}` : "/expenses",
+        { errorMessage: "Failed to load expenses." },
+      ),
+  });
+  const expenses = useMemo(() => expensesQuery.data ?? [], [expensesQuery.data]);
+  const refresh = () => queryClient.invalidateQueries({ queryKey: ["expenses"] });
+
+  const projectsQuery = useQuery({
+    queryKey: ["billing_project_options", spaceId],
+    enabled: isAuthenticated && !!spaceId,
+    queryFn: () =>
+      apiGet<{ options: EngagementOption[] }>(`/spaces/${spaceId}/engagement-options`, {
+        errorMessage: "Failed to load engagements.",
+      }).then((r) => r.options ?? []),
+  });
+  const projects = useMemo(() => projectsQuery.data ?? [], [projectsQuery.data]);
+  const noProjects = !projectsQuery.isLoading && projects.length === 0;
+  const projectName = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const p of projects) m.set(p["@id"], p.name);
+    return m;
+  }, [projects]);
+
+  useEffect(() => {
+    if (!engagementIri && projects.length > 0) setEngagementIri(projects[0]["@id"]);
+  }, [projects, engagementIri]);
+
+  const resetComposer = () => {
+    setSpentOn(todayInput());
+    setCategory("");
+    setDescription("");
+    setAmount("");
+    setBillable(true);
+    setReceiptFile(null);
+    setShowComposer(false);
+  };
+
+  const logExpense = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const amountMinor = Math.round((parseFloat(amount) || 0) * 100);
+    if (amountMinor <= 0) {
+      setActionError("Enter an amount.");
+      return;
+    }
+    setBusy(true);
+    setActionError(null);
+    try {
+      let receiptIri: string | null = null;
+      if (receiptFile) {
+        receiptIri = await uploadAttachmentFile(receiptFile);
+      }
+      await apiSend<Expense>("POST", "/expenses", {
+        errorMessage: "Failed to log the expense.",
+        body: {
+          engagement: engagementIri,
+          spentOn,
+          category: category.trim() || null,
+          description: description.trim() || null,
+          amount: amountMinor,
+          billable,
+          ...(receiptIri ? { receipt: receiptIri } : {}),
+          ...(spaceIri ? { space: spaceIri } : {}),
+        },
+      });
+      resetComposer();
+      void refresh();
+    } catch (e) {
+      setActionError(e instanceof Error ? e.message : "Failed to log the expense.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const deleteExpense = useMutation({
+    mutationFn: (iri: string) =>
+      apiSend("DELETE", iri, { errorMessage: "Failed to delete the expense." }),
+    onSuccess: () => {
+      setActionError(null);
+      void refresh();
+    },
+    onError: (e) =>
+      setActionError(e instanceof Error ? e.message : "Failed to delete the expense."),
+  });
+
+  const [editingIri, setEditingIri] = useState<string | null>(null);
+  const updateExpense = useMutation({
+    mutationFn: ({ iri, body }: { iri: string; body: Record<string, unknown> }) =>
+      apiSend<Expense>("PATCH", iri, {
+        contentType: MERGE_PATCH,
+        errorMessage: "Failed to update the expense.",
+        body,
+      }),
+    onSuccess: () => {
+      setEditingIri(null);
+      setActionError(null);
+      void refresh();
+    },
+    onError: (e) =>
+      setActionError(e instanceof Error ? e.message : "Failed to update the expense."),
+  });
+
+  const canCreate = can("time_entries", "create");
+  const isOwn = (expense: Expense) => !!currentUserIri && expense.user === currentUserIri;
+  const canModify = (expense: Expense) =>
+    !expense.billedAt && (isOwn(expense) || can("time_entries", "update"));
+  const error = actionError || (expensesQuery.isError ? "Failed to load expenses." : null);
+
+  if (authLoading || !isAuthenticated) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-muted">
+        <p className="text-muted-foreground">Loading…</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Expenses — Madori</title>
+      </Head>
+      <div className="min-h-screen bg-background px-4 py-12">
+        <div className="mx-auto max-w-5xl">
+          <PageHeader
+            title="Expenses"
+            icon={<ReceiptText className="size-6 text-amber-600 dark:text-amber-400" />}
+          />
+
+          {canCreate && noProjects && (
+            <Alert className="mb-4">
+              <AlertDescription>
+                You need an engagement to log expenses.{" "}
+                <Link href="/engagements" className="underline">
+                  Set one up
+                </Link>{" "}
+                (or ask a space admin).
+              </AlertDescription>
+            </Alert>
+          )}
+
+          {error && (
+            <Alert variant="destructive" className="mb-4">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          {expensesQuery.isLoading ? (
+            <p className="text-muted-foreground">Loading…</p>
+          ) : (
+            <Card>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+                      <th className="px-4 py-2 font-medium">Date</th>
+                      <th className="px-4 py-2 font-medium">Engagement</th>
+                      <th className="px-4 py-2 font-medium">Category</th>
+                      <th className="px-4 py-2 font-medium">Description</th>
+                      <th className="px-4 py-2 font-medium">Status</th>
+                      <th className="px-4 py-2 text-right font-medium">Amount</th>
+                      <th className="px-2 py-2" aria-label="Actions" />
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {canCreate && !noProjects &&
+                      (showComposer ? (
+                        <tr className="border-b bg-muted/10">
+                          <td colSpan={7} className="px-4 py-4">
+                            <form onSubmit={(e) => void logExpense(e)} className="space-y-4">
+                              <div className="grid gap-3 sm:grid-cols-3">
+                                <div className="space-y-1.5">
+                                  <Label htmlFor="ex-date">Date</Label>
+                                  <Input
+                                    id="ex-date"
+                                    type="date"
+                                    value={spentOn}
+                                    onChange={(e) => setSpentOn(e.target.value)}
+                                    required
+                                  />
+                                </div>
+                                <div className="space-y-1.5">
+                                  <Label htmlFor="ex-project">Engagement</Label>
+                                  <select
+                                    id="ex-project"
+                                    value={engagementIri}
+                                    onChange={(e) => setEngagementIri(e.target.value)}
+                                    className={SELECT_CLASS}
+                                  >
+                                    {projects.map((p) => (
+                                      <option key={p["@id"]} value={p["@id"]}>
+                                        {p.name}
+                                      </option>
+                                    ))}
+                                  </select>
+                                </div>
+                                <div className="space-y-1.5">
+                                  <Label htmlFor="ex-amount">Amount</Label>
+                                  <Input
+                                    id="ex-amount"
+                                    type="number"
+                                    step="0.01"
+                                    min="0"
+                                    value={amount}
+                                    onChange={(e) => setAmount(e.target.value)}
+                                    required
+                                  />
+                                </div>
+                              </div>
+                              <div className="grid gap-3 sm:grid-cols-2">
+                                <div className="space-y-1.5">
+                                  <Label htmlFor="ex-category">
+                                    Category{" "}
+                                    <span className="font-normal text-muted-foreground">
+                                      (optional)
+                                    </span>
+                                  </Label>
+                                  <Input
+                                    id="ex-category"
+                                    value={category}
+                                    onChange={(e) => setCategory(e.target.value)}
+                                    maxLength={80}
+                                    placeholder="Travel, software, materials…"
+                                  />
+                                </div>
+                                <div className="space-y-1.5">
+                                  <Label htmlFor="ex-desc">
+                                    Description{" "}
+                                    <span className="font-normal text-muted-foreground">
+                                      (optional)
+                                    </span>
+                                  </Label>
+                                  <Input
+                                    id="ex-desc"
+                                    value={description}
+                                    onChange={(e) => setDescription(e.target.value)}
+                                    maxLength={1000}
+                                  />
+                                </div>
+                              </div>
+                              <div className="flex flex-wrap items-center gap-4">
+                                <label className="flex items-center gap-2 text-sm">
+                                  <input
+                                    type="checkbox"
+                                    checked={billable}
+                                    onChange={(e) => setBillable(e.target.checked)}
+                                  />
+                                  Billable
+                                </label>
+                                <div className="flex items-center gap-2 text-sm">
+                                  <Label htmlFor="ex-receipt" className="font-normal">
+                                    Receipt
+                                  </Label>
+                                  <input
+                                    id="ex-receipt"
+                                    type="file"
+                                    accept="image/*,application/pdf"
+                                    onChange={(e) =>
+                                      setReceiptFile(e.target.files?.[0] ?? null)
+                                    }
+                                    className="text-sm"
+                                  />
+                                </div>
+                              </div>
+                              <div className="flex items-center justify-end gap-2">
+                                <Button
+                                  type="button"
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={resetComposer}
+                                >
+                                  Cancel
+                                </Button>
+                                <Button type="submit" size="sm" disabled={busy || !engagementIri}>
+                                  {busy ? "Saving…" : "Log expense"}
+                                </Button>
+                              </div>
+                            </form>
+                          </td>
+                        </tr>
+                      ) : (
+                        <tr className="border-b">
+                          <td colSpan={7} className="px-4 py-2">
+                            <button
+                              type="button"
+                              onClick={() => setShowComposer(true)}
+                              className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+                            >
+                              <Plus className="h-4 w-4" /> Add expense
+                            </button>
+                          </td>
+                        </tr>
+                      ))}
+
+                    {expenses.length === 0 ? (
+                      <tr>
+                        <td colSpan={7} className="px-4 py-10 text-center text-muted-foreground">
+                          No expenses yet. Use “Add expense” to log one.
+                        </td>
+                      </tr>
+                    ) : (
+                      expenses.map((expense) =>
+                        editingIri === expense["@id"] ? (
+                          <EditExpenseRow
+                            key={expense["@id"]}
+                            expense={expense}
+                            projects={projects}
+                            pending={updateExpense.isPending}
+                            onCancel={() => setEditingIri(null)}
+                            onSave={(body) => updateExpense.mutate({ iri: expense["@id"], body })}
+                          />
+                        ) : (
+                          <tr
+                            key={expense["@id"]}
+                            className="group border-b align-middle last:border-0"
+                          >
+                            <td className="whitespace-nowrap px-4 py-2.5 text-muted-foreground">
+                              {new Date(expense.spentOn).toLocaleDateString(undefined, {
+                                dateStyle: "medium",
+                              })}
+                            </td>
+                            <td className="px-4 py-2.5 text-muted-foreground">
+                              {expense.engagement
+                                ? projectName.get(expense.engagement) ?? "—"
+                                : "—"}
+                            </td>
+                            <td className="px-4 py-2.5">{expense.category ?? "—"}</td>
+                            <td className="px-4 py-2.5">
+                              <span className="inline-flex items-center gap-1.5">
+                                {expense.description?.trim() || (
+                                  <span className="text-muted-foreground">—</span>
+                                )}
+                                {expense.receipt && (
+                                  <button
+                                    type="button"
+                                    onClick={() =>
+                                      void openReceipt(expense.receipt ?? "", setActionError)
+                                    }
+                                    aria-label="Open receipt"
+                                    title="Open receipt"
+                                    className="text-muted-foreground hover:text-foreground"
+                                  >
+                                    <Paperclip className="h-3.5 w-3.5" />
+                                  </button>
+                                )}
+                              </span>
+                            </td>
+                            <td className="px-4 py-2.5">
+                              <div className="flex items-center gap-1.5">
+                                {!expense.billable && (
+                                  <Badge variant="secondary">Non-billable</Badge>
+                                )}
+                                {expense.billedAt && <Badge variant="secondary">Invoiced</Badge>}
+                              </div>
+                            </td>
+                            <td className="whitespace-nowrap px-4 py-2.5 text-right font-medium tabular-nums">
+                              {formatMoney(expense.amount, expense.currency ?? "USD")}
+                            </td>
+                            <td className="whitespace-nowrap px-2 py-2.5 text-right">
+                              {canModify(expense) && (
+                                <span className="inline-flex items-center gap-0.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
+                                  <button
+                                    type="button"
+                                    onClick={() => setEditingIri(expense["@id"])}
+                                    aria-label="Edit expense"
+                                    className="rounded p-1 text-muted-foreground hover:text-foreground"
+                                  >
+                                    <Pencil className="h-3.5 w-3.5" />
+                                  </button>
+                                  <button
+                                    type="button"
+                                    onClick={() => {
+                                      if (window.confirm("Delete this expense?")) {
+                                        deleteExpense.mutate(expense["@id"]);
+                                      }
+                                    }}
+                                    aria-label="Delete expense"
+                                    className="rounded p-1 text-muted-foreground hover:text-destructive"
+                                  >
+                                    <Trash2 className="h-3.5 w-3.5" />
+                                  </button>
+                                </span>
+                              )}
+                            </td>
+                          </tr>
+                        ),
+                      )
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </Card>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+/** Inline editor for one expense — local state keyed per row. */
+const EditExpenseRow = ({
+  expense,
+  projects,
+  pending,
+  onSave,
+  onCancel,
+}: {
+  expense: Expense;
+  projects: EngagementOption[];
+  pending: boolean;
+  onSave: (body: Record<string, unknown>) => void;
+  onCancel: () => void;
+}) => {
+  const [eDate, setEDate] = useState(expense.spentOn.slice(0, 10));
+  const [eEngagement, setEEngagement] = useState(expense.engagement ?? "");
+  const [eCategory, setECategory] = useState(expense.category ?? "");
+  const [eDescription, setEDescription] = useState(expense.description ?? "");
+  const [eAmount, setEAmount] = useState((expense.amount / 100).toFixed(2));
+  const [eBillable, setEBillable] = useState(expense.billable);
+
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    onSave({
+      spentOn: eDate,
+      engagement: eEngagement,
+      category: eCategory.trim() || null,
+      description: eDescription.trim() || null,
+      amount: Math.round((parseFloat(eAmount) || 0) * 100),
+      billable: eBillable,
+    });
+  };
+
+  return (
+    <tr className="border-b bg-muted/10">
+      <td colSpan={7} className="px-4 py-4">
+        <form onSubmit={submit} className="space-y-4">
+          <div className="grid gap-3 sm:grid-cols-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="exe-date">Date</Label>
+              <Input
+                id="exe-date"
+                type="date"
+                value={eDate}
+                onChange={(e) => setEDate(e.target.value)}
+                required
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="exe-project">Engagement</Label>
+              <select
+                id="exe-project"
+                value={eEngagement}
+                onChange={(e) => setEEngagement(e.target.value)}
+                className={SELECT_CLASS}
+              >
+                {projects.map((p) => (
+                  <option key={p["@id"]} value={p["@id"]}>
+                    {p.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="exe-category">Category</Label>
+              <Input
+                id="exe-category"
+                value={eCategory}
+                onChange={(e) => setECategory(e.target.value)}
+                maxLength={80}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="exe-amount">Amount</Label>
+              <Input
+                id="exe-amount"
+                type="number"
+                step="0.01"
+                min="0"
+                value={eAmount}
+                onChange={(e) => setEAmount(e.target.value)}
+                required
+              />
+            </div>
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="exe-desc">Description</Label>
+            <Input
+              id="exe-desc"
+              value={eDescription}
+              onChange={(e) => setEDescription(e.target.value)}
+              maxLength={1000}
+            />
+          </div>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={eBillable}
+              onChange={(e) => setEBillable(e.target.checked)}
+            />
+            Billable
+          </label>
+          <div className="flex items-center justify-end gap-2">
+            <Button type="button" variant="ghost" size="sm" onClick={onCancel}>
+              Cancel
+            </Button>
+            <Button type="submit" size="sm" disabled={pending || !eEngagement}>
+              {pending ? "Saving…" : "Save changes"}
+            </Button>
+          </div>
+        </form>
+      </td>
+    </tr>
+  );
+};
+
+export default ExpensesPage;

--- a/pwa/pages/invoices/index.tsx
+++ b/pwa/pages/invoices/index.tsx
@@ -43,8 +43,19 @@ interface PreviewEntry {
   amount: number;
 }
 
+/** One candidate expense from the from-time preview endpoint (#650). */
+interface PreviewExpense {
+  "@id": string;
+  id: string;
+  description: string | null;
+  category: string | null;
+  spentOn: string | null;
+  amount: number;
+}
+
 interface GenPreview {
   entries: PreviewEntry[];
+  expenses: PreviewExpense[];
   count: number;
   subtotal: number;
   currency: string;
@@ -62,6 +73,7 @@ const InvoicesPage = () => {
   const [genTo, setGenTo] = useState("");
   const [preview, setPreview] = useState<GenPreview | null>(null);
   const [checked, setChecked] = useState<Set<string>>(new Set());
+  const [checkedExpenses, setCheckedExpenses] = useState<Set<string>>(new Set());
   const [notice, setNotice] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -110,6 +122,7 @@ const InvoicesPage = () => {
     setGenTo("");
     setPreview(null);
     setChecked(new Set());
+    setCheckedExpenses(new Set());
     setShowComposer(false);
   };
 
@@ -117,6 +130,7 @@ const InvoicesPage = () => {
   const clearPreview = () => {
     setPreview(null);
     setChecked(new Set());
+    setCheckedExpenses(new Set());
   };
 
   const loadPreview = useMutation({
@@ -131,6 +145,7 @@ const InvoicesPage = () => {
       setPreview(res);
       // Everything ticked by default — the list is for *un*ticking.
       setChecked(new Set((res?.entries ?? []).map((e) => e["@id"])));
+      setCheckedExpenses(new Set((res?.expenses ?? []).map((x) => x["@id"])));
     },
     onError: (e) => setError(e instanceof Error ? e.message : "Failed to load unbilled time."),
   });
@@ -140,7 +155,11 @@ const InvoicesPage = () => {
       apiSend<{ id: string; lineItemCount: number }>("POST", "/invoices/from-time-entries", {
         contentType: "application/json",
         errorMessage: "Failed to generate an invoice.",
-        body: { ...rangeBody(), entries: Array.from(checked) },
+        body: {
+          ...rangeBody(),
+          entries: Array.from(checked),
+          expenses: Array.from(checkedExpenses),
+        },
       }),
     onSuccess: (res) => {
       setError(null);
@@ -154,6 +173,18 @@ const InvoicesPage = () => {
 
   const toggleChecked = (iri: string) => {
     setChecked((prev) => {
+      const next = new Set(prev);
+      if (next.has(iri)) {
+        next.delete(iri);
+      } else {
+        next.add(iri);
+      }
+      return next;
+    });
+  };
+
+  const toggleCheckedExpense = (iri: string) => {
+    setCheckedExpenses((prev) => {
       const next = new Set(prev);
       if (next.has(iri)) {
         next.delete(iri);
@@ -336,14 +367,17 @@ const InvoicesPage = () => {
                               )}
                             </div>
 
-                            {preview && preview.entries.length === 0 && (
+                            {preview &&
+                              preview.entries.length === 0 &&
+                              preview.expenses.length === 0 && (
                               <p className="mt-3 text-sm text-muted-foreground">
-                                No unbilled billable time
+                                No unbilled billable time or expenses
                                 {genFrom || genTo ? " in this range" : ""} for this engagement.
                               </p>
                             )}
 
-                            {preview && preview.entries.length > 0 && (
+                            {preview &&
+                              (preview.entries.length > 0 || preview.expenses.length > 0) && (
                               <div className="mt-3 space-y-2">
                                 <div className="max-h-64 overflow-y-auto rounded-md border">
                                   <table className="w-full text-sm">
@@ -394,24 +428,82 @@ const InvoicesPage = () => {
                                           </td>
                                         </tr>
                                       ))}
+                                      {/* Unbilled billable expenses ride along (#650). */}
+                                      {preview.expenses.length > 0 && (
+                                        <tr className="border-b bg-muted/40">
+                                          <td
+                                            colSpan={5}
+                                            className="px-3 py-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+                                          >
+                                            Expenses
+                                          </td>
+                                        </tr>
+                                      )}
+                                      {preview.expenses.map((expense) => (
+                                        <tr
+                                          key={expense["@id"]}
+                                          className={cn(
+                                            "border-b last:border-b-0",
+                                            !checkedExpenses.has(expense["@id"]) && "opacity-50",
+                                          )}
+                                        >
+                                          <td className="px-3 py-1.5">
+                                            <input
+                                              type="checkbox"
+                                              checked={checkedExpenses.has(expense["@id"])}
+                                              onChange={() =>
+                                                toggleCheckedExpense(expense["@id"])
+                                              }
+                                              aria-label="Include this expense"
+                                            />
+                                          </td>
+                                          <td className="whitespace-nowrap px-3 py-1.5">
+                                            {expense.spentOn
+                                              ? new Date(expense.spentOn).toLocaleDateString()
+                                              : "—"}
+                                          </td>
+                                          <td className="px-3 py-1.5">
+                                            {expense.description || "Expense"}
+                                            {expense.category && (
+                                              <span className="ml-1.5 text-xs text-muted-foreground">
+                                                {expense.category}
+                                              </span>
+                                            )}
+                                          </td>
+                                          <td className="px-3 py-1.5" />
+                                          <td className="px-3 py-1.5 text-right tabular-nums">
+                                            {formatMoney(expense.amount, preview.currency)}
+                                          </td>
+                                        </tr>
+                                      ))}
                                     </tbody>
                                   </table>
                                 </div>
                                 <div className="flex flex-wrap items-center justify-between gap-3">
                                   <p className="text-sm text-muted-foreground">
-                                    {checked.size} of {preview.entries.length} entr
-                                    {preview.entries.length === 1 ? "y" : "ies"} selected ·{" "}
+                                    {checked.size + checkedExpenses.size} of{" "}
+                                    {preview.entries.length + preview.expenses.length} item
+                                    {preview.entries.length + preview.expenses.length === 1
+                                      ? ""
+                                      : "s"}{" "}
+                                    selected ·{" "}
                                     {formatMoney(
                                       preview.entries
                                         .filter((e) => checked.has(e["@id"]))
-                                        .reduce((sum, e) => sum + e.amount, 0),
+                                        .reduce((sum, e) => sum + e.amount, 0) +
+                                        preview.expenses
+                                          .filter((x) => checkedExpenses.has(x["@id"]))
+                                          .reduce((sum, x) => sum + x.amount, 0),
                                       preview.currency,
                                     )}
                                   </p>
                                   <Button
                                     size="sm"
                                     onClick={() => generate.mutate()}
-                                    disabled={checked.size === 0 || generate.isPending}
+                                    disabled={
+                                      (checked.size === 0 && checkedExpenses.size === 0) ||
+                                      generate.isPending
+                                    }
                                   >
                                     {generate.isPending ? "Generating…" : "Generate draft"}
                                   </Button>


### PR DESCRIPTION
Closes #650

## What
Harvest-parity expense tracking, wired into the existing invoice pipeline.

**`Expense` entity** (`/expenses`): space (denormalised from the engagement), **engagement (required)**, server-stamped spender, `spentOn`, free-text category, amount + currency (defaults engagement → client → USD), description, `billable` flag, optional **receipt** MediaObject, and a **`billedAt` lock** — a billed expense can't be edited or deleted (422), same freeze as time entries. Access mirrors time entries: any member logs their own; author / space admin / `time_entries.*` grantees modify; collection scoped by `ExpenseAccessExtension`.

**Invoice flow (#644 integration)**: `POST /invoices/from-time-entries` now also pulls the engagement's unbilled billable expenses —
- same `from`/`to` window (on `spentOn`), **same-currency only** (an invoice pins one currency; foreign-currency expenses stay in the pool)
- `preview: true` returns them in their own `expenses` section; `expenses: []` selection works like the `entries` selection (subset-or-422); `includeExpenses: false` opts out
- billed as `Expense — Category: description` lines (qty 1) with a `sourceExpense` back-link; **void releases expenses** exactly like time entries
- an expense-only invoice (no tracked time) is valid

**Receipts**: uploaded via the existing `POST /media-objects` flow; bytes stream through the gated `/media-objects/{id}/download`, readable by the spender, a space admin, or a `time_entries.read` grantee.

**PWA**: `/expenses` under the Billing sidebar group — inline add row (date / engagement / amount / category / description / billable / receipt file), hover edit/delete with the billed lock, Non-billable + Invoiced badges, receipt paperclip opens the gated download. The invoice generate preview shows the Expenses section with per-row unticks and a combined selected subtotal.

## Migration
`Version20260716150000`: `expense` table + `invoice_line_item.source_expense_id`.

## Tests
`ExpenseTest`:
- member logs their own expense (spender stamped, currency defaulted), edits it while unbilled, then billed → PATCH + DELETE 422
- billable expense previews + generates onto an expense-only invoice (non-billable excluded), `billedAt` stamped, second generation 422s (pool drained), **void releases** it