### PR TITLE
feat(billing): engagement budgets + threshold alerts

### DIFF
--- a/api/migrations/Version20260716160000.php
+++ b/api/migrations/Version20260716160000.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Engagement budgets + threshold alerts (#651): budget_type (hours|fees),
+ * budget_amount (minutes / minor units), and the budget_alerts_sent ledger
+ * the nightly sweep checks before emailing space admins.
+ */
+final class Version20260716160000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Engagement budgets: budget_type/budget_amount + budget_alerts_sent ledger.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE engagement ADD budget_type VARCHAR(10) DEFAULT NULL');
+        $this->addSql('ALTER TABLE engagement ADD budget_amount INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE engagement ADD budget_alerts_sent JSON DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE engagement DROP budget_type');
+        $this->addSql('ALTER TABLE engagement DROP budget_amount');
+        $this->addSql('ALTER TABLE engagement DROP budget_alerts_sent');
+    }
+}

--- a/api/src/Entity/Engagement.php
+++ b/api/src/Entity/Engagement.php
@@ -14,6 +14,7 @@ use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
 use App\Repository\EngagementRepository;
+use App\State\EngagementBudgetProvider;
 use App\State\EngagementCreatorProcessor;
 use App\Validator\ValidEngagementAttachments;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -41,6 +42,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
     operations: [
         new GetCollection(
             security: "is_granted('ROLE_USER')",
+            provider: EngagementBudgetProvider::class,
         ),
         new Post(
             security: "is_granted('ROLE_USER')",
@@ -49,6 +51,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
         ),
         new Get(
             security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or (object.getSpace().hasMember(user) and is_granted('space.invoices.read', object)))",
+            provider: EngagementBudgetProvider::class,
         ),
         new Patch(
             security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getSpace().isAdmin(user) or (object.getSpace().hasMember(user) and is_granted('space.invoices.update', object)))",
@@ -74,6 +77,15 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 class Engagement
 {
     public const MAX_NAME_LENGTH = 200;
+
+    public const BUDGET_HOURS = 'hours';
+    public const BUDGET_FEES = 'fees';
+
+    /** @var list<string> */
+    public const BUDGET_TYPES = [self::BUDGET_HOURS, self::BUDGET_FEES];
+
+    /** Percent thresholds the nightly sweep alerts on, in firing order. */
+    public const BUDGET_ALERT_THRESHOLDS = [80, 100];
 
     #[ORM\Id]
     #[ORM\Column(type: 'uuid', unique: true)]
@@ -115,6 +127,42 @@ class Engagement
     #[ORM\Column(type: 'boolean')]
     #[Groups(['engagement:read', 'engagement:write'])]
     private bool $archived = false;
+
+    /**
+     * Budget (#651): `hours` tracks total tracked time against
+     * {@see $budgetAmount} in minutes; `fees` tracks the billable amount
+     * against it in minor units of {@see $currency}. Null = no budget.
+     */
+    #[ORM\Column(length: 10, nullable: true)]
+    #[Assert\Choice(choices: self::BUDGET_TYPES, message: 'Invalid budget type.')]
+    #[Groups(['engagement:read', 'engagement:write'])]
+    private ?string $budgetType = null;
+
+    /** Minutes for an hours budget, minor units for a fees budget. */
+    #[ORM\Column(type: 'integer', nullable: true)]
+    #[Assert\Positive(message: 'The budget must be positive.')]
+    #[Groups(['engagement:read', 'engagement:write'])]
+    private ?int $budgetAmount = null;
+
+    /**
+     * Thresholds (percent) already alerted — the idempotency ledger the
+     * nightly sweep checks. Cleared whenever the budget itself changes so a
+     * raised budget re-alerts when re-crossed.
+     *
+     * @var list<int>|null
+     */
+    #[ORM\Column(type: 'json', nullable: true)]
+    #[Groups(['engagement:read'])]
+    private ?array $budgetAlertsSent = null;
+
+    /**
+     * Transient (#651): consumption against the budget, set per-read by
+     * {@see EngagementBudgetProvider} — minutes for hours budgets, minor
+     * units for fees. Null when no budget is set.
+     */
+    #[ApiProperty(writable: false)]
+    #[Groups(['engagement:read'])]
+    private ?int $budgetSpent = null;
 
     /**
      * @var Collection<int, EngagementCategory>
@@ -205,6 +253,18 @@ class Engagement
             }
             $seen[$key] = true;
         }
+
+        // Budget type and amount come as a pair (#651).
+        if (null !== $this->budgetType && null === $this->budgetAmount) {
+            $context->buildViolation('A budget needs an amount.')
+                ->atPath('budgetAmount')
+                ->addViolation();
+        }
+        if (null !== $this->budgetAmount && null === $this->budgetType) {
+            $context->buildViolation('A budget amount needs a type (hours or fees).')
+                ->atPath('budgetType')
+                ->addViolation();
+        }
     }
 
     public function getId(): ?Uuid
@@ -292,6 +352,65 @@ class Engagement
     public function removeAttachment(MediaObject $media): self
     {
         $this->attachments->removeElement($media);
+
+        return $this;
+    }
+
+    public function getBudgetType(): ?string
+    {
+        return $this->budgetType;
+    }
+
+    public function setBudgetType(?string $budgetType): self
+    {
+        if ($budgetType !== $this->budgetType) {
+            $this->budgetAlertsSent = null;
+        }
+        $this->budgetType = $budgetType;
+
+        return $this;
+    }
+
+    public function getBudgetAmount(): ?int
+    {
+        return $this->budgetAmount;
+    }
+
+    public function setBudgetAmount(?int $budgetAmount): self
+    {
+        if ($budgetAmount !== $this->budgetAmount) {
+            $this->budgetAlertsSent = null;
+        }
+        $this->budgetAmount = $budgetAmount;
+
+        return $this;
+    }
+
+    /** @return list<int> */
+    public function getBudgetAlertsSent(): array
+    {
+        return $this->budgetAlertsSent ?? [];
+    }
+
+    public function addBudgetAlertSent(int $threshold): self
+    {
+        $log = $this->getBudgetAlertsSent();
+        if (!in_array($threshold, $log, true)) {
+            $log[] = $threshold;
+            $this->budgetAlertsSent = $log;
+        }
+
+        return $this;
+    }
+
+    public function getBudgetSpent(): ?int
+    {
+        return $this->budgetSpent;
+    }
+
+    public function setBudgetSpent(?int $budgetSpent): self
+    {
+        $this->budgetSpent = $budgetSpent;
 
         return $this;
     }

--- a/api/src/Message/CheckEngagementBudgets.php
+++ b/api/src/Message/CheckEngagementBudgets.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Message;
+
+/**
+ * Nightly trigger for the engagement budget alert sweep (#651) — handled by
+ * {@see \App\MessageHandler\CheckEngagementBudgetsHandler}.
+ */
+final class CheckEngagementBudgets
+{
+}

--- a/api/src/MessageHandler/CheckEngagementBudgetsHandler.php
+++ b/api/src/MessageHandler/CheckEngagementBudgetsHandler.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\MessageHandler;
+
+use App\Message\CheckEngagementBudgets;
+use App\Service\EngagementBudgetAlerter;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * Runs the engagement budget alert sweep (#651) when the scheduler fires
+ * App\Message\CheckEngagementBudgets (nightly). Idempotent — each
+ * engagement's budgetAlertsSent ledger stops duplicate emails.
+ */
+#[AsMessageHandler]
+final class CheckEngagementBudgetsHandler
+{
+    public function __construct(private EngagementBudgetAlerter $alerter)
+    {
+    }
+
+    public function __invoke(CheckEngagementBudgets $message): void
+    {
+        $this->alerter->dispatchDue();
+    }
+}

--- a/api/src/Repository/EngagementRepository.php
+++ b/api/src/Repository/EngagementRepository.php
@@ -15,4 +15,20 @@ class EngagementRepository extends ServiceEntityRepository
     {
         parent::__construct($registry, Engagement::class);
     }
+
+    /**
+     * Budgeted, non-archived engagements — the nightly alert sweep's pool (#651).
+     *
+     * @return list<Engagement>
+     */
+    public function findBudgeted(): array
+    {
+        /** @var list<Engagement> */
+        return $this->createQueryBuilder('e')
+            ->andWhere('e.budgetType IS NOT NULL')
+            ->andWhere('e.budgetAmount IS NOT NULL')
+            ->andWhere('e.archived = false')
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/api/src/Scheduler/MainScheduleProvider.php
+++ b/api/src/Scheduler/MainScheduleProvider.php
@@ -3,6 +3,7 @@
 namespace App\Scheduler;
 
 use App\Message\CaptureUsageSnapshot;
+use App\Message\CheckEngagementBudgets;
 use App\Message\DispatchNotificationDigest;
 use App\Message\DispatchTaskReminders;
 use App\Message\MarkOverdueInvoices;
@@ -97,6 +98,9 @@ final class MainScheduleProvider implements ScheduleProviderInterface
                 RecurringMessage::cron('*/15 * * * *', new PullCalendarChanges(), $utc),
                 // Overdue invoices: flip sent invoices past their due date to
                 // overdue, daily at 03:50 UTC (InvoiceRepository::markOverdue).
+                // Engagement budget alerts (#651) — daily at 03:40 UTC
+                // (App\Service\EngagementBudgetAlerter).
+                RecurringMessage::cron('40 3 * * *', new CheckEngagementBudgets(), $utc),
                 RecurringMessage::cron('50 3 * * *', new MarkOverdueInvoices(), $utc),
                 // Recurring invoices: clone due templates into fresh drafts,
                 // daily at 03:55 UTC (App\Service\RecurringInvoiceSpawner).

--- a/api/src/Service/EngagementBudgetAlerter.php
+++ b/api/src/Service/EngagementBudgetAlerter.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Engagement;
+use App\Entity\Space;
+use App\Repository\EngagementRepository;
+use App\Service\Mail\MailDispatcher;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+
+/**
+ * The nightly budget alert sweep (#651): for every budgeted, non-archived
+ * engagement, computes consumption and emails the space's admins when a
+ * threshold (80% / 100%) is crossed — once per threshold, stamped in the
+ * engagement's budgetAlertsSent ledger so re-runs are idempotent. Editing the
+ * budget clears the ledger, so a raised budget re-alerts when re-crossed.
+ */
+final class EngagementBudgetAlerter
+{
+    public function __construct(
+        private readonly EngagementRepository $engagements,
+        private readonly EngagementBudgetCalculator $calculator,
+        private readonly MailDispatcher $mail,
+        private readonly EntityManagerInterface $em,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    /** Returns how many alert emails were sent (one per admin per threshold). */
+    public function dispatchDue(): int
+    {
+        $budgeted = $this->engagements->findBudgeted();
+        if ([] === $budgeted) {
+            return 0;
+        }
+
+        $spentMap = $this->calculator->spentByEngagement($budgeted);
+        $sent = 0;
+        $stamped = false;
+        foreach ($budgeted as $engagement) {
+            $budget = $engagement->getBudgetAmount();
+            if (null === $budget || $budget <= 0) {
+                continue;
+            }
+            $row = $spentMap[(string) $engagement->getId()] ?? ['seconds' => 0, 'fees' => 0];
+            $spent = Engagement::BUDGET_HOURS === $engagement->getBudgetType()
+                ? intdiv($row['seconds'], 60)
+                : $row['fees'];
+            $percent = (int) floor($spent / $budget * 100);
+
+            foreach (Engagement::BUDGET_ALERT_THRESHOLDS as $threshold) {
+                if ($percent < $threshold) {
+                    continue;
+                }
+                if (in_array($threshold, $engagement->getBudgetAlertsSent(), true)) {
+                    continue;
+                }
+                $sent += $this->alertAdmins($engagement, $threshold, $spent, $budget, $percent);
+                $engagement->addBudgetAlertSent($threshold);
+                $stamped = true;
+            }
+        }
+
+        if ($stamped) {
+            $this->em->flush();
+        }
+        if ($sent > 0) {
+            $this->logger->info(sprintf('Sent %d engagement budget alert(s).', $sent));
+        }
+
+        return $sent;
+    }
+
+    private function alertAdmins(Engagement $engagement, int $threshold, int $spent, int $budget, int $percent): int
+    {
+        $space = $engagement->getSpace();
+        if (null === $space) {
+            return 0;
+        }
+
+        $sent = 0;
+        foreach ($space->getUserMemberships() as $membership) {
+            if (Space::ROLE_ADMIN !== $membership->getRole()) {
+                continue;
+            }
+            $admin = $membership->getUser();
+            $to = $admin?->getEmail();
+            if (null === $to || '' === trim($to)) {
+                continue;
+            }
+
+            $email = (new TemplatedEmail())
+                ->to($to)
+                ->subject(sprintf(
+                    '%s has used %d%% of its budget',
+                    $engagement->getName(),
+                    $percent,
+                ))
+                ->htmlTemplate('emails/budget_alert.html.twig')
+                ->textTemplate('emails/budget_alert.txt.twig')
+                ->context([
+                    'engagement' => $engagement,
+                    'threshold' => $threshold,
+                    'percent' => $percent,
+                    'spent' => $spent,
+                    'budget' => $budget,
+                    'engagementsUrl' => $this->mail->frontendLink('/engagements'),
+                ]);
+            $this->mail->send($email);
+            ++$sent;
+        }
+
+        return $sent;
+    }
+}

--- a/api/src/Service/EngagementBudgetCalculator.php
+++ b/api/src/Service/EngagementBudgetCalculator.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Engagement;
+use App\Entity\TimeEntry;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Computes budget consumption for engagements (#651) in one grouped query —
+ * shared by the read-side provider (progress bars) and the nightly alert
+ * sweep so the two can never disagree.
+ *
+ * An `hours` budget counts every completed entry's duration (minutes); a
+ * `fees` budget counts the billable amount (Σ seconds × snapshotted rate /
+ * 3600, minor units) — a cheap SQL approximation of the invoice math, close
+ * enough for progress + alerts.
+ */
+final class EngagementBudgetCalculator
+{
+    public function __construct(private readonly EntityManagerInterface $em)
+    {
+    }
+
+    /**
+     * Spent-per-engagement for the given rows, keyed by engagement id:
+     * `['seconds' => total tracked, 'fees' => billable minor units]`.
+     *
+     * @param list<Engagement> $engagements
+     *
+     * @return array<string, array{seconds: int, fees: int}>
+     */
+    public function spentByEngagement(array $engagements): array
+    {
+        if ([] === $engagements) {
+            return [];
+        }
+
+        /** @var list<array{eid: string|null, totalSec: string|int|null, feeSec: string|int|null}> $rows */
+        $rows = $this->em->createQuery(
+            'SELECT IDENTITY(t.engagement) AS eid,
+                    COALESCE(SUM(t.durationSeconds), 0) AS totalSec,
+                    COALESCE(SUM(CASE WHEN t.billable = true THEN t.durationSeconds * COALESCE(t.rateAmount, 0) ELSE 0 END), 0) AS feeSec
+             FROM ' . TimeEntry::class . ' t
+             WHERE t.engagement IN (:engagements) AND t.endedAt IS NOT NULL
+             GROUP BY t.engagement',
+        )->setParameter('engagements', $engagements)->getResult();
+
+        $map = [];
+        foreach ($rows as $row) {
+            if (null === $row['eid']) {
+                continue;
+            }
+            $map[$row['eid']] = [
+                'seconds' => (int) $row['totalSec'],
+                'fees' => (int) round(((int) $row['feeSec']) / 3600),
+            ];
+        }
+
+        return $map;
+    }
+
+    /**
+     * Spent against THIS engagement's budget, in the budget's own unit
+     * (minutes for hours, minor units for fees). Null when it has no budget.
+     */
+    public function spentFor(Engagement $engagement): ?int
+    {
+        if (null === $engagement->getBudgetType()) {
+            return null;
+        }
+        $id = (string) $engagement->getId();
+        $spent = $this->spentByEngagement([$engagement])[$id] ?? ['seconds' => 0, 'fees' => 0];
+
+        return Engagement::BUDGET_HOURS === $engagement->getBudgetType()
+            ? intdiv($spent['seconds'], 60)
+            : $spent['fees'];
+    }
+}

--- a/api/src/State/EngagementBudgetProvider.php
+++ b/api/src/State/EngagementBudgetProvider.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\State;
+
+use ApiPlatform\Metadata\CollectionOperationInterface;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\Entity\Engagement;
+use App\Service\EngagementBudgetCalculator;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Enriches engagement reads with budget consumption (#651) — the transient
+ * `budgetSpent` field the PWA's progress bars render — in one grouped query
+ * per page, mirroring {@see DiscussionAggregateProvider}. Delegates to the
+ * stock Doctrine providers so access scoping / pagination / 404s behave
+ * exactly as before.
+ *
+ * @implements ProviderInterface<Engagement>
+ */
+final class EngagementBudgetProvider implements ProviderInterface
+{
+    /**
+     * @param ProviderInterface<Engagement> $collectionProvider
+     * @param ProviderInterface<Engagement> $itemProvider
+     */
+    public function __construct(
+        #[Autowire(service: 'api_platform.doctrine.orm.state.collection_provider')]
+        private ProviderInterface $collectionProvider,
+        #[Autowire(service: 'api_platform.doctrine.orm.state.item_provider')]
+        private ProviderInterface $itemProvider,
+        private EngagementBudgetCalculator $calculator,
+    ) {
+    }
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
+    {
+        if ($operation instanceof CollectionOperationInterface) {
+            $data = $this->collectionProvider->provide($operation, $uriVariables, $context);
+            if (is_iterable($data)) {
+                $engagements = [];
+                foreach ($data as $engagement) {
+                    $engagements[] = $engagement;
+                }
+                $this->enrich($engagements);
+            }
+
+            return $data;
+        }
+
+        $item = $this->itemProvider->provide($operation, $uriVariables, $context);
+        if ($item instanceof Engagement) {
+            $this->enrich([$item]);
+        }
+
+        return $item;
+    }
+
+    /**
+     * @param list<Engagement> $engagements
+     */
+    private function enrich(array $engagements): void
+    {
+        $budgeted = array_values(array_filter(
+            $engagements,
+            static fn (Engagement $e): bool => null !== $e->getBudgetType(),
+        ));
+        if ([] === $budgeted) {
+            return;
+        }
+
+        $spent = $this->calculator->spentByEngagement($budgeted);
+        foreach ($budgeted as $engagement) {
+            $row = $spent[(string) $engagement->getId()] ?? ['seconds' => 0, 'fees' => 0];
+            $engagement->setBudgetSpent(
+                Engagement::BUDGET_HOURS === $engagement->getBudgetType()
+                    ? intdiv($row['seconds'], 60)
+                    : $row['fees'],
+            );
+        }
+    }
+}

--- a/api/templates/emails/budget_alert.html.twig
+++ b/api/templates/emails/budget_alert.html.twig
@@ -1,0 +1,25 @@
+{# @var engagement \App\Entity\Engagement #}
+{# @var threshold int 80 or 100 #}
+<p>Hi,</p>
+
+<p>
+    <strong>{{ engagement.name }}</strong>
+    {% if engagement.client %}({{ engagement.client.name }}){% endif %}
+    has used <strong>{{ percent }}%</strong> of its
+    {% if engagement.budgetType == 'hours' %}
+        {{ (budget / 60)|number_format(1) }}-hour budget
+        ({{ (spent / 60)|number_format(1) }} hours tracked).
+    {% else %}
+        {{ (budget / 100)|number_format(2) }} {{ engagement.currency ?? '' }} fees budget
+        ({{ (spent / 100)|number_format(2) }} {{ engagement.currency ?? '' }} billable so far).
+    {% endif %}
+</p>
+
+<p>
+    <a href="{{ engagementsUrl }}">Review the engagement</a>
+</p>
+
+<p style="color: #9ca3af; font-size: 12px;">
+    You're receiving this because you're an admin of the engagement's space.
+    {% if threshold >= 100 %}This engagement is now over budget.{% endif %}
+</p>

--- a/api/templates/emails/budget_alert.txt.twig
+++ b/api/templates/emails/budget_alert.txt.twig
@@ -1,0 +1,8 @@
+{# @var engagement \App\Entity\Engagement #}
+Hi,
+
+{{ engagement.name }}{% if engagement.client %} ({{ engagement.client.name }}){% endif %} has used {{ percent }}% of its {% if engagement.budgetType == 'hours' %}{{ (budget / 60)|number_format(1) }}-hour budget ({{ (spent / 60)|number_format(1) }} hours tracked).{% else %}{{ (budget / 100)|number_format(2) }} {{ engagement.currency ?? '' }} fees budget ({{ (spent / 100)|number_format(2) }} {{ engagement.currency ?? '' }} billable so far).{% endif %}
+
+Review the engagement: {{ engagementsUrl }}
+
+You're receiving this because you're an admin of the engagement's space.{% if threshold >= 100 %} This engagement is now over budget.{% endif %}

--- a/api/tests/Api/EngagementBudgetTest.php
+++ b/api/tests/Api/EngagementBudgetTest.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\Engagement;
+use App\Entity\Space;
+use App\Entity\SpaceMembership;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Engagement budgets + threshold alerts (#651): hours/fees budgets, the
+ * transient budgetSpent read-side, and the nightly 80%/100% alert sweep with
+ * its per-threshold idempotency ledger.
+ */
+class EngagementBudgetTest extends ApiTestCase
+{
+    use SpaceMembershipFixture;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = static::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\TimeEntry')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\EngagementCategory')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Engagement')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Client')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\SpaceMembership')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Space')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testBudgetProgressAndThresholdAlerts(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $space = $this->createSharedSpace($admin);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $clientIri = $clientRow['@id'];
+        $this->assertIsString($clientIri);
+
+        // A budget type without an amount is rejected.
+        $client->request('POST', '/engagements', [
+            'json' => [
+                'space' => $spaceIri,
+                'client' => $clientIri,
+                'name' => 'No amount',
+                'currency' => 'USD',
+                'budgetType' => 'hours',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+
+        // A 2-hour budget (120 minutes) with one billable category.
+        $engagement = $client->request('POST', '/engagements', [
+            'json' => [
+                'space' => $spaceIri,
+                'client' => $clientIri,
+                'name' => 'Budgeted work',
+                'currency' => 'USD',
+                'budgetType' => 'hours',
+                'budgetAmount' => 120,
+                'categories' => [['name' => 'Dev', 'rateAmount' => 6000, 'position' => 0]],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $engagementIri = $engagement['@id'];
+        $this->assertIsString($engagementIri);
+        $categories = $engagement['categories'] ?? null;
+        $this->assertIsArray($categories);
+        $first = $categories[0];
+        $this->assertIsArray($first);
+        $categoryIri = $first['@id'];
+        $this->assertIsString($categoryIri);
+
+        $track = function (string $startedAt, string $endedAt) use ($client, $spaceIri, $engagementIri, $categoryIri): void {
+            $client->request('POST', '/time_entries', [
+                'json' => [
+                    'space' => $spaceIri,
+                    'engagement' => $engagementIri,
+                    'category' => $categoryIri,
+                    'startedAt' => $startedAt,
+                    'endedAt' => $endedAt,
+                ],
+                'headers' => ['Content-Type' => 'application/ld+json'],
+            ]);
+            $this->assertResponseStatusCodeSame(201);
+        };
+
+        // 1h tracked = 50% — progress surfaces, no alert threshold crossed.
+        $track('2026-07-10T09:00:00+00:00', '2026-07-10T10:00:00+00:00');
+        $list = $client->request('GET', '/engagements?space=' . $spaceIri)->toArray();
+        $members = $list['member'] ?? $list['hydra:member'] ?? null;
+        $this->assertIsArray($members);
+        $this->assertCount(1, $members);
+        $row = $members[0];
+        $this->assertIsArray($row);
+        $this->assertSame('hours', $row['budgetType'] ?? null);
+        $this->assertSame(120, $row['budgetAmount'] ?? null);
+        $this->assertSame(60, $row['budgetSpent'] ?? null);
+
+        // Another 1h = 100%: the sweep crosses 80 AND 100 in one run — one
+        // email per threshold to the space admin. No HTTP requests after this
+        // point: each client request reboots the kernel and resets the mailer
+        // logger, so the counts below see only the in-process sweep sends.
+        $track('2026-07-11T09:00:00+00:00', '2026-07-11T10:00:00+00:00');
+
+        $alerter = static::getContainer()->get(\App\Service\EngagementBudgetAlerter::class);
+        $sent = $alerter->dispatchDue();
+        $this->assertSame(2, $sent);
+        $this->assertEmailCount(2);
+        $message = $this->getMailerMessage();
+        $this->assertNotNull($message);
+        $this->assertEmailAddressContains($message, 'To', 'admin@example.com');
+
+        // Idempotent: a re-run finds both thresholds already stamped.
+        $this->assertSame(0, $alerter->dispatchDue());
+        $this->assertEmailCount(2);
+
+        // Raising the budget clears the ledger; at 20% nothing re-fires yet.
+        $em = static::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $engagementId = $engagement['id'];
+        $this->assertIsString($engagementId);
+        $entity = $em->getRepository(Engagement::class)->find($engagementId);
+        $this->assertInstanceOf(Engagement::class, $entity);
+        $entity->setBudgetAmount(600); // 10 hours
+        $em->flush();
+        $this->assertSame([], $entity->getBudgetAlertsSent());
+        $this->assertSame(0, $alerter->dispatchDue());
+        $this->assertEmailCount(2);
+    }
+
+    private function createSharedSpace(User $admin, ?User $member = null): Space
+    {
+        $space = (new Space())->setName('Studio')->setCreatedBy($admin);
+        $this->entityManager->persist($space);
+        $adminMembership = (new SpaceMembership())
+            ->setUser($admin)
+            ->setRole(Space::ROLE_ADMIN);
+        $space->addUserMembership($adminMembership);
+        $this->entityManager->persist($adminMembership);
+        if (null !== $member) {
+            $memberMembership = (new SpaceMembership())
+                ->setUser($member)
+                ->setRole(Space::ROLE_MEMBER);
+            $space->addUserMembership($memberMembership);
+            $this->entityManager->persist($memberMembership);
+        }
+        $this->entityManager->flush();
+
+        return $space;
+    }
+
+    private function createUser(string $email): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/pwa/pages/engagements/index.tsx
+++ b/pwa/pages/engagements/index.tsx
@@ -58,6 +58,9 @@ interface Engagement {
   categories: CategoryRow[];
   attachments: Attachment[];
   assignedProjectList: { id: string; title: string }[];
+  budgetType: "hours" | "fees" | null;
+  budgetAmount: number | null;
+  budgetSpent: number | null;
 }
 
 /** A form category with the rate as a decimal string for editing. */
@@ -73,6 +76,34 @@ const money = (minor: number, currency: string | null): string =>
   new Intl.NumberFormat(undefined, { style: "currency", currency: currency || "USD" }).format(minor / 100);
 
 const NEW = "new";
+
+/** Budget progress copy: "1.0 / 2.0 h" or "$500.00 / $2,000.00" (#651). */
+const budgetLabel = (bp: Engagement): string => {
+  if (!bp.budgetType || !bp.budgetAmount) return "";
+  const spent = bp.budgetSpent ?? 0;
+  if (bp.budgetType === "hours") {
+    return `${(spent / 60).toFixed(1)} / ${(bp.budgetAmount / 60).toFixed(1)} h`;
+  }
+  return `${money(spent, bp.currency)} / ${money(bp.budgetAmount, bp.currency)}`;
+};
+
+/** Small budget progress bar — amber past 80%, red past 100%. */
+const BudgetBar = ({ bp }: { bp: Engagement }) => {
+  if (!bp.budgetType || !bp.budgetAmount) return null;
+  const pct = Math.round(((bp.budgetSpent ?? 0) / bp.budgetAmount) * 100);
+  const width = Math.min(100, pct);
+  const tone = pct >= 100 ? "bg-red-500" : pct >= 80 ? "bg-amber-500" : "bg-emerald-500";
+  return (
+    <div className="mt-1 w-44">
+      <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+        <div className={`h-full ${tone}`} style={{ width: `${width}%` }} />
+      </div>
+      <p className="mt-0.5 text-xs text-muted-foreground">
+        {budgetLabel(bp)} · {pct}%
+      </p>
+    </div>
+  );
+};
 
 const EngagementsPage = () => {
   const { isAuthenticated, isLoading: authLoading } = useAuth();
@@ -93,6 +124,8 @@ const EngagementsPage = () => {
   const [clientIri, setClientIri] = useState("");
   const [currency, setCurrency] = useState("USD");
   const [description, setDescription] = useState("");
+  const [budgetType, setBudgetType] = useState("");
+  const [budgetValue, setBudgetValue] = useState("");
   const [cats, setCats] = useState<DraftCategory[]>([{ name: "", rate: "", billable: true }]);
   const [assigned, setAssigned] = useState<string[]>([]);
   const [attachments, setAttachments] = useState<Attachment[]>([]);
@@ -144,6 +177,8 @@ const EngagementsPage = () => {
     setClientIri(clients[0]?.["@id"] ?? "");
     setCurrency(clients[0]?.currency ?? "USD");
     setDescription("");
+    setBudgetType("");
+    setBudgetValue("");
     setCats([{ name: "", rate: "", billable: true }]);
     setAssigned([]);
     setAttachments([]);
@@ -156,6 +191,14 @@ const EngagementsPage = () => {
     setClientIri(bp.client);
     setCurrency(bp.currency ?? "USD");
     setDescription(bp.description ?? "");
+    setBudgetType(bp.budgetType ?? "");
+    setBudgetValue(
+      bp.budgetAmount === null
+        ? ""
+        : bp.budgetType === "hours"
+          ? String(bp.budgetAmount / 60)
+          : (bp.budgetAmount / 100).toFixed(2),
+    );
     setCats(
       bp.categories.length > 0
         ? bp.categories.map((c) => ({ name: c.name, rate: toMajor(c.rateAmount), billable: c.billable }))
@@ -198,6 +241,14 @@ const EngagementsPage = () => {
         description: description.trim() || null,
         categories,
         attachments: attachmentIris,
+        // Budget (#651): hours stored as minutes, fees as minor units.
+        budgetType: budgetType || null,
+        budgetAmount:
+          budgetType === ""
+            ? null
+            : budgetType === "hours"
+              ? Math.round((parseFloat(budgetValue) || 0) * 60)
+              : Math.round((parseFloat(budgetValue) || 0) * 100),
       };
       const saved = editingIri
         ? await apiSend<Engagement>("PATCH", editingIri, {
@@ -334,6 +385,7 @@ const EngagementsPage = () => {
                             <span className="font-medium">{bp.name}</span>
                             {bp.archived && <Badge variant="secondary">Archived</Badge>}
                           </div>
+                          <BudgetBar bp={bp} />
                         </td>
                         <td className="px-4 py-3 text-muted-foreground">
                           {clientName.get(bp.client) ?? "Client"}
@@ -427,6 +479,37 @@ const EngagementsPage = () => {
                   className="uppercase"
                 />
               </div>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-1.5">
+                <Label htmlFor="bp-budget-type">Budget</Label>
+                <select
+                  id="bp-budget-type"
+                  value={budgetType}
+                  onChange={(e) => setBudgetType(e.target.value)}
+                  className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
+                >
+                  <option value="">No budget</option>
+                  <option value="hours">Hours</option>
+                  <option value="fees">Fees</option>
+                </select>
+              </div>
+              {budgetType !== "" && (
+                <div className="space-y-1.5">
+                  <Label htmlFor="bp-budget-value">
+                    {budgetType === "hours" ? "Budget hours" : `Budget amount (${currency})`}
+                  </Label>
+                  <Input
+                    id="bp-budget-value"
+                    type="number"
+                    step={budgetType === "hours" ? "0.5" : "0.01"}
+                    min="0"
+                    value={budgetValue}
+                    onChange={(e) => setBudgetValue(e.target.value)}
+                  />
+                </div>
+              )}
             </div>
 
             <div className="space-y-1.5">


### PR DESCRIPTION
Closes #651

## What
Harvest-parity budgets on engagements.

- **Budget on Engagement**: `budgetType` (`hours` | `fees`) + `budgetAmount` (minutes for hours, minor units for fees), validated as a pair. Editing the budget clears the alert ledger so a raised budget re-alerts when re-crossed.
- **Progress**: `EngagementBudgetProvider` decorates the Engagement item + collection reads with a transient `budgetSpent` — one grouped query per page (no N+1), computed by the shared `EngagementBudgetCalculator` (hours = all completed tracked time; fees = billable seconds × snapshotted rate ÷ 3600 — a cheap SQL approximation of the invoice math, close enough for progress + alerts).
- **Alerts**: nightly sweep (`CheckEngagementBudgets`, 03:40 UTC on the existing scheduler) emails **space admins** when a budgeted, non-archived engagement crosses **80% / 100%** — one email per threshold, stamped in `budgetAlertsSent` so re-runs are idempotent.
- **PWA**: budget editor (type + hours/amount) in the engagement sheet; progress bar on `/engagements` rows (emerald → amber ≥80% → red ≥100%) with a "spent / budget · %" caption.

## Tests
`EngagementBudgetTest`: type-without-amount 422; `budgetSpent` surfaces at 50%; crossing both thresholds in one run sends exactly two admin emails; a re-run sends nothing (ledger); raising the budget clears the ledger and stays quiet at 20%.