### PR TITLE
feat(billing): estimates with public accept/decline + convert to invoice

### DIFF
--- a/api/migrations/Version20260716170000.php
+++ b/api/migrations/Version20260716170000.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Estimates (#652): the estimate + estimate_line_item tables — Invoice's
+ * pre-sales sibling with a draft/sent/accepted/declined lifecycle, a public
+ * accept/decline token, and a converted_invoice back-link.
+ */
+final class Version20260716170000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Estimate + estimate_line_item tables (quotes with accept/decline + convert-to-invoice).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE estimate (id UUID NOT NULL, number VARCHAR(40) DEFAULT NULL, status VARCHAR(20) NOT NULL, currency VARCHAR(3) NOT NULL, tax_rate INT NOT NULL, notes TEXT DEFAULT NULL, subtotal INT NOT NULL, tax_amount INT NOT NULL, total INT NOT NULL, public_token VARCHAR(64) DEFAULT NULL, sent_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL, decided_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL, space_id UUID NOT NULL, client_id UUID NOT NULL, converted_invoice_id UUID DEFAULT NULL, created_by_id UUID NOT NULL, PRIMARY KEY (id))');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_D2EA4607AE981E3B ON estimate (public_token)');
+        $this->addSql('CREATE INDEX idx_estimate_space_created ON estimate (space_id, created_at)');
+        $this->addSql('CREATE INDEX idx_estimate_client ON estimate (client_id)');
+        $this->addSql('CREATE INDEX IDX_D2EA46079DC100AB ON estimate (converted_invoice_id)');
+        $this->addSql('CREATE INDEX IDX_D2EA4607B03A8386 ON estimate (created_by_id)');
+        $this->addSql('ALTER TABLE estimate ADD CONSTRAINT FK_D2EA460723575340 FOREIGN KEY (space_id) REFERENCES space (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE estimate ADD CONSTRAINT FK_D2EA460719EB6921 FOREIGN KEY (client_id) REFERENCES client (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE estimate ADD CONSTRAINT FK_D2EA46079DC100AB FOREIGN KEY (converted_invoice_id) REFERENCES invoice (id) ON DELETE SET NULL NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE estimate ADD CONSTRAINT FK_D2EA4607B03A8386 FOREIGN KEY (created_by_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('CREATE TABLE estimate_line_item (id UUID NOT NULL, description VARCHAR(500) NOT NULL, quantity DOUBLE PRECISION NOT NULL, unit_amount INT NOT NULL, amount INT NOT NULL, position INT NOT NULL, estimate_id UUID NOT NULL, PRIMARY KEY (id))');
+        $this->addSql('CREATE INDEX IDX_B8D23DEB85F23082 ON estimate_line_item (estimate_id)');
+        $this->addSql('CREATE INDEX idx_estimate_line_item_estimate_position ON estimate_line_item (estimate_id, position)');
+        $this->addSql('ALTER TABLE estimate_line_item ADD CONSTRAINT FK_B8D23DEB85F23082 FOREIGN KEY (estimate_id) REFERENCES estimate (id) ON DELETE CASCADE NOT DEFERRABLE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE estimate_line_item DROP CONSTRAINT FK_B8D23DEB85F23082');
+        $this->addSql('DROP TABLE estimate_line_item');
+        $this->addSql('ALTER TABLE estimate DROP CONSTRAINT FK_D2EA460723575340');
+        $this->addSql('ALTER TABLE estimate DROP CONSTRAINT FK_D2EA460719EB6921');
+        $this->addSql('ALTER TABLE estimate DROP CONSTRAINT FK_D2EA46079DC100AB');
+        $this->addSql('ALTER TABLE estimate DROP CONSTRAINT FK_D2EA4607B03A8386');
+        $this->addSql('DROP TABLE estimate');
+    }
+}

--- a/api/src/Controller/EstimateActionController.php
+++ b/api/src/Controller/EstimateActionController.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\Estimate;
+use App\Entity\Invoice;
+use App\Entity\InvoiceLineItem;
+use App\Entity\User;
+use App\Repository\EstimateRepository;
+use App\Security\Permission\SpacePermission;
+use App\Security\Permission\SpacePermissionResolver;
+use App\Service\EstimateMailer;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Estimate lifecycle transitions (#652):
+ *
+ *  - send: assign the next per-space EST number, mint the public
+ *    accept/decline token (sha256 at rest), move draft → sent, and email the
+ *    client the link.
+ *  - convert: copy the lines onto a fresh draft {@see Invoice} and back-link
+ *    it — the quote → bill handoff. Declined estimates can't convert; an
+ *    estimate converts at most once.
+ *
+ * Both are admin-reserved (invoices.update) and hide a non-member's target
+ * behind a 404, like the rest of the access model.
+ */
+class EstimateActionController extends AbstractController
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private EstimateRepository $estimates,
+        private SpacePermissionResolver $permissions,
+        private EstimateMailer $mailer,
+    ) {
+    }
+
+    #[Route('/estimates/{id}/send', name: 'estimate_send', methods: ['POST'])]
+    public function send(string $id, #[CurrentUser] ?User $user): JsonResponse
+    {
+        $estimate = $this->authorize($id, $user);
+        if ($estimate instanceof JsonResponse) {
+            return $estimate;
+        }
+        if (Estimate::STATUS_DECLINED === $estimate->getStatus()) {
+            return $this->json(['error' => 'A declined estimate cannot be re-sent.'], 409);
+        }
+
+        $space = $estimate->getSpace();
+        if (null !== $space && null === $estimate->getNumber()) {
+            $next = $this->estimates->countNumbered($space) + 1;
+            $estimate->setNumber('EST-' . str_pad((string) $next, 4, '0', STR_PAD_LEFT));
+        }
+
+        // Mint the shareable accept/decline token (sha256 at rest, rotated on
+        // every send so the freshest email is authoritative).
+        $plain = bin2hex(random_bytes(32));
+        $estimate->setPublicToken(hash('sha256', $plain));
+        if (Estimate::STATUS_DRAFT === $estimate->getStatus()) {
+            $estimate->setStatus(Estimate::STATUS_SENT);
+        }
+        $estimate->setSentAt(new \DateTimeImmutable());
+        $this->em->flush();
+
+        $this->mailer->sendEstimate($estimate, $plain);
+
+        return $this->json([
+            'id' => (string) $estimate->getId(),
+            'number' => $estimate->getNumber(),
+            'status' => $estimate->getStatus(),
+            'token' => $plain,
+            'publicUrl' => '/public/estimates/' . $plain,
+        ], 201);
+    }
+
+    #[Route('/estimates/{id}/convert', name: 'estimate_convert', methods: ['POST'])]
+    public function convert(string $id, #[CurrentUser] ?User $user): JsonResponse
+    {
+        $estimate = $this->authorize($id, $user);
+        if ($estimate instanceof JsonResponse) {
+            return $estimate;
+        }
+        if (Estimate::STATUS_DECLINED === $estimate->getStatus()) {
+            return $this->json(['error' => 'A declined estimate cannot be converted.'], 409);
+        }
+        if (null !== $estimate->getConvertedInvoice()) {
+            return $this->json(['error' => 'This estimate was already converted.'], 409);
+        }
+        $space = $estimate->getSpace();
+        $client = $estimate->getClient();
+        if (null === $space || null === $client) {
+            return $this->json(['error' => 'This estimate has no client.'], 422);
+        }
+
+        $invoice = (new Invoice())
+            ->setSpace($space)
+            ->setClient($client)
+            ->setCurrency($estimate->getCurrency())
+            ->setTaxRate($estimate->getTaxRate())
+            ->setNotes($estimate->getNotes())
+            ->setCreatedBy($user instanceof User ? $user : $estimate->getCreatedBy());
+
+        $subtotal = 0;
+        foreach ($estimate->getLineItems() as $line) {
+            $amount = $line->getAmount();
+            $subtotal += $amount;
+            $invoice->addLineItem(
+                (new InvoiceLineItem())
+                    ->setDescription($line->getDescription())
+                    ->setQuantity($line->getQuantity())
+                    ->setUnitAmount($line->getUnitAmount())
+                    ->setAmount($amount)
+                    ->setPosition($line->getPosition()),
+            );
+        }
+        $taxAmount = (int) round($subtotal * $estimate->getTaxRate() / 10000);
+        $invoice->setSubtotal($subtotal);
+        $invoice->setTaxAmount($taxAmount);
+        $invoice->setTotal($subtotal + $taxAmount);
+
+        $this->em->persist($invoice);
+        $estimate->setConvertedInvoice($invoice);
+        $this->em->flush();
+
+        return $this->json([
+            'estimate' => (string) $estimate->getId(),
+            'invoice' => [
+                '@id' => '/invoices/' . $invoice->getId(),
+                'id' => (string) $invoice->getId(),
+                'status' => $invoice->getStatus(),
+                'total' => $invoice->getTotal(),
+            ],
+        ], 201);
+    }
+
+    /**
+     * Load the estimate and confirm the caller may manage it, or return the
+     * error response to short-circuit with.
+     */
+    private function authorize(string $id, ?User $user): Estimate|JsonResponse
+    {
+        if (null === $user) {
+            return $this->json(['error' => 'Not authenticated.'], 401);
+        }
+        if (!Uuid::isValid($id)) {
+            return $this->json(['error' => 'Estimate not found.'], 404);
+        }
+        $estimate = $this->estimates->find($id);
+        $space = $estimate?->getSpace();
+        if (
+            null === $estimate || null === $space
+            || (!$this->isGranted('ROLE_ADMIN') && !$space->hasMember($user))
+        ) {
+            return $this->json(['error' => 'Estimate not found.'], 404);
+        }
+        if (
+            !$this->isGranted('ROLE_ADMIN')
+            && !$this->permissions->canByExplicitGrant($user, $space, SpacePermission::INVOICES, SpacePermission::UPDATE)
+        ) {
+            return $this->json(['error' => 'You cannot manage estimates in this space.'], 403);
+        }
+
+        return $estimate;
+    }
+}

--- a/api/src/Controller/PublicEstimateController.php
+++ b/api/src/Controller/PublicEstimateController.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\Estimate;
+use App\Repository\EstimateRepository;
+use App\Service\EstimateMailer;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * The public, unauthenticated estimate view (#652) a client reaches from the
+ * shareable link minted by {@see EstimateActionController::send()} — plus the
+ * accept/decline actions the client decides right on the page. The token is
+ * sha256-hashed at rest; an unknown token 404s; a decision is final (the
+ * space re-sends a fresh estimate to renegotiate). Deciding emails the
+ * estimate's creator so the team hears about it immediately.
+ */
+class PublicEstimateController extends AbstractController
+{
+    public function __construct(
+        private EstimateRepository $estimates,
+        private EntityManagerInterface $em,
+        private EstimateMailer $mailer,
+    ) {
+    }
+
+    #[Route('/public/estimates/{token}', name: 'public_estimate_view', methods: ['GET'])]
+    public function view(string $token): JsonResponse
+    {
+        $estimate = $this->resolve($token);
+        if (null === $estimate) {
+            return $this->json(['error' => 'Estimate not found.'], 404);
+        }
+
+        $lines = [];
+        foreach ($estimate->getLineItems() as $line) {
+            $lines[] = [
+                'description' => $line->getDescription(),
+                'quantity' => $line->getQuantity(),
+                'unitAmount' => $line->getUnitAmount(),
+                'amount' => $line->getAmount(),
+            ];
+        }
+
+        return $this->json([
+            'number' => $estimate->getNumber(),
+            'status' => $estimate->getStatus(),
+            'currency' => $estimate->getCurrency(),
+            'from' => $estimate->getSpace()?->getName(),
+            'billTo' => $estimate->getClient()?->getName(),
+            'notes' => $estimate->getNotes(),
+            'lineItems' => $lines,
+            'subtotal' => $estimate->getSubtotal(),
+            'taxAmount' => $estimate->getTaxAmount(),
+            'total' => $estimate->getTotal(),
+            'decidedAt' => $estimate->getDecidedAt()?->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+
+    #[Route('/public/estimates/{token}/accept', name: 'public_estimate_accept', methods: ['POST'])]
+    public function accept(string $token): JsonResponse
+    {
+        return $this->decide($token, Estimate::STATUS_ACCEPTED);
+    }
+
+    #[Route('/public/estimates/{token}/decline', name: 'public_estimate_decline', methods: ['POST'])]
+    public function decline(string $token): JsonResponse
+    {
+        return $this->decide($token, Estimate::STATUS_DECLINED);
+    }
+
+    private function decide(string $token, string $status): JsonResponse
+    {
+        $estimate = $this->resolve($token);
+        if (null === $estimate) {
+            return $this->json(['error' => 'Estimate not found.'], 404);
+        }
+        if (Estimate::STATUS_SENT !== $estimate->getStatus()) {
+            return $this->json(['error' => 'This estimate has already been decided.'], 409);
+        }
+
+        $estimate->setStatus($status);
+        $estimate->setDecidedAt(new \DateTimeImmutable());
+        $this->em->flush();
+
+        // Tell the team right away (best-effort).
+        $this->mailer->sendDecision($estimate);
+
+        return $this->json([
+            'status' => $estimate->getStatus(),
+            'decidedAt' => $estimate->getDecidedAt()?->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+
+    private function resolve(string $token): ?Estimate
+    {
+        if ('' === trim($token)) {
+            return null;
+        }
+
+        return $this->estimates->findByPublicTokenHash(hash('sha256', $token));
+    }
+}

--- a/api/src/Doctrine/EstimateAccessExtension.php
+++ b/api/src/Doctrine/EstimateAccessExtension.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Doctrine;
+
+use App\Entity\Estimate;
+use App\Security\Permission\SpacePermission;
+
+/**
+ * Scopes Estimate queries to the spaces the current user belongs to (#652),
+ * via the `estimate.space` FK, and read-gates on the admin-reserved
+ * `invoices` permission category — the exact shape of
+ * {@see InvoiceAccessExtension}.
+ */
+final class EstimateAccessExtension extends AbstractSpaceAccessExtension
+{
+    protected function getResourceClass(): string
+    {
+        return Estimate::class;
+    }
+
+    protected function getAliasPrefix(): string
+    {
+        return 'estimate_access';
+    }
+
+    protected function getImpersonationItemType(): ?string
+    {
+        return null;
+    }
+
+    protected function getPermissionCategory(): string
+    {
+        return SpacePermission::INVOICES;
+    }
+}

--- a/api/src/Entity/Estimate.php
+++ b/api/src/Entity/Estimate.php
@@ -1,0 +1,434 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Doctrine\Orm\Filter\OrderFilter;
+use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
+use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use App\Repository\EstimateRepository;
+use App\State\EstimateProcessor;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+
+/**
+ * An estimate/quote a space sends to a {@see Client} (#652) — the Invoice's
+ * pre-sales sibling: same line-item + derived-totals model, but its lifecycle
+ * is draft → sent → accepted/declined, decided by the client from the public
+ * token page. An accepted estimate converts into a draft {@see Invoice}
+ * (copied lines, {@see $convertedInvoice} back-link) so the quote and the
+ * bill stay traceable.
+ *
+ * Totals are derived server-side by EstimateProcessor (never trusted from
+ * the payload). Space-scoped and gated on the admin-reserved `invoices`
+ * permission category like Invoice/Client.
+ */
+#[ApiResource(
+    shortName: 'Estimate',
+    operations: [
+        new GetCollection(
+            security: "is_granted('ROLE_USER')",
+        ),
+        new Post(
+            security: "is_granted('ROLE_USER')",
+            securityPostDenormalize: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or (object.getSpace() !== null and object.getSpace().hasMember(user) and is_granted('space.invoices.create', object)))",
+            processor: EstimateProcessor::class,
+        ),
+        new Get(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or (object.getSpace().hasMember(user) and is_granted('space.invoices.read', object)))",
+        ),
+        new Patch(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getSpace().isAdmin(user) or (object.getSpace().hasMember(user) and is_granted('space.invoices.update', object)))",
+            processor: EstimateProcessor::class,
+        ),
+        new Delete(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getSpace().isAdmin(user) or (object.getSpace().hasMember(user) and is_granted('space.invoices.delete', object)))",
+        ),
+    ],
+    normalizationContext: ['groups' => ['estimate:read']],
+    denormalizationContext: ['groups' => ['estimate:write']],
+    order: ['createdAt' => 'DESC'],
+)]
+#[ApiFilter(SearchFilter::class, properties: ['space' => 'exact', 'client' => 'exact', 'status' => 'exact'])]
+#[ApiFilter(OrderFilter::class, properties: ['createdAt', 'number'])]
+#[ORM\Entity(repositoryClass: EstimateRepository::class)]
+#[ORM\Table(name: 'estimate')]
+#[ORM\Index(columns: ['space_id', 'created_at'], name: 'idx_estimate_space_created')]
+#[ORM\Index(columns: ['client_id'], name: 'idx_estimate_client')]
+#[ORM\HasLifecycleCallbacks]
+#[Assert\Callback('validateConsistency')]
+class Estimate
+{
+    public const STATUS_DRAFT = 'draft';
+    public const STATUS_SENT = 'sent';
+    public const STATUS_ACCEPTED = 'accepted';
+    public const STATUS_DECLINED = 'declined';
+
+    /** @var list<string> */
+    public const STATUSES = [
+        self::STATUS_DRAFT,
+        self::STATUS_SENT,
+        self::STATUS_ACCEPTED,
+        self::STATUS_DECLINED,
+    ];
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
+    #[Groups(['estimate:read'])]
+    private ?Uuid $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Space::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    #[Assert\NotNull(message: 'Space is required.')]
+    #[Groups(['estimate:read', 'estimate:write'])]
+    private ?Space $space = null;
+
+    #[ApiProperty(readableLink: true)]
+    #[ORM\ManyToOne(targetEntity: Client::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    #[Assert\NotNull(message: 'A client is required.')]
+    #[Groups(['estimate:read', 'estimate:write'])]
+    private ?Client $client = null;
+
+    /** Sequential per-space number, assigned on send (null while draft). */
+    #[ORM\Column(length: 40, nullable: true)]
+    #[Groups(['estimate:read'])]
+    private ?string $number = null;
+
+    #[ORM\Column(length: 20)]
+    #[Assert\Choice(choices: self::STATUSES, message: 'Invalid estimate status.')]
+    #[Groups(['estimate:read', 'estimate:write'])]
+    private string $status = self::STATUS_DRAFT;
+
+    #[ORM\Column(type: 'string', length: 3)]
+    #[Assert\NotBlank(message: 'A currency is required.')]
+    #[Assert\Currency]
+    #[Groups(['estimate:read', 'estimate:write'])]
+    private string $currency = 'USD';
+
+    /** Tax rate in basis points (e.g. 875 = 8.75%). */
+    #[ORM\Column(type: 'integer')]
+    #[Assert\Range(min: 0, max: 100000)]
+    #[Groups(['estimate:read', 'estimate:write'])]
+    private int $taxRate = 0;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    #[Groups(['estimate:read', 'estimate:write'])]
+    private ?string $notes = null;
+
+    /**
+     * @var Collection<int, EstimateLineItem>
+     */
+    #[ORM\OneToMany(mappedBy: 'estimate', targetEntity: EstimateLineItem::class, cascade: ['persist'], orphanRemoval: true)]
+    #[ORM\OrderBy(['position' => 'ASC'])]
+    #[Assert\Valid]
+    #[Groups(['estimate:read', 'estimate:write'])]
+    private Collection $lineItems;
+
+    /** Sum of line amounts, minor units. Derived. */
+    #[ORM\Column(type: 'integer')]
+    #[Groups(['estimate:read'])]
+    private int $subtotal = 0;
+
+    /** subtotal × taxRate, minor units. Derived. */
+    #[ORM\Column(type: 'integer')]
+    #[Groups(['estimate:read'])]
+    private int $taxAmount = 0;
+
+    /** subtotal + taxAmount, minor units. Derived. */
+    #[ORM\Column(type: 'integer')]
+    #[Groups(['estimate:read'])]
+    private int $total = 0;
+
+    /** The invoice this estimate was converted into (#652). */
+    #[ApiProperty(readableLink: false)]
+    #[ORM\ManyToOne(targetEntity: Invoice::class)]
+    #[ORM\JoinColumn(name: 'converted_invoice_id', nullable: true, onDelete: 'SET NULL')]
+    #[Groups(['estimate:read'])]
+    private ?Invoice $convertedInvoice = null;
+
+    #[ApiProperty(readableLink: false)]
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    #[Groups(['estimate:read'])]
+    private ?User $createdBy = null;
+
+    /** sha256 of the public accept/decline token; plaintext only leaves in the link. */
+    #[ORM\Column(length: 64, nullable: true, unique: true)]
+    private ?string $publicToken = null;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    #[Groups(['estimate:read'])]
+    private ?\DateTimeImmutable $sentAt = null;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    #[Groups(['estimate:read'])]
+    private ?\DateTimeImmutable $decidedAt = null;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    #[Groups(['estimate:read'])]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    #[Groups(['estimate:read'])]
+    private ?\DateTimeImmutable $updatedAt = null;
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTimeImmutable();
+        $this->lineItems = new ArrayCollection();
+    }
+
+    #[ORM\PreUpdate]
+    public function onPreUpdate(): void
+    {
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function validateConsistency(ExecutionContextInterface $context): void
+    {
+        if (
+            null !== $this->client && null !== $this->space
+            && true !== $this->client->getSpace()?->getId()?->equals($this->space->getId())
+        ) {
+            $context->buildViolation('Client must belong to the same space.')
+                ->atPath('client')
+                ->addViolation();
+        }
+    }
+
+    public function getId(): ?Uuid
+    {
+        return $this->id;
+    }
+
+    public function getSpace(): ?Space
+    {
+        return $this->space;
+    }
+
+    public function setSpace(?Space $space): self
+    {
+        $this->space = $space;
+
+        return $this;
+    }
+
+    public function getClient(): ?Client
+    {
+        return $this->client;
+    }
+
+    public function setClient(?Client $client): self
+    {
+        $this->client = $client;
+
+        return $this;
+    }
+
+    public function getNumber(): ?string
+    {
+        return $this->number;
+    }
+
+    public function setNumber(?string $number): self
+    {
+        $this->number = $number;
+
+        return $this;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(string $status): self
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    public function getCurrency(): string
+    {
+        return $this->currency;
+    }
+
+    public function setCurrency(string $currency): self
+    {
+        $this->currency = $currency;
+
+        return $this;
+    }
+
+    public function getTaxRate(): int
+    {
+        return $this->taxRate;
+    }
+
+    public function setTaxRate(int $taxRate): self
+    {
+        $this->taxRate = $taxRate;
+
+        return $this;
+    }
+
+    public function getNotes(): ?string
+    {
+        return $this->notes;
+    }
+
+    public function setNotes(?string $notes): self
+    {
+        $this->notes = $notes;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, EstimateLineItem>
+     */
+    public function getLineItems(): Collection
+    {
+        return $this->lineItems;
+    }
+
+    public function addLineItem(EstimateLineItem $lineItem): self
+    {
+        if (!$this->lineItems->contains($lineItem)) {
+            $this->lineItems->add($lineItem);
+            $lineItem->setEstimate($this);
+        }
+
+        return $this;
+    }
+
+    public function removeLineItem(EstimateLineItem $lineItem): self
+    {
+        if ($this->lineItems->removeElement($lineItem) && $lineItem->getEstimate() === $this) {
+            $lineItem->setEstimate(null);
+        }
+
+        return $this;
+    }
+
+    public function getSubtotal(): int
+    {
+        return $this->subtotal;
+    }
+
+    public function setSubtotal(int $subtotal): self
+    {
+        $this->subtotal = $subtotal;
+
+        return $this;
+    }
+
+    public function getTaxAmount(): int
+    {
+        return $this->taxAmount;
+    }
+
+    public function setTaxAmount(int $taxAmount): self
+    {
+        $this->taxAmount = $taxAmount;
+
+        return $this;
+    }
+
+    public function getTotal(): int
+    {
+        return $this->total;
+    }
+
+    public function setTotal(int $total): self
+    {
+        $this->total = $total;
+
+        return $this;
+    }
+
+    public function getConvertedInvoice(): ?Invoice
+    {
+        return $this->convertedInvoice;
+    }
+
+    public function setConvertedInvoice(?Invoice $convertedInvoice): self
+    {
+        $this->convertedInvoice = $convertedInvoice;
+
+        return $this;
+    }
+
+    public function getCreatedBy(): ?User
+    {
+        return $this->createdBy;
+    }
+
+    public function setCreatedBy(?User $createdBy): self
+    {
+        $this->createdBy = $createdBy;
+
+        return $this;
+    }
+
+    public function getPublicToken(): ?string
+    {
+        return $this->publicToken;
+    }
+
+    public function setPublicToken(?string $publicToken): self
+    {
+        $this->publicToken = $publicToken;
+
+        return $this;
+    }
+
+    public function getSentAt(): ?\DateTimeImmutable
+    {
+        return $this->sentAt;
+    }
+
+    public function setSentAt(?\DateTimeImmutable $sentAt): self
+    {
+        $this->sentAt = $sentAt;
+
+        return $this;
+    }
+
+    public function getDecidedAt(): ?\DateTimeImmutable
+    {
+        return $this->decidedAt;
+    }
+
+    public function setDecidedAt(?\DateTimeImmutable $decidedAt): self
+    {
+        $this->decidedAt = $decidedAt;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): ?\DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+}

--- a/api/src/Entity/EstimateLineItem.php
+++ b/api/src/Entity/EstimateLineItem.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * One line on an {@see Estimate} (#652) — the quote-side twin of
+ * {@see InvoiceLineItem}: written as part of the estimate's `lineItems`
+ * array, with {@see $amount} derived server-side by EstimateProcessor.
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'estimate_line_item')]
+#[ORM\Index(columns: ['estimate_id', 'position'], name: 'idx_estimate_line_item_estimate_position')]
+class EstimateLineItem
+{
+    public const MAX_DESCRIPTION_LENGTH = 500;
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
+    #[Groups(['estimate:read'])]
+    private ?Uuid $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Estimate::class, inversedBy: 'lineItems')]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private ?Estimate $estimate = null;
+
+    #[ORM\Column(length: self::MAX_DESCRIPTION_LENGTH)]
+    #[Assert\NotBlank(message: 'A line description is required.')]
+    #[Assert\Length(max: self::MAX_DESCRIPTION_LENGTH)]
+    #[Groups(['estimate:read', 'estimate:write'])]
+    private string $description = '';
+
+    /** Hours or units (may be fractional). */
+    #[ORM\Column(type: 'float')]
+    #[Assert\PositiveOrZero]
+    #[Groups(['estimate:read', 'estimate:write'])]
+    private float $quantity = 1.0;
+
+    /** Price per unit/hour in minor units of the estimate's currency. */
+    #[ORM\Column(type: 'integer')]
+    #[Groups(['estimate:read', 'estimate:write'])]
+    private int $unitAmount = 0;
+
+    /** Derived: round(quantity × unitAmount), in minor units. Read-only. */
+    #[ORM\Column(type: 'integer')]
+    #[Groups(['estimate:read'])]
+    private int $amount = 0;
+
+    #[ORM\Column(type: 'integer')]
+    #[Groups(['estimate:read', 'estimate:write'])]
+    private int $position = 0;
+
+    public function getId(): ?Uuid
+    {
+        return $this->id;
+    }
+
+    public function getEstimate(): ?Estimate
+    {
+        return $this->estimate;
+    }
+
+    public function setEstimate(?Estimate $estimate): self
+    {
+        $this->estimate = $estimate;
+
+        return $this;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): self
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function getQuantity(): float
+    {
+        return $this->quantity;
+    }
+
+    public function setQuantity(float $quantity): self
+    {
+        $this->quantity = $quantity;
+
+        return $this;
+    }
+
+    public function getUnitAmount(): int
+    {
+        return $this->unitAmount;
+    }
+
+    public function setUnitAmount(int $unitAmount): self
+    {
+        $this->unitAmount = $unitAmount;
+
+        return $this;
+    }
+
+    public function getAmount(): int
+    {
+        return $this->amount;
+    }
+
+    public function setAmount(int $amount): self
+    {
+        $this->amount = $amount;
+
+        return $this;
+    }
+
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function setPosition(int $position): self
+    {
+        $this->position = $position;
+
+        return $this;
+    }
+}

--- a/api/src/Repository/EstimateRepository.php
+++ b/api/src/Repository/EstimateRepository.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Estimate;
+use App\Entity\Space;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Estimate>
+ */
+class EstimateRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Estimate::class);
+    }
+
+    /** Count estimates already numbered in a space — basis for the next EST number. */
+    public function countNumbered(Space $space): int
+    {
+        $count = $this->createQueryBuilder('e')
+            ->select('COUNT(e.id)')
+            ->andWhere('e.space = :space')
+            ->andWhere('e.number IS NOT NULL')
+            ->setParameter('space', $space)
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        return (int) $count;
+    }
+
+    /** Resolve an estimate from a public-link token (caller passes the sha256 hash). */
+    public function findByPublicTokenHash(string $hash): ?Estimate
+    {
+        return $this->findOneBy(['publicToken' => $hash]);
+    }
+}

--- a/api/src/Security/Permission/SpacePermissionVoter.php
+++ b/api/src/Security/Permission/SpacePermissionVoter.php
@@ -10,6 +10,8 @@ use App\Entity\Client;
 use App\Entity\Comment;
 use App\Entity\CustomFieldDefinition;
 use App\Entity\Discussion;
+use App\Entity\Estimate;
+use App\Entity\Expense;
 use App\Entity\Invoice;
 use App\Entity\Page;
 use App\Entity\Board;
@@ -95,6 +97,8 @@ final class SpacePermissionVoter extends Voter
             $subject instanceof Engagement => $subject->getSpace(),
             $subject instanceof EngagementCategory => $subject->getEngagement()?->getSpace(),
             $subject instanceof Invoice => $subject->getSpace(),
+            $subject instanceof Estimate => $subject->getSpace(),
+            $subject instanceof Expense => $subject->getSpace(),
             $subject instanceof TaskRelationship => $subject->getSource()?->getBoard()?->getSpace(),
             $subject instanceof Comment => $this->commentSpace($subject),
             default => null,

--- a/api/src/Service/EstimateMailer.php
+++ b/api/src/Service/EstimateMailer.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Estimate;
+use App\Service\Mail\MailDispatcher;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+
+/**
+ * Emails for the estimate lifecycle (#652): the "here's your estimate" link
+ * when it's sent (public accept/decline page, plaintext token only ever in
+ * the email), and the accepted/declined notice back to the estimate's
+ * creator when the client decides. No-ops without an email on file.
+ */
+final class EstimateMailer
+{
+    public function __construct(
+        private readonly MailDispatcher $mail,
+    ) {
+    }
+
+    public function sendEstimate(Estimate $estimate, string $plainToken): void
+    {
+        $to = $estimate->getClient()?->getEmail();
+        if (null === $to || '' === trim($to)) {
+            return;
+        }
+
+        $from = $estimate->getSpace()?->getName() ?? 'Madori';
+        $number = $estimate->getNumber() ?? 'estimate';
+
+        $email = (new TemplatedEmail())
+            ->to($to)
+            ->subject(sprintf('%s from %s', ucfirst($number), $from))
+            ->htmlTemplate('emails/estimate.html.twig')
+            ->textTemplate('emails/estimate.txt.twig')
+            ->context([
+                'estimate' => $estimate,
+                'client' => $estimate->getClient(),
+                'fromName' => $from,
+                'viewUrl' => $this->mail->frontendLink('/e/' . $plainToken),
+            ]);
+
+        $this->mail->send($email);
+    }
+
+    public function sendDecision(Estimate $estimate): void
+    {
+        $to = $estimate->getCreatedBy()?->getEmail();
+        if (null === $to || '' === trim($to)) {
+            return;
+        }
+
+        $accepted = Estimate::STATUS_ACCEPTED === $estimate->getStatus();
+        $number = $estimate->getNumber() ?? 'Your estimate';
+
+        $email = (new TemplatedEmail())
+            ->to($to)
+            ->subject(sprintf('%s was %s', ucfirst($number), $accepted ? 'accepted' : 'declined'))
+            ->htmlTemplate('emails/estimate_decision.html.twig')
+            ->textTemplate('emails/estimate_decision.txt.twig')
+            ->context([
+                'estimate' => $estimate,
+                'accepted' => $accepted,
+                'estimatesUrl' => $this->mail->frontendLink('/estimates'),
+            ]);
+
+        $this->mail->send($email);
+    }
+}

--- a/api/src/State/EstimateProcessor.php
+++ b/api/src/State/EstimateProcessor.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\Entity\Estimate;
+use App\Security\AuthenticatedUserResolver;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Stamps the creator on create, then recomputes every monetary total from
+ * the line items server-side (#652) — the quote-side twin of
+ * InvoiceProcessor: line amount = round(quantity × unitAmount); subtotal =
+ * Σ amounts; taxAmount = round(subtotal × taxRate / 10000); total =
+ * subtotal + taxAmount.
+ *
+ * @implements ProcessorInterface<Estimate, Estimate>
+ */
+final class EstimateProcessor implements ProcessorInterface
+{
+    private const BASIS_POINTS = 10000;
+
+    /**
+     * @param ProcessorInterface<Estimate, Estimate> $persistProcessor
+     */
+    public function __construct(
+        #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
+        private ProcessorInterface $persistProcessor,
+        private AuthenticatedUserResolver $auth,
+    ) {
+    }
+
+    /**
+     * @param Estimate $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Estimate
+    {
+        $user = $this->auth->requireUser('manage estimates');
+
+        if (null === $data->getCreatedBy()) {
+            $data->setCreatedBy($user);
+        }
+
+        $subtotal = 0;
+        foreach ($data->getLineItems() as $line) {
+            $amount = (int) round($line->getQuantity() * $line->getUnitAmount());
+            $line->setAmount($amount);
+            $subtotal += $amount;
+        }
+        $taxAmount = (int) round($subtotal * $data->getTaxRate() / self::BASIS_POINTS);
+        $data->setSubtotal($subtotal);
+        $data->setTaxAmount($taxAmount);
+        $data->setTotal($subtotal + $taxAmount);
+
+        return $this->persistProcessor->process($data, $operation, $uriVariables, $context);
+    }
+}

--- a/api/templates/emails/estimate.html.twig
+++ b/api/templates/emails/estimate.html.twig
@@ -1,0 +1,17 @@
+{# @var estimate \App\Entity\Estimate #}
+{# @var client \App\Entity\Client #}
+<p>Hi {{ client.name }},</p>
+
+<p>
+    {{ fromName }} has sent you
+    {% if estimate.number %}estimate <strong>{{ estimate.number }}</strong>{% else %}an estimate{% endif %}
+    for <strong>{{ (estimate.total / 100)|number_format(2) }} {{ estimate.currency }}</strong>.
+</p>
+
+<p>
+    <a href="{{ viewUrl }}">Review, accept, or decline the estimate</a>
+</p>
+
+<p style="color: #9ca3af; font-size: 12px;">
+    You can review the line items and respond directly from that page.
+</p>

--- a/api/templates/emails/estimate.txt.twig
+++ b/api/templates/emails/estimate.txt.twig
@@ -1,0 +1,9 @@
+{# @var estimate \App\Entity\Estimate #}
+{# @var client \App\Entity\Client #}
+Hi {{ client.name }},
+
+{{ fromName }} has sent you {% if estimate.number %}estimate {{ estimate.number }}{% else %}an estimate{% endif %} for {{ (estimate.total / 100)|number_format(2) }} {{ estimate.currency }}.
+
+Review, accept, or decline the estimate: {{ viewUrl }}
+
+You can review the line items and respond directly from that page.

--- a/api/templates/emails/estimate_decision.html.twig
+++ b/api/templates/emails/estimate_decision.html.twig
@@ -1,0 +1,18 @@
+{# @var estimate \App\Entity\Estimate #}
+{# @var accepted bool #}
+<p>Hi,</p>
+
+<p>
+    {% if estimate.client %}{{ estimate.client.name }}{% else %}Your client{% endif %}
+    has <strong>{{ accepted ? 'accepted' : 'declined' }}</strong>
+    {% if estimate.number %}estimate <strong>{{ estimate.number }}</strong>{% else %}your estimate{% endif %}
+    for <strong>{{ (estimate.total / 100)|number_format(2) }} {{ estimate.currency }}</strong>.
+</p>
+
+{% if accepted %}
+<p>You can convert it into a draft invoice from the estimates page.</p>
+{% endif %}
+
+<p>
+    <a href="{{ estimatesUrl }}">Open estimates</a>
+</p>

--- a/api/templates/emails/estimate_decision.txt.twig
+++ b/api/templates/emails/estimate_decision.txt.twig
@@ -1,0 +1,9 @@
+{# @var estimate \App\Entity\Estimate #}
+Hi,
+
+{% if estimate.client %}{{ estimate.client.name }}{% else %}Your client{% endif %} has {{ accepted ? 'accepted' : 'declined' }} {% if estimate.number %}estimate {{ estimate.number }}{% else %}your estimate{% endif %} for {{ (estimate.total / 100)|number_format(2) }} {{ estimate.currency }}.
+{% if accepted %}
+You can convert it into a draft invoice from the estimates page.
+{% endif %}
+
+Open estimates: {{ estimatesUrl }}

--- a/api/tests/Api/EstimateTest.php
+++ b/api/tests/Api/EstimateTest.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\Space;
+use App\Entity\SpaceMembership;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Estimates (#652): derived totals, the send → public accept/decline
+ * lifecycle, and conversion into a draft invoice.
+ */
+class EstimateTest extends ApiTestCase
+{
+    use SpaceMembershipFixture;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = static::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Estimate')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Invoice')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Client')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\SpaceMembership')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Space')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testEstimateLifecycleAcceptAndConvert(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $space = $this->createSharedSpace($admin);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'email' => 'billing@acme.test', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+
+        // Totals derive server-side: 2×5000 + 1.5×8000 = 22000; 10% tax = 2200.
+        $estimate = $client->request('POST', '/estimates', [
+            'json' => [
+                'space' => $spaceIri,
+                'client' => $clientRow['@id'],
+                'currency' => 'USD',
+                'taxRate' => 1000,
+                'lineItems' => [
+                    ['description' => 'Design', 'quantity' => 2, 'unitAmount' => 5000, 'position' => 0],
+                    ['description' => 'Build', 'quantity' => 1.5, 'unitAmount' => 8000, 'position' => 1],
+                ],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertSame(22000, $estimate['subtotal'] ?? null);
+        $this->assertSame(2200, $estimate['taxAmount'] ?? null);
+        $this->assertSame(24200, $estimate['total'] ?? null);
+        $this->assertSame('draft', $estimate['status'] ?? null);
+        $estimateIri = $estimate['@id'];
+        $this->assertIsString($estimateIri);
+
+        // Send: assigns EST number, mints the public token, emails the client.
+        $sent = $client->request('POST', $estimateIri . '/send', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertSame('EST-0001', $sent['number'] ?? null);
+        $this->assertSame('sent', $sent['status'] ?? null);
+        $this->assertEmailCount(1);
+        $token = $sent['token'];
+        $this->assertIsString($token);
+
+        // The public page resolves the estimate; an unknown token 404s.
+        $public = $client->request('GET', '/public/estimates/' . $token)->toArray();
+        $this->assertSame('EST-0001', $public['number'] ?? null);
+        $this->assertSame(24200, $public['total'] ?? null);
+        $this->assertSame('Acme Co', $public['billTo'] ?? null);
+        $client->request('GET', '/public/estimates/deadbeef');
+        $this->assertResponseStatusCodeSame(404);
+
+        // The client accepts from the public page — the creator is emailed.
+        $accepted = $client->request('POST', '/public/estimates/' . $token . '/accept', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertSame('accepted', $accepted['status'] ?? null);
+        $this->assertEmailCount(1);
+        $decision = $this->getMailerMessage();
+        $this->assertNotNull($decision);
+        $this->assertEmailAddressContains($decision, 'To', 'admin@example.com');
+
+        // A decision is final.
+        $client->request('POST', '/public/estimates/' . $token . '/decline', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(409);
+
+        // Convert: copies the lines onto a fresh draft invoice + back-links it.
+        $converted = $client->request('POST', $estimateIri . '/convert', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $invoice = $converted['invoice'] ?? null;
+        $this->assertIsArray($invoice);
+        $this->assertSame('draft', $invoice['status'] ?? null);
+        $this->assertSame(24200, $invoice['total'] ?? null);
+        $invoiceIri = $invoice['@id'];
+        $this->assertIsString($invoiceIri);
+
+        $invoiceFull = $client->request('GET', $invoiceIri)->toArray();
+        $lines = $invoiceFull['lineItems'] ?? null;
+        $this->assertIsArray($lines);
+        $this->assertCount(2, $lines);
+
+        // At most one conversion.
+        $client->request('POST', $estimateIri . '/convert', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(409);
+
+        $refreshed = $client->request('GET', $estimateIri)->toArray();
+        $this->assertSame($invoiceIri, $refreshed['convertedInvoice'] ?? null);
+    }
+
+    public function testDeclinedEstimateCannotConvert(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $space = $this->createSharedSpace($admin);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $estimate = $client->request('POST', '/estimates', [
+            'json' => [
+                'space' => $spaceIri,
+                'client' => $clientRow['@id'],
+                'currency' => 'USD',
+                'lineItems' => [['description' => 'Work', 'quantity' => 1, 'unitAmount' => 5000]],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $estimateIri = $estimate['@id'];
+        $this->assertIsString($estimateIri);
+
+        $sent = $client->request('POST', $estimateIri . '/send', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $token = $sent['token'];
+        $this->assertIsString($token);
+
+        $client->request('POST', '/public/estimates/' . $token . '/decline', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(200);
+
+        $client->request('POST', $estimateIri . '/convert', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(409);
+    }
+
+    private function createSharedSpace(User $admin, ?User $member = null): Space
+    {
+        $space = (new Space())->setName('Studio')->setCreatedBy($admin);
+        $this->entityManager->persist($space);
+        $adminMembership = (new SpaceMembership())
+            ->setUser($admin)
+            ->setRole(Space::ROLE_ADMIN);
+        $space->addUserMembership($adminMembership);
+        $this->entityManager->persist($adminMembership);
+        if (null !== $member) {
+            $memberMembership = (new SpaceMembership())
+                ->setUser($member)
+                ->setRole(Space::ROLE_MEMBER);
+            $space->addUserMembership($memberMembership);
+            $this->entityManager->persist($memberMembership);
+        }
+        $this->entityManager->flush();
+
+        return $space;
+    }
+
+    private function createUser(string $email): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/pwa/components/common/SidebarNav.tsx
+++ b/pwa/components/common/SidebarNav.tsx
@@ -578,6 +578,7 @@ const BillingSection = ({
     { href: "/engagements", label: "Engagements", match: "/engagements", show: canInvoices },
     { href: "/clients", label: "Clients", match: "/clients", show: canInvoices },
     { href: "/invoices", label: "Invoices", match: "/invoices", show: canInvoices },
+    { href: "/estimates", label: "Estimates", match: "/estimates", show: canInvoices },
     { href: "/reports", label: "Reports", match: "/reports", show: canInvoices },
   ].filter((l) => l.show);
 

--- a/pwa/lib/estimateTypes.ts
+++ b/pwa/lib/estimateTypes.ts
@@ -1,0 +1,44 @@
+/** Wire shapes for `/estimates` (#652). */
+
+export interface EstimateLineItem {
+  "@id"?: string;
+  id?: string;
+  description: string;
+  quantity: number;
+  unitAmount: number;
+  amount?: number;
+  position?: number;
+}
+
+export type EstimateStatus = "draft" | "sent" | "accepted" | "declined";
+
+export interface Estimate {
+  "@id": string;
+  id: string;
+  space: string;
+  client: { "@id": string; id: string; name: string } | string;
+  number: string | null;
+  status: EstimateStatus;
+  currency: string;
+  taxRate: number;
+  notes: string | null;
+  lineItems: EstimateLineItem[];
+  subtotal: number;
+  taxAmount: number;
+  total: number;
+  convertedInvoice: string | null;
+  sentAt: string | null;
+  decidedAt: string | null;
+  createdAt: string;
+  updatedAt: string | null;
+}
+
+export const ESTIMATE_STATUS_META: Record<EstimateStatus, { label: string; badgeClass: string }> = {
+  draft: { label: "Draft", badgeClass: "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300" },
+  sent: { label: "Sent", badgeClass: "bg-sky-100 text-sky-700 dark:bg-sky-950 dark:text-sky-300" },
+  accepted: { label: "Accepted", badgeClass: "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300" },
+  declined: { label: "Declined", badgeClass: "bg-rose-100 text-rose-700 dark:bg-rose-950 dark:text-rose-300" },
+};
+
+export const estimateClientName = (client: Estimate["client"]): string =>
+  typeof client === "string" ? "" : client.name;

--- a/pwa/pages/e/[token].tsx
+++ b/pwa/pages/e/[token].tsx
@@ -1,0 +1,234 @@
+import Head from "next/head";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import { FileSpreadsheet } from "lucide-react";
+import { ENTRYPOINT } from "@/config/entrypoint";
+import { formatMoney } from "@/lib/invoiceTypes";
+import { ESTIMATE_STATUS_META, EstimateStatus } from "@/lib/estimateTypes";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+interface PublicLine {
+  description: string;
+  quantity: number;
+  unitAmount: number;
+  amount: number;
+}
+
+interface PublicEstimate {
+  number: string | null;
+  status: EstimateStatus;
+  currency: string;
+  from: string | null;
+  billTo: string | null;
+  notes: string | null;
+  lineItems: PublicLine[];
+  subtotal: number;
+  taxAmount: number;
+  total: number;
+  decidedAt: string | null;
+}
+
+/**
+ * Public, unauthenticated estimate view (#652) a client reaches from the
+ * shared link — review the quote, then Accept or Decline right here.
+ */
+const PublicEstimatePage = () => {
+  const router = useRouter();
+  const { token } = router.query;
+  const shareToken = typeof token === "string" ? token : null;
+
+  const [estimate, setEstimate] = useState<PublicEstimate | null>(null);
+  const [notFound, setNotFound] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [deciding, setDeciding] = useState(false);
+
+  useEffect(() => {
+    if (!shareToken) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch(
+          `${ENTRYPOINT}/public/estimates/${encodeURIComponent(shareToken)}`,
+          { headers: { Accept: "application/json" } },
+        );
+        if (cancelled) return;
+        if (res.status === 404) {
+          setNotFound(true);
+          return;
+        }
+        if (!res.ok) throw new Error("Failed to load the estimate.");
+        setEstimate((await res.json()) as PublicEstimate);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to load the estimate.");
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [shareToken]);
+
+  const decide = async (action: "accept" | "decline") => {
+    if (!shareToken) return;
+    setDeciding(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `${ENTRYPOINT}/public/estimates/${encodeURIComponent(shareToken)}/${action}`,
+        { method: "POST", headers: { Accept: "application/json" } },
+      );
+      const data = (await res.json().catch(() => ({}))) as {
+        status?: EstimateStatus;
+        error?: string;
+      };
+      if (res.ok && data.status) {
+        setEstimate((prev) => (prev ? { ...prev, status: data.status as EstimateStatus } : prev));
+        return;
+      }
+      setError(data.error ?? "Could not record your decision.");
+    } catch {
+      setError("Could not record your decision.");
+    } finally {
+      setDeciding(false);
+    }
+  };
+
+  let body;
+  if (notFound) {
+    body = (
+      <div className="space-y-2 text-center">
+        <FileSpreadsheet className="mx-auto h-10 w-10 text-muted-foreground" aria-hidden />
+        <h1 className="text-xl font-semibold">Estimate not found</h1>
+        <p className="text-sm text-muted-foreground">
+          This link isn&apos;t valid — it may have been replaced by a newer one.
+        </p>
+      </div>
+    );
+  } else if (error && !estimate) {
+    body = (
+      <div className="space-y-2 text-center">
+        <h1 className="text-xl font-semibold">Something went wrong</h1>
+        <p className="text-sm text-muted-foreground">{error}</p>
+      </div>
+    );
+  } else if (!estimate) {
+    body = <p className="text-center text-sm text-muted-foreground">Loading estimate…</p>;
+  } else {
+    const meta = ESTIMATE_STATUS_META[estimate.status];
+    body = (
+      <div className="space-y-6">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-semibold">Estimate {estimate.number ?? ""}</h1>
+            {estimate.from && (
+              <p className="text-sm text-muted-foreground">From {estimate.from}</p>
+            )}
+          </div>
+          <span className={cn("rounded px-2 py-1 text-xs font-medium", meta.badgeClass)}>
+            {meta.label}
+          </span>
+        </div>
+
+        {estimate.billTo && (
+          <div className="text-sm">
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Prepared for</p>
+            <p>{estimate.billTo}</p>
+          </div>
+        )}
+
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+              <th className="py-2">Description</th>
+              <th className="py-2 text-right">Qty</th>
+              <th className="py-2 text-right">Unit</th>
+              <th className="py-2 text-right">Amount</th>
+            </tr>
+          </thead>
+          <tbody>
+            {estimate.lineItems.map((line, i) => (
+              <tr key={i} className="border-b">
+                <td className="py-2">{line.description}</td>
+                <td className="py-2 text-right tabular-nums">{line.quantity}</td>
+                <td className="py-2 text-right tabular-nums">
+                  {formatMoney(line.unitAmount, estimate.currency)}
+                </td>
+                <td className="py-2 text-right tabular-nums">
+                  {formatMoney(line.amount, estimate.currency)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        <div className="ml-auto w-full max-w-xs space-y-1 text-sm">
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Subtotal</span>
+            <span className="tabular-nums">
+              {formatMoney(estimate.subtotal, estimate.currency)}
+            </span>
+          </div>
+          {estimate.taxAmount > 0 && (
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Tax</span>
+              <span className="tabular-nums">
+                {formatMoney(estimate.taxAmount, estimate.currency)}
+              </span>
+            </div>
+          )}
+          <div className="flex justify-between border-t pt-1 text-base font-semibold">
+            <span>Total</span>
+            <span className="tabular-nums">{formatMoney(estimate.total, estimate.currency)}</span>
+          </div>
+        </div>
+
+        {estimate.notes && (
+          <p className="whitespace-pre-wrap text-sm text-muted-foreground">{estimate.notes}</p>
+        )}
+
+        {error && <p className="text-center text-sm text-destructive">{error}</p>}
+
+        <div className="flex flex-wrap items-center justify-end gap-3">
+          {estimate.status === "sent" ? (
+            <>
+              <Button
+                variant="outline"
+                onClick={() => void decide("decline")}
+                disabled={deciding}
+              >
+                Decline
+              </Button>
+              <Button onClick={() => void decide("accept")} disabled={deciding}>
+                {deciding ? "Saving…" : "Accept estimate"}
+              </Button>
+            </>
+          ) : estimate.status === "accepted" ? (
+            <span className="text-sm font-medium text-emerald-600 dark:text-emerald-400">
+              Accepted — thank you
+            </span>
+          ) : estimate.status === "declined" ? (
+            <span className="text-sm font-medium text-muted-foreground">Declined</span>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Estimate — Madori</title>
+      </Head>
+      <div className="container mx-auto max-w-2xl px-4 py-16">
+        <Card>
+          <CardContent className="py-8">{body}</CardContent>
+        </Card>
+      </div>
+    </>
+  );
+};
+
+export default PublicEstimatePage;

--- a/pwa/pages/estimates/[id].tsx
+++ b/pwa/pages/estimates/[id].tsx
@@ -1,0 +1,380 @@
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { ArrowLeft, Plus, Trash2 } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { apiGet, apiSend } from "@/lib/apiClient";
+import { signinHrefForCurrent } from "@/lib/authRedirect";
+import { formatMoney } from "@/lib/invoiceTypes";
+import { Estimate, ESTIMATE_STATUS_META, EstimateStatus, estimateClientName } from "@/lib/estimateTypes";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+
+const MERGE_PATCH = "application/merge-patch+json";
+
+interface EditableLine {
+  key: string;
+  description: string;
+  quantity: string;
+  unit: string; // major units
+}
+
+/** Estimate detail (#652) — the quote editor, mirroring the invoice detail. */
+const EstimateDetailPage = () => {
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
+  const router = useRouter();
+  const { id } = router.query;
+  const estimateId = typeof id === "string" ? id : null;
+
+  const [lines, setLines] = useState<EditableLine[]>([]);
+  const [notes, setNotes] = useState("");
+  const [taxPercent, setTaxPercent] = useState("0");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) {
+      router.replace(signinHrefForCurrent(router.asPath));
+    }
+  }, [authLoading, isAuthenticated, router]);
+
+  const estimateQuery = useQuery({
+    queryKey: ["estimate", estimateId],
+    enabled: isAuthenticated && estimateId !== null,
+    queryFn: () =>
+      apiGet<Estimate>(`/estimates/${estimateId}`, {
+        errorMessage: "Failed to load the estimate.",
+      }),
+  });
+  const estimate = estimateQuery.data ?? null;
+  const currency = estimate?.currency ?? "USD";
+  const editable = estimate?.status === "draft" || estimate?.status === "sent";
+
+  useEffect(() => {
+    if (!estimate) return;
+    setLines(
+      estimate.lineItems.map((l, i) => ({
+        key: `${i}`,
+        description: l.description,
+        quantity: String(l.quantity),
+        unit: (l.unitAmount / 100).toFixed(2),
+      })),
+    );
+    setNotes(estimate.notes ?? "");
+    setTaxPercent(String(estimate.taxRate / 100));
+  }, [estimate]);
+
+  const preview = useMemo(() => {
+    const subtotal = lines.reduce((sum, l) => {
+      const qty = parseFloat(l.quantity) || 0;
+      const unitMinor = Math.round((parseFloat(l.unit) || 0) * 100);
+      return sum + Math.round(qty * unitMinor);
+    }, 0);
+    const tax = Math.round((subtotal * (parseFloat(taxPercent) || 0) * 100) / 10000);
+    return { subtotal, tax, total: subtotal + tax };
+  }, [lines, taxPercent]);
+
+  const addLine = () =>
+    setLines((prev) => [
+      ...prev,
+      { key: `new-${prev.length}-${Date.now()}`, description: "", quantity: "1", unit: "0.00" },
+    ]);
+  const removeLine = (key: string) => setLines((prev) => prev.filter((l) => l.key !== key));
+  const updateLine = (key: string, patch: Partial<EditableLine>) =>
+    setLines((prev) => prev.map((l) => (l.key === key ? { ...l, ...patch } : l)));
+
+  const save = async () => {
+    if (!estimate) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await apiSend<Estimate>("PATCH", estimate["@id"], {
+        contentType: MERGE_PATCH,
+        errorMessage: "Failed to save.",
+        body: {
+          notes: notes.trim() || null,
+          taxRate: Math.round((parseFloat(taxPercent) || 0) * 100),
+          lineItems: lines.map((l, i) => ({
+            description: l.description.trim() || "—",
+            quantity: parseFloat(l.quantity) || 0,
+            unitAmount: Math.round((parseFloat(l.unit) || 0) * 100),
+            position: i,
+          })),
+        },
+      });
+      setNotice("Saved.");
+      void estimateQuery.refetch();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to save.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const runAction = async (action: "send" | "convert") => {
+    if (!estimate) return;
+    setError(null);
+    try {
+      const res = await apiSend<{ token?: string; invoice?: { id: string } }>(
+        "POST",
+        `${estimate["@id"]}/${action}`,
+        {
+          contentType: "application/json",
+          errorMessage: `Failed to ${action}.`,
+          body: {},
+        },
+      );
+      if (action === "send" && res?.token) {
+        setNotice(`Sent. Link: ${window.location.origin}/e/${res.token}`);
+      }
+      if (action === "convert" && res?.invoice?.id) {
+        void router.push(`/invoices/${res.invoice.id}`);
+        return;
+      }
+      void estimateQuery.refetch();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Action failed.");
+    }
+  };
+
+  if (authLoading || !isAuthenticated) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-muted">
+        <p className="text-muted-foreground">Loading…</p>
+      </div>
+    );
+  }
+
+  const status: EstimateStatus | null = estimate?.status ?? null;
+
+  return (
+    <>
+      <Head>
+        <title>Estimate — Madori</title>
+      </Head>
+      <div className="min-h-screen bg-background px-4 py-12">
+        <div className="mx-auto max-w-3xl">
+          <Link
+            href="/estimates"
+            className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+          >
+            <ArrowLeft className="size-4" /> Estimates
+          </Link>
+
+          {estimateQuery.isLoading ? (
+            <p className="text-muted-foreground">Loading…</p>
+          ) : !estimate ? (
+            <Alert variant="destructive">
+              <AlertDescription>Estimate not found.</AlertDescription>
+            </Alert>
+          ) : (
+            <>
+              <div className="mb-6 flex items-center justify-between gap-4">
+                <div>
+                  <h1 className="flex items-center gap-2 text-2xl font-semibold">
+                    {estimate.number ?? "Draft estimate"}
+                    {status && (
+                      <span
+                        className={cn(
+                          "rounded px-2 py-0.5 text-xs font-medium",
+                          ESTIMATE_STATUS_META[status].badgeClass,
+                        )}
+                      >
+                        {ESTIMATE_STATUS_META[status].label}
+                      </span>
+                    )}
+                  </h1>
+                  <p className="text-sm text-muted-foreground">
+                    {estimateClientName(estimate.client)}
+                    {estimate.decidedAt &&
+                      ` · decided ${new Date(estimate.decidedAt).toLocaleDateString(undefined, { dateStyle: "medium" })}`}
+                  </p>
+                </div>
+              </div>
+
+              {notice && (
+                <Alert className="mb-4">
+                  <AlertDescription>{notice}</AlertDescription>
+                </Alert>
+              )}
+              {error && (
+                <Alert variant="destructive" className="mb-4">
+                  <AlertDescription>{error}</AlertDescription>
+                </Alert>
+              )}
+
+              <Card className="mb-6">
+                <CardContent className="space-y-4 py-6">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+                        <th className="py-2">Description</th>
+                        <th className="w-20 py-2 text-right">Qty</th>
+                        <th className="w-28 py-2 text-right">Unit</th>
+                        <th className="w-28 py-2 text-right">Amount</th>
+                        {editable && <th className="w-8" />}
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {lines.map((line) => {
+                        const amount = Math.round(
+                          (parseFloat(line.quantity) || 0) *
+                            Math.round((parseFloat(line.unit) || 0) * 100),
+                        );
+                        return (
+                          <tr key={line.key} className="border-b">
+                            <td className="py-1.5 pr-2">
+                              {editable ? (
+                                <Input
+                                  value={line.description}
+                                  onChange={(e) =>
+                                    updateLine(line.key, { description: e.target.value })
+                                  }
+                                  className="h-8"
+                                />
+                              ) : (
+                                line.description
+                              )}
+                            </td>
+                            <td className="py-1.5 text-right">
+                              {editable ? (
+                                <Input
+                                  type="number"
+                                  step="0.25"
+                                  value={line.quantity}
+                                  onChange={(e) =>
+                                    updateLine(line.key, { quantity: e.target.value })
+                                  }
+                                  className="h-8 text-right"
+                                />
+                              ) : (
+                                line.quantity
+                              )}
+                            </td>
+                            <td className="py-1.5 text-right">
+                              {editable ? (
+                                <Input
+                                  type="number"
+                                  step="0.01"
+                                  value={line.unit}
+                                  onChange={(e) => updateLine(line.key, { unit: e.target.value })}
+                                  className="h-8 text-right"
+                                />
+                              ) : (
+                                formatMoney(
+                                  Math.round((parseFloat(line.unit) || 0) * 100),
+                                  currency,
+                                )
+                              )}
+                            </td>
+                            <td className="py-1.5 text-right tabular-nums">
+                              {formatMoney(amount, currency)}
+                            </td>
+                            {editable && (
+                              <td className="py-1.5 text-right">
+                                <Button
+                                  variant="ghost"
+                                  size="icon"
+                                  onClick={() => removeLine(line.key)}
+                                  aria-label="Remove line"
+                                >
+                                  <Trash2 className="size-4 text-muted-foreground" />
+                                </Button>
+                              </td>
+                            )}
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+
+                  {editable && (
+                    <Button variant="outline" size="sm" onClick={addLine} className="gap-1.5">
+                      <Plus className="size-4" /> Add line
+                    </Button>
+                  )}
+
+                  <div className="ml-auto w-full max-w-xs space-y-1 text-sm">
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">Subtotal</span>
+                      <span className="tabular-nums">{formatMoney(preview.subtotal, currency)}</span>
+                    </div>
+                    {preview.tax > 0 && (
+                      <div className="flex justify-between">
+                        <span className="text-muted-foreground">Tax</span>
+                        <span className="tabular-nums">{formatMoney(preview.tax, currency)}</span>
+                      </div>
+                    )}
+                    <div className="flex justify-between border-t pt-1 text-base font-semibold">
+                      <span>Total</span>
+                      <span className="tabular-nums">{formatMoney(preview.total, currency)}</span>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+
+              {editable && (
+                <Card className="mb-6">
+                  <CardContent className="space-y-4 py-6">
+                    <div className="space-y-1.5">
+                      <Label htmlFor="est-tax">Tax %</Label>
+                      <Input
+                        id="est-tax"
+                        type="number"
+                        step="0.01"
+                        min="0"
+                        value={taxPercent}
+                        onChange={(e) => setTaxPercent(e.target.value)}
+                        className="w-40"
+                      />
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="est-notes">Notes</Label>
+                      <Textarea
+                        id="est-notes"
+                        value={notes}
+                        onChange={(e) => setNotes(e.target.value)}
+                        rows={2}
+                      />
+                    </div>
+                    <Button onClick={() => void save()} disabled={saving}>
+                      {saving ? "Saving…" : "Save"}
+                    </Button>
+                  </CardContent>
+                </Card>
+              )}
+
+              <div className="flex flex-wrap gap-2">
+                {status !== "declined" && (
+                  <Button variant="outline" onClick={() => void runAction("send")}>
+                    {status === "draft" ? "Send" : "Re-send"}
+                  </Button>
+                )}
+                {status !== "declined" && !estimate.convertedInvoice && (
+                  <Button variant="outline" onClick={() => void runAction("convert")}>
+                    Convert to invoice
+                  </Button>
+                )}
+                {estimate.convertedInvoice && (
+                  <p className="self-center text-sm text-muted-foreground">
+                    Converted to an invoice.
+                  </p>
+                )}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default EstimateDetailPage;

--- a/pwa/pages/estimates/index.tsx
+++ b/pwa/pages/estimates/index.tsx
@@ -1,0 +1,322 @@
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { FileSpreadsheet, MoreHorizontal, Plus } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
+import { apiGetCollection, apiSend } from "@/lib/apiClient";
+import { signinHrefForCurrent } from "@/lib/authRedirect";
+import { formatMoney } from "@/lib/invoiceTypes";
+import { Estimate, ESTIMATE_STATUS_META, estimateClientName } from "@/lib/estimateTypes";
+import PageHeader from "@/components/common/PageHeader";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+interface ClientLite {
+  "@id": string;
+  name: string;
+  currency?: string | null;
+}
+
+/**
+ * Estimates (#652): quotes with a draft → sent → accepted/declined
+ * lifecycle. Rows link into the detail editor; accepted estimates convert
+ * into draft invoices.
+ */
+const EstimatesPage = () => {
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
+  const { activeSpace, can } = useActiveSpace();
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const [showComposer, setShowComposer] = useState(false);
+  const [newClient, setNewClient] = useState("");
+  const [notice, setNotice] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) {
+      router.replace(signinHrefForCurrent(router.asPath));
+    }
+  }, [authLoading, isAuthenticated, router]);
+
+  const spaceIri = activeSpace?.["@id"] ?? null;
+  const canManage = can("invoices", "create");
+
+  const estimatesQuery = useQuery({
+    queryKey: ["estimates", spaceIri],
+    enabled: isAuthenticated,
+    queryFn: () =>
+      apiGetCollection<Estimate>(
+        spaceIri ? `/estimates?space=${encodeURIComponent(spaceIri)}` : "/estimates",
+        { errorMessage: "Failed to load estimates." },
+      ),
+  });
+  const clientsQuery = useQuery({
+    queryKey: ["clients", spaceIri],
+    enabled: isAuthenticated && canManage,
+    queryFn: () =>
+      apiGetCollection<ClientLite>(
+        spaceIri ? `/clients?space=${encodeURIComponent(spaceIri)}` : "/clients",
+        { errorMessage: "Failed to load clients." },
+      ),
+  });
+  const estimates = estimatesQuery.data ?? [];
+  const clients = clientsQuery.data ?? [];
+  const refresh = () => queryClient.invalidateQueries({ queryKey: ["estimates"] });
+
+  const create = useMutation({
+    mutationFn: () => {
+      const clientRow = clients.find((c) => c["@id"] === newClient);
+      return apiSend<Estimate>("POST", "/estimates", {
+        errorMessage: "Failed to create the estimate.",
+        body: {
+          space: spaceIri,
+          client: newClient,
+          currency: clientRow?.currency ?? "USD",
+          lineItems: [],
+        },
+      });
+    },
+    onSuccess: (res) => {
+      setError(null);
+      setShowComposer(false);
+      setNewClient("");
+      if (res?.id) void router.push(`/estimates/${res.id}`);
+    },
+    onError: (e) => setError(e instanceof Error ? e.message : "Failed to create the estimate."),
+  });
+
+  const act = useMutation({
+    mutationFn: ({ estimate, action }: { estimate: Estimate; action: "send" | "convert" }) =>
+      apiSend<{ token?: string; invoice?: { id: string } }>(
+        "POST",
+        `${estimate["@id"]}/${action}`,
+        {
+          contentType: "application/json",
+          errorMessage: `Failed to ${action} the estimate.`,
+          body: {},
+        },
+      ),
+    onSuccess: (res, { action }) => {
+      setError(null);
+      if (action === "send" && res?.token) {
+        setNotice(`Estimate sent. Shareable link: ${window.location.origin}/e/${res.token}`);
+      } else if (action === "convert" && res?.invoice?.id) {
+        setNotice("Converted to a draft invoice.");
+        void router.push(`/invoices/${res.invoice.id}`);
+      }
+      void refresh();
+    },
+    onError: (e) => setError(e instanceof Error ? e.message : "Action failed."),
+  });
+
+  if (authLoading || !isAuthenticated) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-muted">
+        <p className="text-muted-foreground">Loading…</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Estimates — Madori</title>
+      </Head>
+      <div className="min-h-screen bg-background px-4 py-12">
+        <div className="mx-auto max-w-4xl">
+          <PageHeader
+            title="Estimates"
+            icon={<FileSpreadsheet className="size-6 text-teal-600 dark:text-teal-400" />}
+          />
+
+          {notice && (
+            <Alert className="mb-4">
+              <AlertDescription>{notice}</AlertDescription>
+            </Alert>
+          )}
+          {error && (
+            <Alert variant="destructive" className="mb-4">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          {estimatesQuery.isLoading ? (
+            <p className="text-muted-foreground">Loading…</p>
+          ) : (
+            <Card>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+                      <th className="px-4 py-2 font-medium">Estimate</th>
+                      <th className="px-4 py-2 font-medium">Client</th>
+                      <th className="px-4 py-2 text-right font-medium">Total</th>
+                      <th className="px-4 py-2" />
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {canManage &&
+                      (showComposer ? (
+                        <tr className="border-b bg-muted/10">
+                          <td colSpan={4} className="px-4 py-4">
+                            <div className="flex flex-wrap items-end gap-3">
+                              <div className="space-y-1.5">
+                                <Label htmlFor="est-client">New estimate for</Label>
+                                <select
+                                  id="est-client"
+                                  value={newClient}
+                                  onChange={(e) => setNewClient(e.target.value)}
+                                  className="h-9 w-64 max-w-full rounded-md border border-input bg-background px-3 text-sm"
+                                >
+                                  <option value="">Select a client…</option>
+                                  {clients.map((c) => (
+                                    <option key={c["@id"]} value={c["@id"]}>
+                                      {c.name}
+                                    </option>
+                                  ))}
+                                </select>
+                              </div>
+                              <Button
+                                size="sm"
+                                onClick={() => create.mutate()}
+                                disabled={!newClient || create.isPending}
+                              >
+                                {create.isPending ? "Creating…" : "Create draft"}
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => setShowComposer(false)}
+                              >
+                                Cancel
+                              </Button>
+                              {clients.length === 0 && (
+                                <p className="text-sm text-muted-foreground">
+                                  Add a{" "}
+                                  <Link href="/clients" className="text-primary hover:underline">
+                                    client
+                                  </Link>{" "}
+                                  first.
+                                </p>
+                              )}
+                            </div>
+                          </td>
+                        </tr>
+                      ) : (
+                        <tr className="border-b">
+                          <td colSpan={4} className="px-4 py-2">
+                            <button
+                              type="button"
+                              onClick={() => setShowComposer(true)}
+                              className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+                            >
+                              <Plus className="h-4 w-4" /> New estimate
+                            </button>
+                          </td>
+                        </tr>
+                      ))}
+
+                    {estimates.length === 0 ? (
+                      <tr>
+                        <td colSpan={4} className="px-4 py-10 text-center text-muted-foreground">
+                          No estimates yet.
+                        </td>
+                      </tr>
+                    ) : (
+                      estimates.map((estimate) => {
+                        const meta = ESTIMATE_STATUS_META[estimate.status];
+                        return (
+                          <tr
+                            key={estimate["@id"]}
+                            className="border-b align-middle last:border-0"
+                          >
+                            <td className="px-4 py-3">
+                              <Link
+                                href={`/estimates/${estimate.id}`}
+                                className="flex items-center gap-2 font-medium hover:opacity-80"
+                              >
+                                {estimate.number ?? "Draft"}
+                                <span
+                                  className={cn(
+                                    "rounded px-1.5 py-0.5 text-xs font-medium",
+                                    meta.badgeClass,
+                                  )}
+                                >
+                                  {meta.label}
+                                </span>
+                                {estimate.convertedInvoice && (
+                                  <span className="text-xs text-muted-foreground">
+                                    → invoiced
+                                  </span>
+                                )}
+                              </Link>
+                            </td>
+                            <td className="px-4 py-3 text-muted-foreground">
+                              {estimateClientName(estimate.client) || "—"}
+                            </td>
+                            <td className="px-4 py-3 text-right font-medium tabular-nums">
+                              {formatMoney(estimate.total, estimate.currency)}
+                            </td>
+                            <td className="px-4 py-3 text-right">
+                              {canManage && (
+                                <DropdownMenu>
+                                  <DropdownMenuTrigger asChild>
+                                    <Button
+                                      variant="ghost"
+                                      size="icon"
+                                      aria-label="Estimate actions"
+                                    >
+                                      <MoreHorizontal className="size-4" />
+                                    </Button>
+                                  </DropdownMenuTrigger>
+                                  <DropdownMenuContent align="end">
+                                    {estimate.status !== "declined" && (
+                                      <DropdownMenuItem
+                                        onClick={() => act.mutate({ estimate, action: "send" })}
+                                      >
+                                        {estimate.status === "draft" ? "Send" : "Re-send"}
+                                      </DropdownMenuItem>
+                                    )}
+                                    {estimate.status !== "declined" &&
+                                      !estimate.convertedInvoice && (
+                                        <DropdownMenuItem
+                                          onClick={() =>
+                                            act.mutate({ estimate, action: "convert" })
+                                          }
+                                        >
+                                          Convert to invoice
+                                        </DropdownMenuItem>
+                                      )}
+                                  </DropdownMenuContent>
+                                </DropdownMenu>
+                              )}
+                            </td>
+                          </tr>
+                        );
+                      })
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </Card>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default EstimatesPage;


### PR DESCRIPTION
Closes #652

## What
Harvest-parity quotes — the Invoice's pre-sales sibling.

- **`Estimate` + `EstimateLineItem`** (`/estimates`): same line-item + server-derived-totals model as Invoice (`EstimateProcessor`), same `invoices`-category gating + space scoping (`EstimateAccessExtension`). Lifecycle: **draft → sent → accepted/declined**.
- **Send** (`POST /estimates/{id}/send`): assigns the next per-space `EST-NNNN` number, mints the public token (sha256 at rest, rotated per send), moves draft → sent, emails the client the `/e/{token}` link.
- **Public page** (`GET /public/estimates/{token}` + `/accept` + `/decline`): the client reviews and decides right on the page; a decision is final (409 on the second decision) and stamps `decidedAt`; the estimate's **creator is emailed the outcome**.
- **Convert** (`POST /estimates/{id}/convert`): copies the lines onto a fresh **draft Invoice** and back-links it (`convertedInvoice`). Declined estimates can't convert; an estimate converts at most once (409).
- **PWA**: `/estimates` under the Billing sidebar (create-draft-for-client composer, status badges, send / convert row actions), `/estimates/{id}` line editor (editable while draft/sent), public `/e/{token}` page with Accept / Decline.

## Migration
`Version20260716170000`: `estimate` + `estimate_line_item`.

## Tests
`EstimateTest`:
- derived totals; send assigns EST-0001 + emails the client; public view resolves + unknown token 404s; accept flips status + emails the creator; second decision 409s; convert copies both lines onto a draft invoice with matching totals + back-links; second convert 409s
- declined estimates can't convert