### PR TITLE
feat(billing): per-person + cost rates with profitability reports

### DIFF
--- a/api/migrations/Version20260716180000.php
+++ b/api/migrations/Version20260716180000.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Per-person + cost rates (#653): engagement_user_rate (per-engagement
+ * billable rate overrides), space_membership.cost_rate_amount (space-level
+ * internal cost), and time_entry.cost_rate_amount (the per-entry snapshot
+ * profitability reports read).
+ */
+final class Version20260716180000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'engagement_user_rate table + cost_rate_amount on space_membership and time_entry.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE engagement_user_rate (id UUID NOT NULL, rate_amount INT NOT NULL, engagement_id UUID NOT NULL, user_id UUID NOT NULL, PRIMARY KEY (id))');
+        $this->addSql('CREATE UNIQUE INDEX uniq_engagement_user_rate ON engagement_user_rate (engagement_id, user_id)');
+        $this->addSql('CREATE INDEX idx_engagement_user_rate_user ON engagement_user_rate (user_id)');
+        $this->addSql('ALTER TABLE engagement_user_rate ADD CONSTRAINT FK_1F155505D30F6F97 FOREIGN KEY (engagement_id) REFERENCES engagement (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE engagement_user_rate ADD CONSTRAINT FK_1F155505A76ED395 FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE space_membership ADD cost_rate_amount INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE time_entry ADD cost_rate_amount INT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE engagement_user_rate DROP CONSTRAINT FK_1F155505D30F6F97');
+        $this->addSql('ALTER TABLE engagement_user_rate DROP CONSTRAINT FK_1F155505A76ED395');
+        $this->addSql('DROP TABLE engagement_user_rate');
+        $this->addSql('ALTER TABLE space_membership DROP cost_rate_amount');
+        $this->addSql('ALTER TABLE time_entry DROP cost_rate_amount');
+    }
+}

--- a/api/src/Controller/ReportController.php
+++ b/api/src/Controller/ReportController.php
@@ -67,11 +67,11 @@ class ReportController extends AbstractController
 
         $entries = $this->timeEntries->findCompletedForSpace($space, $from, $to?->modify('+1 day'));
 
-        /** @var array<string, array{label: string, seconds: int, billableSeconds: int, amounts: array<string, int>}> $rows */
+        /** @var array<string, array{label: string, seconds: int, billableSeconds: int, amounts: array<string, int>, costs: array<string, int>}> $rows */
         $rows = [];
         foreach ($entries as $entry) {
             [$key, $label] = $this->groupKey($entry, $groupBy);
-            $row = $rows[$key] ?? ['label' => $label, 'seconds' => 0, 'billableSeconds' => 0, 'amounts' => []];
+            $row = $rows[$key] ?? ['label' => $label, 'seconds' => 0, 'billableSeconds' => 0, 'amounts' => [], 'costs' => []];
 
             $seconds = $entry->getDurationSeconds() ?? 0;
             $row['seconds'] += $seconds;
@@ -83,18 +83,31 @@ class ReportController extends AbstractController
                     $row['amounts'][$currency] = ($row['amounts'][$currency] ?? 0) + $amount;
                 }
             }
+            // Cost (#653) accrues on ALL tracked time — non-billable hours
+            // still cost the team — using the entry's snapshotted cost rate.
+            $costRate = $entry->getCostRateAmount();
+            if (null !== $costRate && $costRate > 0) {
+                $cost = (int) round(round($seconds / 3600, 2) * $costRate);
+                if ($cost > 0) {
+                    $currency = $this->entryCurrency($entry);
+                    $row['costs'][$currency] = ($row['costs'][$currency] ?? 0) + $cost;
+                }
+            }
             $rows[$key] = $row;
         }
 
         uasort($rows, static fn (array $a, array $b): int => strcasecmp($a['label'], $b['label']));
 
-        $totals = ['seconds' => 0, 'billableSeconds' => 0, 'amounts' => []];
+        $totals = ['seconds' => 0, 'billableSeconds' => 0, 'amounts' => [], 'costs' => []];
         $list = [];
         foreach ($rows as $key => $row) {
             $totals['seconds'] += $row['seconds'];
             $totals['billableSeconds'] += $row['billableSeconds'];
             foreach ($row['amounts'] as $currency => $amount) {
                 $totals['amounts'][$currency] = ($totals['amounts'][$currency] ?? 0) + $amount;
+            }
+            foreach ($row['costs'] as $currency => $cost) {
+                $totals['costs'][$currency] = ($totals['costs'][$currency] ?? 0) + $cost;
             }
             $list[] = [
                 'key' => $key,
@@ -104,6 +117,8 @@ class ReportController extends AbstractController
                 'billableSeconds' => $row['billableSeconds'],
                 'billableHours' => round($row['billableSeconds'] / 3600, 2),
                 'amounts' => $row['amounts'],
+                'costs' => $row['costs'],
+                'profit' => $this->profitOf($row['amounts'], $row['costs']),
             ];
         }
 
@@ -115,12 +130,14 @@ class ReportController extends AbstractController
                     number_format($row['hours'], 2, '.', ''),
                     number_format($row['billableHours'], 2, '.', ''),
                     $this->amountsLabel($row['amounts']),
+                    $this->amountsLabel($row['costs']),
+                    $this->amountsLabel($row['profit']),
                 ];
             }
 
             return $this->csv(
                 sprintf('time-summary-by-%s.csv', $groupBy),
-                [ucfirst($groupBy), 'Hours', 'Billable hours', 'Billable amount'],
+                [ucfirst($groupBy), 'Hours', 'Billable hours', 'Billable amount', 'Cost', 'Profit'],
                 $csvRows,
             );
         }
@@ -136,8 +153,29 @@ class ReportController extends AbstractController
                 'billableSeconds' => $totals['billableSeconds'],
                 'billableHours' => round($totals['billableSeconds'] / 3600, 2),
                 'amounts' => $totals['amounts'],
+                'costs' => $totals['costs'],
+                'profit' => $this->profitOf($totals['amounts'], $totals['costs']),
             ],
         ]);
+    }
+
+    /**
+     * Billable amount − cost, per currency (#653). Currencies that only
+     * appear on one side still surface (cost-only → negative profit).
+     *
+     * @param array<string, int> $amounts
+     * @param array<string, int> $costs
+     *
+     * @return array<string, int>
+     */
+    private function profitOf(array $amounts, array $costs): array
+    {
+        $profit = $amounts;
+        foreach ($costs as $currency => $cost) {
+            $profit[$currency] = ($profit[$currency] ?? 0) - $cost;
+        }
+
+        return $profit;
     }
 
     #[Route('/spaces/{id}/reports/uninvoiced', name: 'report_uninvoiced', methods: ['GET'])]

--- a/api/src/Controller/SpaceMemberController.php
+++ b/api/src/Controller/SpaceMemberController.php
@@ -176,6 +176,16 @@ class SpaceMemberController extends AbstractController
             $membership->setRole($role);
         }
 
+        // Internal cost rate (#653): minor units per hour, null clears it.
+        // Admin-only by the shared guard above; feeds profitability reports.
+        if (array_key_exists('costRateAmount', $payload)) {
+            $costRate = $payload['costRateAmount'];
+            if (null !== $costRate && (!is_int($costRate) || $costRate < 0)) {
+                return $this->json(['error' => 'costRateAmount must be a non-negative integer or null.'], 422);
+            }
+            $membership->setCostRateAmount($costRate);
+        }
+
         if (array_key_exists('roles', $payload)) {
             $resolved = $this->resolveRoles($space, $payload['roles']);
             if ($resolved instanceof JsonResponse) {

--- a/api/src/Entity/Engagement.php
+++ b/api/src/Entity/Engagement.php
@@ -178,6 +178,22 @@ class Engagement
     private Collection $categories;
 
     /**
+     * Per-person billable rate overrides (#653) — when a user has a row
+     * here, their tracked time snapshots this rate instead of the
+     * category's. Written as part of the engagement like categories.
+     *
+     * @var Collection<int, EngagementUserRate>
+     */
+    #[ORM\OneToMany(
+        mappedBy: 'engagement',
+        targetEntity: EngagementUserRate::class,
+        cascade: ['persist', 'remove'],
+        orphanRemoval: true,
+    )]
+    #[Groups(['engagement:read', 'engagement:write'])]
+    private Collection $userRates;
+
+    /**
      * Task-management boards assigned to this engagement (inverse of
      * {@see Board::$engagement}). Read-only summary for the detail page.
      *
@@ -218,9 +234,25 @@ class Engagement
     public function __construct()
     {
         $this->categories = new ArrayCollection();
+        $this->userRates = new ArrayCollection();
         $this->assignedProjects = new ArrayCollection();
         $this->attachments = new ArrayCollection();
         $this->createdAt = new \DateTimeImmutable();
+    }
+
+    /**
+     * The billable rate override for a user (#653), or null when they bill
+     * at the category rate. UUID-based comparison so it survives EM::clear().
+     */
+    public function getUserRateFor(User $user): ?int
+    {
+        foreach ($this->userRates as $rate) {
+            if (true === $rate->getUser()?->getId()?->equals($user->getId())) {
+                return $rate->getRateAmount();
+            }
+        }
+
+        return null;
     }
 
     #[ORM\PreUpdate]
@@ -448,6 +480,31 @@ class Engagement
     public function removeCategory(EngagementCategory $category): self
     {
         $this->categories->removeElement($category);
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, EngagementUserRate>
+     */
+    public function getUserRates(): Collection
+    {
+        return $this->userRates;
+    }
+
+    public function addUserRate(EngagementUserRate $userRate): self
+    {
+        if (!$this->userRates->contains($userRate)) {
+            $this->userRates->add($userRate);
+            $userRate->setEngagement($this);
+        }
+
+        return $this;
+    }
+
+    public function removeUserRate(EngagementUserRate $userRate): self
+    {
+        $this->userRates->removeElement($userRate);
 
         return $this;
     }

--- a/api/src/Entity/EngagementUserRate.php
+++ b/api/src/Entity/EngagementUserRate.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Metadata\ApiProperty;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * A per-person billable rate override on an {@see Engagement} (#653) —
+ * Harvest's "person rate": when set, time this user tracks on the engagement
+ * snapshots this rate instead of the category's. Written as part of the
+ * engagement's `userRates` array (like categories), one row per user.
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'engagement_user_rate')]
+#[ORM\UniqueConstraint(name: 'uniq_engagement_user_rate', columns: ['engagement_id', 'user_id'])]
+#[ORM\Index(columns: ['user_id'], name: 'idx_engagement_user_rate_user')]
+class EngagementUserRate
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
+    #[Groups(['engagement:read'])]
+    private ?Uuid $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Engagement::class, inversedBy: 'userRates')]
+    #[ORM\JoinColumn(name: 'engagement_id', nullable: false, onDelete: 'CASCADE')]
+    private ?Engagement $engagement = null;
+
+    #[ApiProperty(readableLink: false)]
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    #[Assert\NotNull(message: 'A user is required.')]
+    #[Groups(['engagement:read', 'engagement:write'])]
+    private ?User $user = null;
+
+    /** Hourly billable rate in minor units of the engagement's currency. */
+    #[ORM\Column(type: 'integer')]
+    #[Assert\PositiveOrZero]
+    #[Groups(['engagement:read', 'engagement:write'])]
+    private int $rateAmount = 0;
+
+    public function getId(): ?Uuid
+    {
+        return $this->id;
+    }
+
+    public function getEngagement(): ?Engagement
+    {
+        return $this->engagement;
+    }
+
+    public function setEngagement(?Engagement $engagement): self
+    {
+        $this->engagement = $engagement;
+
+        return $this;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(?User $user): self
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    public function getRateAmount(): int
+    {
+        return $this->rateAmount;
+    }
+
+    public function setRateAmount(int $rateAmount): self
+    {
+        $this->rateAmount = $rateAmount;
+
+        return $this;
+    }
+}

--- a/api/src/Entity/Space.php
+++ b/api/src/Entity/Space.php
@@ -593,6 +593,25 @@ class Space
     }
 
     /**
+     * The member's space-level internal cost rate (#653), or null when
+     * unset / not a direct member. UUID-based comparison like the other
+     * membership helpers.
+     */
+    public function getCostRateFor(?User $user): ?int
+    {
+        if (null === $user || null === $user->getId()) {
+            return null;
+        }
+        foreach ($this->userMemberships as $membership) {
+            if (true === $membership->getUser()?->getId()?->equals($user->getId())) {
+                return $membership->getCostRateAmount();
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Shared scan for direct user memberships, optionally filtered to
      * a specific role. Pulled out so {@see isAdmin()} and
      * {@see hasMember()} stay one-liners.

--- a/api/src/Entity/SpaceMembership.php
+++ b/api/src/Entity/SpaceMembership.php
@@ -53,6 +53,16 @@ class SpaceMembership
     private \DateTimeImmutable $joinedAt;
 
     /**
+     * Internal cost rate (#653): what an hour of this member costs the team,
+     * in minor units — the profitability reports subtract it from billable
+     * amounts. Admin-set via POST /spaces/{id}/members/{userId}/cost-rate;
+     * space-level so it follows the person across engagements.
+     */
+    #[ORM\Column(type: 'integer', nullable: true)]
+    #[Groups(['space:read'])]
+    private ?int $costRateAmount = null;
+
+    /**
      * Custom roles assigned to this member (#space-roles). Effective
      * permissions are the union of these; an empty set = unrestricted
      * (back-compat). Admins are never restricted regardless.
@@ -111,6 +121,17 @@ class SpaceMembership
     public function getJoinedAt(): \DateTimeImmutable
     {
         return $this->joinedAt;
+    }
+
+    public function getCostRateAmount(): ?int
+    {
+        return $this->costRateAmount;
+    }
+
+    public function setCostRateAmount(?int $costRateAmount): static
+    {
+        $this->costRateAmount = $costRateAmount;
+        return $this;
     }
 
     /**

--- a/api/src/Entity/TimeEntry.php
+++ b/api/src/Entity/TimeEntry.php
@@ -174,6 +174,15 @@ class TimeEntry
     #[Groups(['time_entry:read'])]
     private ?string $rateCurrency = null;
 
+    /**
+     * Internal cost rate (#653), snapshotted from the member's space-level
+     * cost rate on save — profitability reports subtract it from billable
+     * amounts. Derived, read-only, never exposed to non-invoicing members
+     * (it's not in any read group; reports are the read surface).
+     */
+    #[ORM\Column(type: 'integer', nullable: true)]
+    private ?int $costRateAmount = null;
+
     /** Set when the entry is pulled onto an invoice; locks it against re-billing. */
     #[ORM\Column(type: 'datetime_immutable', nullable: true)]
     #[Groups(['time_entry:read'])]
@@ -209,8 +218,20 @@ class TimeEntry
         // later category change never rewrites already-logged (or billed) time.
         if (null !== $this->category) {
             $this->rateAmount = $this->category->getRateAmount();
+            // #653: a per-person engagement rate overrides the category rate.
+            if (null !== $this->engagement && null !== $this->user) {
+                $override = $this->engagement->getUserRateFor($this->user);
+                if (null !== $override) {
+                    $this->rateAmount = $override;
+                }
+            }
             $this->rateCurrency = $this->engagement?->getCurrency();
             $this->billable = $this->category->isBillable();
+        }
+
+        // #653: snapshot the member's space-level cost rate for profitability.
+        if (null !== $this->space && null !== $this->user) {
+            $this->costRateAmount = $this->space->getCostRateFor($this->user);
         }
 
         $this->durationSeconds = null;
@@ -404,6 +425,11 @@ class TimeEntry
         $this->billedAt = $billedAt;
 
         return $this;
+    }
+
+    public function getCostRateAmount(): ?int
+    {
+        return $this->costRateAmount;
     }
 
     public function getCreatedAt(): \DateTimeImmutable

--- a/api/tests/Api/PersonCostRateTest.php
+++ b/api/tests/Api/PersonCostRateTest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\Space;
+use App\Entity\SpaceMembership;
+use App\Entity\TimeEntry;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Per-person + cost rates (#653): engagement person-rate overrides win over
+ * the category rate, space-level cost rates snapshot onto entries, and the
+ * time-summary report surfaces cost + profit.
+ */
+class PersonCostRateTest extends ApiTestCase
+{
+    use SpaceMembershipFixture;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = static::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\TimeEntry')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\EngagementUserRate')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\EngagementCategory')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Engagement')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Client')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\SpaceMembership')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Space')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testPersonRateOverrideCostSnapshotAndProfitReport(): void
+    {
+        $admin = $this->createUser('admin@example.com', 'Alice');
+        $member = $this->createUser('member@example.com', 'Bob');
+        $space = $this->createSharedSpace($admin, $member);
+        $spaceId = (string) $space->getId();
+        $spaceIri = '/spaces/' . $spaceId;
+        $memberIri = '/users/' . $member->getId();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+
+        // Dev bills at 6000/h; Bob has a 9000/h person-rate override.
+        $engagement = $client->request('POST', '/engagements', [
+            'json' => [
+                'space' => $spaceIri,
+                'client' => $clientRow['@id'],
+                'name' => 'Acme Website',
+                'currency' => 'USD',
+                'categories' => [['name' => 'Dev', 'rateAmount' => 6000, 'position' => 0]],
+                'userRates' => [['user' => $memberIri, 'rateAmount' => 9000]],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $engagementIri = $engagement['@id'];
+        $this->assertIsString($engagementIri);
+        $rates = $engagement['userRates'] ?? null;
+        $this->assertIsArray($rates);
+        $this->assertCount(1, $rates);
+        $categories = $engagement['categories'] ?? null;
+        $this->assertIsArray($categories);
+        $firstCategory = $categories[0];
+        $this->assertIsArray($firstCategory);
+        $categoryIri = $firstCategory['@id'];
+        $this->assertIsString($categoryIri);
+
+        // Bob's space-level cost rate: 4000/h, set via the membership PATCH.
+        $membership = $this->entityManager->getRepository(SpaceMembership::class)
+            ->findOneBy(['space' => $space, 'user' => $member]);
+        $this->assertInstanceOf(SpaceMembership::class, $membership);
+        $client->request('PATCH', '/spaces/' . $spaceId . '/members/' . $membership->getId(), [
+            'json' => ['costRateAmount' => 4000],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(200);
+
+        // Bob tracks 1h: bills at his 9000 override, costs 4000.
+        $client->loginUser($member);
+        $bobEntry = $client->request('POST', '/time_entries', [
+            'json' => [
+                'space' => $spaceIri,
+                'engagement' => $engagementIri,
+                'category' => $categoryIri,
+                'startedAt' => '2026-07-10T09:00:00+00:00',
+                'endedAt' => '2026-07-10T10:00:00+00:00',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertSame(9000, $bobEntry['rateAmount'] ?? null);
+
+        // The cost snapshot isn't client-visible — check it on the entity.
+        $em = static::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $bobEntryId = $bobEntry['id'];
+        $this->assertIsString($bobEntryId);
+        $entity = $em->getRepository(TimeEntry::class)->find($bobEntryId);
+        $this->assertInstanceOf(TimeEntry::class, $entity);
+        $this->assertSame(4000, $entity->getCostRateAmount());
+
+        // Alice tracks 30m: category rate, no cost rate set.
+        $client->loginUser($admin);
+        $aliceEntry = $client->request('POST', '/time_entries', [
+            'json' => [
+                'space' => $spaceIri,
+                'engagement' => $engagementIri,
+                'category' => $categoryIri,
+                'startedAt' => '2026-07-10T11:00:00+00:00',
+                'endedAt' => '2026-07-10T11:30:00+00:00',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->assertSame(6000, $aliceEntry['rateAmount'] ?? null);
+
+        // Profitability by person: Bob 9000 − 4000 = 5000; Alice 3000 − 0.
+        $report = $client->request('GET', '/spaces/' . $spaceId . '/reports/time-summary?groupBy=person')->toArray();
+        $this->assertResponseStatusCodeSame(200);
+        $rows = $report['rows'];
+        $this->assertIsArray($rows);
+        $byLabel = [];
+        foreach ($rows as $row) {
+            $this->assertIsArray($row);
+            $label = $row['label'];
+            $this->assertIsString($label);
+            $byLabel[$label] = $row;
+        }
+        $bob = $byLabel['Bob User'] ?? null;
+        $this->assertIsArray($bob);
+        $this->assertSame(['USD' => 9000], $bob['amounts'] ?? null);
+        $this->assertSame(['USD' => 4000], $bob['costs'] ?? null);
+        $this->assertSame(['USD' => 5000], $bob['profit'] ?? null);
+        $alice = $byLabel['Alice User'] ?? null;
+        $this->assertIsArray($alice);
+        $this->assertSame(['USD' => 3000], $alice['amounts'] ?? null);
+        $this->assertSame([], $alice['costs'] ?? null);
+        $this->assertSame(['USD' => 3000], $alice['profit'] ?? null);
+
+        // An invalid cost rate is rejected.
+        $client->request('PATCH', '/spaces/' . $spaceId . '/members/' . ($membership->getId() ?? ''), [
+            'json' => ['costRateAmount' => -5],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    private function createSharedSpace(User $admin, ?User $member = null): Space
+    {
+        $space = (new Space())->setName('Studio')->setCreatedBy($admin);
+        $this->entityManager->persist($space);
+        $adminMembership = (new SpaceMembership())
+            ->setUser($admin)
+            ->setRole(Space::ROLE_ADMIN);
+        $space->addUserMembership($adminMembership);
+        $this->entityManager->persist($adminMembership);
+        if (null !== $member) {
+            $memberMembership = (new SpaceMembership())
+                ->setUser($member)
+                ->setRole(Space::ROLE_MEMBER);
+            $space->addUserMembership($memberMembership);
+            $this->entityManager->persist($memberMembership);
+        }
+        $this->entityManager->flush();
+
+        return $space;
+    }
+
+    private function createUser(string $email, string $givenName): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName($givenName);
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/pwa/pages/engagements/index.tsx
+++ b/pwa/pages/engagements/index.tsx
@@ -61,6 +61,7 @@ interface Engagement {
   budgetType: "hours" | "fees" | null;
   budgetAmount: number | null;
   budgetSpent: number | null;
+  userRates: { "@id"?: string; user: string; rateAmount: number }[];
 }
 
 /** A form category with the rate as a decimal string for editing. */
@@ -69,6 +70,27 @@ interface DraftCategory {
   rate: string;
   billable: boolean;
 }
+
+/** A person-rate override row (#653) with the rate as a decimal string. */
+interface DraftUserRate {
+  user: string;
+  rate: string;
+}
+
+/** A space member as embedded in GET /spaces/{id} (space:read). */
+interface SpaceMemberRow {
+  user: {
+    "@id": string;
+    givenName?: string;
+    familyName?: string;
+    email?: string;
+  };
+}
+
+const memberLabel = (m: SpaceMemberRow): string => {
+  const name = `${m.user.givenName ?? ""} ${m.user.familyName ?? ""}`.trim();
+  return name !== "" ? name : m.user.email ?? m.user["@id"];
+};
 
 const toMinor = (rate: string): number => Math.round((parseFloat(rate) || 0) * 100);
 const toMajor = (minor: number): string => (minor / 100).toFixed(2);
@@ -127,6 +149,8 @@ const EngagementsPage = () => {
   const [budgetType, setBudgetType] = useState("");
   const [budgetValue, setBudgetValue] = useState("");
   const [cats, setCats] = useState<DraftCategory[]>([{ name: "", rate: "", billable: true }]);
+  const [userRates, setUserRates] = useState<DraftUserRate[]>([]);
+  const [members, setMembers] = useState<SpaceMemberRow[]>([]);
   const [assigned, setAssigned] = useState<string[]>([]);
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [saving, setSaving] = useState(false);
@@ -144,14 +168,16 @@ const EngagementsPage = () => {
     setLoadError(null);
     try {
       const q = `?space=${encodeURIComponent(spaceIri)}`;
-      const [bps, cls, prj] = await Promise.all([
+      const [bps, cls, prj, space] = await Promise.all([
         apiGetCollection<Engagement>(`/engagements${q}`),
         apiGetCollection<ClientRow>(`/clients${q}`),
         apiGetCollection<BoardRow>(`/boards${q}`),
+        apiGet<{ userMemberships?: SpaceMemberRow[] }>(spaceIri),
       ]);
       setProjects(bps);
       setClients(cls);
       setTaskBoards(prj);
+      setMembers(space.userMemberships ?? []);
     } catch (e) {
       setLoadError(
         e instanceof ApiError && e.status === 403
@@ -180,6 +206,7 @@ const EngagementsPage = () => {
     setBudgetType("");
     setBudgetValue("");
     setCats([{ name: "", rate: "", billable: true }]);
+    setUserRates([]);
     setAssigned([]);
     setAttachments([]);
     setFormError(null);
@@ -203,6 +230,9 @@ const EngagementsPage = () => {
       bp.categories.length > 0
         ? bp.categories.map((c) => ({ name: c.name, rate: toMajor(c.rateAmount), billable: c.billable }))
         : [{ name: "", rate: "", billable: true }],
+    );
+    setUserRates(
+      (bp.userRates ?? []).map((r) => ({ user: r.user, rate: toMajor(r.rateAmount) })),
     );
     setAssigned(bp.assignedProjectList.map((p) => `/boards/${p.id}`));
     setAttachments(bp.attachments ?? []);
@@ -249,6 +279,10 @@ const EngagementsPage = () => {
             : budgetType === "hours"
               ? Math.round((parseFloat(budgetValue) || 0) * 60)
               : Math.round((parseFloat(budgetValue) || 0) * 100),
+        // Person rates (#653): per-user billable overrides.
+        userRates: userRates
+          .filter((r) => r.user && r.rate.trim() !== "")
+          .map((r) => ({ user: r.user, rateAmount: toMinor(r.rate) })),
       };
       const saved = editingIri
         ? await apiSend<Engagement>("PATCH", editingIri, {
@@ -577,6 +611,68 @@ const EngagementsPage = () => {
               >
                 <Plus className="h-3.5 w-3.5" />
                 Add category
+              </Button>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Person rates</Label>
+              <p className="text-xs text-muted-foreground">
+                Optional per-person billable rate overrides — time this person tracks on
+                this engagement bills at their rate instead of the category&apos;s.
+              </p>
+              {userRates.map((r, i) => (
+                <div key={i} className="flex items-center gap-2">
+                  <select
+                    value={r.user}
+                    onChange={(e) =>
+                      setUserRates((prev) =>
+                        prev.map((row, j) => (j === i ? { ...row, user: e.target.value } : row)),
+                      )
+                    }
+                    className={SELECT_CLASS}
+                    aria-label="Member"
+                  >
+                    <option value="">Member…</option>
+                    {members.map((m) => (
+                      <option key={m.user["@id"]} value={m.user["@id"]}>
+                        {memberLabel(m)}
+                      </option>
+                    ))}
+                  </select>
+                  <Input
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    value={r.rate}
+                    onChange={(e) =>
+                      setUserRates((prev) =>
+                        prev.map((row, j) => (j === i ? { ...row, rate: e.target.value } : row)),
+                      )
+                    }
+                    placeholder="Rate / h"
+                    className="w-32"
+                    aria-label="Hourly rate"
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => setUserRates((prev) => prev.filter((_, j) => j !== i))}
+                    aria-label="Remove person rate"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+              ))}
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="gap-1.5"
+                onClick={() => setUserRates((prev) => [...prev, { user: "", rate: "" }])}
+              >
+                <Plus className="h-3.5 w-3.5" />
+                Add person rate
               </Button>
             </div>
 

--- a/pwa/pages/reports/index.tsx
+++ b/pwa/pages/reports/index.tsx
@@ -31,6 +31,8 @@ interface SummaryRow {
   billableSeconds: number;
   billableHours: number;
   amounts: Record<string, number>;
+  costs: Record<string, number>;
+  profit: Record<string, number>;
 }
 
 interface SummaryReport {
@@ -44,6 +46,8 @@ interface SummaryReport {
     billableSeconds: number;
     billableHours: number;
     amounts: Record<string, number>;
+    costs: Record<string, number>;
+    profit: Record<string, number>;
   };
 }
 
@@ -265,18 +269,20 @@ const ReportsPage = () => {
                             <th className="px-4 py-2 text-right font-medium">Hours</th>
                             <th className="px-4 py-2 text-right font-medium">Billable hours</th>
                             <th className="px-4 py-2 text-right font-medium">Billable amount</th>
+                            <th className="px-4 py-2 text-right font-medium">Cost</th>
+                            <th className="px-4 py-2 text-right font-medium">Profit</th>
                           </tr>
                         </thead>
                         <tbody>
                           {summaryQuery.isLoading ? (
                             <tr>
-                              <td colSpan={4} className="px-4 py-10 text-center text-muted-foreground">
+                              <td colSpan={6} className="px-4 py-10 text-center text-muted-foreground">
                                 Loading…
                               </td>
                             </tr>
                           ) : !summary || summary.rows.length === 0 ? (
                             <tr>
-                              <td colSpan={4} className="px-4 py-10 text-center text-muted-foreground">
+                              <td colSpan={6} className="px-4 py-10 text-center text-muted-foreground">
                                 No tracked time in this period.
                               </td>
                             </tr>
@@ -292,6 +298,12 @@ const ReportsPage = () => {
                                 </td>
                                 <td className="px-4 py-2.5 text-right tabular-nums">
                                   {amountsLabel(row.amounts)}
+                                </td>
+                                <td className="px-4 py-2.5 text-right tabular-nums">
+                                  {amountsLabel(row.costs)}
+                                </td>
+                                <td className="px-4 py-2.5 text-right tabular-nums">
+                                  {amountsLabel(row.profit)}
                                 </td>
                               </tr>
                             ))
@@ -309,6 +321,12 @@ const ReportsPage = () => {
                               </td>
                               <td className="px-4 py-2 text-right tabular-nums">
                                 {amountsLabel(summary.totals.amounts)}
+                              </td>
+                              <td className="px-4 py-2 text-right tabular-nums">
+                                {amountsLabel(summary.totals.costs)}
+                              </td>
+                              <td className="px-4 py-2 text-right tabular-nums">
+                                {amountsLabel(summary.totals.profit)}
                               </td>
                             </tr>
                           </tfoot>


### PR DESCRIPTION
Closes #653

## What
Agency-grade rate control + profitability (Harvest parity).

**Person rates** — `EngagementUserRate` (`engagement_user_rate`, unique per engagement+user), written as part of the engagement's `userRates` array exactly like categories. When a user has a row, their tracked time **snapshots the override instead of the category rate** (existing snapshot semantics — later changes never rewrite logged time).

**Cost rates** — `SpaceMembership.costRateAmount` (space-level, follows the person across engagements), admin-set through the existing membership PATCH (`{costRateAmount: int|null}`, 422 on negatives). Each entry snapshots it into `time_entry.cost_rate_amount` on save. **Not exposed in any serialization group** — the invoices-gated reports are the only read surface, so plain members never see internal cost data.

**Profitability** — the time-summary report (#647) now returns per-currency `costs` + `profit` (billable amount − cost) per row and in totals; cost accrues on **all** tracked time (non-billable hours still cost the team). CSV export gains Cost + Profit columns.

**PWA** — Person rates editor in the engagement sheet (member picker + hourly rate rows, saved with the engagement); Cost + Profit columns on `/reports`.

## Migration
`Version20260716180000`: `engagement_user_rate` + `cost_rate_amount` on `space_membership` and `time_entry`.

## Tests
`PersonCostRateTest`: override wins over category rate (9000 vs 6000); cost rate set via membership PATCH snapshots onto the entry (asserted at the entity level since it's not in the wire format); by-person report shows amounts/costs/profit for the override user and cost-free amounts for the other; negative cost rate 422s.