### PR TITLE
feat(time): weekly timesheet approvals

### DIFF
--- a/api/migrations/Version20260716190000.php
+++ b/api/migrations/Version20260716190000.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Timesheet approvals (#654): the timesheet_submission table — one row per
+ * (space, user, week), pending/approved freeze the week's time entries.
+ */
+final class Version20260716190000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'timesheet_submission table (weekly submissions with approve/reject).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE timesheet_submission (id UUID NOT NULL, week_start DATE NOT NULL, status VARCHAR(20) NOT NULL, submitted_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, decided_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL, note VARCHAR(500) DEFAULT NULL, space_id UUID NOT NULL, user_id UUID NOT NULL, decided_by_id UUID DEFAULT NULL, PRIMARY KEY (id))');
+        $this->addSql('CREATE UNIQUE INDEX uniq_timesheet_submission_week ON timesheet_submission (space_id, user_id, week_start)');
+        $this->addSql('CREATE INDEX idx_timesheet_submission_space_status ON timesheet_submission (space_id, status)');
+        $this->addSql('CREATE INDEX idx_timesheet_submission_user ON timesheet_submission (user_id)');
+        $this->addSql('CREATE INDEX IDX_3C20375EE26B496B ON timesheet_submission (decided_by_id)');
+        $this->addSql('ALTER TABLE timesheet_submission ADD CONSTRAINT FK_3C20375E23575340 FOREIGN KEY (space_id) REFERENCES space (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE timesheet_submission ADD CONSTRAINT FK_3C20375EA76ED395 FOREIGN KEY (user_id) REFERENCES "user" (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE timesheet_submission ADD CONSTRAINT FK_3C20375EE26B496B FOREIGN KEY (decided_by_id) REFERENCES "user" (id) ON DELETE SET NULL NOT DEFERRABLE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE timesheet_submission DROP CONSTRAINT FK_3C20375E23575340');
+        $this->addSql('ALTER TABLE timesheet_submission DROP CONSTRAINT FK_3C20375EA76ED395');
+        $this->addSql('ALTER TABLE timesheet_submission DROP CONSTRAINT FK_3C20375EE26B496B');
+        $this->addSql('DROP TABLE timesheet_submission');
+    }
+}

--- a/api/src/Controller/TimesheetController.php
+++ b/api/src/Controller/TimesheetController.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\Space;
+use App\Entity\TimeEntry;
+use App\Entity\TimesheetSubmission;
+use App\Entity\User;
+use App\Repository\TimesheetSubmissionRepository;
+use App\Service\TimesheetMailer;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Weekly timesheet approvals (#654):
+ *
+ *  - submit: a member submits their own week — entries in it freeze until a
+ *    decision (pending/approved lock, rejection unlocks). Re-submitting a
+ *    rejected week flips it back to pending.
+ *  - list: members see their own submissions; space admins see everyone's
+ *    (the approvals queue), each row carrying the week's tracked total.
+ *  - approve / reject: space admins decide; a note (most useful on
+ *    rejection) is emailed back to the member.
+ */
+class TimesheetController extends AbstractController
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private TimesheetSubmissionRepository $submissions,
+        private TimesheetMailer $mailer,
+    ) {
+    }
+
+    #[Route('/spaces/{id}/timesheets/submit', name: 'timesheet_submit', methods: ['POST'])]
+    public function submit(string $id, Request $request, #[CurrentUser] ?User $user): JsonResponse
+    {
+        $space = $this->memberSpaceOr($id, $user);
+        if ($space instanceof JsonResponse) {
+            return $space;
+        }
+        assert($user instanceof User);
+
+        $payload = $request->toArray();
+        $raw = $payload['weekStart'] ?? null;
+        if (!is_string($raw) || '' === trim($raw)) {
+            return $this->json(['error' => 'weekStart (YYYY-MM-DD) is required.'], 422);
+        }
+        $parsed = \DateTimeImmutable::createFromFormat('!Y-m-d', trim($raw), new \DateTimeZone('UTC'));
+        if (false === $parsed) {
+            return $this->json(['error' => 'weekStart must be formatted YYYY-MM-DD.'], 422);
+        }
+        $weekStart = TimesheetSubmissionRepository::weekStartOf($parsed);
+
+        $submission = $this->submissions->findForWeek($space, $user, $weekStart);
+        if (null !== $submission && TimesheetSubmission::STATUS_REJECTED !== $submission->getStatus()) {
+            return $this->json(['error' => 'This week has already been submitted.'], 409);
+        }
+        if (null === $submission) {
+            $submission = (new TimesheetSubmission())
+                ->setSpace($space)
+                ->setUser($user)
+                ->setWeekStart($weekStart);
+            $this->em->persist($submission);
+        } else {
+            // Re-submission after a rejection: back to pending, fresh clock.
+            $submission->setStatus(TimesheetSubmission::STATUS_PENDING);
+            $submission->setSubmittedAt(new \DateTimeImmutable());
+            $submission->setDecidedAt(null);
+            $submission->setDecidedBy(null);
+            $submission->setNote(null);
+        }
+        $this->em->flush();
+
+        $this->mailer->sendSubmitted($submission);
+
+        return $this->json($this->row($submission), 201);
+    }
+
+    #[Route('/spaces/{id}/timesheets', name: 'timesheet_list', methods: ['GET'])]
+    public function list(string $id, Request $request, #[CurrentUser] ?User $user): JsonResponse
+    {
+        $space = $this->memberSpaceOr($id, $user);
+        if ($space instanceof JsonResponse) {
+            return $space;
+        }
+        assert($user instanceof User);
+
+        $status = $request->query->get('status');
+        if (null !== $status && !in_array($status, TimesheetSubmission::STATUSES, true)) {
+            return $this->json(['error' => 'Unknown status.'], 422);
+        }
+
+        $rows = [];
+        $isAdmin = $this->isGranted('ROLE_ADMIN') || $space->isAdmin($user);
+        foreach ($this->submissions->findForSpace($space, $status) as $submission) {
+            // Members only see their own submissions; admins see the queue.
+            if (!$isAdmin && true !== $submission->getUser()?->getId()?->equals($user->getId())) {
+                continue;
+            }
+            $rows[] = $this->row($submission);
+        }
+
+        return $this->json(['rows' => $rows]);
+    }
+
+    #[Route('/timesheets/{id}/approve', name: 'timesheet_approve', methods: ['POST'])]
+    public function approve(string $id, Request $request, #[CurrentUser] ?User $user): JsonResponse
+    {
+        return $this->decide($id, $request, $user, TimesheetSubmission::STATUS_APPROVED);
+    }
+
+    #[Route('/timesheets/{id}/reject', name: 'timesheet_reject', methods: ['POST'])]
+    public function reject(string $id, Request $request, #[CurrentUser] ?User $user): JsonResponse
+    {
+        return $this->decide($id, $request, $user, TimesheetSubmission::STATUS_REJECTED);
+    }
+
+    private function decide(string $id, Request $request, ?User $user, string $status): JsonResponse
+    {
+        if (null === $user) {
+            return $this->json(['error' => 'Not authenticated.'], 401);
+        }
+        if (!Uuid::isValid($id)) {
+            return $this->json(['error' => 'Submission not found.'], 404);
+        }
+        $submission = $this->submissions->find($id);
+        $space = $submission?->getSpace();
+        if (
+            null === $submission || null === $space
+            || (!$this->isGranted('ROLE_ADMIN') && !$space->hasMember($user))
+        ) {
+            return $this->json(['error' => 'Submission not found.'], 404);
+        }
+        if (!$this->isGranted('ROLE_ADMIN') && !$space->isAdmin($user)) {
+            return $this->json(['error' => 'Only space admins can review timesheets.'], 403);
+        }
+        if (TimesheetSubmission::STATUS_PENDING !== $submission->getStatus()) {
+            return $this->json(['error' => 'This submission has already been decided.'], 409);
+        }
+
+        $payload = $request->toArray();
+        $note = $payload['note'] ?? null;
+        $submission->setStatus($status);
+        $submission->setDecidedAt(new \DateTimeImmutable());
+        $submission->setDecidedBy($user);
+        $submission->setNote(
+            is_string($note) && '' !== trim($note)
+                ? mb_substr(trim($note), 0, TimesheetSubmission::MAX_NOTE_LENGTH)
+                : null,
+        );
+        $this->em->flush();
+
+        $this->mailer->sendDecision($submission);
+
+        return $this->json($this->row($submission));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function row(TimesheetSubmission $submission): array
+    {
+        $member = $submission->getUser();
+        $name = null === $member
+            ? ''
+            : trim($member->getGivenName() . ' ' . $member->getFamilyName());
+
+        return [
+            'id' => (string) $submission->getId(),
+            'user' => [
+                '@id' => '/users/' . $member?->getId(),
+                'name' => '' !== $name ? $name : ($member?->getEmail() ?? ''),
+            ],
+            'weekStart' => $submission->getWeekStart()?->format('Y-m-d'),
+            'status' => $submission->getStatus(),
+            'submittedAt' => $submission->getSubmittedAt()->format(\DateTimeInterface::ATOM),
+            'decidedAt' => $submission->getDecidedAt()?->format(\DateTimeInterface::ATOM),
+            'note' => $submission->getNote(),
+            'totalSeconds' => $this->weekSeconds($submission),
+        ];
+    }
+
+    /** Total tracked seconds in the submission's week (the queue's context). */
+    private function weekSeconds(TimesheetSubmission $submission): int
+    {
+        $weekStart = $submission->getWeekStart();
+        $space = $submission->getSpace();
+        $member = $submission->getUser();
+        if (null === $weekStart || null === $space || null === $member) {
+            return 0;
+        }
+
+        $total = $this->em->createQuery(
+            'SELECT COALESCE(SUM(t.durationSeconds), 0) FROM ' . TimeEntry::class . ' t
+             WHERE t.space = :space AND t.user = :user AND t.endedAt IS NOT NULL
+               AND t.startedAt >= :from AND t.startedAt < :to',
+        )
+            ->setParameter('space', $space)
+            ->setParameter('user', $member)
+            ->setParameter('from', $weekStart)
+            ->setParameter('to', $weekStart->modify('+7 days'))
+            ->getSingleScalarResult();
+
+        return (int) $total;
+    }
+
+    private function memberSpaceOr(string $id, ?User $user): Space|JsonResponse
+    {
+        if (null === $user) {
+            return $this->json(['error' => 'Not authenticated.'], 401);
+        }
+        if (!Uuid::isValid($id)) {
+            return $this->json(['error' => 'Space not found.'], 404);
+        }
+        $space = $this->em->getRepository(Space::class)->find($id);
+        if (null === $space || (!$this->isGranted('ROLE_ADMIN') && !$space->hasMember($user))) {
+            return $this->json(['error' => 'Space not found.'], 404);
+        }
+
+        return $space;
+    }
+}

--- a/api/src/Entity/TimesheetSubmission.php
+++ b/api/src/Entity/TimesheetSubmission.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\TimesheetSubmissionRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * A member's weekly timesheet submission (#654): one row per
+ * (space, user, weekStart). While `pending` or `approved`, every time entry
+ * the user started in that week is frozen (create/edit/delete 422) — the
+ * same lock model as billed entries. A rejection unlocks the week (with a
+ * note back to the member); re-submitting flips the row back to pending.
+ *
+ * Server-written only (submit / approve / reject endpoints in
+ * {@see \App\Controller\TimesheetController}); not an API resource.
+ */
+#[ORM\Entity(repositoryClass: TimesheetSubmissionRepository::class)]
+#[ORM\Table(name: 'timesheet_submission')]
+#[ORM\UniqueConstraint(name: 'uniq_timesheet_submission_week', columns: ['space_id', 'user_id', 'week_start'])]
+#[ORM\Index(columns: ['space_id', 'status'], name: 'idx_timesheet_submission_space_status')]
+#[ORM\Index(columns: ['user_id'], name: 'idx_timesheet_submission_user')]
+class TimesheetSubmission
+{
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_APPROVED = 'approved';
+    public const STATUS_REJECTED = 'rejected';
+
+    /** @var list<string> */
+    public const STATUSES = [self::STATUS_PENDING, self::STATUS_APPROVED, self::STATUS_REJECTED];
+
+    public const MAX_NOTE_LENGTH = 500;
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
+    private ?Uuid $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Space::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private ?Space $space = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private ?User $user = null;
+
+    /** Monday (UTC date) of the submitted week. */
+    #[ORM\Column(type: 'date_immutable')]
+    private ?\DateTimeImmutable $weekStart = null;
+
+    #[ORM\Column(length: 20)]
+    private string $status = self::STATUS_PENDING;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $submittedAt;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?\DateTimeImmutable $decidedAt = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'decided_by_id', nullable: true, onDelete: 'SET NULL')]
+    private ?User $decidedBy = null;
+
+    /** Reviewer note — most useful on rejection ("split Friday's entry"). */
+    #[ORM\Column(length: self::MAX_NOTE_LENGTH, nullable: true)]
+    private ?string $note = null;
+
+    public function __construct()
+    {
+        $this->submittedAt = new \DateTimeImmutable();
+    }
+
+    /** Pending + approved freeze the week; rejected unlocks it. */
+    public function locksWeek(): bool
+    {
+        return self::STATUS_REJECTED !== $this->status;
+    }
+
+    public function getId(): ?Uuid
+    {
+        return $this->id;
+    }
+
+    public function getSpace(): ?Space
+    {
+        return $this->space;
+    }
+
+    public function setSpace(?Space $space): self
+    {
+        $this->space = $space;
+
+        return $this;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(?User $user): self
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    public function getWeekStart(): ?\DateTimeImmutable
+    {
+        return $this->weekStart;
+    }
+
+    public function setWeekStart(?\DateTimeImmutable $weekStart): self
+    {
+        $this->weekStart = $weekStart;
+
+        return $this;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(string $status): self
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    public function getSubmittedAt(): \DateTimeImmutable
+    {
+        return $this->submittedAt;
+    }
+
+    public function setSubmittedAt(\DateTimeImmutable $submittedAt): self
+    {
+        $this->submittedAt = $submittedAt;
+
+        return $this;
+    }
+
+    public function getDecidedAt(): ?\DateTimeImmutable
+    {
+        return $this->decidedAt;
+    }
+
+    public function setDecidedAt(?\DateTimeImmutable $decidedAt): self
+    {
+        $this->decidedAt = $decidedAt;
+
+        return $this;
+    }
+
+    public function getDecidedBy(): ?User
+    {
+        return $this->decidedBy;
+    }
+
+    public function setDecidedBy(?User $decidedBy): self
+    {
+        $this->decidedBy = $decidedBy;
+
+        return $this;
+    }
+
+    public function getNote(): ?string
+    {
+        return $this->note;
+    }
+
+    public function setNote(?string $note): self
+    {
+        $this->note = $note;
+
+        return $this;
+    }
+}

--- a/api/src/Repository/TimesheetSubmissionRepository.php
+++ b/api/src/Repository/TimesheetSubmissionRepository.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Space;
+use App\Entity\TimesheetSubmission;
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<TimesheetSubmission>
+ */
+class TimesheetSubmissionRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, TimesheetSubmission::class);
+    }
+
+    /** The (unique) submission covering one member's week, if any. */
+    public function findForWeek(Space $space, User $user, \DateTimeImmutable $weekStart): ?TimesheetSubmission
+    {
+        return $this->findOneBy(['space' => $space, 'user' => $user, 'weekStart' => $weekStart]);
+    }
+
+    /**
+     * The Monday (UTC date) of the week containing a timestamp — the shared
+     * bucketing rule for submissions and the entry lock.
+     */
+    public static function weekStartOf(\DateTimeImmutable $moment): \DateTimeImmutable
+    {
+        $day = \DateTimeImmutable::createFromFormat(
+            '!Y-m-d',
+            $moment->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d'),
+            new \DateTimeZone('UTC'),
+        );
+        assert(false !== $day);
+        $dow = (int) $day->format('N'); // 1 (Mon) … 7 (Sun)
+
+        return $day->modify(sprintf('-%d days', $dow - 1));
+    }
+
+    /**
+     * True when the entry's week is frozen by a pending/approved submission
+     * for its tracker — the guard TimeEntry create/edit/delete run through.
+     */
+    public function weekIsLocked(Space $space, User $user, \DateTimeImmutable $startedAt): bool
+    {
+        $submission = $this->findForWeek($space, $user, self::weekStartOf($startedAt));
+
+        return null !== $submission && $submission->locksWeek();
+    }
+
+    /**
+     * A space's submissions, optionally filtered by status, newest week first.
+     *
+     * @return list<TimesheetSubmission>
+     */
+    public function findForSpace(Space $space, ?string $status = null): array
+    {
+        $qb = $this->createQueryBuilder('t')
+            ->andWhere('t.space = :space')
+            ->setParameter('space', $space)
+            ->orderBy('t.weekStart', 'DESC')
+            ->addOrderBy('t.submittedAt', 'DESC');
+        if (null !== $status) {
+            $qb->andWhere('t.status = :status')->setParameter('status', $status);
+        }
+
+        /** @var list<TimesheetSubmission> */
+        return $qb->getQuery()->getResult();
+    }
+}

--- a/api/src/Service/TimesheetMailer.php
+++ b/api/src/Service/TimesheetMailer.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Space;
+use App\Entity\TimesheetSubmission;
+use App\Service\Mail\MailDispatcher;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+
+/**
+ * Emails for the timesheet approval flow (#654): submission → the space's
+ * admins (the reviewers); approve/reject → the member who submitted.
+ * Best-effort, no-ops without an email on file.
+ */
+final class TimesheetMailer
+{
+    public function __construct(
+        private readonly MailDispatcher $mail,
+    ) {
+    }
+
+    public function sendSubmitted(TimesheetSubmission $submission): void
+    {
+        $space = $submission->getSpace();
+        $member = $submission->getUser();
+        $weekStart = $submission->getWeekStart();
+        if (null === $space || null === $member || null === $weekStart) {
+            return;
+        }
+
+        $name = trim($member->getGivenName() . ' ' . $member->getFamilyName());
+        foreach ($space->getUserMemberships() as $membership) {
+            if (Space::ROLE_ADMIN !== $membership->getRole()) {
+                continue;
+            }
+            $admin = $membership->getUser();
+            // Submitting your own week (as an admin) shouldn't self-notify.
+            if (null === $admin || true === $admin->getId()?->equals($member->getId())) {
+                continue;
+            }
+            $to = $admin->getEmail();
+            if ('' === trim($to)) {
+                continue;
+            }
+
+            $email = (new TemplatedEmail())
+                ->to($to)
+                ->subject(sprintf(
+                    '%s submitted their timesheet for the week of %s',
+                    '' !== $name ? $name : $member->getEmail(),
+                    $weekStart->format('M j'),
+                ))
+                ->htmlTemplate('emails/timesheet_submitted.html.twig')
+                ->textTemplate('emails/timesheet_submitted.txt.twig')
+                ->context([
+                    'submission' => $submission,
+                    'memberName' => '' !== $name ? $name : $member->getEmail(),
+                    'approvalsUrl' => $this->mail->frontendLink('/approvals'),
+                ]);
+            $this->mail->send($email);
+        }
+    }
+
+    public function sendDecision(TimesheetSubmission $submission): void
+    {
+        $member = $submission->getUser();
+        $weekStart = $submission->getWeekStart();
+        if (null === $member || null === $weekStart) {
+            return;
+        }
+        $to = $member->getEmail();
+        if ('' === trim($to)) {
+            return;
+        }
+
+        $approved = TimesheetSubmission::STATUS_APPROVED === $submission->getStatus();
+        $email = (new TemplatedEmail())
+            ->to($to)
+            ->subject(sprintf(
+                'Your timesheet for the week of %s was %s',
+                $weekStart->format('M j'),
+                $approved ? 'approved' : 'rejected',
+            ))
+            ->htmlTemplate('emails/timesheet_decision.html.twig')
+            ->textTemplate('emails/timesheet_decision.txt.twig')
+            ->context([
+                'submission' => $submission,
+                'approved' => $approved,
+                'timeUrl' => $this->mail->frontendLink('/time'),
+            ]);
+        $this->mail->send($email);
+    }
+}

--- a/api/src/State/TimeEntryDeleteProcessor.php
+++ b/api/src/State/TimeEntryDeleteProcessor.php
@@ -5,6 +5,7 @@ namespace App\State;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\Entity\TimeEntry;
+use App\Repository\TimesheetSubmissionRepository;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
@@ -14,6 +15,9 @@ use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
  * deleting it would silently desync the invoice from the time that backs it.
  * The PWA hides the delete affordance for billed rows; this enforces the same
  * rule server-side (422, mirroring the edit guard in TimeEntryUserProcessor).
+ *
+ * Entries in a submitted (pending/approved) timesheet week (#654) are frozen
+ * the same way — a rejection unlocks them.
  *
  * @implements ProcessorInterface<TimeEntry, void>
  */
@@ -25,6 +29,7 @@ final class TimeEntryDeleteProcessor implements ProcessorInterface
     public function __construct(
         #[Autowire(service: 'api_platform.doctrine.orm.state.remove_processor')]
         private ProcessorInterface $removeProcessor,
+        private TimesheetSubmissionRepository $timesheets,
     ) {
     }
 
@@ -36,6 +41,19 @@ final class TimeEntryDeleteProcessor implements ProcessorInterface
         if (null !== $data->getBilledAt()) {
             throw new UnprocessableEntityHttpException(
                 'This entry is on an invoice and can no longer be deleted.',
+            );
+        }
+
+        // Timesheet approvals (#654): a submitted week is frozen.
+        $space = $data->getSpace();
+        $tracker = $data->getUser();
+        $startedAt = $data->getStartedAt();
+        if (
+            null !== $space && null !== $tracker && null !== $startedAt
+            && $this->timesheets->weekIsLocked($space, $tracker, $startedAt)
+        ) {
+            throw new UnprocessableEntityHttpException(
+                'This week has been submitted for approval and is locked.',
             );
         }
 

--- a/api/src/State/TimeEntryUserProcessor.php
+++ b/api/src/State/TimeEntryUserProcessor.php
@@ -6,6 +6,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\Entity\TimeEntry;
 use App\Repository\TimeEntryRepository;
+use App\Repository\TimesheetSubmissionRepository;
 use App\Security\AuthenticatedUserResolver;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -36,6 +37,7 @@ final class TimeEntryUserProcessor implements ProcessorInterface
         private ProcessorInterface $persistProcessor,
         private AuthenticatedUserResolver $auth,
         private TimeEntryRepository $timeEntries,
+        private TimesheetSubmissionRepository $timesheets,
         private EntityManagerInterface $em,
     ) {
     }
@@ -69,6 +71,20 @@ final class TimeEntryUserProcessor implements ProcessorInterface
                     $this->em->flush();
                 }
             }
+        }
+
+        // Timesheet approvals (#654): a submitted (pending/approved) week is
+        // frozen for the entry's tracker — creates and edits both bounce.
+        $space = $data->getSpace() ?? $data->getEngagement()?->getSpace();
+        $tracker = $data->getUser();
+        $startedAt = $data->getStartedAt();
+        if (
+            null !== $space && null !== $tracker && null !== $startedAt
+            && $this->timesheets->weekIsLocked($space, $tracker, $startedAt)
+        ) {
+            throw new UnprocessableEntityHttpException(
+                'This week has been submitted for approval and is locked.',
+            );
         }
 
         return $this->persistProcessor->process($data, $operation, $uriVariables, $context);

--- a/api/templates/emails/timesheet_decision.html.twig
+++ b/api/templates/emails/timesheet_decision.html.twig
@@ -1,0 +1,21 @@
+{# @var submission \App\Entity\TimesheetSubmission #}
+{# @var approved bool #}
+<p>Hi,</p>
+
+<p>
+    Your timesheet for the week of
+    <strong>{{ submission.weekStart|date('M j, Y') }}</strong> was
+    <strong>{{ approved ? 'approved' : 'rejected' }}</strong>.
+</p>
+
+{% if submission.note %}
+<p>Note from the reviewer: {{ submission.note }}</p>
+{% endif %}
+
+{% if not approved %}
+<p>The week is unlocked — fix the entries and submit it again.</p>
+{% endif %}
+
+<p>
+    <a href="{{ timeUrl }}">Open your timesheet</a>
+</p>

--- a/api/templates/emails/timesheet_decision.txt.twig
+++ b/api/templates/emails/timesheet_decision.txt.twig
@@ -1,0 +1,12 @@
+{# @var submission \App\Entity\TimesheetSubmission #}
+Hi,
+
+Your timesheet for the week of {{ submission.weekStart|date('M j, Y') }} was {{ approved ? 'approved' : 'rejected' }}.
+{% if submission.note %}
+Note from the reviewer: {{ submission.note }}
+{% endif %}
+{% if not approved %}
+The week is unlocked — fix the entries and submit it again.
+{% endif %}
+
+Open your timesheet: {{ timeUrl }}

--- a/api/templates/emails/timesheet_submitted.html.twig
+++ b/api/templates/emails/timesheet_submitted.html.twig
@@ -1,0 +1,15 @@
+{# @var submission \App\Entity\TimesheetSubmission #}
+<p>Hi,</p>
+
+<p>
+    <strong>{{ memberName }}</strong> submitted their timesheet for the week of
+    <strong>{{ submission.weekStart|date('M j, Y') }}</strong> for approval.
+</p>
+
+<p>
+    <a href="{{ approvalsUrl }}">Review it in the approvals queue</a>
+</p>
+
+<p style="color: #9ca3af; font-size: 12px;">
+    You're receiving this because you're an admin of the space.
+</p>

--- a/api/templates/emails/timesheet_submitted.txt.twig
+++ b/api/templates/emails/timesheet_submitted.txt.twig
@@ -1,0 +1,8 @@
+{# @var submission \App\Entity\TimesheetSubmission #}
+Hi,
+
+{{ memberName }} submitted their timesheet for the week of {{ submission.weekStart|date('M j, Y') }} for approval.
+
+Review it in the approvals queue: {{ approvalsUrl }}
+
+You're receiving this because you're an admin of the space.

--- a/api/tests/Api/TimesheetApprovalTest.php
+++ b/api/tests/Api/TimesheetApprovalTest.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\Space;
+use App\Entity\SpaceMembership;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Timesheet approvals (#654): submitting a week freezes its entries,
+ * rejection unlocks (with a note), approval re-locks, and only space admins
+ * decide.
+ */
+class TimesheetApprovalTest extends ApiTestCase
+{
+    use SpaceMembershipFixture;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = static::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\TimesheetSubmission')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\TimeEntry')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\EngagementCategory')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Engagement')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Client')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\SpaceMembership')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Space')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testSubmitLockRejectUnlockAndApprove(): void
+    {
+        $admin = $this->createUser('admin@example.com', 'Alice');
+        $member = $this->createUser('member@example.com', 'Bob');
+        $space = $this->createSharedSpace($admin, $member);
+        $spaceId = (string) $space->getId();
+        $spaceIri = '/spaces/' . $spaceId;
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $engagement = $client->request('POST', '/engagements', [
+            'json' => [
+                'space' => $spaceIri,
+                'client' => $clientRow['@id'],
+                'name' => 'Acme Website',
+                'currency' => 'USD',
+                'categories' => [['name' => 'Dev', 'rateAmount' => 6000, 'position' => 0]],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $engagementIri = $engagement['@id'];
+        $this->assertIsString($engagementIri);
+        $categories = $engagement['categories'] ?? null;
+        $this->assertIsArray($categories);
+        $firstCategory = $categories[0];
+        $this->assertIsArray($firstCategory);
+        $categoryIri = $firstCategory['@id'];
+        $this->assertIsString($categoryIri);
+
+        // Bob tracks 1h on Wednesday 2026-07-15 (week of Monday 2026-07-13).
+        $client->loginUser($member);
+        $entry = $client->request('POST', '/time_entries', [
+            'json' => [
+                'space' => $spaceIri,
+                'engagement' => $engagementIri,
+                'category' => $categoryIri,
+                'startedAt' => '2026-07-15T09:00:00+00:00',
+                'endedAt' => '2026-07-15T10:00:00+00:00',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $entryIri = $entry['@id'];
+        $this->assertIsString($entryIri);
+
+        // Submitting any day of the week normalises to its Monday and emails
+        // the space admin (one request cycle => one email counted).
+        $submitted = $client->request('POST', '/spaces/' . $spaceId . '/timesheets/submit', [
+            'json' => ['weekStart' => '2026-07-15'],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertSame('2026-07-13', $submitted['weekStart'] ?? null);
+        $this->assertSame('pending', $submitted['status'] ?? null);
+        $this->assertSame(3600, $submitted['totalSeconds'] ?? null);
+        $this->assertEmailCount(1);
+        $submissionId = $submitted['id'];
+        $this->assertIsString($submissionId);
+
+        // The week is frozen: edit, create-in-week, and delete all bounce.
+        $client->request('PATCH', $entryIri, [
+            'json' => ['description' => 'tweak'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+        $client->request('POST', '/time_entries', [
+            'json' => [
+                'space' => $spaceIri,
+                'engagement' => $engagementIri,
+                'category' => $categoryIri,
+                'startedAt' => '2026-07-17T09:00:00+00:00',
+                'endedAt' => '2026-07-17T10:00:00+00:00',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+        $client->request('DELETE', $entryIri);
+        $this->assertResponseStatusCodeSame(422);
+
+        // Next week is unaffected.
+        $client->request('POST', '/time_entries', [
+            'json' => [
+                'space' => $spaceIri,
+                'engagement' => $engagementIri,
+                'category' => $categoryIri,
+                'startedAt' => '2026-07-21T09:00:00+00:00',
+                'endedAt' => '2026-07-21T10:00:00+00:00',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+
+        // Double-submit 409s; a member can't decide.
+        $client->request('POST', '/spaces/' . $spaceId . '/timesheets/submit', [
+            'json' => ['weekStart' => '2026-07-13'],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(409);
+        $client->request('POST', '/timesheets/' . $submissionId . '/approve', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(403);
+
+        // The member's list shows only their own row.
+        $mine = $client->request('GET', '/spaces/' . $spaceId . '/timesheets')->toArray();
+        $mineRows = $mine['rows'] ?? null;
+        $this->assertIsArray($mineRows);
+        $this->assertCount(1, $mineRows);
+
+        // Admin rejects with a note: the member is emailed, the week unlocks.
+        $client->loginUser($admin);
+        $rejected = $client->request('POST', '/timesheets/' . $submissionId . '/reject', [
+            'json' => ['note' => 'Split Wednesday into two entries.'],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertSame('rejected', $rejected['status'] ?? null);
+        $this->assertEmailCount(1);
+
+        $client->loginUser($member);
+        $client->request('PATCH', $entryIri, [
+            'json' => ['description' => 'fixed as asked'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(200);
+
+        // Re-submit flips back to pending; admin approves; the week re-locks.
+        $resubmitted = $client->request('POST', '/spaces/' . $spaceId . '/timesheets/submit', [
+            'json' => ['weekStart' => '2026-07-13'],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertSame('pending', $resubmitted['status'] ?? null);
+
+        $client->loginUser($admin);
+        $approved = $client->request('POST', '/timesheets/' . $submissionId . '/approve', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $this->assertSame('approved', $approved['status'] ?? null);
+
+        $client->loginUser($member);
+        $client->request('PATCH', $entryIri, [
+            'json' => ['description' => 'too late'],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+
+        // A decided submission can't be decided again.
+        $client->loginUser($admin);
+        $client->request('POST', '/timesheets/' . $submissionId . '/reject', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(409);
+    }
+
+    private function createSharedSpace(User $admin, ?User $member = null): Space
+    {
+        $space = (new Space())->setName('Studio')->setCreatedBy($admin);
+        $this->entityManager->persist($space);
+        $adminMembership = (new SpaceMembership())
+            ->setUser($admin)
+            ->setRole(Space::ROLE_ADMIN);
+        $space->addUserMembership($adminMembership);
+        $this->entityManager->persist($adminMembership);
+        if (null !== $member) {
+            $memberMembership = (new SpaceMembership())
+                ->setUser($member)
+                ->setRole(Space::ROLE_MEMBER);
+            $space->addUserMembership($memberMembership);
+            $this->entityManager->persist($memberMembership);
+        }
+        $this->entityManager->flush();
+
+        return $space;
+    }
+
+    private function createUser(string $email, string $givenName): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName($givenName);
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/pwa/components/common/SidebarNav.tsx
+++ b/pwa/components/common/SidebarNav.tsx
@@ -580,6 +580,7 @@ const BillingSection = ({
     { href: "/invoices", label: "Invoices", match: "/invoices", show: canInvoices },
     { href: "/estimates", label: "Estimates", match: "/estimates", show: canInvoices },
     { href: "/reports", label: "Reports", match: "/reports", show: canInvoices },
+    { href: "/approvals", label: "Approvals", match: "/approvals", show: canInvoices },
   ].filter((l) => l.show);
 
   if (links.length === 0) return null;

--- a/pwa/components/time/WeekTimesheet.tsx
+++ b/pwa/components/time/WeekTimesheet.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ChevronLeft, ChevronRight, CopyPlus, Lock, Plus } from "lucide-react";
-import { apiGetCollection, apiSend } from "@/lib/apiClient";
+import { ChevronLeft, ChevronRight, CopyPlus, Lock, Plus, Send } from "lucide-react";
+import { apiGet, apiGetCollection, apiSend } from "@/lib/apiClient";
 import {
   EngagementOption,
   TimeEntry,
@@ -44,6 +44,20 @@ interface CellData {
   entries: TimeEntry[];
   total: number;
 }
+
+/** One row from GET /spaces/{id}/timesheets (#654). */
+interface TimesheetRow {
+  id: string;
+  weekStart: string | null;
+  status: "pending" | "approved" | "rejected";
+  note: string | null;
+}
+
+const SUBMISSION_BADGE: Record<TimesheetRow["status"], string> = {
+  pending: "bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-300",
+  approved: "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300",
+  rejected: "bg-rose-100 text-rose-700 dark:bg-rose-950 dark:text-rose-300",
+};
 
 interface RowData {
   key: string;
@@ -110,6 +124,33 @@ const WeekTimesheet = ({
       }),
   });
   const refresh = () => queryClient.invalidateQueries({ queryKey: ["time_entries"] });
+
+  // Timesheet approvals (#654): the viewer's own submission for this week.
+  const spaceId = spaceIri ? spaceIri.slice(spaceIri.lastIndexOf("/") + 1) : null;
+  const submissionQuery = useQuery({
+    queryKey: ["timesheets", spaceId, weekKey],
+    enabled: !!spaceId,
+    queryFn: () =>
+      apiGet<{ rows: TimesheetRow[] }>(`/spaces/${spaceId}/timesheets`, {
+        errorMessage: "Failed to load the timesheet status.",
+      }).then((r) => (r.rows ?? []).find((row) => row.weekStart === weekKey) ?? null),
+  });
+  const submission = submissionQuery.data ?? null;
+  const weekLocked = !!submission && submission.status !== "rejected";
+
+  const submitWeek = useMutation({
+    mutationFn: () =>
+      apiSend("POST", `/spaces/${spaceId}/timesheets/submit`, {
+        contentType: "application/json",
+        errorMessage: "Failed to submit the week.",
+        body: { weekStart: weekKey },
+      }),
+    onSuccess: () => {
+      onError(null);
+      void queryClient.invalidateQueries({ queryKey: ["timesheets"] });
+    },
+    onError: (e) => onError(e instanceof Error ? e.message : "Failed to submit the week."),
+  });
 
   // Completed entries bucketed by (pair, local day) inside the shown week.
   const rows = useMemo((): RowData[] => {
@@ -317,17 +358,49 @@ const WeekTimesheet = ({
           </Button>
           <span className="ml-2 text-sm font-medium">{rangeLabel}</span>
         </div>
-        {canCreate && (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => copyLastWeek.mutate()}
-            disabled={copyLastWeek.isPending}
-          >
-            <CopyPlus className="h-4 w-4" />
-            {copyLastWeek.isPending ? "Copying…" : "Copy last week"}
-          </Button>
-        )}
+        <div className="flex flex-wrap items-center gap-2">
+          {submission && (
+            <span
+              className={cn(
+                "rounded px-2 py-0.5 text-xs font-medium",
+                SUBMISSION_BADGE[submission.status],
+              )}
+              title={submission.note ?? undefined}
+            >
+              {submission.status === "pending"
+                ? "Submitted — pending approval"
+                : submission.status === "approved"
+                  ? "Approved"
+                  : `Rejected${submission.note ? ` — ${submission.note}` : ""}`}
+            </span>
+          )}
+          {canCreate && !weekLocked && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => copyLastWeek.mutate()}
+              disabled={copyLastWeek.isPending}
+            >
+              <CopyPlus className="h-4 w-4" />
+              {copyLastWeek.isPending ? "Copying…" : "Copy last week"}
+            </Button>
+          )}
+          {canCreate && !weekLocked && (
+            <Button
+              size="sm"
+              onClick={() => submitWeek.mutate()}
+              disabled={submitWeek.isPending}
+              title="Submit this week for approval — entries lock until it's reviewed"
+            >
+              <Send className="h-4 w-4" />
+              {submitWeek.isPending
+                ? "Submitting…"
+                : submission?.status === "rejected"
+                  ? "Re-submit week"
+                  : "Submit week"}
+            </Button>
+          )}
+        </div>
       </div>
 
       <Card>
@@ -383,6 +456,7 @@ const WeekTimesheet = ({
                         const cellId = `${row.key}@${dayKey}`;
                         const editable =
                           canCreate &&
+                          !weekLocked &&
                           (!cell ||
                             (cell.entries.length === 1 && canModify(cell.entries[0])));
                         const display =
@@ -449,7 +523,7 @@ const WeekTimesheet = ({
               )}
 
               {/* Add-row control */}
-              {canCreate && (
+              {canCreate && !weekLocked && (
                 <tr className="border-b">
                   <td colSpan={9} className="px-4 py-2">
                     {addingRow ? (

--- a/pwa/pages/approvals/index.tsx
+++ b/pwa/pages/approvals/index.tsx
@@ -1,0 +1,226 @@
+import Head from "next/head";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { CheckSquare } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
+import { apiGet, apiSend } from "@/lib/apiClient";
+import { signinHrefForCurrent } from "@/lib/authRedirect";
+import PageHeader from "@/components/common/PageHeader";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+interface SubmissionRow {
+  id: string;
+  user: { "@id": string; name: string };
+  weekStart: string | null;
+  status: "pending" | "approved" | "rejected";
+  submittedAt: string;
+  decidedAt: string | null;
+  note: string | null;
+  totalSeconds: number;
+}
+
+const STATUS_BADGE: Record<SubmissionRow["status"], string> = {
+  pending: "bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-300",
+  approved: "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300",
+  rejected: "bg-rose-100 text-rose-700 dark:bg-rose-950 dark:text-rose-300",
+};
+
+const hoursOf = (seconds: number): string => (seconds / 3600).toFixed(2);
+
+/**
+ * Timesheet approvals queue (#654) — space admins review submitted weeks:
+ * approve locks the entries like billed ones; reject (with a note) unlocks
+ * the week so the member can fix and re-submit.
+ */
+const ApprovalsPage = () => {
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
+  const { activeSpace, isActiveSpaceAdmin } = useActiveSpace();
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const [error, setError] = useState<string | null>(null);
+  const [showAll, setShowAll] = useState(false);
+
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) {
+      router.replace(signinHrefForCurrent(router.asPath));
+    }
+  }, [authLoading, isAuthenticated, router]);
+
+  const spaceId = activeSpace?.id ?? null;
+
+  const queueQuery = useQuery({
+    queryKey: ["approvals", spaceId, showAll],
+    enabled: isAuthenticated && !!spaceId && isActiveSpaceAdmin,
+    queryFn: () =>
+      apiGet<{ rows: SubmissionRow[] }>(
+        `/spaces/${spaceId}/timesheets${showAll ? "" : "?status=pending"}`,
+        { errorMessage: "Failed to load the approvals queue." },
+      ),
+  });
+  const rows = queueQuery.data?.rows ?? [];
+
+  const decide = useMutation({
+    mutationFn: ({ id, action, note }: { id: string; action: "approve" | "reject"; note?: string }) =>
+      apiSend("POST", `/timesheets/${id}/${action}`, {
+        contentType: "application/json",
+        errorMessage: `Failed to ${action}.`,
+        body: note ? { note } : {},
+      }),
+    onSuccess: () => {
+      setError(null);
+      void queryClient.invalidateQueries({ queryKey: ["approvals"] });
+    },
+    onError: (e) => setError(e instanceof Error ? e.message : "Action failed."),
+  });
+
+  const reject = (row: SubmissionRow) => {
+    const note = window.prompt("Add a note for the member (why is this rejected)?") ?? "";
+    decide.mutate({ id: row.id, action: "reject", note: note.trim() || undefined });
+  };
+
+  if (authLoading || !isAuthenticated) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-muted">
+        <p className="text-muted-foreground">Loading…</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Approvals — Madori</title>
+      </Head>
+      <div className="min-h-screen bg-background px-4 py-12">
+        <div className="mx-auto max-w-4xl">
+          <PageHeader
+            title="Timesheet approvals"
+            icon={<CheckSquare className="size-6 text-emerald-600 dark:text-emerald-400" />}
+          />
+
+          {!isActiveSpaceAdmin ? (
+            <Alert>
+              <AlertDescription>
+                Timesheet approvals are managed by space admins.
+              </AlertDescription>
+            </Alert>
+          ) : (
+            <>
+              {error && (
+                <Alert variant="destructive" className="mb-4">
+                  <AlertDescription>{error}</AlertDescription>
+                </Alert>
+              )}
+
+              <div className="mb-3 flex justify-end">
+                <label className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <input
+                    type="checkbox"
+                    checked={showAll}
+                    onChange={(e) => setShowAll(e.target.checked)}
+                  />
+                  Show decided weeks
+                </label>
+              </div>
+
+              <Card>
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+                        <th className="px-4 py-2 font-medium">Member</th>
+                        <th className="px-4 py-2 font-medium">Week of</th>
+                        <th className="px-4 py-2 text-right font-medium">Hours</th>
+                        <th className="px-4 py-2 font-medium">Status</th>
+                        <th className="px-4 py-2" />
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {queueQuery.isLoading ? (
+                        <tr>
+                          <td colSpan={5} className="px-4 py-10 text-center text-muted-foreground">
+                            Loading…
+                          </td>
+                        </tr>
+                      ) : rows.length === 0 ? (
+                        <tr>
+                          <td colSpan={5} className="px-4 py-10 text-center text-muted-foreground">
+                            {showAll
+                              ? "No timesheet submissions yet."
+                              : "Nothing waiting for approval."}
+                          </td>
+                        </tr>
+                      ) : (
+                        rows.map((row) => (
+                          <tr key={row.id} className="border-b align-middle last:border-0">
+                            <td className="px-4 py-3 font-medium">{row.user.name}</td>
+                            <td className="px-4 py-3 text-muted-foreground">
+                              {row.weekStart
+                                ? new Date(row.weekStart).toLocaleDateString(undefined, {
+                                    dateStyle: "medium",
+                                  })
+                                : "—"}
+                            </td>
+                            <td className="px-4 py-3 text-right tabular-nums">
+                              {hoursOf(row.totalSeconds)}
+                            </td>
+                            <td className="px-4 py-3">
+                              <span
+                                className={cn(
+                                  "rounded px-2 py-0.5 text-xs font-medium",
+                                  STATUS_BADGE[row.status],
+                                )}
+                                title={row.note ?? undefined}
+                              >
+                                {row.status}
+                              </span>
+                              {row.note && (
+                                <span className="ml-2 text-xs text-muted-foreground">
+                                  {row.note}
+                                </span>
+                              )}
+                            </td>
+                            <td className="px-4 py-3 text-right">
+                              {row.status === "pending" && (
+                                <span className="inline-flex gap-2">
+                                  <Button
+                                    size="sm"
+                                    onClick={() =>
+                                      decide.mutate({ id: row.id, action: "approve" })
+                                    }
+                                    disabled={decide.isPending}
+                                  >
+                                    Approve
+                                  </Button>
+                                  <Button
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={() => reject(row)}
+                                    disabled={decide.isPending}
+                                  >
+                                    Reject
+                                  </Button>
+                                </span>
+                              )}
+                            </td>
+                          </tr>
+                        ))
+                      )}
+                    </tbody>
+                  </table>
+                </div>
+              </Card>
+            </>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ApprovalsPage;


### PR DESCRIPTION
Closes #654 — the final item of the Harvest gap analysis.

## What
Harvest-style weekly approvals for teams.

- **`TimesheetSubmission`** (`timesheet_submission`, unique per space+user+week): a member submits their week; while **pending or approved**, every time entry they started in that week is frozen — create, edit, and delete all 422 (the same lock model as billed entries; the shared Monday-UTC bucketing lives in `TimesheetSubmissionRepository::weekStartOf`). **Rejection unlocks** the week; re-submitting flips the row back to pending with a fresh clock.
- **Endpoints**: `POST /spaces/{id}/timesheets/submit` (`{weekStart}`, any day normalises to its Monday; 409 while pending/approved); `GET /spaces/{id}/timesheets[?status=]` — members see only their own rows, space admins see everyone's, each row carrying the week's tracked total; `POST /timesheets/{id}/approve|reject` (space admin only, optional note, 409 once decided).
- **Emails**: submit → the space's admins (skipping self-submission); approve/reject → the member, with the reviewer's note. (The issue mentions the in-app Notification pipeline — that enum is deliberately small and adding a type ripples across the bell/digest/preferences matrix, so v1 ships email like the budget alerts; in-app rows can follow.)
- **PWA**: the week grid (#645) gains a **Submit week** button + status badge (pending/approved lock the cells read-only; rejected shows the note inline and offers Re-submit). `/approvals` is the admin queue — member, week, tracked hours, Approve / Reject-with-note, show-decided toggle — linked from the Billing sidebar group.

## Notes
- Week bucketing is UTC-date based; an entry logged around local midnight near a week boundary may bucket into the adjacent UTC week — acceptable v1 edge, documented here.
- Invoice generation still stamps `billedAt` on approved weeks' entries (billing shouldn't wait on the lock — it writes through the EM, not the guarded processors).

## Tests
`TimesheetApprovalTest`: submit normalises to Monday + emails the admin + reports the week total; edit/create/delete in the submitted week 422 while next week is unaffected; double-submit 409; member can't approve (403); member list shows own row only; reject (note) emails the member and unlocks; re-submit → approve re-locks; deciding twice 409s.