### PR TITLE
chore(billing): Harvest-parity loose ends — cost-rate UI, report deep-link, expense-aware budgets

### DIFF
--- a/api/src/Service/EngagementBudgetCalculator.php
+++ b/api/src/Service/EngagementBudgetCalculator.php
@@ -3,6 +3,7 @@
 namespace App\Service;
 
 use App\Entity\Engagement;
+use App\Entity\Expense;
 use App\Entity\TimeEntry;
 use Doctrine\ORM\EntityManagerInterface;
 
@@ -13,8 +14,8 @@ use Doctrine\ORM\EntityManagerInterface;
  *
  * An `hours` budget counts every completed entry's duration (minutes); a
  * `fees` budget counts the billable amount (Σ seconds × snapshotted rate /
- * 3600, minor units) — a cheap SQL approximation of the invoice math, close
- * enough for progress + alerts.
+ * 3600, minor units) **plus billable expenses** (#666) — a cheap SQL
+ * approximation of the invoice math, close enough for progress + alerts.
  */
 final class EngagementBudgetCalculator
 {
@@ -55,6 +56,26 @@ final class EngagementBudgetCalculator
                 'seconds' => (int) $row['totalSec'],
                 'fees' => (int) round(((int) $row['feeSec']) / 3600),
             ];
+        }
+
+        // Billable expenses consume a fees budget too (#666) — an engagement
+        // that burns its budget on costs rather than hours still alerts.
+        /** @var list<array{eid: string|null, amount: string|int|null}> $expenseRows */
+        $expenseRows = $this->em->createQuery(
+            'SELECT IDENTITY(x.engagement) AS eid,
+                    COALESCE(SUM(x.amount), 0) AS amount
+             FROM ' . Expense::class . ' x
+             WHERE x.engagement IN (:engagements) AND x.billable = true
+             GROUP BY x.engagement',
+        )->setParameter('engagements', $engagements)->getResult();
+
+        foreach ($expenseRows as $row) {
+            if (null === $row['eid']) {
+                continue;
+            }
+            $entry = $map[$row['eid']] ?? ['seconds' => 0, 'fees' => 0];
+            $entry['fees'] += (int) $row['amount'];
+            $map[$row['eid']] = $entry;
         }
 
         return $map;

--- a/api/tests/Api/EngagementBudgetTest.php
+++ b/api/tests/Api/EngagementBudgetTest.php
@@ -28,6 +28,7 @@ class EngagementBudgetTest extends ApiTestCase
         assert($em instanceof EntityManagerInterface);
         $this->entityManager = $em;
 
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Expense')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\TimeEntry')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\EngagementCategory')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Engagement')->execute();
@@ -144,6 +145,89 @@ class EngagementBudgetTest extends ApiTestCase
         $this->assertSame([], $entity->getBudgetAlertsSent());
         $this->assertSame(0, $alerter->dispatchDue());
         $this->assertEmailCount(2);
+    }
+
+    public function testFeesBudgetCountsBillableExpenses(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $space = $this->createSharedSpace($admin);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $clientIri = $clientRow['@id'];
+        $this->assertIsString($clientIri);
+
+        // A $100 fees budget (10000 minor units) with Dev @ $60/h.
+        $engagement = $client->request('POST', '/engagements', [
+            'json' => [
+                'space' => $spaceIri,
+                'client' => $clientIri,
+                'name' => 'Fees budget',
+                'currency' => 'USD',
+                'budgetType' => 'fees',
+                'budgetAmount' => 10000,
+                'categories' => [['name' => 'Dev', 'rateAmount' => 6000, 'position' => 0]],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $engagementIri = $engagement['@id'];
+        $this->assertIsString($engagementIri);
+        $categories = $engagement['categories'] ?? null;
+        $this->assertIsArray($categories);
+        $first = $categories[0];
+        $this->assertIsArray($first);
+        $categoryIri = $first['@id'];
+        $this->assertIsString($categoryIri);
+
+        // 1h Dev = 6000 in fees.
+        $client->request('POST', '/time_entries', [
+            'json' => [
+                'space' => $spaceIri,
+                'engagement' => $engagementIri,
+                'category' => $categoryIri,
+                'startedAt' => '2026-07-10T09:00:00+00:00',
+                'endedAt' => '2026-07-10T10:00:00+00:00',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+
+        // A billable expense adds to the burn; a non-billable one doesn't (#666).
+        foreach ([[2500, true], [5000, false]] as [$amount, $billable]) {
+            $client->request('POST', '/expenses', [
+                'json' => [
+                    'space' => $spaceIri,
+                    'engagement' => $engagementIri,
+                    'spentOn' => '2026-07-10',
+                    'category' => 'Travel',
+                    'amount' => $amount,
+                    'billable' => $billable,
+                ],
+                'headers' => ['Content-Type' => 'application/ld+json'],
+            ]);
+            $this->assertResponseStatusCodeSame(201);
+        }
+
+        $list = $client->request('GET', '/engagements?space=' . $spaceIri)->toArray();
+        $members = $list['member'] ?? $list['hydra:member'] ?? null;
+        $this->assertIsArray($members);
+        $this->assertCount(1, $members);
+        $row = $members[0];
+        $this->assertIsArray($row);
+        // 6000 tracked + 2500 billable expense = 8500 (85%); the 5000
+        // non-billable expense never counts.
+        $this->assertSame(8500, $row['budgetSpent'] ?? null);
+
+        // 85% crosses the 80 threshold only — one alert.
+        $alerter = static::getContainer()->get(\App\Service\EngagementBudgetAlerter::class);
+        $this->assertSame(1, $alerter->dispatchDue());
+        $this->assertEmailCount(1);
     }
 
     private function createSharedSpace(User $admin, ?User $member = null): Space

--- a/api/tests/Api/ExpenseTest.php
+++ b/api/tests/Api/ExpenseTest.php
@@ -4,10 +4,12 @@ namespace App\Tests\Api;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use App\Entity\Expense;
+use App\Entity\MediaObject;
 use App\Entity\Space;
 use App\Entity\SpaceMembership;
 use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
+use League\Flysystem\FilesystemOperator;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 /**
@@ -20,6 +22,7 @@ class ExpenseTest extends ApiTestCase
     use SpaceMembershipFixture;
 
     private EntityManagerInterface $entityManager;
+    private FilesystemOperator $storage;
 
     protected function setUp(): void
     {
@@ -27,6 +30,9 @@ class ExpenseTest extends ApiTestCase
         $em = static::getContainer()->get('doctrine')->getManager();
         assert($em instanceof EntityManagerInterface);
         $this->entityManager = $em;
+        $storage = static::getContainer()->get('media.storage');
+        assert($storage instanceof FilesystemOperator);
+        $this->storage = $storage;
 
         $this->entityManager->createQuery('DELETE FROM App\Entity\Invoice')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Expense')->execute();
@@ -184,6 +190,75 @@ class ExpenseTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(200);
         $released = $client->request('GET', $this->iri($billableExpense))->toArray();
         $this->assertNull($released['billedAt'] ?? null);
+    }
+
+    public function testReceiptDownloadGatedToSpenderAndTimeReaders(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $member = $this->createUser('member@example.com');
+        $space = $this->createSharedSpace($admin, $member);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $bpIri = $this->createEngagement($client, $spaceIri, $this->iri($clientRow));
+
+        // The member uploads a receipt and attaches it to their expense.
+        $receipt = $this->createReceipt($member);
+        $client->loginUser($member);
+        $client->request('POST', '/expenses', [
+            'json' => [
+                'space' => $spaceIri,
+                'engagement' => $bpIri,
+                'spentOn' => '2026-07-10',
+                'category' => 'Travel',
+                'amount' => 2500,
+                'receipt' => '/media-objects/' . $receipt->getId(),
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+
+        $downloadUrl = '/media-objects/' . $receipt->getId() . '/download';
+
+        // Spender (owner) downloads their own receipt.
+        $client->request('GET', $downloadUrl);
+        $this->assertResponseIsSuccessful();
+
+        // A space admin (not the uploader) can download it too.
+        $client->loginUser($admin);
+        $client->request('GET', $downloadUrl);
+        $this->assertResponseIsSuccessful();
+
+        // An outsider gets 404 — not 403, to avoid leaking existence.
+        $outsider = $this->createUser('outsider@example.com');
+        $client->loginUser($outsider);
+        $client->request('GET', $downloadUrl);
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    /** A stored receipt file + MediaObject row owned by $owner. */
+    private function createReceipt(User $owner): MediaObject
+    {
+        $bytes = 'RECEIPT-IMAGE-BYTES';
+        $path = 'attachments/expense-test-' . bin2hex(random_bytes(4)) . '-receipt.png';
+        $this->storage->write($path, $bytes);
+
+        $media = (new MediaObject())
+            ->setOwner($owner)
+            ->setKind(MediaObject::KIND_ATTACHMENT)
+            ->setVariants(['original' => $path])
+            ->setOriginalName('receipt.png')
+            ->setMimeType('image/png')
+            ->setByteSize(\strlen($bytes));
+        $this->entityManager->persist($media);
+        $this->entityManager->flush();
+
+        return $media;
     }
 
     /**

--- a/api/tests/Api/ExpenseTest.php
+++ b/api/tests/Api/ExpenseTest.php
@@ -30,9 +30,7 @@ class ExpenseTest extends ApiTestCase
         $em = static::getContainer()->get('doctrine')->getManager();
         assert($em instanceof EntityManagerInterface);
         $this->entityManager = $em;
-        $storage = static::getContainer()->get('media.storage');
-        assert($storage instanceof FilesystemOperator);
-        $this->storage = $storage;
+        $this->storage = static::getContainer()->get('media.storage');
 
         $this->entityManager->createQuery('DELETE FROM App\Entity\Invoice')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Expense')->execute();
@@ -198,6 +196,10 @@ class ExpenseTest extends ApiTestCase
         $member = $this->createUser('member@example.com');
         $space = $this->createSharedSpace($admin, $member);
         $spaceIri = '/spaces/' . $space->getId();
+        // Created before any HTTP request — the client kernel reboots detach
+        // this EM's entities, and persisting a MediaObject with a detached
+        // owner would trip Doctrine's new-entity-through-relationship check.
+        $receipt = $this->createReceipt($member);
 
         $client = static::createClient();
         $client->loginUser($admin);
@@ -207,8 +209,7 @@ class ExpenseTest extends ApiTestCase
         ])->toArray();
         $bpIri = $this->createEngagement($client, $spaceIri, $this->iri($clientRow));
 
-        // The member uploads a receipt and attaches it to their expense.
-        $receipt = $this->createReceipt($member);
+        // The member attaches their uploaded receipt to a new expense.
         $client->loginUser($member);
         $client->request('POST', '/expenses', [
             'json' => [

--- a/pwa/contexts/ActiveSpaceContext.tsx
+++ b/pwa/contexts/ActiveSpaceContext.tsx
@@ -33,6 +33,8 @@ export interface SpaceMembershipRow {
   role: "admin" | "member";
   /** Custom roles assigned to this member (#space-roles); empty = unrestricted. */
   roles?: { "@id": string; id: string; name: string; color: string | null }[];
+  /** Internal cost rate (#653), minor units per hour; null = not set. */
+  costRateAmount?: number | null;
 }
 
 export interface SpaceAttachment {

--- a/pwa/pages/invoices/index.tsx
+++ b/pwa/pages/invoices/index.tsx
@@ -83,6 +83,20 @@ const InvoicesPage = () => {
     }
   }, [authLoading, isAuthenticated, router]);
 
+  // Deep link from the uninvoiced report (#666): /invoices?generate={engagementId}
+  // opens the composer with the engagement preselected and previews it.
+  const [autoPreview, setAutoPreview] = useState(false);
+  useEffect(() => {
+    if (!router.isReady) return;
+    const generateParam = router.query.generate;
+    if (typeof generateParam !== "string" || generateParam === "") return;
+    setShowComposer(true);
+    setGenEngagement(`/engagements/${generateParam}`);
+    setAutoPreview(true);
+    void router.replace("/invoices", undefined, { shallow: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router.isReady, router.query.generate]);
+
   const spaceIri = activeSpace?.["@id"] ?? null;
 
   const invoicesQuery = useQuery({
@@ -149,6 +163,15 @@ const InvoicesPage = () => {
     },
     onError: (e) => setError(e instanceof Error ? e.message : "Failed to load unbilled time."),
   });
+
+  // Fire the deep-linked preview once the preselected engagement is in state.
+  useEffect(() => {
+    if (autoPreview && genEngagement !== "") {
+      setAutoPreview(false);
+      loadPreview.mutate();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autoPreview, genEngagement]);
 
   const generate = useMutation({
     mutationFn: () =>

--- a/pwa/pages/reports/index.tsx
+++ b/pwa/pages/reports/index.tsx
@@ -382,7 +382,7 @@ const ReportsPage = () => {
                               </td>
                               <td className="px-4 py-2.5 text-right">
                                 <Link
-                                  href="/invoices"
+                                  href={`/invoices?generate=${encodeURIComponent(row.engagementId)}`}
                                   className="text-sm text-primary hover:underline"
                                 >
                                   Create invoice

--- a/pwa/pages/spaces/[id]/users.tsx
+++ b/pwa/pages/spaces/[id]/users.tsx
@@ -57,6 +57,59 @@ const toAvatarUser = (m: SpaceMember): AvatarUser => ({
   personalizedColor: m.personalizedColor ?? "#64748b",
 });
 
+/**
+ * Inline editor for a member's internal cost rate (#653/#666) — currency
+ * units in the box, minor units on the wire. Blank clears the rate. Commits
+ * on blur/Enter so tabbing down the roster is fast.
+ */
+const CostRateInput = ({
+  value,
+  onCommit,
+}: {
+  value: number | null;
+  onCommit: (minor: number | null) => void;
+}) => {
+  const [draft, setDraft] = useState(value === null ? "" : (value / 100).toFixed(2));
+  useEffect(() => {
+    setDraft(value === null ? "" : (value / 100).toFixed(2));
+  }, [value]);
+
+  const commit = () => {
+    const trimmed = draft.trim();
+    if (trimmed === "") {
+      if (value !== null) onCommit(null);
+      return;
+    }
+    const parsed = parseFloat(trimmed);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      setDraft(value === null ? "" : (value / 100).toFixed(2));
+      return;
+    }
+    const minor = Math.round(parsed * 100);
+    if (minor !== value) onCommit(minor);
+  };
+
+  return (
+    <div
+      className="flex items-center gap-1"
+      title="Internal cost per hour — feeds the profitability report"
+    >
+      <Input
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") e.currentTarget.blur();
+        }}
+        inputMode="decimal"
+        placeholder="cost/h"
+        aria-label="Cost rate per hour"
+        className="h-8 w-20 text-right text-sm tabular-nums"
+      />
+    </div>
+  );
+};
+
 /** Compact role picker (Admin / Member) — used per member row and on invite. */
 const RoleSelect = ({
   value,
@@ -309,6 +362,29 @@ const SpaceUsers = () => {
     await refresh();
   };
 
+  const handleSetCostRate = async (
+    membership: { id: string },
+    costRateAmount: number | null,
+  ) => {
+    if (!space) return;
+    setError(null);
+    const res = await fetch(
+      `${ENTRYPOINT}/spaces/${encodeURIComponent(space.id)}/members/${encodeURIComponent(membership.id)}`,
+      {
+        method: "PATCH",
+        credentials: "include",
+        headers: { "Content-Type": "application/merge-patch+json" },
+        body: JSON.stringify({ costRateAmount }),
+      },
+    );
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      setError(data.error || "Failed to update the cost rate.");
+      return;
+    }
+    await load();
+  };
+
   const handleRemoveMember = async (membership: { id: string }, label: string) => {
     if (!space) return;
     if (!window.confirm(`Remove ${label} from this space?`)) return;
@@ -508,6 +584,10 @@ const SpaceUsers = () => {
                             {m.user.email}
                           </p>
                         </div>
+                        <CostRateInput
+                          value={m.costRateAmount ?? null}
+                          onCommit={(minor) => void handleSetCostRate(m, minor)}
+                        />
                         <RoleSelect
                           value={m.role}
                           onChange={(role) => void handleChangeRole(m, role)}


### PR DESCRIPTION
Closes #666

Four follow-ups noted in the #655–#665 sprint:

1. **Cost-rate editing UI** — the space users page gets an inline per-member cost-rate input (currency units in the box, minor units on the wire via the existing membership PATCH; blank clears). Feeds the profitability report (#653).
2. **Uninvoiced → Create invoice deep-link** — the report row links `/invoices?generate={engagementId}`; the invoices page opens the composer with the engagement preselected and auto-runs the preview, then strips the param (shallow) so refresh doesn't re-trigger.
3. **Fees budgets count billable expenses** — `EngagementBudgetCalculator` adds a grouped billable-expense sum to the fees burn, so an engagement that burns budget on costs still alerts. Non-billable expenses never count; hours budgets unchanged.
4. **Tests** — `ExpenseTest::testReceiptDownloadGatedToSpenderAndTimeReaders` (spender + non-uploader space admin download OK, outsider 404) and `EngagementBudgetTest::testFeesBudgetCountsBillableExpenses` (8500/10000 = 85% → exactly the 80% alert fires).