### PR TITLE
feat(invoices): invoice branding — logo, terms, number prefix

### DIFF
--- a/api/migrations/Version20260716210000.php
+++ b/api/migrations/Version20260716210000.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Invoice branding (#669): space-level logo, default terms/footer, invoice
+ * number prefix + next-number counter.
+ */
+final class Version20260716210000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Space invoice branding: logo FK, terms, number prefix + next counter.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE space ADD invoice_logo_id UUID DEFAULT NULL');
+        $this->addSql('ALTER TABLE space ADD invoice_terms TEXT DEFAULT NULL');
+        $this->addSql('ALTER TABLE space ADD invoice_number_prefix VARCHAR(20) DEFAULT NULL');
+        $this->addSql('ALTER TABLE space ADD invoice_number_next INT DEFAULT NULL');
+        $this->addSql('CREATE INDEX IDX_2972C13A0B562299 ON space (invoice_logo_id)');
+        $this->addSql('ALTER TABLE space ADD CONSTRAINT FK_2972C13A0B562299 FOREIGN KEY (invoice_logo_id) REFERENCES media_object (id) ON DELETE SET NULL NOT DEFERRABLE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE space DROP CONSTRAINT FK_2972C13A0B562299');
+        $this->addSql('ALTER TABLE space DROP invoice_logo_id');
+        $this->addSql('ALTER TABLE space DROP invoice_terms');
+        $this->addSql('ALTER TABLE space DROP invoice_number_prefix');
+        $this->addSql('ALTER TABLE space DROP invoice_number_next');
+    }
+}

--- a/api/migrations/Version20260716210000.php
+++ b/api/migrations/Version20260716210000.php
@@ -24,13 +24,13 @@ final class Version20260716210000 extends AbstractMigration
         $this->addSql('ALTER TABLE space ADD invoice_terms TEXT DEFAULT NULL');
         $this->addSql('ALTER TABLE space ADD invoice_number_prefix VARCHAR(20) DEFAULT NULL');
         $this->addSql('ALTER TABLE space ADD invoice_number_next INT DEFAULT NULL');
-        $this->addSql('CREATE INDEX IDX_2972C13A0B562299 ON space (invoice_logo_id)');
-        $this->addSql('ALTER TABLE space ADD CONSTRAINT FK_2972C13A0B562299 FOREIGN KEY (invoice_logo_id) REFERENCES media_object (id) ON DELETE SET NULL NOT DEFERRABLE');
+        $this->addSql('CREATE INDEX IDX_2972C13AB562299 ON space (invoice_logo_id)');
+        $this->addSql('ALTER TABLE space ADD CONSTRAINT FK_2972C13AB562299 FOREIGN KEY (invoice_logo_id) REFERENCES media_object (id) ON DELETE SET NULL NOT DEFERRABLE');
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE space DROP CONSTRAINT FK_2972C13A0B562299');
+        $this->addSql('ALTER TABLE space DROP CONSTRAINT FK_2972C13AB562299');
         $this->addSql('ALTER TABLE space DROP invoice_logo_id');
         $this->addSql('ALTER TABLE space DROP invoice_terms');
         $this->addSql('ALTER TABLE space DROP invoice_number_prefix');

--- a/api/src/Controller/InvoiceActionController.php
+++ b/api/src/Controller/InvoiceActionController.php
@@ -37,6 +37,7 @@ class InvoiceActionController extends AbstractController
         private InvoiceRepository $invoices,
         private SpacePermissionResolver $permissions,
         private InvoiceMailer $mailer,
+        private \App\Service\InvoiceNumberer $numberer,
     ) {
     }
 
@@ -52,11 +53,7 @@ class InvoiceActionController extends AbstractController
             return $this->json(['error' => 'Only a draft invoice can be issued.'], 409);
         }
 
-        $space = $invoice->getSpace();
-        if (null !== $space && null === $invoice->getNumber()) {
-            $next = $this->invoices->countNumbered($space) + 1;
-            $invoice->setNumber('INV-' . str_pad((string) $next, 4, '0', STR_PAD_LEFT));
-        }
+        $this->numberer->assign($invoice);
         if (null === $invoice->getIssueDate()) {
             $invoice->setIssueDate(new \DateTimeImmutable('today'));
         }
@@ -201,11 +198,7 @@ class InvoiceActionController extends AbstractController
         }
 
         // Assign a number on first send (like issue), so a sent invoice is final.
-        $space = $invoice->getSpace();
-        if (null !== $space && null === $invoice->getNumber()) {
-            $next = $this->invoices->countNumbered($space) + 1;
-            $invoice->setNumber('INV-' . str_pad((string) $next, 4, '0', STR_PAD_LEFT));
-        }
+        $this->numberer->assign($invoice);
         if (null === $invoice->getIssueDate()) {
             $invoice->setIssueDate(new \DateTimeImmutable('today'));
         }

--- a/api/src/Controller/PublicEstimateController.php
+++ b/api/src/Controller/PublicEstimateController.php
@@ -45,6 +45,8 @@ class PublicEstimateController extends AbstractController
             ];
         }
 
+        $logoUrls = $estimate->getSpace()?->getInvoiceLogo()?->getVariantUrls() ?? [];
+
         return $this->json([
             'number' => $estimate->getNumber(),
             'status' => $estimate->getStatus(),
@@ -57,6 +59,9 @@ class PublicEstimateController extends AbstractController
             'taxAmount' => $estimate->getTaxAmount(),
             'total' => $estimate->getTotal(),
             'decidedAt' => $estimate->getDecidedAt()?->format(\DateTimeInterface::ATOM),
+            // Branding (#669): shared with invoices — the space logo + terms.
+            'logoUrl' => $logoUrls['profile'] ?? array_values($logoUrls)[0] ?? null,
+            'terms' => $estimate->getSpace()?->getInvoiceTerms(),
         ]);
     }
 

--- a/api/src/Controller/PublicInvoiceController.php
+++ b/api/src/Controller/PublicInvoiceController.php
@@ -57,6 +57,8 @@ class PublicInvoiceController extends AbstractController
             ];
         }
 
+        $logoUrls = $invoice->getSpace()?->getInvoiceLogo()?->getVariantUrls() ?? [];
+
         return $this->json([
             'number' => $invoice->getNumber(),
             'status' => $invoice->getStatus(),
@@ -74,6 +76,10 @@ class PublicInvoiceController extends AbstractController
             'balanceDue' => $invoice->getBalanceDue(),
             'payments' => $payments,
             'pdfUrl' => '/public/invoices/' . $token . '/pdf',
+            // Branding (#669): the logo is avatar-kind media on the public
+            // /media/ route, so exposing the URL leaks nothing sensitive.
+            'logoUrl' => $logoUrls['profile'] ?? array_values($logoUrls)[0] ?? null,
+            'terms' => $invoice->getSpace()?->getInvoiceTerms(),
         ]);
     }
 

--- a/api/src/Entity/Space.php
+++ b/api/src/Entity/Space.php
@@ -270,6 +270,41 @@ class Space
     private Collection $attachments;
 
     /**
+     * Invoice branding (#669): logo rendered on the invoice PDF + the public
+     * invoice/estimate pages. Uploaded as an avatar-kind MediaObject so the
+     * public pages can use the plain `/media/...` URL; the PDF embeds the
+     * bytes as a data URI (dompdf runs with remote fetches disabled).
+     */
+    #[ORM\ManyToOne(targetEntity: MediaObject::class)]
+    #[ORM\JoinColumn(name: 'invoice_logo_id', nullable: true, onDelete: 'SET NULL')]
+    #[Groups(['space:read', 'space:write'])]
+    private ?MediaObject $invoiceLogo = null;
+
+    /** Default terms/footer text printed on every invoice (#669). */
+    #[ORM\Column(type: 'text', nullable: true)]
+    #[Assert\Length(max: 2000)]
+    #[Groups(['space:read', 'space:write'])]
+    private ?string $invoiceTerms = null;
+
+    /** Invoice number prefix, e.g. "ACME-" (default "INV-") (#669). */
+    #[ORM\Column(length: 20, nullable: true)]
+    #[Assert\Length(max: 20)]
+    #[Assert\Regex(pattern: '/^[A-Za-z0-9._-]*$/', message: 'Use letters, digits, dots, dashes.')]
+    #[Groups(['space:read', 'space:write'])]
+    private ?string $invoiceNumberPrefix = null;
+
+    /**
+     * Next sequential invoice number to assign (#669). Null = derive from
+     * the count of already-numbered invoices (the pre-branding behaviour);
+     * once set (by an admin, or by the numberer after each assignment) it
+     * is authoritative and increments per issued invoice.
+     */
+    #[ORM\Column(type: 'integer', nullable: true)]
+    #[Assert\Positive]
+    #[Groups(['space:read', 'space:write'])]
+    private ?int $invoiceNumberNext = null;
+
+    /**
      * Transient list of email addresses to invite at creation time —
      * consumed by {@see SpaceCreateProcessor}, never persisted. Validated
      * inline so a single bad address fails the whole create with 422
@@ -357,6 +392,54 @@ class Space
     public function setDescription(?string $description): static
     {
         $this->description = $description;
+        return $this;
+    }
+
+    public function getInvoiceLogo(): ?MediaObject
+    {
+        return $this->invoiceLogo;
+    }
+
+    public function setInvoiceLogo(?MediaObject $invoiceLogo): static
+    {
+        $this->invoiceLogo = $invoiceLogo;
+
+        return $this;
+    }
+
+    public function getInvoiceTerms(): ?string
+    {
+        return $this->invoiceTerms;
+    }
+
+    public function setInvoiceTerms(?string $invoiceTerms): static
+    {
+        $this->invoiceTerms = $invoiceTerms;
+
+        return $this;
+    }
+
+    public function getInvoiceNumberPrefix(): ?string
+    {
+        return $this->invoiceNumberPrefix;
+    }
+
+    public function setInvoiceNumberPrefix(?string $invoiceNumberPrefix): static
+    {
+        $this->invoiceNumberPrefix = $invoiceNumberPrefix;
+
+        return $this;
+    }
+
+    public function getInvoiceNumberNext(): ?int
+    {
+        return $this->invoiceNumberNext;
+    }
+
+    public function setInvoiceNumberNext(?int $invoiceNumberNext): static
+    {
+        $this->invoiceNumberNext = $invoiceNumberNext;
+
         return $this;
     }
 

--- a/api/src/Entity/Space.php
+++ b/api/src/Entity/Space.php
@@ -275,6 +275,7 @@ class Space
      * public pages can use the plain `/media/...` URL; the PDF embeds the
      * bytes as a data URI (dompdf runs with remote fetches disabled).
      */
+    #[\ApiPlatform\Metadata\ApiProperty(readableLink: true)]
     #[ORM\ManyToOne(targetEntity: MediaObject::class)]
     #[ORM\JoinColumn(name: 'invoice_logo_id', nullable: true, onDelete: 'SET NULL')]
     #[Groups(['space:read', 'space:write'])]

--- a/api/src/Service/InvoiceNumberer.php
+++ b/api/src/Service/InvoiceNumberer.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Invoice;
+use App\Repository\InvoiceRepository;
+
+/**
+ * Assigns the next sequential invoice number (#669) — one code path for the
+ * issue and send transitions so branding (custom prefix + explicit next
+ * counter) can't drift between them.
+ *
+ * Prefix defaults to "INV-"; the counter starts from the space's
+ * `invoiceNumberNext` when set (admin-configurable), else falls back to
+ * count-of-numbered + 1 (the pre-branding behaviour). Every assignment
+ * advances the counter, so once a space issues one branded invoice the
+ * explicit counter is authoritative and renumbering/prefix changes never
+ * reuse a value.
+ */
+final class InvoiceNumberer
+{
+    public function __construct(private readonly InvoiceRepository $invoices)
+    {
+    }
+
+    /** No-op when the invoice is already numbered or has no space. */
+    public function assign(Invoice $invoice): void
+    {
+        $space = $invoice->getSpace();
+        if (null === $space || null !== $invoice->getNumber()) {
+            return;
+        }
+
+        $prefix = $space->getInvoiceNumberPrefix();
+        if (null === $prefix || '' === trim($prefix)) {
+            $prefix = 'INV-';
+        }
+        $next = $space->getInvoiceNumberNext() ?? ($this->invoices->countNumbered($space) + 1);
+
+        $invoice->setNumber($prefix . str_pad((string) $next, 4, '0', STR_PAD_LEFT));
+        $space->setInvoiceNumberNext($next + 1);
+    }
+}

--- a/api/src/Service/InvoicePdfRenderer.php
+++ b/api/src/Service/InvoicePdfRenderer.php
@@ -7,6 +7,9 @@ namespace App\Service;
 use App\Entity\Invoice;
 use Dompdf\Dompdf;
 use Dompdf\Options;
+use League\Flysystem\FilesystemException;
+use League\Flysystem\FilesystemOperator;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Twig\Environment;
 
 /**
@@ -14,16 +17,27 @@ use Twig\Environment;
  * (pure PHP, no wkhtmltopdf binary — fits the slim FrankenPHP image). We own the
  * layout + numbering, so no third-party invoicing product is needed; the PDF is
  * generated on demand and streamed by {@see \App\Controller\InvoicePdfController}.
+ *
+ * Branding (#669): the space's logo is embedded as a base64 data URI (dompdf
+ * runs with remote fetches disabled, so a URL wouldn't load) and the space's
+ * default terms print in the footer.
  */
 final class InvoicePdfRenderer
 {
-    public function __construct(private Environment $twig)
-    {
+    public function __construct(
+        private Environment $twig,
+        #[Autowire(service: 'media.storage')]
+        private FilesystemOperator $storage,
+    ) {
     }
 
     public function render(Invoice $invoice): string
     {
-        $html = $this->twig->render('invoice/pdf.html.twig', ['invoice' => $invoice]);
+        $html = $this->twig->render('invoice/pdf.html.twig', [
+            'invoice' => $invoice,
+            'logoDataUri' => $this->logoDataUri($invoice),
+            'terms' => $invoice->getSpace()?->getInvoiceTerms(),
+        ]);
 
         $options = new Options();
         $options->set('isRemoteEnabled', false);
@@ -45,5 +59,30 @@ final class InvoicePdfRenderer
         $safe = preg_replace('/[^A-Za-z0-9._-]/', '-', $base);
 
         return ($safe ?? 'invoice') . '.pdf';
+    }
+
+    /** The space logo as a data URI, or null (no logo / unreadable bytes). */
+    private function logoDataUri(Invoice $invoice): ?string
+    {
+        $logo = $invoice->getSpace()?->getInvoiceLogo();
+        if (null === $logo) {
+            return null;
+        }
+        $path = $logo->getVariantPath('profile')
+            ?? $logo->getVariantPath('original')
+            ?? array_values($logo->getVariants())[0]
+            ?? null;
+        if (null === $path) {
+            return null;
+        }
+
+        try {
+            $bytes = $this->storage->read($path);
+        } catch (FilesystemException) {
+            return null;
+        }
+        $mime = '' !== $logo->getMimeType() ? $logo->getMimeType() : 'image/png';
+
+        return 'data:' . $mime . ';base64,' . base64_encode($bytes);
     }
 }

--- a/api/src/Validator/ValidSpaceAttachmentsValidator.php
+++ b/api/src/Validator/ValidSpaceAttachmentsValidator.php
@@ -59,5 +59,27 @@ final class ValidSpaceAttachmentsValidator extends ConstraintValidator
                 return;
             }
         }
+
+        // The invoice logo (#669) plays by the same rules, but must be an
+        // image (avatar-kind — publicly served, image-validated on upload)
+        // and uploaded by a member.
+        $logo = $value->getInvoiceLogo();
+        if (null !== $logo) {
+            $logoOwner = $logo->getOwner();
+            if (
+                null === $logoOwner || null === $logoOwner->getId()
+                || !isset($memberIds[(string) $logoOwner->getId()])
+            ) {
+                $this->context->buildViolation($constraint->messageNotMember)
+                    ->atPath('invoiceLogo')
+                    ->addViolation();
+                return;
+            }
+            if (MediaObject::KIND_AVATAR !== $logo->getKind()) {
+                $this->context->buildViolation('The invoice logo must be an uploaded image.')
+                    ->atPath('invoiceLogo')
+                    ->addViolation();
+            }
+        }
     }
 }

--- a/api/templates/invoice/pdf.html.twig
+++ b/api/templates/invoice/pdf.html.twig
@@ -23,6 +23,9 @@
     .totals td { padding: 4px 8px; }
     .totals .grand td { border-top: 2px solid #111827; font-weight: bold; font-size: 14px; }
     .notes { margin-top: 28px; padding-top: 12px; border-top: 1px solid #e5e7eb; white-space: pre-wrap; }
+    .logo { max-height: 56px; max-width: 200px; margin-bottom: 8px; }
+    .terms { margin-top: 20px; padding-top: 10px; border-top: 1px solid #e5e7eb;
+        white-space: pre-wrap; color: #6b7280; font-size: 10px; }
 </style>
 </head>
 <body>
@@ -32,6 +35,7 @@
 
 <div class="header">
     <span class="status">{{ invoice.status }}</span>
+    {% if logoDataUri %}<img class="logo" src="{{ logoDataUri }}" alt="">{% endif %}
     <h1>INVOICE</h1>
     <div class="muted">{{ invoice.number ?? 'Draft' }}</div>
 </div>
@@ -141,6 +145,10 @@
 
 {% if invoice.notes %}
 <div class="notes">{{ invoice.notes }}</div>
+{% endif %}
+
+{% if terms %}
+<div class="terms">{{ terms }}</div>
 {% endif %}
 </body>
 </html>

--- a/api/tests/Api/ClientInvoiceTest.php
+++ b/api/tests/Api/ClientInvoiceTest.php
@@ -719,6 +719,106 @@ class ClientInvoiceTest extends ApiTestCase
         $this->assertNotNull($refreshed['paidAt'] ?? null);
     }
 
+    public function testInvoiceBrandingNumbersLogoAndTerms(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $space = $this->createSharedSpace($admin);
+        $spaceId = (string) $space->getId();
+        $spaceIri = '/spaces/' . $spaceId;
+
+        // Media rows created before the HTTP phase — the client kernel
+        // reboots detach this EM's entities.
+        $storage = static::getContainer()->get('media.storage');
+        $logoPath = 'avatars/branding-test-' . bin2hex(random_bytes(4)) . '.png';
+        $storage->write($logoPath, 'LOGO-PNG-BYTES');
+        $logo = (new \App\Entity\MediaObject())
+            ->setOwner($admin)
+            ->setKind(\App\Entity\MediaObject::KIND_AVATAR)
+            ->setVariants(['profile' => $logoPath])
+            ->setOriginalName('logo.png')
+            ->setMimeType('image/png')
+            ->setByteSize(14);
+        $this->entityManager->persist($logo);
+        $doc = (new \App\Entity\MediaObject())
+            ->setOwner($admin)
+            ->setKind(\App\Entity\MediaObject::KIND_ATTACHMENT)
+            ->setVariants(['original' => $logoPath])
+            ->setOriginalName('doc.pdf')
+            ->setMimeType('application/pdf')
+            ->setByteSize(1);
+        $this->entityManager->persist($doc);
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+
+        // Admin configures branding on the space.
+        $client->request('PATCH', $spaceIri, [
+            'json' => [
+                'invoiceNumberPrefix' => 'ACME-',
+                'invoiceNumberNext' => 42,
+                'invoiceTerms' => 'Net 30. Thank you!',
+                'invoiceLogo' => '/media-objects/' . $logo->getId(),
+            ],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(200);
+
+        // An attachment-kind logo is rejected (must be an uploaded image).
+        $client->request('PATCH', $spaceIri, [
+            'json' => ['invoiceLogo' => '/media-objects/' . $doc->getId()],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $makeInvoice = function () use ($client, $spaceIri, $clientRow): array {
+            $row = $client->request('POST', '/invoices', [
+                'json' => [
+                    'space' => $spaceIri,
+                    'client' => $clientRow['@id'],
+                    'currency' => 'USD',
+                    'lineItems' => [['description' => 'Work', 'quantity' => 1, 'unitAmount' => 5000]],
+                ],
+                'headers' => ['Content-Type' => 'application/ld+json'],
+            ])->toArray();
+            $this->assertResponseStatusCodeSame(201);
+
+            return $row;
+        };
+
+        // Numbering honours the prefix + explicit counter, and advances.
+        $first = $makeInvoice();
+        $issued = $client->request('POST', $this->iri($first) . '/issue', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $this->assertSame('ACME-0042', $issued['number'] ?? null);
+
+        $second = $makeInvoice();
+        $sent = $client->request('POST', $this->iri($second) . '/send', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertSame('ACME-0043', $sent['number'] ?? null);
+        $token = $sent['token'];
+        $this->assertIsString($token);
+
+        // The public page carries the logo URL + terms.
+        $publicView = $client->request('GET', '/public/invoices/' . $token)->toArray();
+        $this->assertSame('/media/' . $logoPath, $publicView['logoUrl'] ?? null);
+        $this->assertSame('Net 30. Thank you!', $publicView['terms'] ?? null);
+
+        // The PDF renders with the branding embedded.
+        $pdf = $client->request('GET', '/public/invoices/' . $token . '/pdf');
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertStringStartsWith('%PDF', $pdf->getContent());
+    }
+
     public function testDiscountAppliesBetweenSubtotalAndTax(): void
     {
         $admin = $this->createUser('admin@example.com');

--- a/pwa/components/spaces/InvoiceBrandingCard.tsx
+++ b/pwa/components/spaces/InvoiceBrandingCard.tsx
@@ -1,0 +1,241 @@
+import { useRef, useState } from "react";
+import { ENTRYPOINT } from "@/config/entrypoint";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+
+interface MediaObjectResponse {
+  "@id": string;
+  variantUrls?: { thumb?: string; profile?: string };
+}
+
+export interface BrandingSpace {
+  id: string;
+  invoiceLogo?: { "@id": string; variantUrls?: { thumb?: string; profile?: string } } | null;
+  invoiceTerms?: string | null;
+  invoiceNumberPrefix?: string | null;
+  invoiceNumberNext?: number | null;
+}
+
+/**
+ * Invoice branding (#669) — space-admin card on the space settings page:
+ * logo (shown on the PDF + public invoice/estimate pages), default
+ * terms/footer text, and the invoice number prefix + next counter.
+ */
+const InvoiceBrandingCard = ({
+  space,
+  onSaved,
+}: {
+  space: BrandingSpace;
+  onSaved: () => void | Promise<void>;
+}) => {
+  const [terms, setTerms] = useState(space.invoiceTerms ?? "");
+  const [prefix, setPrefix] = useState(space.invoiceNumberPrefix ?? "");
+  const [nextNumber, setNextNumber] = useState(
+    space.invoiceNumberNext !== null && space.invoiceNumberNext !== undefined
+      ? String(space.invoiceNumberNext)
+      : "",
+  );
+  const [saving, setSaving] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [message, setMessage] = useState<{ text: string; kind: "success" | "error" } | null>(
+    null,
+  );
+  const fileRef = useRef<HTMLInputElement | null>(null);
+
+  const patchSpace = async (body: Record<string, unknown>): Promise<boolean> => {
+    const res = await fetch(`${ENTRYPOINT}/spaces/${encodeURIComponent(space.id)}`, {
+      method: "PATCH",
+      credentials: "include",
+      headers: { "Content-Type": "application/merge-patch+json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      setMessage({
+        text: data["hydra:description"] || data.detail || data.error || "Failed to save.",
+        kind: "error",
+      });
+      return false;
+    }
+    return true;
+  };
+
+  const saveText = async () => {
+    setSaving(true);
+    setMessage(null);
+    const parsedNext = nextNumber.trim() === "" ? null : parseInt(nextNumber, 10);
+    if (parsedNext !== null && (!Number.isFinite(parsedNext) || parsedNext < 1)) {
+      setMessage({ text: "Next number must be a positive integer.", kind: "error" });
+      setSaving(false);
+      return;
+    }
+    const ok = await patchSpace({
+      invoiceTerms: terms.trim() === "" ? null : terms,
+      invoiceNumberPrefix: prefix.trim() === "" ? null : prefix.trim(),
+      invoiceNumberNext: parsedNext,
+    });
+    if (ok) {
+      setMessage({ text: "Branding saved.", kind: "success" });
+      await onSaved();
+    }
+    setSaving(false);
+  };
+
+  const uploadLogo = async (file: File) => {
+    setUploading(true);
+    setMessage(null);
+    try {
+      const form = new FormData();
+      form.append("file", file);
+      const uploadRes = await fetch(`${ENTRYPOINT}/media-objects`, {
+        method: "POST",
+        credentials: "include",
+        body: form,
+      });
+      if (!uploadRes.ok) {
+        const data = await uploadRes.json().catch(() => ({}));
+        throw new Error(data.detail || data.error || "Upload failed.");
+      }
+      const media = (await uploadRes.json()) as MediaObjectResponse;
+      if (await patchSpace({ invoiceLogo: media["@id"] })) {
+        setMessage({ text: "Logo updated.", kind: "success" });
+        await onSaved();
+      }
+    } catch (e) {
+      setMessage({
+        text: e instanceof Error ? e.message : "Upload failed.",
+        kind: "error",
+      });
+    } finally {
+      setUploading(false);
+      if (fileRef.current) fileRef.current.value = "";
+    }
+  };
+
+  const removeLogo = async () => {
+    setMessage(null);
+    if (await patchSpace({ invoiceLogo: null })) {
+      setMessage({ text: "Logo removed.", kind: "success" });
+      await onSaved();
+    }
+  };
+
+  const logoUrl = space.invoiceLogo?.variantUrls?.profile ?? null;
+
+  return (
+    <Card className="mb-6">
+      <CardContent className="pt-6 space-y-4">
+        <div>
+          <h2 className="font-semibold">Invoice branding</h2>
+          <p className="text-sm text-muted-foreground">
+            Logo, default terms, and numbering used on this space&apos;s invoices,
+            estimates, and their public pages.
+          </p>
+        </div>
+
+        {message && (
+          <Alert variant={message.kind === "error" ? "destructive" : "default"}>
+            <AlertDescription>{message.text}</AlertDescription>
+          </Alert>
+        )}
+
+        <div className="flex items-center gap-4">
+          {logoUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={logoUrl}
+              alt="Invoice logo"
+              className="h-14 w-auto max-w-48 rounded border object-contain p-1"
+            />
+          ) : (
+            <div className="flex h-14 w-28 items-center justify-center rounded border border-dashed text-xs text-muted-foreground">
+              No logo
+            </div>
+          )}
+          <div className="flex items-center gap-2">
+            <input
+              ref={fileRef}
+              type="file"
+              accept="image/*"
+              className="hidden"
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                if (file) void uploadLogo(file);
+              }}
+            />
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={uploading}
+              onClick={() => fileRef.current?.click()}
+            >
+              {uploading ? "Uploading…" : logoUrl ? "Replace logo" : "Upload logo"}
+            </Button>
+            {logoUrl && (
+              <Button variant="ghost" size="sm" onClick={() => void removeLogo()}>
+                Remove
+              </Button>
+            )}
+          </div>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="brand-prefix">Invoice number prefix</Label>
+            <Input
+              id="brand-prefix"
+              value={prefix}
+              onChange={(e) => setPrefix(e.target.value)}
+              placeholder="INV-"
+              maxLength={20}
+            />
+            <p className="text-xs text-muted-foreground">
+              e.g. &quot;ACME-&quot; → ACME-0042. Blank keeps the default INV-.
+            </p>
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="brand-next">Next invoice number</Label>
+            <Input
+              id="brand-next"
+              type="number"
+              min={1}
+              value={nextNumber}
+              onChange={(e) => setNextNumber(e.target.value)}
+              placeholder="auto"
+            />
+            <p className="text-xs text-muted-foreground">
+              Blank continues from the count of issued invoices.
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="brand-terms">Default terms / footer</Label>
+          <Textarea
+            id="brand-terms"
+            value={terms}
+            onChange={(e) => setTerms(e.target.value)}
+            rows={3}
+            maxLength={2000}
+            placeholder="Payment due within 30 days. Late payments accrue 1.5% monthly interest."
+          />
+          <p className="text-xs text-muted-foreground">
+            Printed at the bottom of every invoice PDF and public page.
+          </p>
+        </div>
+
+        <div className="flex justify-end">
+          <Button size="sm" onClick={() => void saveText()} disabled={saving}>
+            {saving ? "Saving…" : "Save branding"}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default InvoiceBrandingCard;

--- a/pwa/contexts/ActiveSpaceContext.tsx
+++ b/pwa/contexts/ActiveSpaceContext.tsx
@@ -73,6 +73,14 @@ export interface Space {
     personalizedColor?: string;
   } | null;
   userMemberships: SpaceMembershipRow[];
+  /** Invoice branding (#669) — admin-editable on the space settings page. */
+  invoiceLogo?: {
+    "@id": string;
+    variantUrls?: { thumb?: string; profile?: string };
+  } | null;
+  invoiceTerms?: string | null;
+  invoiceNumberPrefix?: string | null;
+  invoiceNumberNext?: number | null;
   /** EXTRA_LAZY-counted on the API (`Space::getProjectsCount`). */
   boardsCount: number;
   /** EXTRA_LAZY-counted on the API (`Space::getPagesCount`). */

--- a/pwa/pages/e/[token].tsx
+++ b/pwa/pages/e/[token].tsx
@@ -28,6 +28,8 @@ interface PublicEstimate {
   taxAmount: number;
   total: number;
   decidedAt: string | null;
+  logoUrl: string | null;
+  terms: string | null;
 }
 
 /**
@@ -122,6 +124,14 @@ const PublicEstimatePage = () => {
       <div className="space-y-6">
         <div className="flex items-start justify-between gap-4">
           <div>
+            {estimate.logoUrl && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={estimate.logoUrl}
+                alt={estimate.from ?? "Logo"}
+                className="mb-3 h-12 w-auto max-w-48 object-contain"
+              />
+            )}
             <h1 className="text-2xl font-semibold">Estimate {estimate.number ?? ""}</h1>
             {estimate.from && (
               <p className="text-sm text-muted-foreground">From {estimate.from}</p>
@@ -213,6 +223,12 @@ const PublicEstimatePage = () => {
             <span className="text-sm font-medium text-muted-foreground">Declined</span>
           ) : null}
         </div>
+
+        {estimate.terms && (
+          <p className="whitespace-pre-wrap border-t pt-4 text-xs text-muted-foreground">
+            {estimate.terms}
+          </p>
+        )}
       </div>
     );
   }

--- a/pwa/pages/i/[token].tsx
+++ b/pwa/pages/i/[token].tsx
@@ -31,6 +31,8 @@ interface PublicInvoice {
   amountPaid: number;
   balanceDue: number;
   payments: { amount: number; paidOn: string; method: string | null }[];
+  logoUrl: string | null;
+  terms: string | null;
 }
 
 const fmtDate = (iso: string | null): string =>
@@ -143,6 +145,14 @@ const PublicInvoicePage = () => {
       <div className="space-y-6">
         <div className="flex items-start justify-between gap-4">
           <div>
+            {invoice.logoUrl && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={invoice.logoUrl}
+                alt={invoice.from ?? "Logo"}
+                className="mb-3 h-12 w-auto max-w-48 object-contain"
+              />
+            )}
             <h1 className="text-2xl font-semibold">Invoice {invoice.number ?? ""}</h1>
             {invoice.from && <p className="text-sm text-muted-foreground">From {invoice.from}</p>}
           </div>
@@ -268,6 +278,12 @@ const PublicInvoicePage = () => {
             </span>
           )}
         </div>
+
+        {invoice.terms && (
+          <p className="whitespace-pre-wrap border-t pt-4 text-xs text-muted-foreground">
+            {invoice.terms}
+          </p>
+        )}
       </div>
     );
   }

--- a/pwa/pages/spaces/[id]/settings.tsx
+++ b/pwa/pages/spaces/[id]/settings.tsx
@@ -17,6 +17,7 @@ import MarkdownEditor from "@/components/editor/MarkdownEditor";
 import ColorSwatchPicker from "@/components/common/ColorSwatchPicker";
 import SpaceTile from "@/components/spaces/SpaceTile";
 import SpaceBillingCard from "@/components/spaces/SpaceBillingCard";
+import InvoiceBrandingCard from "@/components/spaces/InvoiceBrandingCard";
 import DeleteSpaceDialog from "@/components/spaces/DeleteSpaceDialog";
 import ChangeVisibilityDialog from "@/components/spaces/ChangeVisibilityDialog";
 
@@ -367,6 +368,9 @@ const SpaceSettings = () => {
         {BILLING_ENABLED && !space.isPersonal && (
           <SpaceBillingCard spaceId={space.id} />
         )}
+
+        {/* Invoice branding (#669): logo, terms, numbering. */}
+        <InvoiceBrandingCard space={space} onSaved={load} />
 
         {/* Export space data */}
         <Card className="mb-6">


### PR DESCRIPTION
Closes #669

## What
Space-level invoice branding, editable by space admins on the space settings page:

- **Logo** — an avatar-kind MediaObject (publicly served `/media/...`, image-validated on upload; `ValidSpaceAttachments` enforces member-uploaded + image kind). Rendered on the invoice PDF (embedded as a **base64 data URI** since dompdf runs with remote fetches disabled), the public invoice page, and the public estimate page.
- **Default terms / footer** — printed at the bottom of every invoice PDF + both public pages.
- **Numbering** — `invoiceNumberPrefix` (default `INV-`) + `invoiceNumberNext` counter. New `InvoiceNumberer` service is the single assignment path for both the issue and send transitions: starts from the explicit counter when set (else count-of-numbered + 1, the old behaviour) and advances it on every assignment, so prefix changes or renumbering never reuse a value. Existing spaces behave identically until an admin edits the settings.

## PWA
`InvoiceBrandingCard` on `/spaces/{id}/settings`: logo upload/replace/remove (reuses the avatar upload flow), prefix + next-number inputs, terms textarea. Public pages show the logo above the title and the terms under the actions.

## Tests
`ClientInvoiceTest::testInvoiceBrandingNumbersLogoAndTerms` — PATCH branding, attachment-kind logo 422s, `ACME-0042` on issue → `ACME-0043` on send, public payload carries `logoUrl` + `terms`, PDF renders (`%PDF`) with the branding embedded.