### PR TITLE
feat(time): timesheet submission reminder nudges

### DIFF
--- a/api/src/Entity/Notification.php
+++ b/api/src/Entity/Notification.php
@@ -91,6 +91,8 @@ class Notification
     public const TYPE_TIMESHEET_SUBMITTED = 'timesheet_submitted';
     /** Your timesheet was approved or rejected (#654/#667). */
     public const TYPE_TIMESHEET_DECIDED = 'timesheet_decided';
+    /** You tracked time last week but haven't submitted the week yet (#668). */
+    public const TYPE_TIMESHEET_NUDGE = 'timesheet_nudge';
     /** An engagement crossed a budget threshold (→ space admins) (#651/#667). */
     public const TYPE_BUDGET_ALERT = 'budget_alert';
 

--- a/api/src/Message/SendTimesheetNudges.php
+++ b/api/src/Message/SendTimesheetNudges.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Message;
+
+/**
+ * Weekly trigger for the timesheet submission nudges (#668) — handled by
+ * App\MessageHandler\SendTimesheetNudgesHandler.
+ */
+final class SendTimesheetNudges
+{
+}

--- a/api/src/MessageHandler/SendTimesheetNudgesHandler.php
+++ b/api/src/MessageHandler/SendTimesheetNudgesHandler.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\MessageHandler;
+
+use App\Message\SendTimesheetNudges;
+use App\Service\TimesheetNudgeDispatcher;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * Runs the weekly timesheet submission nudge sweep (#668) when the
+ * scheduler fires App\Message\SendTimesheetNudges (Monday mornings).
+ */
+#[AsMessageHandler]
+final class SendTimesheetNudgesHandler
+{
+    public function __construct(
+        private TimesheetNudgeDispatcher $nudges,
+    ) {
+    }
+
+    public function __invoke(SendTimesheetNudges $message): void
+    {
+        $this->nudges->dispatchDue(new \DateTimeImmutable());
+    }
+}

--- a/api/src/Scheduler/MainScheduleProvider.php
+++ b/api/src/Scheduler/MainScheduleProvider.php
@@ -12,6 +12,7 @@ use App\Message\PruneAccountExports;
 use App\Message\PruneSpaceExports;
 use App\Message\PullCalendarChanges;
 use App\Message\RunBackup;
+use App\Message\SendTimesheetNudges;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Scheduler\Attribute\AsSchedule;
 use Symfony\Component\Scheduler\RecurringMessage;
@@ -105,6 +106,10 @@ final class MainScheduleProvider implements ScheduleProviderInterface
                 // Recurring invoices: clone due templates into fresh drafts,
                 // daily at 03:55 UTC (App\Service\RecurringInvoiceSpawner).
                 RecurringMessage::cron('55 3 * * *', new SpawnRecurringInvoices(), $utc),
+                // Timesheet nudges (#668): Monday 09:00 UTC — members who
+                // tracked time last week but haven't submitted it
+                // (App\Service\TimesheetNudgeDispatcher).
+                RecurringMessage::cron('0 9 * * 1', new SendTimesheetNudges(), $utc),
             )
             ->stateful($this->cache)
             ->processOnlyLastMissedRun(true)

--- a/api/src/Service/NotificationDispatcher.php
+++ b/api/src/Service/NotificationDispatcher.php
@@ -64,6 +64,7 @@ final class NotificationDispatcher
         Notification::TYPE_STATUS => 'status',
         Notification::TYPE_TIMESHEET_SUBMITTED => 'timesheets',
         Notification::TYPE_TIMESHEET_DECIDED => 'timesheets',
+        Notification::TYPE_TIMESHEET_NUDGE => 'timesheets',
         Notification::TYPE_BUDGET_ALERT => 'budgets',
     ];
 

--- a/api/src/Service/TimesheetNudgeDispatcher.php
+++ b/api/src/Service/TimesheetNudgeDispatcher.php
@@ -45,16 +45,20 @@ final class TimesheetNudgeDispatcher
 
         /** @var list<Space> $spaces */
         $spaces = $this->em->createQuery(
-            'SELECT DISTINCT s FROM ' . TimesheetSubmission::class . ' t JOIN t.space s',
+            'SELECT s FROM ' . Space::class . ' s
+             WHERE EXISTS (SELECT 1 FROM ' . TimesheetSubmission::class . ' t WHERE t.space = s)',
         )->getResult();
 
         $sent = 0;
         foreach ($spaces as $space) {
             /** @var list<User> $trackers */
             $trackers = $this->em->createQuery(
-                'SELECT DISTINCT u FROM ' . TimeEntry::class . ' e JOIN e.user u
-                 WHERE e.space = :space AND e.endedAt IS NOT NULL
-                   AND e.startedAt >= :from AND e.startedAt < :to',
+                'SELECT u FROM ' . User::class . ' u
+                 WHERE EXISTS (
+                     SELECT 1 FROM ' . TimeEntry::class . ' e
+                     WHERE e.user = u AND e.space = :space AND e.endedAt IS NOT NULL
+                       AND e.startedAt >= :from AND e.startedAt < :to
+                 )',
             )
                 ->setParameter('space', $space)
                 ->setParameter('from', $weekStart)

--- a/api/src/Service/TimesheetNudgeDispatcher.php
+++ b/api/src/Service/TimesheetNudgeDispatcher.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Notification;
+use App\Entity\Space;
+use App\Entity\TimeEntry;
+use App\Entity\TimesheetSubmission;
+use App\Entity\User;
+use App\Repository\TimesheetSubmissionRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * The weekly timesheet submission nudge (#668): every Monday, members who
+ * tracked time last week but haven't submitted it for approval get one
+ * reminder — in-app + email through NotificationDispatcher's usual
+ * preference gates.
+ *
+ * Scope: only spaces where approvals are actually in use (any
+ * TimesheetSubmission row exists). A rejected submission still nudges (the
+ * member is expected to fix + re-submit); pending/approved doesn't.
+ *
+ * Idempotency: each nudge row stamps `reminderOffset` with
+ * `timesheet-nudge:<weekStart>`, and the sweep skips recipients that
+ * already have one — a re-run (or a missed-then-caught-up scheduler) can't
+ * double-nudge a week.
+ */
+final class TimesheetNudgeDispatcher
+{
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly TimesheetSubmissionRepository $submissions,
+        private readonly NotificationDispatcher $notifier,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    /** Returns how many nudges were sent. */
+    public function dispatchDue(\DateTimeImmutable $now): int
+    {
+        $weekStart = TimesheetSubmissionRepository::weekStartOf($now)->modify('-7 days');
+        $weekEnd = $weekStart->modify('+7 days');
+        $offsetKey = 'timesheet-nudge:' . $weekStart->format('Y-m-d');
+
+        /** @var list<Space> $spaces */
+        $spaces = $this->em->createQuery(
+            'SELECT DISTINCT s FROM ' . TimesheetSubmission::class . ' t JOIN t.space s',
+        )->getResult();
+
+        $sent = 0;
+        foreach ($spaces as $space) {
+            /** @var list<User> $trackers */
+            $trackers = $this->em->createQuery(
+                'SELECT DISTINCT u FROM ' . TimeEntry::class . ' e JOIN e.user u
+                 WHERE e.space = :space AND e.endedAt IS NOT NULL
+                   AND e.startedAt >= :from AND e.startedAt < :to',
+            )
+                ->setParameter('space', $space)
+                ->setParameter('from', $weekStart)
+                ->setParameter('to', $weekEnd)
+                ->getResult();
+
+            foreach ($trackers as $tracker) {
+                $submission = $this->submissions->findForWeek($space, $tracker, $weekStart);
+                if (null !== $submission && $submission->locksWeek()) {
+                    continue; // pending or approved — nothing to nudge
+                }
+                if ($this->alreadyNudged($tracker, $offsetKey)) {
+                    continue;
+                }
+
+                $notification = $this->notifier->notify(
+                    recipient: $tracker,
+                    type: Notification::TYPE_TIMESHEET_NUDGE,
+                    actor: null,
+                    title: sprintf(
+                        "Don't forget to submit your timesheet for the week of %s",
+                        $weekStart->format('M j'),
+                    ),
+                    body: null !== $submission
+                        ? 'Your submission was rejected — fix the entries and submit the week again.'
+                        : 'You tracked time last week but haven\'t submitted it for approval yet.',
+                    targetPath: '/time',
+                );
+                if (null !== $notification) {
+                    $notification->setReminderOffset($offsetKey);
+                    ++$sent;
+                }
+            }
+        }
+
+        if ($sent > 0) {
+            $this->em->flush();
+            $this->logger->info(sprintf('Sent %d timesheet nudge(s).', $sent));
+        }
+
+        return $sent;
+    }
+
+    private function alreadyNudged(User $tracker, string $offsetKey): bool
+    {
+        $count = (int) $this->em->createQuery(
+            'SELECT COUNT(n.id) FROM ' . Notification::class . ' n
+             WHERE n.recipient = :recipient AND n.type = :type AND n.reminderOffset = :offset',
+        )
+            ->setParameter('recipient', $tracker)
+            ->setParameter('type', Notification::TYPE_TIMESHEET_NUDGE)
+            ->setParameter('offset', $offsetKey)
+            ->getSingleScalarResult();
+
+        return $count > 0;
+    }
+}

--- a/api/tests/Api/TimesheetNudgeTest.php
+++ b/api/tests/Api/TimesheetNudgeTest.php
@@ -1,0 +1,232 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\Notification;
+use App\Entity\Space;
+use App\Entity\SpaceMembership;
+use App\Entity\TimesheetSubmission;
+use App\Entity\User;
+use App\Repository\TimesheetSubmissionRepository;
+use App\Service\TimesheetNudgeDispatcher;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Timesheet submission nudges (#668): members who tracked time last week
+ * but haven't submitted it get one reminder — only in spaces where
+ * approvals are in use, idempotent per (user, week).
+ */
+class TimesheetNudgeTest extends ApiTestCase
+{
+    use SpaceMembershipFixture;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = static::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Notification')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\TimesheetSubmission')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\TimeEntry')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\EngagementCategory')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Engagement')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Client')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\SpaceMembership')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Space')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testNudgesUnsubmittedTrackersOnceAndSkipsSubmitted(): void
+    {
+        $now = new \DateTimeImmutable();
+        $lastWeekStart = TimesheetSubmissionRepository::weekStartOf($now)->modify('-7 days');
+
+        $admin = $this->createUser('admin@example.com');
+        $member = $this->createUser('member@example.com');
+        $submitted = $this->createUser('diligent@example.com');
+        $space = $this->createSharedSpace($admin, $member);
+        $extraMembership = (new SpaceMembership())
+            ->setUser($submitted)
+            ->setRole(Space::ROLE_MEMBER);
+        $space->addUserMembership($extraMembership);
+        $this->entityManager->persist($extraMembership);
+
+        // Approvals are "in use" here: an older decided submission exists.
+        $history = (new TimesheetSubmission())
+            ->setSpace($space)
+            ->setUser($admin)
+            ->setWeekStart($lastWeekStart->modify('-14 days'))
+            ->setStatus(TimesheetSubmission::STATUS_APPROVED);
+        $this->entityManager->persist($history);
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => '/spaces/' . $space->getId(), 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $engagement = $client->request('POST', '/engagements', [
+            'json' => [
+                'space' => '/spaces/' . $space->getId(),
+                'client' => $clientRow['@id'],
+                'name' => 'Acme Website',
+                'currency' => 'USD',
+                'categories' => [['name' => 'Dev', 'rateAmount' => 6000, 'position' => 0]],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $engagementIri = $engagement['@id'];
+        $this->assertIsString($engagementIri);
+        $categories = $engagement['categories'] ?? null;
+        $this->assertIsArray($categories);
+        $firstCategory = $categories[0];
+        $this->assertIsArray($firstCategory);
+        $categoryIri = $firstCategory['@id'];
+        $this->assertIsString($categoryIri);
+
+        // Both members tracked an hour last week.
+        foreach ([$member, $submitted] as $tracker) {
+            $client->loginUser($tracker);
+            $client->request('POST', '/time_entries', [
+                'json' => [
+                    'space' => '/spaces/' . $space->getId(),
+                    'engagement' => $engagementIri,
+                    'category' => $categoryIri,
+                    'startedAt' => $lastWeekStart->modify('+2 days')->setTime(9, 0)->format(\DateTimeInterface::ATOM),
+                    'endedAt' => $lastWeekStart->modify('+2 days')->setTime(10, 0)->format(\DateTimeInterface::ATOM),
+                ],
+                'headers' => ['Content-Type' => 'application/ld+json'],
+            ]);
+            $this->assertResponseStatusCodeSame(201);
+        }
+
+        // The diligent member submits their week (pending) — after tracking,
+        // since a pending submission locks the week's entries.
+        $client->loginUser($submitted);
+        $client->request('POST', '/spaces/' . $space->getId() . '/timesheets/submit', [
+            'json' => ['weekStart' => $lastWeekStart->format('Y-m-d')],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+
+        // No HTTP requests from here — the mailer counts below only see the
+        // in-process sweep sends.
+        $dispatcher = static::getContainer()->get(TimesheetNudgeDispatcher::class);
+
+        // Only the unsubmitted tracker is nudged; the pending submitter isn't.
+        $this->assertSame(1, $dispatcher->dispatchDue($now));
+        $this->assertEmailCount(1);
+        $message = $this->getMailerMessage();
+        $this->assertNotNull($message);
+        $this->assertEmailAddressContains($message, 'To', 'member@example.com');
+
+        // Idempotent: the same week never nudges twice.
+        $this->assertSame(0, $dispatcher->dispatchDue($now));
+        $this->assertEmailCount(1);
+
+        // The in-app row landed with the idempotency key + deep-link.
+        $em = static::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $rows = $em->getRepository(Notification::class)->findBy([
+            'recipient' => $member->getId(),
+            'type' => Notification::TYPE_TIMESHEET_NUDGE,
+        ]);
+        $this->assertCount(1, $rows);
+        $this->assertSame('/time', $rows[0]->getTargetUrl());
+    }
+
+    public function testSpacesWithoutApprovalHistoryAreLeftAlone(): void
+    {
+        $now = new \DateTimeImmutable();
+        $lastWeekStart = TimesheetSubmissionRepository::weekStartOf($now)->modify('-7 days');
+
+        $admin = $this->createUser('admin@example.com');
+        $space = $this->createSharedSpace($admin);
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => '/spaces/' . $space->getId(), 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $engagement = $client->request('POST', '/engagements', [
+            'json' => [
+                'space' => '/spaces/' . $space->getId(),
+                'client' => $clientRow['@id'],
+                'name' => 'Acme Website',
+                'currency' => 'USD',
+                'categories' => [['name' => 'Dev', 'rateAmount' => 6000, 'position' => 0]],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $engagementIri = $engagement['@id'];
+        $this->assertIsString($engagementIri);
+        $categories = $engagement['categories'] ?? null;
+        $this->assertIsArray($categories);
+        $firstCategory = $categories[0];
+        $this->assertIsArray($firstCategory);
+        $categoryIri = $firstCategory['@id'];
+        $this->assertIsString($categoryIri);
+
+        $client->request('POST', '/time_entries', [
+            'json' => [
+                'space' => '/spaces/' . $space->getId(),
+                'engagement' => $engagementIri,
+                'category' => $categoryIri,
+                'startedAt' => $lastWeekStart->modify('+2 days')->setTime(9, 0)->format(\DateTimeInterface::ATOM),
+                'endedAt' => $lastWeekStart->modify('+2 days')->setTime(10, 0)->format(\DateTimeInterface::ATOM),
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+
+        // Nobody in this space has ever submitted a timesheet — no nudges.
+        $dispatcher = static::getContainer()->get(TimesheetNudgeDispatcher::class);
+        $this->assertSame(0, $dispatcher->dispatchDue($now));
+        $this->assertEmailCount(0);
+    }
+
+    private function createSharedSpace(User $admin, ?User $member = null): Space
+    {
+        $space = (new Space())->setName('Studio')->setCreatedBy($admin);
+        $this->entityManager->persist($space);
+        $adminMembership = (new SpaceMembership())
+            ->setUser($admin)
+            ->setRole(Space::ROLE_ADMIN);
+        $space->addUserMembership($adminMembership);
+        $this->entityManager->persist($adminMembership);
+        if (null !== $member) {
+            $memberMembership = (new SpaceMembership())
+                ->setUser($member)
+                ->setRole(Space::ROLE_MEMBER);
+            $space->addUserMembership($memberMembership);
+            $this->entityManager->persist($memberMembership);
+        }
+        $this->entityManager->flush();
+
+        return $space;
+    }
+
+    private function createUser(string $email): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/api/tests/Api/TimesheetNudgeTest.php
+++ b/api/tests/Api/TimesheetNudgeTest.php
@@ -116,8 +116,13 @@ class TimesheetNudgeTest extends ApiTestCase
         ]);
         $this->assertResponseStatusCodeSame(201);
 
-        // No HTTP requests from here — the mailer counts below only see the
-        // in-process sweep sends.
+        // The submit itself emailed the admin (#667) into this container's
+        // mailer logger — make one email-free request so the logger resets and
+        // the counts below only see the in-process sweep sends. No HTTP
+        // requests after this point.
+        $client->request('GET', '/spaces/' . $space->getId() . '/timesheets');
+        $this->assertResponseStatusCodeSame(200);
+
         $dispatcher = static::getContainer()->get(TimesheetNudgeDispatcher::class);
 
         // Only the unsubmitted tracker is nudged; the pending submitter isn't.

--- a/pwa/lib/notificationTypes.ts
+++ b/pwa/lib/notificationTypes.ts
@@ -21,6 +21,7 @@ export type NotificationType =
   | "task_reminder"
   | "timesheet_submitted"
   | "timesheet_decided"
+  | "timesheet_nudge"
   | "budget_alert";
 
 export type NotificationActor = AvatarUser & {
@@ -135,6 +136,13 @@ export const NOTIFICATION_META: Record<NotificationType, NotificationMeta> = {
     icon_color: "text-teal-600 dark:text-teal-400",
     stripe: "bg-teal-500",
   },
+  timesheet_nudge: {
+    label: "TIMESHEET",
+    icon: ClipboardCheck,
+    badge: "border-teal-500/30 bg-teal-500/10 text-teal-700 dark:text-teal-300",
+    icon_color: "text-teal-600 dark:text-teal-400",
+    stripe: "bg-teal-500",
+  },
   budget_alert: {
     label: "BUDGET",
     icon: Gauge,
@@ -168,6 +176,7 @@ export const NOTIFICATION_TABS: {
       "task_reminder",
       "timesheet_submitted",
       "timesheet_decided",
+      "timesheet_nudge",
       "budget_alert",
     ],
   },


### PR DESCRIPTION
Closes #668

## What
Harvest-style "don't forget your timesheet" reminders, riding the notification pipeline shipped in #676:

- **Monday 09:00 UTC cron** (`SendTimesheetNudges` on the shared scheduler) runs `TimesheetNudgeDispatcher`.
- Scope: only spaces where approvals are actually in use (≥1 `TimesheetSubmission` row ever — a team that never uses approvals is never nagged).
- For each such space: members with completed time entries last week and **no pending/approved submission** for that week get one nudge. A **rejected** submission still nudges (the member is expected to fix + re-submit), with tailored copy.
- Delivery through `NotificationDispatcher`: in-app bell row (deep-links `/time`), push + email under the member's own `timesheets` matrix row, quiet hours, digest cadence.
- **Idempotent** per (user, week): each row stamps `reminderOffset = timesheet-nudge:<weekStart>` and the sweep skips existing ones, so re-runs / missed-scheduler catch-ups can't double-nudge.

## Tests
`TimesheetNudgeTest`:
- unsubmitted tracker nudged once (email + in-app row with the idempotency key + deep-link), pending submitter skipped, re-run sends nothing
- a space with no approval history is left alone entirely