### PR TITLE
feat(billing): client portal — one link listing all invoices + estimates

### DIFF
--- a/api/migrations/Version20260716220000.php
+++ b/api/migrations/Version20260716220000.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Client portal (#674): client.portal_token — sha256 of the portal link
+ * token (unique; rotating invalidates the previous link).
+ */
+final class Version20260716220000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'client.portal_token for the tokenized client portal.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE client ADD portal_token VARCHAR(64) DEFAULT NULL');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_C7440455F7DA88A9 ON client (portal_token)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX UNIQ_C7440455F7DA88A9');
+        $this->addSql('ALTER TABLE client DROP portal_token');
+    }
+}

--- a/api/src/Controller/ClientPortalController.php
+++ b/api/src/Controller/ClientPortalController.php
@@ -1,0 +1,292 @@
+<?php
+
+namespace App\Controller;
+
+use App\Billing\BillingException;
+use App\Billing\Payment\PaymentGatewayRegistry;
+use App\Entity\Client;
+use App\Entity\Estimate;
+use App\Entity\Invoice;
+use App\Entity\User;
+use App\Security\Permission\SpacePermission;
+use App\Security\Permission\SpacePermissionResolver;
+use App\Service\EstimateMailer;
+use App\Service\InvoicePdfRenderer;
+use App\Service\Mail\MailDispatcher;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Client portal (#674): one tokenized link a client keeps, listing every
+ * (non-draft) invoice and estimate they've received — instead of hunting
+ * through per-document emails. The token is sha256-hashed at rest like the
+ * per-document tokens; rotating (re-minting) invalidates the old link.
+ *
+ * Documents are actioned through portal-scoped routes (PDF, pay,
+ * accept/decline) because per-document plaintext tokens can't be recovered
+ * from their hashes — the portal token itself is the credential, and each
+ * document route re-checks the document belongs to the portal's client.
+ *
+ * Minting/rotating the link is admin-reserved (invoices.update), same bar
+ * as the invoice lifecycle actions.
+ */
+class ClientPortalController extends AbstractController
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private SpacePermissionResolver $permissions,
+        private InvoicePdfRenderer $renderer,
+        private PaymentGatewayRegistry $gateways,
+        private EstimateMailer $estimateMailer,
+        private MailDispatcher $mail,
+        #[Autowire('%env(default::APP_FRONTEND_URL)%')]
+        private string $frontendUrl,
+    ) {
+    }
+
+    #[Route('/clients/{id}/portal-link', name: 'client_portal_link', methods: ['POST'], priority: 10)]
+    public function mint(string $id, Request $request, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if (null === $user) {
+            return $this->json(['error' => 'Not authenticated.'], 401);
+        }
+        if (!Uuid::isValid($id)) {
+            return $this->json(['error' => 'Client not found.'], 404);
+        }
+        $client = $this->em->getRepository(Client::class)->find($id);
+        $space = $client?->getSpace();
+        if (
+            null === $client || null === $space
+            || (!$this->isGranted('ROLE_ADMIN') && !$space->hasMember($user))
+        ) {
+            return $this->json(['error' => 'Client not found.'], 404);
+        }
+        if (
+            !$this->isGranted('ROLE_ADMIN')
+            && !$space->isAdmin($user)
+            && !$this->permissions->canByExplicitGrant($user, $space, SpacePermission::INVOICES, SpacePermission::UPDATE)
+        ) {
+            return $this->json(['error' => 'You cannot manage clients in this space.'], 403);
+        }
+
+        // Rotate: the freshest link is the only working one.
+        $plain = bin2hex(random_bytes(32));
+        $client->setPortalToken(hash('sha256', $plain));
+        $this->em->flush();
+
+        $url = rtrim($this->frontendUrl, '/') . '/portal/' . $plain;
+
+        $payload = $request->toArray();
+        $emailed = false;
+        $to = $client->getEmail();
+        if (true === ($payload['send'] ?? false) && null !== $to && '' !== trim($to)) {
+            $email = (new TemplatedEmail())
+                ->to($to)
+                ->subject(sprintf('Your billing portal at %s', $space->getName()))
+                ->htmlTemplate('emails/client_portal.html.twig')
+                ->textTemplate('emails/client_portal.txt.twig')
+                ->context([
+                    'client' => $client,
+                    'fromName' => $space->getName(),
+                    'portalUrl' => $url,
+                ]);
+            $this->mail->send($email);
+            $emailed = true;
+        }
+
+        return $this->json(['token' => $plain, 'url' => $url, 'emailed' => $emailed], 201);
+    }
+
+    #[Route('/portal/{token}', name: 'client_portal_view', methods: ['GET'])]
+    public function view(string $token): JsonResponse
+    {
+        $client = $this->resolveClient($token);
+        if (null === $client) {
+            return $this->json(['error' => 'Portal not found.'], 404);
+        }
+        $space = $client->getSpace();
+
+        $invoices = [];
+        /** @var list<Invoice> $invoiceRows */
+        $invoiceRows = $this->em->getRepository(Invoice::class)
+            ->findBy(['client' => $client], ['createdAt' => 'DESC']);
+        foreach ($invoiceRows as $invoice) {
+            if (in_array($invoice->getStatus(), [Invoice::STATUS_DRAFT, Invoice::STATUS_VOID], true)) {
+                continue; // drafts are internal; void is dead paper
+            }
+            $invoices[] = [
+                'id' => (string) $invoice->getId(),
+                'number' => $invoice->getNumber(),
+                'status' => $invoice->getStatus(),
+                'issueDate' => $invoice->getIssueDate()?->format('Y-m-d'),
+                'dueDate' => $invoice->getDueDate()?->format('Y-m-d'),
+                'currency' => $invoice->getCurrency(),
+                'total' => $invoice->getTotal(),
+                'amountPaid' => $invoice->getAmountPaid(),
+                'balanceDue' => $invoice->getBalanceDue(),
+            ];
+        }
+
+        $estimates = [];
+        /** @var list<Estimate> $estimateRows */
+        $estimateRows = $this->em->getRepository(Estimate::class)
+            ->findBy(['client' => $client], ['createdAt' => 'DESC']);
+        foreach ($estimateRows as $estimate) {
+            if (Estimate::STATUS_DRAFT === $estimate->getStatus()) {
+                continue;
+            }
+            $estimates[] = [
+                'id' => (string) $estimate->getId(),
+                'number' => $estimate->getNumber(),
+                'status' => $estimate->getStatus(),
+                'currency' => $estimate->getCurrency(),
+                'total' => $estimate->getTotal(),
+                'decidedAt' => $estimate->getDecidedAt()?->format(\DateTimeInterface::ATOM),
+            ];
+        }
+
+        $logoUrls = $space?->getInvoiceLogo()?->getVariantUrls() ?? [];
+
+        return $this->json([
+            'clientName' => $client->getName(),
+            'from' => $space?->getName(),
+            'logoUrl' => $logoUrls['profile'] ?? array_values($logoUrls)[0] ?? null,
+            'invoices' => $invoices,
+            'estimates' => $estimates,
+        ]);
+    }
+
+    #[Route('/portal/{token}/invoices/{id}/pdf', name: 'client_portal_invoice_pdf', methods: ['GET'])]
+    public function invoicePdf(string $token, string $id): Response
+    {
+        $invoice = $this->resolveInvoice($token, $id);
+        if (null === $invoice) {
+            return $this->json(['error' => 'Invoice not found.'], 404);
+        }
+
+        return new Response($this->renderer->render($invoice), Response::HTTP_OK, [
+            'Content-Type' => 'application/pdf',
+            'Content-Disposition' => 'attachment; filename="' . $this->renderer->filename($invoice) . '"',
+        ]);
+    }
+
+    #[Route('/portal/{token}/invoices/{id}/pay', name: 'client_portal_invoice_pay', methods: ['POST'])]
+    public function invoicePay(string $token, string $id): JsonResponse
+    {
+        $invoice = $this->resolveInvoice($token, $id);
+        if (null === $invoice) {
+            return $this->json(['error' => 'Invoice not found.'], 404);
+        }
+        if (Invoice::STATUS_PAID === $invoice->getStatus()) {
+            return $this->json(['error' => 'This invoice is already paid.'], 409);
+        }
+        if ($invoice->getBalanceDue() <= 0) {
+            return $this->json(['error' => 'Nothing to pay on this invoice.'], 409);
+        }
+
+        $gateway = $this->gateways->default();
+        if (null === $gateway || !$gateway->isConfigured()) {
+            return $this->json(['error' => 'Online payment is not available.'], 503);
+        }
+
+        $base = rtrim($this->frontendUrl, '/') . '/portal/' . $token;
+        try {
+            $url = $gateway->createInvoicePayment($invoice, $base . '?paid=1', $base);
+        } catch (BillingException $e) {
+            return $this->json(['error' => 'Could not start payment: ' . $e->getMessage()], 502);
+        }
+
+        return $this->json(['provider' => $gateway->key(), 'url' => $url], 201);
+    }
+
+    #[Route('/portal/{token}/estimates/{id}/accept', name: 'client_portal_estimate_accept', methods: ['POST'])]
+    public function estimateAccept(string $token, string $id): JsonResponse
+    {
+        return $this->decideEstimate($token, $id, Estimate::STATUS_ACCEPTED);
+    }
+
+    #[Route('/portal/{token}/estimates/{id}/decline', name: 'client_portal_estimate_decline', methods: ['POST'])]
+    public function estimateDecline(string $token, string $id): JsonResponse
+    {
+        return $this->decideEstimate($token, $id, Estimate::STATUS_DECLINED);
+    }
+
+    private function decideEstimate(string $token, string $id, string $status): JsonResponse
+    {
+        $estimate = $this->resolveEstimate($token, $id);
+        if (null === $estimate) {
+            return $this->json(['error' => 'Estimate not found.'], 404);
+        }
+        if (Estimate::STATUS_SENT !== $estimate->getStatus()) {
+            return $this->json(['error' => 'This estimate has already been decided.'], 409);
+        }
+
+        $estimate->setStatus($status);
+        $estimate->setDecidedAt(new \DateTimeImmutable());
+        $this->em->flush();
+
+        // Tell the team right away (best-effort) — same as the public page.
+        $this->estimateMailer->sendDecision($estimate);
+
+        return $this->json([
+            'status' => $estimate->getStatus(),
+            'decidedAt' => $estimate->getDecidedAt()?->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+
+    private function resolveClient(string $token): ?Client
+    {
+        if ('' === trim($token)) {
+            return null;
+        }
+
+        return $this->em->getRepository(Client::class)
+            ->findOneBy(['portalToken' => hash('sha256', $token)]);
+    }
+
+    /** The invoice, only when it belongs to the portal's client and isn't internal. */
+    private function resolveInvoice(string $token, string $id): ?Invoice
+    {
+        $client = $this->resolveClient($token);
+        if (null === $client || !Uuid::isValid($id)) {
+            return null;
+        }
+        $invoice = $this->em->getRepository(Invoice::class)->find($id);
+        if (
+            null === $invoice
+            || true !== $invoice->getClient()?->getId()?->equals($client->getId())
+            || in_array($invoice->getStatus(), [Invoice::STATUS_DRAFT, Invoice::STATUS_VOID], true)
+        ) {
+            return null;
+        }
+
+        return $invoice;
+    }
+
+    /** The estimate, only when it belongs to the portal's client and isn't a draft. */
+    private function resolveEstimate(string $token, string $id): ?Estimate
+    {
+        $client = $this->resolveClient($token);
+        if (null === $client || !Uuid::isValid($id)) {
+            return null;
+        }
+        $estimate = $this->em->getRepository(Estimate::class)->find($id);
+        if (
+            null === $estimate
+            || true !== $estimate->getClient()?->getId()?->equals($client->getId())
+            || Estimate::STATUS_DRAFT === $estimate->getStatus()
+        ) {
+            return null;
+        }
+
+        return $estimate;
+    }
+}

--- a/api/src/Entity/Client.php
+++ b/api/src/Entity/Client.php
@@ -106,6 +106,14 @@ class Client
     #[Groups(['client:read', 'client:write'])]
     private ?string $notes = null;
 
+    /**
+     * sha256 of the client-portal token (#674) — the plaintext only ever
+     * leaves in the link/email minted by POST /clients/{id}/portal-link.
+     * Rotating invalidates the previous link. Never serialized.
+     */
+    #[ORM\Column(length: 64, nullable: true, unique: true)]
+    private ?string $portalToken = null;
+
     #[ApiProperty(readableLink: false)]
     #[ORM\ManyToOne(targetEntity: User::class)]
     #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
@@ -134,6 +142,18 @@ class Client
     public function getId(): ?Uuid
     {
         return $this->id;
+    }
+
+    public function getPortalToken(): ?string
+    {
+        return $this->portalToken;
+    }
+
+    public function setPortalToken(?string $portalToken): self
+    {
+        $this->portalToken = $portalToken;
+
+        return $this;
     }
 
     public function getSpace(): ?Space

--- a/api/templates/emails/client_portal.html.twig
+++ b/api/templates/emails/client_portal.html.twig
@@ -1,0 +1,18 @@
+{# @var client \App\Entity\Client #}
+<p>Hi {{ client.name }},</p>
+
+<p>
+    {{ fromName }} set up a billing portal for you — one page listing every
+    invoice and estimate they've sent you, with online payment and PDF
+    downloads.
+</p>
+
+<p>
+    <a href="{{ portalUrl }}">Open your billing portal</a>
+</p>
+
+<p style="color: #9ca3af; font-size: 12px;">
+    Keep this link private — anyone with it can see your invoices. If you
+    lose it, ask {{ fromName }} to send a fresh one (older links stop
+    working when a new one is issued).
+</p>

--- a/api/templates/emails/client_portal.txt.twig
+++ b/api/templates/emails/client_portal.txt.twig
@@ -1,0 +1,8 @@
+{# @var client \App\Entity\Client #}
+Hi {{ client.name }},
+
+{{ fromName }} set up a billing portal for you — one page listing every invoice and estimate they've sent you, with online payment and PDF downloads.
+
+Open your billing portal: {{ portalUrl }}
+
+Keep this link private — anyone with it can see your invoices. If you lose it, ask {{ fromName }} to send a fresh one (older links stop working when a new one is issued).

--- a/api/tests/Api/ClientPortalTest.php
+++ b/api/tests/Api/ClientPortalTest.php
@@ -1,0 +1,229 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\Space;
+use App\Entity\SpaceMembership;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Client portal (#674): one tokenized link listing the client's non-draft
+ * invoices + estimates, with portal-scoped PDF / pay / accept endpoints.
+ * Minting is admin-reserved; rotation invalidates the old link.
+ */
+class ClientPortalTest extends ApiTestCase
+{
+    use SpaceMembershipFixture;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = static::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Estimate')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Invoice')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Client')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\SpaceMembership')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Space')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testPortalListsDocumentsAndScopesActions(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $member = $this->createUser('member@example.com');
+        $space = $this->createSharedSpace($admin, $member);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => [
+                'space' => $spaceIri,
+                'name' => 'Acme Co',
+                'email' => 'billing@acme.test',
+                'currency' => 'USD',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $clientIri = $clientRow['@id'];
+        $this->assertIsString($clientIri);
+        $clientId = $clientRow['id'];
+        $this->assertIsString($clientId);
+
+        // One issued invoice, one draft (drafts stay internal), one sent estimate.
+        $makeInvoice = function () use ($client, $spaceIri, $clientIri): array {
+            $row = $client->request('POST', '/invoices', [
+                'json' => [
+                    'space' => $spaceIri,
+                    'client' => $clientIri,
+                    'currency' => 'USD',
+                    'lineItems' => [['description' => 'Work', 'quantity' => 1, 'unitAmount' => 5000]],
+                ],
+                'headers' => ['Content-Type' => 'application/ld+json'],
+            ])->toArray();
+            $this->assertResponseStatusCodeSame(201);
+
+            return $row;
+        };
+        $issued = $makeInvoice();
+        $client->request('POST', $this->iri($issued) . '/issue', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(200);
+        $makeInvoice(); // stays draft
+
+        $estimate = $client->request('POST', '/estimates', [
+            'json' => [
+                'space' => $spaceIri,
+                'client' => $clientIri,
+                'currency' => 'USD',
+                'lineItems' => [['description' => 'Design', 'quantity' => 2, 'unitAmount' => 5000, 'position' => 0]],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $client->request('POST', $this->iri($estimate) . '/send', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+
+        // Minting is admin-reserved: a plain member is refused.
+        $client->loginUser($member);
+        $client->request('POST', '/clients/' . $clientId . '/portal-link', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(403);
+
+        // Admin mints with send:true — the client is emailed the link.
+        $client->loginUser($admin);
+        $minted = $client->request('POST', '/clients/' . $clientId . '/portal-link', [
+            'json' => ['send' => true],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertTrue($minted['emailed'] ?? null);
+        $this->assertEmailCount(1);
+        $token = $minted['token'];
+        $this->assertIsString($token);
+
+        // Public portal view: the issued invoice + sent estimate, no draft.
+        $portal = $client->request('GET', '/portal/' . $token)->toArray();
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertSame('Acme Co', $portal['clientName'] ?? null);
+        $invoices = $portal['invoices'] ?? null;
+        $this->assertIsArray($invoices);
+        $this->assertCount(1, $invoices);
+        $invoiceRow = $invoices[0];
+        $this->assertIsArray($invoiceRow);
+        $this->assertSame('sent', $invoiceRow['status'] ?? null);
+        $this->assertSame(5000, $invoiceRow['balanceDue'] ?? null);
+        $estimates = $portal['estimates'] ?? null;
+        $this->assertIsArray($estimates);
+        $this->assertCount(1, $estimates);
+        $estimateRow = $estimates[0];
+        $this->assertIsArray($estimateRow);
+        $this->assertSame('sent', $estimateRow['status'] ?? null);
+
+        // Portal-scoped PDF streams; a wrong document id 404s.
+        $invoiceId = $invoiceRow['id'];
+        $this->assertIsString($invoiceId);
+        $pdf = $client->request('GET', '/portal/' . $token . '/invoices/' . $invoiceId . '/pdf');
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertStringStartsWith('%PDF', $pdf->getContent());
+        $estimateId = $estimateRow['id'];
+        $this->assertIsString($estimateId);
+        $client->request('GET', '/portal/' . $token . '/invoices/' . $estimateId . '/pdf');
+        $this->assertResponseStatusCodeSame(404);
+
+        // The client accepts the estimate straight from the portal.
+        $decided = $client->request('POST', '/portal/' . $token . '/estimates/' . $estimateId . '/accept', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertSame('accepted', $decided['status'] ?? null);
+        // Deciding twice 409s.
+        $client->request('POST', '/portal/' . $token . '/estimates/' . $estimateId . '/decline', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(409);
+
+        // Rotation: a new mint invalidates the old link.
+        $rotated = $client->request('POST', '/clients/' . $clientId . '/portal-link', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $newToken = $rotated['token'];
+        $this->assertIsString($newToken);
+        $client->request('GET', '/portal/' . $token);
+        $this->assertResponseStatusCodeSame(404);
+        $client->request('GET', '/portal/' . $newToken);
+        $this->assertResponseStatusCodeSame(200);
+
+        // Unknown tokens 404.
+        $client->request('GET', '/portal/definitely-not-a-token');
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    /**
+     * The `@id` of a decoded resource, narrowed to string for concatenation.
+     *
+     * @param array<int|string, mixed> $row
+     */
+    private function iri(array $row): string
+    {
+        $iri = $row['@id'] ?? null;
+        $this->assertIsString($iri);
+
+        return $iri;
+    }
+
+    private function createSharedSpace(User $admin, ?User $member = null): Space
+    {
+        $space = (new Space())->setName('Studio')->setCreatedBy($admin);
+        $this->entityManager->persist($space);
+        $adminMembership = (new SpaceMembership())
+            ->setUser($admin)
+            ->setRole(Space::ROLE_ADMIN);
+        $space->addUserMembership($adminMembership);
+        $this->entityManager->persist($adminMembership);
+        if (null !== $member) {
+            $memberMembership = (new SpaceMembership())
+                ->setUser($member)
+                ->setRole(Space::ROLE_MEMBER);
+            $space->addUserMembership($memberMembership);
+            $this->entityManager->persist($memberMembership);
+        }
+        $this->entityManager->flush();
+
+        return $space;
+    }
+
+    private function createUser(string $email): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/pwa/pages/clients/index.tsx
+++ b/pwa/pages/clients/index.tsx
@@ -2,7 +2,7 @@ import Head from "next/head";
 import { useRouter } from "next/router";
 import { FormEvent, useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Plus, Users } from "lucide-react";
+import { Link2, Plus, Users } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
 import { apiGetCollection, apiSend } from "@/lib/apiClient";
@@ -32,6 +32,7 @@ const ClientsPage = () => {
   const [currency, setCurrency] = useState("USD");
   const [defaultRate, setDefaultRate] = useState("");
   const [actionError, setActionError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
 
   useEffect(() => {
     if (!authLoading && !isAuthenticated) {
@@ -85,6 +86,40 @@ const ClientsPage = () => {
     createMutation.mutate();
   };
 
+  // Client portal link (#674): mint/rotate, copy to clipboard, optional email.
+  const portalMutation = useMutation({
+    mutationFn: ({ client, send }: { client: Client; send: boolean }) =>
+      apiSend<{ url: string; emailed: boolean }>(
+        "POST",
+        `/clients/${client.id}/portal-link`,
+        {
+          contentType: "application/json",
+          errorMessage: "Failed to create the portal link.",
+          body: { send },
+        },
+      ),
+    onSuccess: async (res) => {
+      setActionError(null);
+      if (!res?.url) return;
+      const suffix = res.emailed ? " and emailed to the client" : "";
+      try {
+        await navigator.clipboard.writeText(res.url);
+        setNotice(`Portal link copied${suffix}. Older portal links no longer work.`);
+      } catch {
+        setNotice(`Portal link${suffix}: ${res.url}`);
+      }
+    },
+    onError: (e) =>
+      setActionError(e instanceof Error ? e.message : "Failed to create the portal link."),
+  });
+
+  const mintPortal = (client: Client) => {
+    const send =
+      !!client.email &&
+      window.confirm(`Also email the new portal link to ${client.email}?`);
+    portalMutation.mutate({ client, send });
+  };
+
   const canCreate = can("invoices", "create");
   const error = actionError || (clientsQuery.isError ? "Failed to load clients." : null);
 
@@ -108,6 +143,11 @@ const ClientsPage = () => {
             icon={<Users className="size-6 text-blue-600 dark:text-blue-400" />}
           />
 
+          {notice && (
+            <Alert className="mb-4">
+              <AlertDescription>{notice}</AlertDescription>
+            </Alert>
+          )}
           {error && (
             <Alert variant="destructive" className="mb-4">
               <AlertDescription>{error}</AlertDescription>
@@ -126,6 +166,7 @@ const ClientsPage = () => {
                       <th className="px-4 py-2 font-medium">Email</th>
                       <th className="px-4 py-2 font-medium">Currency</th>
                       <th className="px-4 py-2 text-right font-medium">Rate / hr</th>
+                      <th className="px-2 py-2" aria-label="Actions" />
                     </tr>
                   </thead>
                   <tbody>
@@ -133,7 +174,7 @@ const ClientsPage = () => {
                     {canCreate &&
                       (showComposer ? (
                         <tr className="border-b bg-muted/10">
-                          <td colSpan={4} className="px-4 py-4">
+                          <td colSpan={5} className="px-4 py-4">
                             <form onSubmit={handleCreate} className="space-y-4">
                               <div className="space-y-1.5">
                                 <Label htmlFor="cl-name">Name</Label>
@@ -223,7 +264,7 @@ const ClientsPage = () => {
                         </tr>
                       ) : (
                         <tr className="border-b">
-                          <td colSpan={4} className="px-4 py-2">
+                          <td colSpan={5} className="px-4 py-2">
                             <button
                               type="button"
                               onClick={() => setShowComposer(true)}
@@ -237,7 +278,7 @@ const ClientsPage = () => {
 
                     {clients.length === 0 ? (
                       <tr>
-                        <td colSpan={4} className="px-4 py-10 text-center text-muted-foreground">
+                        <td colSpan={5} className="px-4 py-10 text-center text-muted-foreground">
                           No clients yet. Use “Add client” to start invoicing.
                         </td>
                       </tr>
@@ -251,6 +292,19 @@ const ClientsPage = () => {
                             {client.defaultRateAmount != null && client.currency
                               ? formatMoney(client.defaultRateAmount, client.currency)
                               : "—"}
+                          </td>
+                          <td className="whitespace-nowrap px-2 py-3 text-right">
+                            {canCreate && (
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => mintPortal(client)}
+                                disabled={portalMutation.isPending}
+                                title="Create (or rotate) this client's billing portal link"
+                              >
+                                <Link2 className="h-3.5 w-3.5" /> Portal
+                              </Button>
+                            )}
                           </td>
                         </tr>
                       ))

--- a/pwa/pages/portal/[token].tsx
+++ b/pwa/pages/portal/[token].tsx
@@ -1,0 +1,345 @@
+import Head from "next/head";
+import { useRouter } from "next/router";
+import { useCallback, useEffect, useState } from "react";
+import { Download, Receipt } from "lucide-react";
+import { ENTRYPOINT } from "@/config/entrypoint";
+import { InvoiceStatus, STATUS_META, formatMoney } from "@/lib/invoiceTypes";
+import { ESTIMATE_STATUS_META, EstimateStatus } from "@/lib/estimateTypes";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+interface PortalInvoice {
+  id: string;
+  number: string | null;
+  status: InvoiceStatus;
+  issueDate: string | null;
+  dueDate: string | null;
+  currency: string;
+  total: number;
+  amountPaid: number;
+  balanceDue: number;
+}
+
+interface PortalEstimate {
+  id: string;
+  number: string | null;
+  status: EstimateStatus;
+  currency: string;
+  total: number;
+  decidedAt: string | null;
+}
+
+interface PortalPayload {
+  clientName: string;
+  from: string | null;
+  logoUrl: string | null;
+  invoices: PortalInvoice[];
+  estimates: PortalEstimate[];
+}
+
+const fmtDate = (iso: string | null): string =>
+  iso ? new Date(iso).toLocaleDateString(undefined, { dateStyle: "medium" }) : "—";
+
+/**
+ * Client billing portal (#674): the one link a client keeps — every invoice
+ * and estimate they've received, with PDF downloads, online payment, and
+ * estimate accept/decline, all against portal-scoped endpoints.
+ */
+const ClientPortalPage = () => {
+  const router = useRouter();
+  const { token } = router.query;
+  const portalToken = typeof token === "string" ? token : null;
+
+  const [portal, setPortal] = useState<PortalPayload | null>(null);
+  const [notFound, setNotFound] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!portalToken) return;
+    try {
+      const res = await fetch(`${ENTRYPOINT}/portal/${encodeURIComponent(portalToken)}`, {
+        headers: { Accept: "application/json" },
+      });
+      if (res.status === 404) {
+        setNotFound(true);
+        return;
+      }
+      if (!res.ok) throw new Error();
+      setPortal((await res.json()) as PortalPayload);
+    } catch {
+      setError("Could not load the portal.");
+    }
+  }, [portalToken]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const downloadPdf = async (invoice: PortalInvoice) => {
+    if (!portalToken) return;
+    try {
+      const res = await fetch(
+        `${ENTRYPOINT}/portal/${encodeURIComponent(portalToken)}/invoices/${invoice.id}/pdf`,
+      );
+      if (!res.ok) {
+        setError("Could not download the PDF.");
+        return;
+      }
+      const blob = await res.blob();
+      const a = document.createElement("a");
+      a.href = URL.createObjectURL(blob);
+      a.download = `${invoice.number ?? "invoice"}.pdf`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+    } catch {
+      setError("Could not download the PDF.");
+    }
+  };
+
+  const payInvoice = async (invoice: PortalInvoice) => {
+    if (!portalToken) return;
+    setBusy(invoice.id);
+    setError(null);
+    try {
+      const res = await fetch(
+        `${ENTRYPOINT}/portal/${encodeURIComponent(portalToken)}/invoices/${invoice.id}/pay`,
+        { method: "POST", headers: { "Content-Type": "application/json" }, body: "{}" },
+      );
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(data.error || "Could not start the payment.");
+        return;
+      }
+      if (typeof data.url === "string") window.location.href = data.url;
+    } catch {
+      setError("Could not start the payment.");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const decideEstimate = async (estimate: PortalEstimate, action: "accept" | "decline") => {
+    if (!portalToken) return;
+    setBusy(estimate.id);
+    setError(null);
+    try {
+      const res = await fetch(
+        `${ENTRYPOINT}/portal/${encodeURIComponent(portalToken)}/estimates/${estimate.id}/${action}`,
+        { method: "POST", headers: { "Content-Type": "application/json" }, body: "{}" },
+      );
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setError(data.error || `Could not ${action} the estimate.`);
+        return;
+      }
+      await load();
+    } catch {
+      setError(`Could not ${action} the estimate.`);
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  let body;
+  if (notFound) {
+    body = (
+      <div className="text-center">
+        <h1 className="text-xl font-semibold">Portal not found</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          This link is invalid or has been replaced by a newer one.
+        </p>
+      </div>
+    );
+  } else if (!portal) {
+    body = <p className="text-center text-sm text-muted-foreground">Loading…</p>;
+  } else {
+    body = (
+      <div className="space-y-8">
+        <div>
+          {portal.logoUrl && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={portal.logoUrl}
+              alt={portal.from ?? "Logo"}
+              className="mb-3 h-12 w-auto max-w-48 object-contain"
+            />
+          )}
+          <h1 className="text-2xl font-semibold">Billing portal</h1>
+          <p className="text-sm text-muted-foreground">
+            {portal.clientName}
+            {portal.from ? ` · from ${portal.from}` : ""}
+          </p>
+        </div>
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
+
+        <section className="space-y-2">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+            Invoices
+          </h2>
+          {portal.invoices.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No invoices yet.</p>
+          ) : (
+            <div className="overflow-x-auto rounded-md border">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+                    <th className="px-3 py-2">Invoice</th>
+                    <th className="px-3 py-2">Issued</th>
+                    <th className="px-3 py-2">Due</th>
+                    <th className="px-3 py-2 text-right">Total</th>
+                    <th className="px-3 py-2 text-right">Balance</th>
+                    <th className="px-3 py-2" />
+                  </tr>
+                </thead>
+                <tbody>
+                  {portal.invoices.map((invoice) => {
+                    const meta = STATUS_META[invoice.status];
+                    return (
+                      <tr key={invoice.id} className="border-b align-middle last:border-0">
+                        <td className="px-3 py-2.5">
+                          <span className="font-medium">{invoice.number ?? "—"}</span>
+                          <span
+                            className={cn(
+                              "ml-2 rounded px-1.5 py-0.5 text-xs font-medium",
+                              meta.badgeClass,
+                            )}
+                          >
+                            {meta.label}
+                          </span>
+                        </td>
+                        <td className="px-3 py-2.5 text-muted-foreground">
+                          {fmtDate(invoice.issueDate)}
+                        </td>
+                        <td className="px-3 py-2.5 text-muted-foreground">
+                          {fmtDate(invoice.dueDate)}
+                        </td>
+                        <td className="px-3 py-2.5 text-right tabular-nums">
+                          {formatMoney(invoice.total, invoice.currency)}
+                        </td>
+                        <td className="px-3 py-2.5 text-right tabular-nums">
+                          {formatMoney(invoice.balanceDue, invoice.currency)}
+                        </td>
+                        <td className="px-3 py-2.5 text-right">
+                          <span className="inline-flex items-center gap-2">
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => void downloadPdf(invoice)}
+                            >
+                              <Download className="h-3.5 w-3.5" /> PDF
+                            </Button>
+                            {invoice.status !== "paid" && invoice.balanceDue > 0 && (
+                              <Button
+                                size="sm"
+                                onClick={() => void payInvoice(invoice)}
+                                disabled={busy === invoice.id}
+                              >
+                                {busy === invoice.id
+                                  ? "Starting…"
+                                  : `Pay ${formatMoney(invoice.balanceDue, invoice.currency)}`}
+                              </Button>
+                            )}
+                          </span>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+            Estimates
+          </h2>
+          {portal.estimates.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No estimates yet.</p>
+          ) : (
+            <div className="overflow-x-auto rounded-md border">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+                    <th className="px-3 py-2">Estimate</th>
+                    <th className="px-3 py-2 text-right">Total</th>
+                    <th className="px-3 py-2" />
+                  </tr>
+                </thead>
+                <tbody>
+                  {portal.estimates.map((estimate) => {
+                    const meta = ESTIMATE_STATUS_META[estimate.status];
+                    return (
+                      <tr key={estimate.id} className="border-b align-middle last:border-0">
+                        <td className="px-3 py-2.5">
+                          <span className="font-medium">{estimate.number ?? "—"}</span>
+                          <span
+                            className={cn(
+                              "ml-2 rounded px-1.5 py-0.5 text-xs font-medium",
+                              meta.badgeClass,
+                            )}
+                          >
+                            {meta.label}
+                          </span>
+                        </td>
+                        <td className="px-3 py-2.5 text-right tabular-nums">
+                          {formatMoney(estimate.total, estimate.currency)}
+                        </td>
+                        <td className="px-3 py-2.5 text-right">
+                          {estimate.status === "sent" && (
+                            <span className="inline-flex items-center gap-2">
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={() => void decideEstimate(estimate, "decline")}
+                                disabled={busy === estimate.id}
+                              >
+                                Decline
+                              </Button>
+                              <Button
+                                size="sm"
+                                onClick={() => void decideEstimate(estimate, "accept")}
+                                disabled={busy === estimate.id}
+                              >
+                                Accept
+                              </Button>
+                            </span>
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Billing portal — Madori</title>
+      </Head>
+      <div className="flex min-h-screen items-start justify-center bg-muted px-4 py-12">
+        <Card className="w-full max-w-3xl">
+          <CardContent className="pt-6">
+            <div className="mb-4 flex items-center gap-2 text-muted-foreground">
+              <Receipt className="h-4 w-4" aria-hidden />
+              <span className="text-xs uppercase tracking-wide">Madori billing</span>
+            </div>
+            {body}
+          </CardContent>
+        </Card>
+      </div>
+    </>
+  );
+};
+
+export default ClientPortalPage;


### PR DESCRIPTION
Closes #674

## What
Harvest-style client portal: instead of hunting through per-document emails, a client keeps **one link** — `/portal/{token}` — listing every non-draft invoice and estimate they've received.

- **Token model**: `client.portal_token`, sha256 at rest like every other public token. `POST /clients/{id}/portal-link` (space admin / `invoices.update` grantee) mints or **rotates** it — older links stop working — returns the plaintext URL once, and with `{"send": true}` emails it to the client (`emails/client_portal.*`).
- **Portal payload**: client name, the space's branding logo (#669-aware), invoices (number, status, issue/due dates, total, paid, **balance due**) and estimates (number, status, total). Drafts and void invoices stay hidden.
- **Portal-scoped actions** — per-document plaintext tokens can't be recovered from their hashes, so the portal token is the credential and every route re-checks the document belongs to the portal's client:
  - `GET /portal/{token}/invoices/{id}/pdf` — streams the branded PDF
  - `POST /portal/{token}/invoices/{id}/pay` — Stripe checkout on the balance due (return URLs land back on the portal)
  - `POST /portal/{token}/estimates/{id}/accept|decline` — same rules as the public estimate page (only from `sent`, team emailed on decision)
- **PWA**: `/portal/{token}` public page (tables + PDF/Pay/Accept/Decline inline) and a **Portal** button on each client row that mints + copies the link and offers to email it.

## Tests
`ClientPortalTest`: member can't mint (403); admin mints with `send:true` (client emailed); portal lists the issued invoice + sent estimate but not the draft; portal PDF streams (`%PDF`) while a foreign document id 404s; estimate accepted via the portal (deciding twice 409s); rotation kills the old token; unknown tokens 404.