### PR TITLE
feat(invoices): per-line-item tax rates

### DIFF
--- a/api/migrations/Version20260716230000.php
+++ b/api/migrations/Version20260716230000.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Per-line-item tax rates (#670): invoice_line_item.tax_rate (basis points,
+ * null = the invoice-level rate, 0 = explicitly tax-free).
+ */
+final class Version20260716230000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'invoice_line_item.tax_rate per-line override.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE invoice_line_item ADD tax_rate INT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE invoice_line_item DROP tax_rate');
+    }
+}

--- a/api/src/Controller/PublicInvoiceController.php
+++ b/api/src/Controller/PublicInvoiceController.php
@@ -45,6 +45,7 @@ class PublicInvoiceController extends AbstractController
                 'quantity' => $line->getQuantity(),
                 'unitAmount' => $line->getUnitAmount(),
                 'amount' => $line->getAmount(),
+                'taxRate' => $line->getTaxRate(),
             ];
         }
 
@@ -71,6 +72,7 @@ class PublicInvoiceController extends AbstractController
             'subtotal' => $invoice->getSubtotal(),
             'discountAmount' => $invoice->getDiscountAmount(),
             'taxAmount' => $invoice->getTaxAmount(),
+            'taxBreakdown' => $invoice->getTaxBreakdown(),
             'total' => $invoice->getTotal(),
             'amountPaid' => $invoice->getAmountPaid(),
             'balanceDue' => $invoice->getBalanceDue(),

--- a/api/src/Entity/Invoice.php
+++ b/api/src/Entity/Invoice.php
@@ -644,6 +644,39 @@ class Invoice
         return $this;
     }
 
+    /**
+     * Tax grouped by effective rate (#670) — one row per distinct nonzero
+     * rate, mirroring InvoiceProcessor's per-line proportional math so the
+     * rows always sum to {@see $taxAmount}. Lets the PDF/public page print
+     * "Tax (10%)" and "Tax (21%)" separately on mixed-rate invoices.
+     *
+     * @return list<array{rate: int, amount: int}>
+     */
+    #[Groups(['invoice:read'])]
+    public function getTaxBreakdown(): array
+    {
+        $taxable = $this->subtotal - $this->discountAmount;
+        $ratio = $this->subtotal > 0 ? $taxable / $this->subtotal : 0.0;
+
+        $byRate = [];
+        foreach ($this->lineItems as $line) {
+            $rate = $line->getTaxRate() ?? $this->taxRate;
+            if ($rate <= 0) {
+                continue;
+            }
+            $byRate[$rate] = ($byRate[$rate] ?? 0)
+                + (int) round($line->getAmount() * $ratio * $rate / 10000);
+        }
+        ksort($byRate);
+
+        $rows = [];
+        foreach ($byRate as $rate => $amount) {
+            $rows[] = ['rate' => $rate, 'amount' => $amount];
+        }
+
+        return $rows;
+    }
+
     public function getTotal(): int
     {
         return $this->total;

--- a/api/src/Entity/InvoiceLineItem.php
+++ b/api/src/Entity/InvoiceLineItem.php
@@ -57,6 +57,15 @@ class InvoiceLineItem
     #[Groups(['invoice:read'])]
     private int $amount = 0;
 
+    /**
+     * Per-line tax rate override in basis points (#670). Null = the line
+     * taxes at the invoice-level rate; 0 = explicitly tax-free.
+     */
+    #[ORM\Column(name: 'tax_rate', type: 'integer', nullable: true)]
+    #[Assert\Range(min: 0, max: 100000)]
+    #[Groups(['invoice:read', 'invoice:write'])]
+    private ?int $taxRate = null;
+
     #[ORM\Column(type: 'integer')]
     #[Groups(['invoice:read', 'invoice:write'])]
     private int $position = 0;
@@ -149,6 +158,24 @@ class InvoiceLineItem
         $this->position = $position;
 
         return $this;
+    }
+
+    public function getTaxRate(): ?int
+    {
+        return $this->taxRate;
+    }
+
+    public function setTaxRate(?int $taxRate): self
+    {
+        $this->taxRate = $taxRate;
+
+        return $this;
+    }
+
+    /** The rate this line actually taxes at: its override, else the invoice's. */
+    public function getEffectiveTaxRate(): int
+    {
+        return $this->taxRate ?? $this->invoice?->getTaxRate() ?? 0;
     }
 
     public function getSourceTimeEntry(): ?TimeEntry

--- a/api/src/State/InvoiceProcessor.php
+++ b/api/src/State/InvoiceProcessor.php
@@ -69,7 +69,22 @@ final class InvoiceProcessor implements ProcessorInterface
         }
 
         $taxable = $subtotal - $discountAmount;
-        $taxAmount = (int) round($taxable * $invoice->getTaxRate() / self::BASIS_POINTS);
+
+        // Per-line tax (#670): each line taxes at its own rate (falling back
+        // to the invoice-level rate) on its discount-adjusted share, so a
+        // mixed-rate invoice (or a tax-free line) totals correctly. With no
+        // overrides this reduces to the old subtotal × rate math (modulo
+        // per-line rounding).
+        $ratio = $subtotal > 0 ? $taxable / $subtotal : 0.0;
+        $taxAmount = 0;
+        foreach ($invoice->getLineItems() as $line) {
+            $rate = $line->getTaxRate() ?? $invoice->getTaxRate();
+            if ($rate <= 0) {
+                continue;
+            }
+            $taxAmount += (int) round($line->getAmount() * $ratio * $rate / self::BASIS_POINTS);
+        }
+
         $invoice->setSubtotal($subtotal);
         $invoice->setDiscountAmount($discountAmount);
         $invoice->setTaxAmount($taxAmount);

--- a/api/templates/invoice/pdf.html.twig
+++ b/api/templates/invoice/pdf.html.twig
@@ -100,12 +100,12 @@
         <td class="num">−{{ fmt.money(invoice.discountAmount, c) }}</td>
     </tr>
     {% endif %}
-    {% if invoice.taxAmount > 0 %}
+    {% for tax in invoice.taxBreakdown %}
     <tr>
-        <td>Tax ({{ (invoice.taxRate / 100)|number_format(2) }}%)</td>
-        <td class="num">{{ fmt.money(invoice.taxAmount, c) }}</td>
+        <td>Tax ({{ (tax.rate / 100)|number_format(2) }}%)</td>
+        <td class="num">{{ fmt.money(tax.amount, c) }}</td>
     </tr>
-    {% endif %}
+    {% endfor %}
     <tr class="grand">
         <td>Total</td>
         <td class="num">{{ fmt.money(invoice.total, c) }}</td>

--- a/api/tests/Api/ClientInvoiceTest.php
+++ b/api/tests/Api/ClientInvoiceTest.php
@@ -819,6 +819,66 @@ class ClientInvoiceTest extends ApiTestCase
         $this->assertStringStartsWith('%PDF', $pdf->getContent());
     }
 
+    public function testPerLineTaxRatesOverrideAndBreakDown(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $space = $this->createSharedSpace($admin);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+
+        // Invoice-level 10%; line B overrides to 20%, line C is tax-free.
+        $invoice = $client->request('POST', '/invoices', [
+            'json' => [
+                'space' => $spaceIri,
+                'client' => $clientRow['@id'],
+                'currency' => 'USD',
+                'taxRate' => 1000,
+                'lineItems' => [
+                    ['description' => 'A', 'quantity' => 1, 'unitAmount' => 10000, 'position' => 0],
+                    ['description' => 'B', 'quantity' => 1, 'unitAmount' => 20000, 'taxRate' => 2000, 'position' => 1],
+                    ['description' => 'C', 'quantity' => 1, 'unitAmount' => 5000, 'taxRate' => 0, 'position' => 2],
+                ],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertSame(35000, $invoice['subtotal'] ?? null);
+        // 10% of 10000 + 20% of 20000 + 0 = 5000.
+        $this->assertSame(5000, $invoice['taxAmount'] ?? null);
+        $this->assertSame(40000, $invoice['total'] ?? null);
+        $this->assertSame(
+            [['rate' => 1000, 'amount' => 1000], ['rate' => 2000, 'amount' => 4000]],
+            $invoice['taxBreakdown'] ?? null,
+        );
+
+        // A 50% discount halves each line's taxable share proportionally.
+        $patched = $client->request('PATCH', $this->iri($invoice), [
+            'json' => ['discountType' => 'percent', 'discountValue' => 5000],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertSame(17500, $patched['discountAmount'] ?? null);
+        $this->assertSame(2500, $patched['taxAmount'] ?? null);
+        $this->assertSame(20000, $patched['total'] ?? null);
+
+        // A line rate outside 0–1000% is rejected.
+        $client->request('PATCH', $this->iri($invoice), [
+            'json' => [
+                'lineItems' => [
+                    ['description' => 'A', 'quantity' => 1, 'unitAmount' => 10000, 'taxRate' => 200000, 'position' => 0],
+                ],
+            ],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+    }
+
     public function testDiscountAppliesBetweenSubtotalAndTax(): void
     {
         $admin = $this->createUser('admin@example.com');

--- a/pwa/lib/invoiceTypes.ts
+++ b/pwa/lib/invoiceTypes.ts
@@ -30,6 +30,8 @@ export interface InvoiceLineItem {
   quantity: number;
   unitAmount: number;
   amount?: number;
+  /** Per-line tax override in basis points (#670); null = invoice rate. */
+  taxRate?: number | null;
   position?: number;
 }
 

--- a/pwa/pages/i/[token].tsx
+++ b/pwa/pages/i/[token].tsx
@@ -27,6 +27,7 @@ interface PublicInvoice {
   subtotal: number;
   discountAmount: number;
   taxAmount: number;
+  taxBreakdown?: { rate: number; amount: number }[];
   total: number;
   amountPaid: number;
   balanceDue: number;
@@ -214,12 +215,12 @@ const PublicInvoicePage = () => {
               </span>
             </div>
           )}
-          {invoice.taxAmount > 0 && (
-            <div className="flex justify-between">
-              <span className="text-muted-foreground">Tax</span>
-              <span className="tabular-nums">{formatMoney(invoice.taxAmount, invoice.currency)}</span>
+          {(invoice.taxBreakdown ?? []).map((tax) => (
+            <div key={tax.rate} className="flex justify-between">
+              <span className="text-muted-foreground">Tax ({(tax.rate / 100).toFixed(2)}%)</span>
+              <span className="tabular-nums">{formatMoney(tax.amount, invoice.currency)}</span>
             </div>
-          )}
+          ))}
           <div className="flex justify-between border-t pt-1 text-base font-semibold">
             <span>Total</span>
             <span className="tabular-nums">{formatMoney(invoice.total, invoice.currency)}</span>

--- a/pwa/pages/invoices/[id].tsx
+++ b/pwa/pages/invoices/[id].tsx
@@ -29,6 +29,8 @@ interface EditableLine {
   description: string;
   quantity: string;
   unit: string; // major units
+  /** Per-line tax % override (#670); "" = inherit the invoice rate. */
+  tax: string;
 }
 
 const InvoiceDetailPage = () => {
@@ -80,6 +82,7 @@ const InvoiceDetailPage = () => {
         description: l.description,
         quantity: String(l.quantity),
         unit: (l.unitAmount / 100).toFixed(2),
+        tax: l.taxRate === null || l.taxRate === undefined ? "" : String(l.taxRate / 100),
       })),
     );
     setDueDate(invoice.dueDate ?? "");
@@ -113,14 +116,23 @@ const InvoiceDetailPage = () => {
     }
     discount = Math.max(0, Math.min(discount, subtotal));
     const taxable = subtotal - discount;
-    const tax = Math.round((taxable * (parseFloat(taxPercent) || 0) * 100) / 10000);
+    // Per-line tax (#670), mirroring InvoiceProcessor's proportional math.
+    const ratio = subtotal > 0 ? taxable / subtotal : 0;
+    const tax = lines.reduce((sum, l) => {
+      const amount = Math.round(
+        (parseFloat(l.quantity) || 0) * Math.round((parseFloat(l.unit) || 0) * 100),
+      );
+      const ratePercent = l.tax.trim() === "" ? parseFloat(taxPercent) || 0 : parseFloat(l.tax) || 0;
+      if (ratePercent <= 0) return sum;
+      return sum + Math.round((amount * ratio * ratePercent * 100) / 10000);
+    }, 0);
     return { subtotal, discount, tax, total: taxable + tax };
   }, [lines, taxPercent, discType, discValue]);
 
   const addLine = () =>
     setLines((prev) => [
       ...prev,
-      { key: `new-${prev.length}-${Date.now()}`, description: "", quantity: "1", unit: "0.00" },
+      { key: `new-${prev.length}-${Date.now()}`, description: "", quantity: "1", unit: "0.00", tax: "" },
     ]);
   const removeLine = (key: string) => setLines((prev) => prev.filter((l) => l.key !== key));
   const updateLine = (key: string, patch: Partial<EditableLine>) =>
@@ -148,6 +160,7 @@ const InvoiceDetailPage = () => {
             description: l.description.trim() || "—",
             quantity: parseFloat(l.quantity) || 0,
             unitAmount: Math.round((parseFloat(l.unit) || 0) * 100),
+            taxRate: l.tax.trim() === "" ? null : Math.round((parseFloat(l.tax) || 0) * 100),
             position: i,
           })),
           recurrenceFrequency: recurring ? freq : null,
@@ -313,6 +326,7 @@ const InvoiceDetailPage = () => {
                         <th className="py-2">Description</th>
                         <th className="w-20 py-2 text-right">Qty</th>
                         <th className="w-28 py-2 text-right">Unit</th>
+                        <th className="w-20 py-2 text-right">Tax %</th>
                         <th className="w-28 py-2 text-right">Amount</th>
                         {editable && <th className="w-8" />}
                       </tr>
@@ -359,6 +373,23 @@ const InvoiceDetailPage = () => {
                                 />
                               ) : (
                                 formatMoney(Math.round((parseFloat(line.unit) || 0) * 100), currency)
+                              )}
+                            </td>
+                            <td className="py-1.5 text-right">
+                              {editable ? (
+                                <Input
+                                  type="number"
+                                  step="0.01"
+                                  value={line.tax}
+                                  placeholder={taxPercent}
+                                  onChange={(e) => updateLine(line.key, { tax: e.target.value })}
+                                  title="Per-line tax % (blank inherits the invoice rate)"
+                                  className="h-8 text-right"
+                                />
+                              ) : line.tax.trim() === "" ? (
+                                <span className="text-muted-foreground">—</span>
+                              ) : (
+                                `${line.tax}%`
                               )}
                             </td>
                             <td className="py-1.5 text-right tabular-nums">{formatMoney(amount, currency)}</td>


### PR DESCRIPTION
Closes #670

## What
Line items can override the invoice-level tax rate:

- **`InvoiceLineItem.taxRate`** (basis points, nullable): `null` inherits the invoice rate, `0` marks a line explicitly tax-free, validated 0–1000%.
- **`InvoiceProcessor`** now taxes each line at its effective rate on its **discount-adjusted share** — the discount still applies between subtotal and tax, distributed proportionally across lines — and reduces to the old `taxable × rate` math when nothing overrides (same per-line rounding both ways).
- **`Invoice.taxBreakdown`** (new serialized getter): tax grouped by effective rate with identical rounding, so the rows always sum to `taxAmount`. The **PDF** and the **public invoice page** print one `Tax (X%)` row per distinct rate instead of a single Tax line.
- **Invoice detail editor**: per-line *Tax %* input (blank = inherit; the placeholder shows the invoice rate) and the client-side preview mirrors the proportional math exactly.

## Tests
`ClientInvoiceTest::testPerLineTaxRatesOverrideAndBreakDown` — mixed 10%/20%/tax-free invoice derives `taxAmount` 5000 with a two-row breakdown; a 50% discount halves each line's taxable share (2500); an out-of-range line rate 422s. The existing discount test pins the no-override path unchanged.