### PR TITLE
feat(expenses): managed expense categories

### DIFF
--- a/api/migrations/Version20260716233000.php
+++ b/api/migrations/Version20260716233000.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Managed expense categories (#671): the expense_category table (per-space
+ * curated list with an optional unit price) + expense.expense_category_id.
+ */
+final class Version20260716233000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'expense_category table + expense.expense_category_id.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE expense_category (id UUID NOT NULL, name VARCHAR(80) NOT NULL, unit_amount INT DEFAULT NULL, archived BOOLEAN DEFAULT false NOT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, space_id UUID NOT NULL, PRIMARY KEY (id))');
+        $this->addSql('CREATE INDEX idx_expense_category_space_name ON expense_category (space_id, name)');
+        $this->addSql('ALTER TABLE expense_category ADD CONSTRAINT FK_C02DDB3823575340 FOREIGN KEY (space_id) REFERENCES space (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE expense ADD expense_category_id UUID DEFAULT NULL');
+        $this->addSql('CREATE INDEX IDX_2D3A8DA66B2A3179 ON expense (expense_category_id)');
+        $this->addSql('ALTER TABLE expense ADD CONSTRAINT FK_2D3A8DA66B2A3179 FOREIGN KEY (expense_category_id) REFERENCES expense_category (id) ON DELETE SET NULL NOT DEFERRABLE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE expense DROP CONSTRAINT FK_2D3A8DA66B2A3179');
+        $this->addSql('ALTER TABLE expense DROP expense_category_id');
+        $this->addSql('ALTER TABLE expense_category DROP CONSTRAINT FK_C02DDB3823575340');
+        $this->addSql('DROP TABLE expense_category');
+    }
+}

--- a/api/src/Doctrine/ExpenseCategoryAccessExtension.php
+++ b/api/src/Doctrine/ExpenseCategoryAccessExtension.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Doctrine;
+
+use App\Entity\ExpenseCategory;
+use App\Security\Permission\SpacePermission;
+
+/**
+ * Scopes ExpenseCategory queries to the spaces the current user belongs to
+ * (#671). Categories are picker data for anyone logging expenses, so reads
+ * ride the `time_entries` permission category (writes are invoices-gated at
+ * the resource level).
+ */
+final class ExpenseCategoryAccessExtension extends AbstractSpaceAccessExtension
+{
+    protected function getResourceClass(): string
+    {
+        return ExpenseCategory::class;
+    }
+
+    protected function getAliasPrefix(): string
+    {
+        return 'expense_category_access';
+    }
+
+    protected function getImpersonationItemType(): ?string
+    {
+        return null;
+    }
+
+    protected function getPermissionCategory(): string
+    {
+        return SpacePermission::TIME_ENTRIES;
+    }
+}

--- a/api/src/Entity/Expense.php
+++ b/api/src/Entity/Expense.php
@@ -111,11 +111,22 @@ class Expense
     #[Groups(['expense:read', 'expense:write'])]
     private ?\DateTimeImmutable $spentOn = null;
 
-    /** Free-text category ("Travel", "Software", …). */
+    /**
+     * Category label. Free text pre-#671; when {@see $expenseCategory} is
+     * set it's denormalised from the category's name on save, so invoice
+     * line labels and historical reads never need the join.
+     */
     #[ORM\Column(length: self::MAX_CATEGORY_LENGTH, nullable: true)]
     #[Assert\Length(max: self::MAX_CATEGORY_LENGTH)]
     #[Groups(['expense:read', 'expense:write'])]
     private ?string $category = null;
+
+    /** Managed category (#671) — optional; free-text stays supported. */
+    #[\ApiPlatform\Metadata\ApiProperty(readableLink: false)]
+    #[ORM\ManyToOne(targetEntity: ExpenseCategory::class)]
+    #[ORM\JoinColumn(name: 'expense_category_id', nullable: true, onDelete: 'SET NULL')]
+    #[Groups(['expense:read', 'expense:write'])]
+    private ?ExpenseCategory $expenseCategory = null;
 
     /** Cost in minor units of {@see $currency}. */
     #[ORM\Column(type: 'integer')]
@@ -178,6 +189,10 @@ class Expense
                 ?? $this->engagement?->getClient()?->getCurrency()
                 ?? 'USD';
         }
+        // A managed category owns the label (#671).
+        if (null !== $this->expenseCategory) {
+            $this->category = $this->expenseCategory->getName();
+        }
     }
 
     #[ORM\PreUpdate]
@@ -188,6 +203,15 @@ class Expense
 
     public function validateConsistency(ExecutionContextInterface $context): void
     {
+        if (
+            null !== $this->expenseCategory && null !== $this->space
+            && true !== $this->expenseCategory->getSpace()?->getId()?->equals($this->space->getId())
+        ) {
+            $context->buildViolation('Category must belong to the same space.')
+                ->atPath('expenseCategory')
+                ->addViolation();
+        }
+
         if (
             null !== $this->engagement && null !== $this->space
             && true !== $this->engagement->getSpace()?->getId()?->equals($this->space->getId())
@@ -247,6 +271,18 @@ class Expense
     public function setSpentOn(?\DateTimeImmutable $spentOn): self
     {
         $this->spentOn = $spentOn;
+
+        return $this;
+    }
+
+    public function getExpenseCategory(): ?ExpenseCategory
+    {
+        return $this->expenseCategory;
+    }
+
+    public function setExpenseCategory(?ExpenseCategory $expenseCategory): self
+    {
+        $this->expenseCategory = $expenseCategory;
 
         return $this;
     }

--- a/api/src/Entity/ExpenseCategory.php
+++ b/api/src/Entity/ExpenseCategory.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Doctrine\Orm\Filter\BooleanFilter;
+use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
+use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use App\Repository\ExpenseCategoryRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Admin-managed expense category (#671) — replaces free-text categories on
+ * {@see Expense} with a curated per-space list ("Travel", "Software",
+ * "Mileage" …). An optional {@see $unitAmount} supports unit-priced
+ * categories (mileage-style: amount = units × unit price, computed
+ * client-side). Archived categories stay on historical expenses but leave
+ * the picker.
+ *
+ * Reads: any space member (they pick from it when logging expenses).
+ * Writes: admin-reserved via the `invoices` category, like engagement and
+ * client management.
+ */
+#[ApiResource(
+    shortName: 'ExpenseCategory',
+    operations: [
+        new GetCollection(
+            security: "is_granted('ROLE_USER')",
+        ),
+        new Post(
+            security: "is_granted('ROLE_USER')",
+            securityPostDenormalize: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or (object.getSpace() !== null and object.getSpace().hasMember(user) and is_granted('space.invoices.create', object)))",
+        ),
+        new Get(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or (object.getSpace().hasMember(user) and is_granted('space.time_entries.read', object)))",
+        ),
+        new Patch(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getSpace().isAdmin(user) or (object.getSpace().hasMember(user) and is_granted('space.invoices.update', object)))",
+        ),
+        new Delete(
+            security: "is_granted('ROLE_USER') and (is_granted('ROLE_ADMIN') or object.getSpace().isAdmin(user) or (object.getSpace().hasMember(user) and is_granted('space.invoices.delete', object)))",
+        ),
+    ],
+    normalizationContext: ['groups' => ['expense_category:read']],
+    denormalizationContext: ['groups' => ['expense_category:write']],
+    order: ['name' => 'ASC'],
+)]
+#[ApiFilter(SearchFilter::class, properties: ['space' => 'exact'])]
+#[ApiFilter(BooleanFilter::class, properties: ['archived'])]
+#[ORM\Entity(repositoryClass: ExpenseCategoryRepository::class)]
+#[ORM\Table(name: 'expense_category')]
+#[ORM\Index(columns: ['space_id', 'name'], name: 'idx_expense_category_space_name')]
+class ExpenseCategory
+{
+    public const MAX_NAME_LENGTH = 80;
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
+    #[Groups(['expense_category:read', 'expense:read'])]
+    private ?Uuid $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Space::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    #[Assert\NotNull(message: 'Space is required.')]
+    #[Groups(['expense_category:read', 'expense_category:write'])]
+    private ?Space $space = null;
+
+    #[ORM\Column(length: self::MAX_NAME_LENGTH)]
+    #[Assert\NotBlank(message: 'A category name is required.')]
+    #[Assert\Length(max: self::MAX_NAME_LENGTH)]
+    #[Groups(['expense_category:read', 'expense_category:write', 'expense:read'])]
+    private string $name = '';
+
+    /**
+     * Optional unit price in minor units (mileage-style categories):
+     * the PWA computes amount = units × unitAmount when set.
+     */
+    #[ORM\Column(type: 'integer', nullable: true)]
+    #[Assert\PositiveOrZero]
+    #[Groups(['expense_category:read', 'expense_category:write', 'expense:read'])]
+    private ?int $unitAmount = null;
+
+    /** Archived categories keep their history but leave the picker. */
+    #[ORM\Column(type: 'boolean', options: ['default' => false])]
+    #[Groups(['expense_category:read', 'expense_category:write'])]
+    private bool $archived = false;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    #[Groups(['expense_category:read'])]
+    private \DateTimeImmutable $createdAt;
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?Uuid
+    {
+        return $this->id;
+    }
+
+    public function getSpace(): ?Space
+    {
+        return $this->space;
+    }
+
+    public function setSpace(?Space $space): self
+    {
+        $this->space = $space;
+
+        return $this;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getUnitAmount(): ?int
+    {
+        return $this->unitAmount;
+    }
+
+    public function setUnitAmount(?int $unitAmount): self
+    {
+        $this->unitAmount = $unitAmount;
+
+        return $this;
+    }
+
+    public function isArchived(): bool
+    {
+        return $this->archived;
+    }
+
+    public function setArchived(bool $archived): self
+    {
+        $this->archived = $archived;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+}

--- a/api/src/Repository/ExpenseCategoryRepository.php
+++ b/api/src/Repository/ExpenseCategoryRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\ExpenseCategory;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<ExpenseCategory>
+ */
+class ExpenseCategoryRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, ExpenseCategory::class);
+    }
+}

--- a/api/src/Security/Permission/SpacePermissionVoter.php
+++ b/api/src/Security/Permission/SpacePermissionVoter.php
@@ -12,6 +12,7 @@ use App\Entity\CustomFieldDefinition;
 use App\Entity\Discussion;
 use App\Entity\Estimate;
 use App\Entity\Expense;
+use App\Entity\ExpenseCategory;
 use App\Entity\Invoice;
 use App\Entity\Page;
 use App\Entity\Board;
@@ -99,6 +100,7 @@ final class SpacePermissionVoter extends Voter
             $subject instanceof Invoice => $subject->getSpace(),
             $subject instanceof Estimate => $subject->getSpace(),
             $subject instanceof Expense => $subject->getSpace(),
+            $subject instanceof ExpenseCategory => $subject->getSpace(),
             $subject instanceof TaskRelationship => $subject->getSource()?->getBoard()?->getSpace(),
             $subject instanceof Comment => $this->commentSpace($subject),
             default => null,

--- a/api/tests/Api/ExpenseTest.php
+++ b/api/tests/Api/ExpenseTest.php
@@ -34,6 +34,7 @@ class ExpenseTest extends ApiTestCase
 
         $this->entityManager->createQuery('DELETE FROM App\Entity\Invoice')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Expense')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\ExpenseCategory')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\TimeEntry')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\EngagementCategory')->execute();
         $this->entityManager->createQuery('DELETE FROM App\Entity\Engagement')->execute();
@@ -188,6 +189,69 @@ class ExpenseTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(200);
         $released = $client->request('GET', $this->iri($billableExpense))->toArray();
         $this->assertNull($released['billedAt'] ?? null);
+    }
+
+    public function testManagedCategoriesCurateThePickerAndLabelExpenses(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $member = $this->createUser('member@example.com');
+        $space = $this->createSharedSpace($admin, $member);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $bpIri = $this->createEngagement($client, $spaceIri, $this->iri($clientRow));
+
+        // Admin curates the list (one unit-priced, one plain).
+        $mileage = $client->request('POST', '/expense_categories', [
+            'json' => ['space' => $spaceIri, 'name' => 'Mileage', 'unitAmount' => 65],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $travel = $client->request('POST', '/expense_categories', [
+            'json' => ['space' => $spaceIri, 'name' => 'Travel'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+
+        // A plain member reads the picker but can't manage it.
+        $client->loginUser($member);
+        $list = $client->request('GET', '/expense_categories?space=' . $spaceIri)->toArray();
+        $this->assertSame(2, $list['totalItems'] ?? null);
+        $client->request('POST', '/expense_categories', [
+            'json' => ['space' => $spaceIri, 'name' => 'Sneaky'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(403);
+
+        // Logging with a managed category denormalises its name as the label.
+        $expense = $client->request('POST', '/expenses', [
+            'json' => [
+                'space' => $spaceIri,
+                'engagement' => $bpIri,
+                'spentOn' => '2026-07-10',
+                'expenseCategory' => $this->iri($travel),
+                'amount' => 2500,
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertSame('Travel', $expense['category'] ?? null);
+        $this->assertSame($this->iri($travel), $expense['expenseCategory'] ?? null);
+
+        // Archiving removes a category from the (archived=false) picker.
+        $client->loginUser($admin);
+        $client->request('PATCH', $this->iri($mileage), [
+            'json' => ['archived' => true],
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(200);
+        $active = $client->request('GET', '/expense_categories?space=' . $spaceIri . '&archived=false')->toArray();
+        $this->assertSame(1, $active['totalItems'] ?? null);
     }
 
     public function testReceiptDownloadGatedToSpenderAndTimeReaders(): void

--- a/pwa/components/spaces/ExpenseCategoriesCard.tsx
+++ b/pwa/components/spaces/ExpenseCategoriesCard.tsx
@@ -1,0 +1,159 @@
+import { useCallback, useEffect, useState } from "react";
+import { Plus } from "lucide-react";
+import { ENTRYPOINT } from "@/config/entrypoint";
+import { ExpenseCategoryRow } from "@/lib/expenseTypes";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+
+/**
+ * Managed expense categories (#671) — space-admin card on the space
+ * settings page: curated list members pick from when logging expenses,
+ * with an optional unit price for mileage-style categories. Archiving
+ * keeps history but removes the category from the picker.
+ */
+const ExpenseCategoriesCard = ({ spaceIri }: { spaceIri: string }) => {
+  const [categories, setCategories] = useState<ExpenseCategoryRow[]>([]);
+  const [name, setName] = useState("");
+  const [unitPrice, setUnitPrice] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch(
+        `${ENTRYPOINT}/expense_categories?space=${encodeURIComponent(spaceIri)}`,
+        { credentials: "include", headers: { Accept: "application/ld+json" } },
+      );
+      if (!res.ok) throw new Error();
+      const data = await res.json();
+      setCategories(data.member ?? data["hydra:member"] ?? []);
+    } catch {
+      setError("Failed to load expense categories.");
+    }
+  }, [spaceIri]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const add = async () => {
+    if (!name.trim()) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(`${ENTRYPOINT}/expense_categories`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/ld+json" },
+        body: JSON.stringify({
+          space: spaceIri,
+          name: name.trim(),
+          unitAmount: unitPrice.trim()
+            ? Math.round((parseFloat(unitPrice) || 0) * 100)
+            : null,
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data["hydra:description"] || data.detail || "Failed to add.");
+      }
+      setName("");
+      setUnitPrice("");
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to add the category.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const setArchived = async (row: ExpenseCategoryRow, archived: boolean) => {
+    setError(null);
+    const res = await fetch(`${ENTRYPOINT}${row["@id"]}`, {
+      method: "PATCH",
+      credentials: "include",
+      headers: { "Content-Type": "application/merge-patch+json" },
+      body: JSON.stringify({ archived }),
+    });
+    if (!res.ok) {
+      setError("Failed to update the category.");
+      return;
+    }
+    await load();
+  };
+
+
+  return (
+    <Card className="mb-6">
+      <CardContent className="pt-6 space-y-4">
+        <div>
+          <h2 className="font-semibold">Expense categories</h2>
+          <p className="text-sm text-muted-foreground">
+            The list members pick from when logging expenses. Add a unit price
+            for mileage-style categories (amount = units × price).
+          </p>
+        </div>
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        {categories.length > 0 && (
+          <ul className="divide-y divide-border rounded-md border">
+            {categories.map((row) => (
+              <li key={row["@id"]} className="flex items-center gap-3 px-3 py-2 text-sm">
+                <span className={row.archived ? "text-muted-foreground line-through" : "font-medium"}>
+                  {row.name}
+                </span>
+                {row.unitAmount != null && (
+                  <span className="text-xs text-muted-foreground">
+                    {(row.unitAmount / 100).toFixed(2)}/unit
+                  </span>
+                )}
+                <span className="ml-auto">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => void setArchived(row, !row.archived)}
+                  >
+                    {row.archived ? "Restore" : "Archive"}
+                  </Button>
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <div className="flex flex-wrap items-end gap-2">
+          <Input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Category name"
+            maxLength={80}
+            className="w-56"
+            aria-label="Category name"
+          />
+          <Input
+            type="number"
+            step="0.01"
+            min="0"
+            value={unitPrice}
+            onChange={(e) => setUnitPrice(e.target.value)}
+            placeholder="Unit price (optional)"
+            className="w-44"
+            aria-label="Unit price"
+          />
+          <Button size="sm" onClick={() => void add()} disabled={busy || !name.trim()}>
+            <Plus className="h-4 w-4" /> Add
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default ExpenseCategoriesCard;

--- a/pwa/lib/expenseTypes.ts
+++ b/pwa/lib/expenseTypes.ts
@@ -7,6 +7,8 @@ export interface Expense {
   user: string;
   spentOn: string;
   category: string | null;
+  /** Managed category IRI (#671); the `category` label mirrors its name. */
+  expenseCategory?: string | null;
   amount: number;
   currency: string | null;
   description: string | null;
@@ -15,4 +17,15 @@ export interface Expense {
   billedAt: string | null;
   createdAt: string;
   updatedAt: string | null;
+}
+
+/** Wire shape for `/expense_categories` (#671). */
+export interface ExpenseCategoryRow {
+  "@id": string;
+  id: string;
+  space: string;
+  name: string;
+  /** Minor units per unit for mileage-style categories; null = plain. */
+  unitAmount: number | null;
+  archived: boolean;
 }

--- a/pwa/pages/expenses/index.tsx
+++ b/pwa/pages/expenses/index.tsx
@@ -9,7 +9,7 @@ import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
 import { apiGet, apiGetCollection, apiSend } from "@/lib/apiClient";
 import { signinHrefForCurrent } from "@/lib/authRedirect";
 import { uploadAttachmentFile } from "@/lib/attachments";
-import { Expense } from "@/lib/expenseTypes";
+import { Expense, ExpenseCategoryRow } from "@/lib/expenseTypes";
 import { EngagementOption } from "@/lib/timeEntryTypes";
 import { formatMoney } from "@/lib/invoiceTypes";
 import PageHeader from "@/components/common/PageHeader";
@@ -61,6 +61,8 @@ const ExpensesPage = () => {
   const [spentOn, setSpentOn] = useState(todayInput);
   const [engagementIri, setEngagementIri] = useState("");
   const [category, setCategory] = useState("");
+  const [expenseCategoryIri, setExpenseCategoryIri] = useState("");
+  const [units, setUnits] = useState("");
   const [description, setDescription] = useState("");
   const [amount, setAmount] = useState("");
   const [billable, setBillable] = useState(true);
@@ -100,6 +102,24 @@ const ExpensesPage = () => {
   });
   const projects = useMemo(() => projectsQuery.data ?? [], [projectsQuery.data]);
   const noProjects = !projectsQuery.isLoading && projects.length === 0;
+
+  // Managed expense categories (#671): the curated picker; free text remains
+  // available when a space hasn't defined any (or via the "Other" choice).
+  const categoriesQuery = useQuery({
+    queryKey: ["expense_categories", spaceIri],
+    enabled: isAuthenticated && !!spaceIri,
+    queryFn: () =>
+      apiGetCollection<ExpenseCategoryRow>(
+        `/expense_categories?space=${encodeURIComponent(spaceIri ?? "")}&archived=false`,
+        { errorMessage: "Failed to load expense categories." },
+      ),
+  });
+  const managedCategories = useMemo(
+    () => categoriesQuery.data ?? [],
+    [categoriesQuery.data],
+  );
+  const selectedManaged =
+    managedCategories.find((c) => c["@id"] === expenseCategoryIri) ?? null;
   const projectName = useMemo(() => {
     const m = new Map<string, string>();
     for (const p of projects) m.set(p["@id"], p.name);
@@ -113,6 +133,8 @@ const ExpensesPage = () => {
   const resetComposer = () => {
     setSpentOn(todayInput());
     setCategory("");
+    setExpenseCategoryIri("");
+    setUnits("");
     setDescription("");
     setAmount("");
     setBillable(true);
@@ -139,7 +161,9 @@ const ExpensesPage = () => {
         body: {
           engagement: engagementIri,
           spentOn,
-          category: category.trim() || null,
+          ...(expenseCategoryIri
+            ? { expenseCategory: expenseCategoryIri }
+            : { category: category.trim() || null }),
           description: description.trim() || null,
           amount: amountMinor,
           billable,
@@ -298,13 +322,63 @@ const ExpensesPage = () => {
                                       (optional)
                                     </span>
                                   </Label>
-                                  <Input
-                                    id="ex-category"
-                                    value={category}
-                                    onChange={(e) => setCategory(e.target.value)}
-                                    maxLength={80}
-                                    placeholder="Travel, software, materials…"
-                                  />
+                                  {managedCategories.length > 0 ? (
+                                    <>
+                                      <select
+                                        id="ex-category"
+                                        value={expenseCategoryIri}
+                                        onChange={(e) => {
+                                          setExpenseCategoryIri(e.target.value);
+                                          setUnits("");
+                                        }}
+                                        className={SELECT_CLASS}
+                                      >
+                                        <option value="">Other (free text)…</option>
+                                        {managedCategories.map((c) => (
+                                          <option key={c["@id"]} value={c["@id"]}>
+                                            {c.name}
+                                            {c.unitAmount != null
+                                              ? ` (${(c.unitAmount / 100).toFixed(2)}/unit)`
+                                              : ""}
+                                          </option>
+                                        ))}
+                                      </select>
+                                      {expenseCategoryIri === "" && (
+                                        <Input
+                                          value={category}
+                                          onChange={(e) => setCategory(e.target.value)}
+                                          maxLength={80}
+                                          placeholder="Travel, software, materials…"
+                                          aria-label="Free-text category"
+                                        />
+                                      )}
+                                      {selectedManaged?.unitAmount != null && (
+                                        <Input
+                                          type="number"
+                                          step="0.1"
+                                          min="0"
+                                          value={units}
+                                          onChange={(e) => {
+                                            setUnits(e.target.value);
+                                            const u = parseFloat(e.target.value) || 0;
+                                            setAmount(
+                                              ((u * (selectedManaged.unitAmount ?? 0)) / 100).toFixed(2),
+                                            );
+                                          }}
+                                          placeholder="Units (auto-computes the amount)"
+                                          aria-label="Units"
+                                        />
+                                      )}
+                                    </>
+                                  ) : (
+                                    <Input
+                                      id="ex-category"
+                                      value={category}
+                                      onChange={(e) => setCategory(e.target.value)}
+                                      maxLength={80}
+                                      placeholder="Travel, software, materials…"
+                                    />
+                                  )}
                                 </div>
                                 <div className="space-y-1.5">
                                   <Label htmlFor="ex-desc">

--- a/pwa/pages/spaces/[id]/settings.tsx
+++ b/pwa/pages/spaces/[id]/settings.tsx
@@ -18,6 +18,7 @@ import ColorSwatchPicker from "@/components/common/ColorSwatchPicker";
 import SpaceTile from "@/components/spaces/SpaceTile";
 import SpaceBillingCard from "@/components/spaces/SpaceBillingCard";
 import InvoiceBrandingCard from "@/components/spaces/InvoiceBrandingCard";
+import ExpenseCategoriesCard from "@/components/spaces/ExpenseCategoriesCard";
 import DeleteSpaceDialog from "@/components/spaces/DeleteSpaceDialog";
 import ChangeVisibilityDialog from "@/components/spaces/ChangeVisibilityDialog";
 
@@ -371,6 +372,9 @@ const SpaceSettings = () => {
 
         {/* Invoice branding (#669): logo, terms, numbering. */}
         <InvoiceBrandingCard space={space} onSaved={load} />
+
+        {/* Managed expense categories (#671). */}
+        <ExpenseCategoriesCard spaceIri={space["@id"]} />
 
         {/* Export space data */}
         <Card className="mb-6">


### PR DESCRIPTION
Closes #671

## What
Harvest-style curated expense categories replacing free-text-only:

- **`ExpenseCategory`** (`/expense_categories`): per-space name, optional **unit price** (minor units — mileage-style categories), `archived` flag. **Reads** for any space member (it's picker data), **writes** admin-reserved via the `invoices` category like client/engagement management. Collection scoped by `ExpenseCategoryAccessExtension`; `SpacePermissionVoter` gets its resolve arm (the recurring gotcha).
- **`Expense.expenseCategory`** (nullable FK, SET NULL): optional — free text stays fully supported. When set, the existing `category` label column is **denormalised from the category's name** on save, so invoice line labels (`Expense — Travel: …`) and historical reads never need the join. Cross-space categories 422.
- **PWA**: the expenses composer shows the curated picker when the space has categories (an *Other (free text)…* choice keeps the old path; picking a unit-priced category reveals a **Units** input that auto-computes the amount). Space settings gains an **Expense categories** card (add with optional unit price, archive/restore).

## Tests
`ExpenseTest::testManagedCategoriesCurateThePickerAndLabelExpenses` — admin curates (unit-priced + plain), member reads the picker but 403s on create, a managed-category expense carries the denormalised label + IRI, archiving removes it from the `archived=false` picker.