### PR TITLE
feat(billing): client retainers — deposits drawn down by invoices

### DIFF
--- a/api/migrations/Version20260717000000.php
+++ b/api/migrations/Version20260717000000.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Client retainers (#673): the retainer_transaction ledger (deposits +
+ * invoice draws; balance = Σ deposits − Σ draws).
+ */
+final class Version20260717000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'retainer_transaction ledger for client retainers.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE retainer_transaction (id UUID NOT NULL, type VARCHAR(10) NOT NULL, amount INT NOT NULL, note VARCHAR(255) DEFAULT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, client_id UUID NOT NULL, invoice_id UUID DEFAULT NULL, created_by_id UUID DEFAULT NULL, PRIMARY KEY (id))');
+        $this->addSql('CREATE INDEX idx_retainer_txn_client_created ON retainer_transaction (client_id, created_at)');
+        $this->addSql('CREATE INDEX IDX_A7A2F9B82989F1FD ON retainer_transaction (invoice_id)');
+        $this->addSql('CREATE INDEX IDX_A7A2F9B8B03A8386 ON retainer_transaction (created_by_id)');
+        $this->addSql('ALTER TABLE retainer_transaction ADD CONSTRAINT FK_A7A2F9B819EB6921 FOREIGN KEY (client_id) REFERENCES client (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE retainer_transaction ADD CONSTRAINT FK_A7A2F9B82989F1FD FOREIGN KEY (invoice_id) REFERENCES invoice (id) ON DELETE SET NULL NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE retainer_transaction ADD CONSTRAINT FK_A7A2F9B8B03A8386 FOREIGN KEY (created_by_id) REFERENCES "user" (id) ON DELETE SET NULL NOT DEFERRABLE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE retainer_transaction DROP CONSTRAINT FK_A7A2F9B819EB6921');
+        $this->addSql('ALTER TABLE retainer_transaction DROP CONSTRAINT FK_A7A2F9B82989F1FD');
+        $this->addSql('ALTER TABLE retainer_transaction DROP CONSTRAINT FK_A7A2F9B8B03A8386');
+        $this->addSql('DROP TABLE retainer_transaction');
+    }
+}

--- a/api/src/Controller/InvoiceActionController.php
+++ b/api/src/Controller/InvoiceActionController.php
@@ -174,6 +174,19 @@ class InvoiceActionController extends AbstractController
             return $this->json(['error' => 'Payment not found.'], 404);
         }
 
+        // Removing a retainer payment refunds the draw (#673) — a reversing
+        // deposit keeps the ledger append-only and the balance whole.
+        if (\App\Entity\InvoicePayment::METHOD_RETAINER === $payment->getMethod() && null !== $invoice->getClient()) {
+            $refund = (new \App\Entity\RetainerTransaction())
+                ->setClient($invoice->getClient())
+                ->setType(\App\Entity\RetainerTransaction::TYPE_DEPOSIT)
+                ->setAmount($payment->getAmount())
+                ->setInvoice($invoice)
+                ->setNote('Reversal — retainer payment removed')
+                ->setCreatedBy($user instanceof User ? $user : null);
+            $this->em->persist($refund);
+        }
+
         $invoice->removePayment($payment);
 
         if (Invoice::STATUS_PAID === $invoice->getStatus() && $invoice->getBalanceDue() > 0) {

--- a/api/src/Controller/RetainerController.php
+++ b/api/src/Controller/RetainerController.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\Client;
+use App\Entity\Invoice;
+use App\Entity\InvoicePayment;
+use App\Entity\RetainerTransaction;
+use App\Entity\User;
+use App\Repository\RetainerTransactionRepository;
+use App\Security\Permission\SpacePermission;
+use App\Security\Permission\SpacePermissionResolver;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Client retainers (#673): pre-paid balances drawn down by invoices.
+ *
+ *  - deposits: an admin records money the client pre-paid;
+ *  - the ledger view: balance + every movement;
+ *  - apply-retainer: pays an invoice's balance due from the retainer —
+ *    one InvoicePayment (method "retainer") + a matching draw, capped at
+ *    min(retainer balance, balance due, requested amount).
+ *
+ * Removing a retainer payment (typo, wrong invoice) refunds the draw with
+ * a reversing deposit — see InvoiceActionController::removePayment().
+ * All routes ride the admin-reserved `invoices` category.
+ */
+class RetainerController extends AbstractController
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private RetainerTransactionRepository $retainers,
+        private SpacePermissionResolver $permissions,
+    ) {
+    }
+
+    #[Route('/clients/{id}/retainer', name: 'client_retainer_view', methods: ['GET'], priority: 10)]
+    public function view(string $id, #[CurrentUser] ?User $user): JsonResponse
+    {
+        $client = $this->authorizeClient($id, $user, SpacePermission::READ);
+        if ($client instanceof JsonResponse) {
+            return $client;
+        }
+
+        $transactions = [];
+        foreach ($this->retainers->findForClient($client) as $txn) {
+            $transactions[] = [
+                'id' => (string) $txn->getId(),
+                'type' => $txn->getType(),
+                'amount' => $txn->getAmount(),
+                'note' => $txn->getNote(),
+                'invoiceNumber' => $txn->getInvoice()?->getNumber(),
+                'createdAt' => $txn->getCreatedAt()->format(\DateTimeInterface::ATOM),
+            ];
+        }
+
+        return $this->json([
+            'balance' => $this->retainers->balanceFor($client),
+            'currency' => $client->getCurrency() ?? 'USD',
+            'transactions' => $transactions,
+        ]);
+    }
+
+    #[Route('/clients/{id}/retainer-deposits', name: 'client_retainer_deposit', methods: ['POST'], priority: 10)]
+    public function deposit(string $id, Request $request, #[CurrentUser] ?User $user): JsonResponse
+    {
+        $client = $this->authorizeClient($id, $user, SpacePermission::UPDATE);
+        if ($client instanceof JsonResponse) {
+            return $client;
+        }
+
+        $payload = $request->toArray();
+        $amount = $payload['amount'] ?? null;
+        if (!is_int($amount) || $amount <= 0) {
+            return $this->json(['error' => 'A positive amount (minor units) is required.'], 422);
+        }
+        $note = $payload['note'] ?? null;
+
+        $txn = (new RetainerTransaction())
+            ->setClient($client)
+            ->setType(RetainerTransaction::TYPE_DEPOSIT)
+            ->setAmount($amount)
+            ->setNote(is_string($note) && '' !== trim($note) ? mb_substr(trim($note), 0, RetainerTransaction::MAX_NOTE_LENGTH) : null)
+            ->setCreatedBy($user);
+        $this->em->persist($txn);
+        $this->em->flush();
+
+        return $this->json(['balance' => $this->retainers->balanceFor($client)], 201);
+    }
+
+    /**
+     * Pay (part of) an invoice from the client's retainer. Optional
+     * `amount` caps the draw; default = as much as possible.
+     */
+    #[Route('/invoices/{id}/apply-retainer', name: 'invoice_apply_retainer', methods: ['POST'])]
+    public function applyToInvoice(string $id, Request $request, #[CurrentUser] ?User $user): JsonResponse
+    {
+        if (null === $user) {
+            return $this->json(['error' => 'Not authenticated.'], 401);
+        }
+        if (!Uuid::isValid($id)) {
+            return $this->json(['error' => 'Invoice not found.'], 404);
+        }
+        $invoice = $this->em->getRepository(Invoice::class)->find($id);
+        $space = $invoice?->getSpace();
+        $client = $invoice?->getClient();
+        if (
+            null === $invoice || null === $space || null === $client
+            || (!$this->isGranted('ROLE_ADMIN') && !$space->hasMember($user))
+        ) {
+            return $this->json(['error' => 'Invoice not found.'], 404);
+        }
+        if (
+            !$this->isGranted('ROLE_ADMIN')
+            && !$space->isAdmin($user)
+            && !$this->permissions->canByExplicitGrant($user, $space, SpacePermission::INVOICES, SpacePermission::UPDATE)
+        ) {
+            return $this->json(['error' => 'You cannot manage invoices in this space.'], 403);
+        }
+        if (in_array($invoice->getStatus(), [Invoice::STATUS_DRAFT, Invoice::STATUS_VOID], true)) {
+            return $this->json(['error' => 'Retainer can only be applied to an issued invoice.'], 409);
+        }
+
+        $balance = $this->retainers->balanceFor($client);
+        $due = $invoice->getBalanceDue();
+        $payload = $request->toArray();
+        $requested = $payload['amount'] ?? null;
+        if (null !== $requested && (!is_int($requested) || $requested <= 0)) {
+            return $this->json(['error' => 'amount must be a positive integer (minor units).'], 422);
+        }
+        $amount = min($balance, $due, $requested ?? PHP_INT_MAX);
+        if ($amount <= 0) {
+            return $this->json(['error' => 'No retainer balance available (or nothing due).'], 409);
+        }
+
+        $payment = (new InvoicePayment())
+            ->setAmount($amount)
+            ->setPaidOn(new \DateTimeImmutable('today'))
+            ->setMethod(InvoicePayment::METHOD_RETAINER)
+            ->setNote('Applied from retainer')
+            ->setCreatedBy($user);
+        $invoice->addPayment($payment);
+
+        $draw = (new RetainerTransaction())
+            ->setClient($client)
+            ->setType(RetainerTransaction::TYPE_DRAW)
+            ->setAmount($amount)
+            ->setInvoice($invoice)
+            ->setNote(null !== $invoice->getNumber() ? 'Applied to ' . $invoice->getNumber() : 'Applied to invoice')
+            ->setCreatedBy($user);
+        $this->em->persist($draw);
+
+        if (0 === $invoice->getBalanceDue()) {
+            $invoice->setStatus(Invoice::STATUS_PAID);
+            $invoice->setPaidAt(new \DateTimeImmutable());
+        }
+        $this->em->flush();
+
+        return $this->json([
+            'applied' => $amount,
+            'balanceDue' => $invoice->getBalanceDue(),
+            'retainerBalance' => $this->retainers->balanceFor($client),
+            'status' => $invoice->getStatus(),
+        ], 201);
+    }
+
+    /**
+     * Load the client and confirm the caller holds the given `invoices`
+     * action, or return the short-circuit response.
+     */
+    private function authorizeClient(string $id, ?User $user, string $action): Client|JsonResponse
+    {
+        if (null === $user) {
+            return $this->json(['error' => 'Not authenticated.'], 401);
+        }
+        if (!Uuid::isValid($id)) {
+            return $this->json(['error' => 'Client not found.'], 404);
+        }
+        $client = $this->em->getRepository(Client::class)->find($id);
+        $space = $client?->getSpace();
+        if (
+            null === $client || null === $space
+            || (!$this->isGranted('ROLE_ADMIN') && !$space->hasMember($user))
+        ) {
+            return $this->json(['error' => 'Client not found.'], 404);
+        }
+        if (
+            !$this->isGranted('ROLE_ADMIN')
+            && !$space->isAdmin($user)
+            && !$this->permissions->canByExplicitGrant($user, $space, SpacePermission::INVOICES, $action)
+        ) {
+            return $this->json(['error' => 'You cannot manage clients in this space.'], 403);
+        }
+
+        return $client;
+    }
+}

--- a/api/src/Entity/InvoicePayment.php
+++ b/api/src/Entity/InvoicePayment.php
@@ -21,6 +21,8 @@ class InvoicePayment
 {
     public const METHOD_MANUAL = 'manual';
     public const METHOD_STRIPE = 'stripe';
+    /** Paid from the client's retainer balance (#673). */
+    public const METHOD_RETAINER = 'retainer';
 
     #[ORM\Id]
     #[ORM\Column(type: 'uuid', unique: true)]

--- a/api/src/Entity/RetainerTransaction.php
+++ b/api/src/Entity/RetainerTransaction.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\RetainerTransactionRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * One movement on a client's retainer ledger (#673): a `deposit` (money the
+ * client pre-paid, recorded by an admin) or a `draw` (retainer balance
+ * applied to an invoice — paired with an InvoicePayment of method
+ * "retainer"). Balance = Σ deposits − Σ draws, in the client's currency.
+ *
+ * Server-written only (RetainerController + the payment-removal reversal);
+ * not an API resource. Rows are never edited — corrections are new
+ * counter-entries, so the ledger stays an audit trail.
+ */
+#[ORM\Entity(repositoryClass: RetainerTransactionRepository::class)]
+#[ORM\Table(name: 'retainer_transaction')]
+#[ORM\Index(columns: ['client_id', 'created_at'], name: 'idx_retainer_txn_client_created')]
+class RetainerTransaction
+{
+    public const TYPE_DEPOSIT = 'deposit';
+    public const TYPE_DRAW = 'draw';
+
+    public const MAX_NOTE_LENGTH = 255;
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: 'doctrine.uuid_generator')]
+    private ?Uuid $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Client::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private ?Client $client = null;
+
+    #[ORM\Column(length: 10)]
+    private string $type = self::TYPE_DEPOSIT;
+
+    /** Minor units of the client's currency; always positive. */
+    #[ORM\Column(type: 'integer')]
+    private int $amount = 0;
+
+    #[ORM\Column(length: self::MAX_NOTE_LENGTH, nullable: true)]
+    private ?string $note = null;
+
+    /** The invoice a draw paid down (null for deposits). */
+    #[ORM\ManyToOne(targetEntity: Invoice::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    private ?Invoice $invoice = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'created_by_id', nullable: true, onDelete: 'SET NULL')]
+    private ?User $createdBy = null;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $createdAt;
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?Uuid
+    {
+        return $this->id;
+    }
+
+    public function getClient(): ?Client
+    {
+        return $this->client;
+    }
+
+    public function setClient(?Client $client): self
+    {
+        $this->client = $client;
+
+        return $this;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function setType(string $type): self
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    public function getAmount(): int
+    {
+        return $this->amount;
+    }
+
+    public function setAmount(int $amount): self
+    {
+        $this->amount = $amount;
+
+        return $this;
+    }
+
+    public function getNote(): ?string
+    {
+        return $this->note;
+    }
+
+    public function setNote(?string $note): self
+    {
+        $this->note = $note;
+
+        return $this;
+    }
+
+    public function getInvoice(): ?Invoice
+    {
+        return $this->invoice;
+    }
+
+    public function setInvoice(?Invoice $invoice): self
+    {
+        $this->invoice = $invoice;
+
+        return $this;
+    }
+
+    public function getCreatedBy(): ?User
+    {
+        return $this->createdBy;
+    }
+
+    public function setCreatedBy(?User $createdBy): self
+    {
+        $this->createdBy = $createdBy;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+}

--- a/api/src/Repository/RetainerTransactionRepository.php
+++ b/api/src/Repository/RetainerTransactionRepository.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Client;
+use App\Entity\RetainerTransaction;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<RetainerTransaction>
+ */
+class RetainerTransactionRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, RetainerTransaction::class);
+    }
+
+    /** Σ deposits − Σ draws, minor units of the client's currency. */
+    public function balanceFor(Client $client): int
+    {
+        /** @var array{deposits: string|int|null, draws: string|int|null} $row */
+        $row = $this->createQueryBuilder('t')
+            ->select(
+                "COALESCE(SUM(CASE WHEN t.type = 'deposit' THEN t.amount ELSE 0 END), 0) AS deposits",
+                "COALESCE(SUM(CASE WHEN t.type = 'draw' THEN t.amount ELSE 0 END), 0) AS draws",
+            )
+            ->andWhere('t.client = :client')
+            ->setParameter('client', $client)
+            ->getQuery()
+            ->getSingleResult();
+
+        return (int) $row['deposits'] - (int) $row['draws'];
+    }
+
+    /**
+     * The ledger, newest first.
+     *
+     * @return list<RetainerTransaction>
+     */
+    public function findForClient(Client $client): array
+    {
+        /** @var list<RetainerTransaction> */
+        return $this->createQueryBuilder('t')
+            ->andWhere('t.client = :client')
+            ->setParameter('client', $client)
+            ->orderBy('t.createdAt', 'DESC')
+            ->getQuery()
+            ->getResult();
+    }
+}

--- a/api/tests/Api/RetainerTest.php
+++ b/api/tests/Api/RetainerTest.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\Space;
+use App\Entity\SpaceMembership;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Client retainers (#673): deposits build a pre-paid balance, invoices draw
+ * it down (payment method "retainer"), and removing a retainer payment
+ * refunds the draw with a reversing deposit.
+ */
+class RetainerTest extends ApiTestCase
+{
+    use SpaceMembershipFixture;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = static::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\RetainerTransaction')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Invoice')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Client')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\SpaceMembership')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Space')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testDepositsDrawDownAndReversals(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $member = $this->createUser('member@example.com');
+        $space = $this->createSharedSpace($admin, $member);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $clientId = $clientRow['id'];
+        $this->assertIsString($clientId);
+
+        // An issued 50.00 invoice to draw against.
+        $invoice = $client->request('POST', '/invoices', [
+            'json' => [
+                'space' => $spaceIri,
+                'client' => $clientRow['@id'],
+                'currency' => 'USD',
+                'lineItems' => [['description' => 'Work', 'quantity' => 1, 'unitAmount' => 5000]],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $invoiceIri = $invoice['@id'];
+        $this->assertIsString($invoiceIri);
+
+        // Applying to a draft is refused; deposits are admin-reserved.
+        $client->request('POST', $invoiceIri . '/apply-retainer', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(409);
+        $client->loginUser($member);
+        $client->request('POST', '/clients/' . $clientId . '/retainer-deposits', [
+            'json' => ['amount' => 10000],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(403);
+
+        // Admin records a 100.00 deposit.
+        $client->loginUser($admin);
+        $deposited = $client->request('POST', '/clients/' . $clientId . '/retainer-deposits', [
+            'json' => ['amount' => 10000, 'note' => 'Q3 retainer'],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertSame(10000, $deposited['balance'] ?? null);
+
+        // Issue the invoice, then draw from the retainer — capped at the
+        // balance due, flipping the invoice paid.
+        $client->request('POST', $invoiceIri . '/issue', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(200);
+        $applied = $client->request('POST', $invoiceIri . '/apply-retainer', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertSame(5000, $applied['applied'] ?? null);
+        $this->assertSame(0, $applied['balanceDue'] ?? null);
+        $this->assertSame(5000, $applied['retainerBalance'] ?? null);
+        $this->assertSame('paid', $applied['status'] ?? null);
+
+        // The ledger shows the deposit + the draw (with the invoice number).
+        $ledger = $client->request('GET', '/clients/' . $clientId . '/retainer')->toArray();
+        $this->assertSame(5000, $ledger['balance'] ?? null);
+        $transactions = $ledger['transactions'] ?? null;
+        $this->assertIsArray($transactions);
+        $this->assertCount(2, $transactions);
+
+        // Nothing due → a second apply is refused.
+        $client->request('POST', $invoiceIri . '/apply-retainer', [
+            'json' => [],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(409);
+
+        // Removing the retainer payment refunds the draw and reopens the invoice.
+        $full = $client->request('GET', $invoiceIri)->toArray();
+        $payments = $full['payments'] ?? null;
+        $this->assertIsArray($payments);
+        $this->assertCount(1, $payments);
+        $paymentRow = $payments[0];
+        $this->assertIsArray($paymentRow);
+        $this->assertSame('retainer', $paymentRow['method'] ?? null);
+        $paymentId = $paymentRow['id'];
+        $this->assertIsString($paymentId);
+
+        $client->request('DELETE', $invoiceIri . '/payments/' . $paymentId);
+        $this->assertResponseStatusCodeSame(200);
+        $refunded = $client->request('GET', '/clients/' . $clientId . '/retainer')->toArray();
+        $this->assertSame(10000, $refunded['balance'] ?? null);
+        $refundedTxns = $refunded['transactions'] ?? null;
+        $this->assertIsArray($refundedTxns);
+        $this->assertCount(3, $refundedTxns);
+        $reopened = $client->request('GET', $invoiceIri)->toArray();
+        $this->assertSame('sent', $reopened['status'] ?? null);
+        $this->assertSame(5000, $reopened['balanceDue'] ?? null);
+    }
+
+    private function createSharedSpace(User $admin, ?User $member = null): Space
+    {
+        $space = (new Space())->setName('Studio')->setCreatedBy($admin);
+        $this->entityManager->persist($space);
+        $adminMembership = (new SpaceMembership())
+            ->setUser($admin)
+            ->setRole(Space::ROLE_ADMIN);
+        $space->addUserMembership($adminMembership);
+        $this->entityManager->persist($adminMembership);
+        if (null !== $member) {
+            $memberMembership = (new SpaceMembership())
+                ->setUser($member)
+                ->setRole(Space::ROLE_MEMBER);
+            $space->addUserMembership($memberMembership);
+            $this->entityManager->persist($memberMembership);
+        }
+        $this->entityManager->flush();
+
+        return $space;
+    }
+
+    private function createUser(string $email): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/pwa/pages/clients/index.tsx
+++ b/pwa/pages/clients/index.tsx
@@ -2,7 +2,7 @@ import Head from "next/head";
 import { useRouter } from "next/router";
 import { FormEvent, useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Link2, Plus, Users } from "lucide-react";
+import { Link2, PiggyBank, Plus, Users } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useActiveSpace } from "@/contexts/ActiveSpaceContext";
 import { apiGetCollection, apiSend } from "@/lib/apiClient";
@@ -118,6 +118,38 @@ const ClientsPage = () => {
       !!client.email &&
       window.confirm(`Also email the new portal link to ${client.email}?`);
     portalMutation.mutate({ client, send });
+  };
+
+  // Retainer deposits (#673): record pre-paid money; invoices draw it down.
+  const depositMutation = useMutation({
+    mutationFn: ({ client, amount }: { client: Client; amount: number }) =>
+      apiSend<{ balance: number }>("POST", `/clients/${client.id}/retainer-deposits`, {
+        contentType: "application/json",
+        errorMessage: "Failed to record the deposit.",
+        body: { amount },
+      }),
+    onSuccess: (res, { client }) => {
+      setActionError(null);
+      setNotice(
+        `Deposit recorded. ${client.name}'s retainer balance: ${formatMoney(
+          res?.balance ?? 0,
+          client.currency ?? "USD",
+        )}.`,
+      );
+    },
+    onError: (e) =>
+      setActionError(e instanceof Error ? e.message : "Failed to record the deposit."),
+  });
+
+  const addDeposit = (client: Client) => {
+    const raw = window.prompt(`Retainer deposit for ${client.name} (amount)?`);
+    if (raw === null) return;
+    const amount = Math.round((parseFloat(raw) || 0) * 100);
+    if (amount <= 0) {
+      setActionError("Enter a positive amount.");
+      return;
+    }
+    depositMutation.mutate({ client, amount });
   };
 
   const canCreate = can("invoices", "create");
@@ -295,15 +327,26 @@ const ClientsPage = () => {
                           </td>
                           <td className="whitespace-nowrap px-2 py-3 text-right">
                             {canCreate && (
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => mintPortal(client)}
-                                disabled={portalMutation.isPending}
-                                title="Create (or rotate) this client's billing portal link"
-                              >
-                                <Link2 className="h-3.5 w-3.5" /> Portal
-                              </Button>
+                              <>
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => addDeposit(client)}
+                                  disabled={depositMutation.isPending}
+                                  title="Record a retainer deposit for this client"
+                                >
+                                  <PiggyBank className="h-3.5 w-3.5" /> Deposit
+                                </Button>
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => mintPortal(client)}
+                                  disabled={portalMutation.isPending}
+                                  title="Create (or rotate) this client's billing portal link"
+                                >
+                                  <Link2 className="h-3.5 w-3.5" /> Portal
+                                </Button>
+                              </>
                             )}
                           </td>
                         </tr>

--- a/pwa/pages/invoices/[id].tsx
+++ b/pwa/pages/invoices/[id].tsx
@@ -229,6 +229,36 @@ const InvoiceDetailPage = () => {
     }
   };
 
+  // Client retainer (#673): available balance + one-click apply.
+  const clientId =
+    invoice && typeof invoice.client !== "string" ? invoice.client.id : null;
+  const retainerQuery = useQuery({
+    queryKey: ["retainer", clientId],
+    enabled: isAuthenticated && !!clientId,
+    queryFn: () =>
+      apiGet<{ balance: number; currency: string }>(`/clients/${clientId}/retainer`, {
+        errorMessage: "Failed to load the retainer balance.",
+      }),
+  });
+  const retainerBalance = retainerQuery.data?.balance ?? 0;
+
+  const applyRetainer = async () => {
+    if (!invoice) return;
+    setError(null);
+    try {
+      await apiSend("POST", `${invoice["@id"]}/apply-retainer`, {
+        contentType: "application/json",
+        errorMessage: "Failed to apply the retainer.",
+        body: {},
+      });
+      setNotice("Retainer applied.");
+      void invoiceQuery.refetch();
+      void retainerQuery.refetch();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to apply the retainer.");
+    }
+  };
+
   const deletePayment = async (paymentId: string) => {
     if (!invoice) return;
     if (!window.confirm("Remove this payment?")) return;
@@ -667,6 +697,21 @@ const InvoiceDetailPage = () => {
                         >
                           {payBusy ? "Recording…" : "Record payment"}
                         </Button>
+                        {retainerBalance > 0 && (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => void applyRetainer()}
+                            title="Pay from the client's retainer balance"
+                          >
+                            Apply retainer (
+                            {formatMoney(
+                              retainerBalance,
+                              retainerQuery.data?.currency ?? currency,
+                            )}
+                            )
+                          </Button>
+                        )}
                       </div>
                     )}
                   </CardContent>


### PR DESCRIPTION
Closes #673

## What
Harvest-style retainers: clients pre-pay, invoices draw the balance down.

- **`RetainerTransaction`** — an append-only per-client ledger (`deposit` / `draw`; balance = Σ deposits − Σ draws, in the client's currency). Corrections are counter-entries, never edits, so it doubles as an audit trail.
- **Endpoints** (admin-reserved `invoices` category):
  - `POST /clients/{id}/retainer-deposits` `{amount, note?}` → new balance
  - `GET /clients/{id}/retainer` → balance + ledger (draws carry the invoice number)
  - `POST /invoices/{id}/apply-retainer` `{amount?}` → creates an **`InvoicePayment` of new method `retainer`** plus the matching draw, capped at min(retainer balance, balance due, requested); a zero balance due flips the invoice `paid` exactly like any other payment; drafts/void 409.
- **Reversal**: deleting a retainer payment (existing `DELETE /invoices/{id}/payments/{pid}`) refunds the draw with a reversing deposit and reopens the invoice per the normal payment-removal rules.
- **PWA**: a *Deposit* action per client row (amount prompt → new-balance notice) and an *Apply retainer ($X)* button in the invoice detail payments card, shown when the client has balance.

## Tests
`RetainerTest` — member deposit 403, draft apply 409, deposit → issue → apply caps at the due amount and flips paid, ledger shows deposit + draw, second apply 409, payment removal refunds the draw (balance restored, 3 ledger rows, invoice back to `sent`).