### PR TITLE
feat(invoices): embed expense receipt images in the invoice PDF

### DIFF
--- a/api/src/Service/InvoicePdfRenderer.php
+++ b/api/src/Service/InvoicePdfRenderer.php
@@ -37,6 +37,7 @@ final class InvoicePdfRenderer
             'invoice' => $invoice,
             'logoDataUri' => $this->logoDataUri($invoice),
             'terms' => $invoice->getSpace()?->getInvoiceTerms(),
+            'receipts' => $this->receiptImages($invoice),
         ]);
 
         $options = new Options();
@@ -49,6 +50,43 @@ final class InvoicePdfRenderer
         $dompdf->render();
 
         return $dompdf->output();
+    }
+
+    /**
+     * Image receipts backing this invoice's expense lines (#672), embedded
+     * as data URIs (dompdf runs with remote fetches off). PDF-kind receipts
+     * are skipped — they can't be inlined into another PDF by dompdf — and
+     * unreadable bytes degrade to "no receipt" rather than failing the
+     * render.
+     *
+     * @return list<array{dataUri: string, caption: string}>
+     */
+    public function receiptImages(Invoice $invoice): array
+    {
+        $receipts = [];
+        foreach ($invoice->getLineItems() as $line) {
+            $media = $line->getSourceExpense()?->getReceipt();
+            if (null === $media || !str_starts_with($media->getMimeType(), 'image/')) {
+                continue;
+            }
+            $path = $media->getVariantPath('original')
+                ?? array_values($media->getVariants())[0]
+                ?? null;
+            if (null === $path) {
+                continue;
+            }
+            try {
+                $bytes = $this->storage->read($path);
+            } catch (FilesystemException) {
+                continue;
+            }
+            $receipts[] = [
+                'dataUri' => 'data:' . $media->getMimeType() . ';base64,' . base64_encode($bytes),
+                'caption' => $line->getDescription(),
+            ];
+        }
+
+        return $receipts;
     }
 
     /** A safe download filename for the invoice. */

--- a/api/templates/invoice/pdf.html.twig
+++ b/api/templates/invoice/pdf.html.twig
@@ -150,5 +150,17 @@
 {% if terms %}
 <div class="terms">{{ terms }}</div>
 {% endif %}
+
+{% if receipts|length > 0 %}
+<div style="page-break-before: always;">
+    <div class="label" style="margin-bottom: 10px;">Receipts</div>
+    {% for receipt in receipts %}
+    <div style="page-break-inside: avoid; margin-bottom: 18px;">
+        <div class="muted" style="font-size: 10px; margin-bottom: 4px;">{{ receipt.caption }}</div>
+        <img src="{{ receipt.dataUri }}" style="max-width: 100%; max-height: 640px;" alt="">
+    </div>
+    {% endfor %}
+</div>
+{% endif %}
 </body>
 </html>

--- a/api/tests/Api/ClientInvoiceTest.php
+++ b/api/tests/Api/ClientInvoiceTest.php
@@ -879,6 +879,79 @@ class ClientInvoiceTest extends ApiTestCase
         $this->assertResponseStatusCodeSame(422);
     }
 
+    public function testPdfEmbedsImageReceiptsFromExpenseLines(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $space = $this->createSharedSpace($admin);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        // A real (tiny) PNG receipt, created before the HTTP phase.
+        $image = imagecreatetruecolor(8, 8);
+        self::assertNotFalse($image);
+        ob_start();
+        imagepng($image);
+        $pngBytes = (string) ob_get_clean();
+        imagedestroy($image);
+        $storage = static::getContainer()->get('media.storage');
+        $receiptPath = 'attachments/pdf-receipt-' . bin2hex(random_bytes(4)) . '.png';
+        $storage->write($receiptPath, $pngBytes);
+        $receipt = (new \App\Entity\MediaObject())
+            ->setOwner($admin)
+            ->setKind(\App\Entity\MediaObject::KIND_ATTACHMENT)
+            ->setVariants(['original' => $receiptPath])
+            ->setOriginalName('receipt.png')
+            ->setMimeType('image/png')
+            ->setByteSize(\strlen($pngBytes));
+        $this->entityManager->persist($receipt);
+        $this->entityManager->flush();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        [$bpIri] = $this->createEngagement($client, $spaceIri, $this->iri($clientRow));
+
+        // A billable expense with the receipt, invoiced on its own.
+        $client->request('POST', '/expenses', [
+            'json' => [
+                'space' => $spaceIri,
+                'engagement' => $bpIri,
+                'spentOn' => '2026-07-10',
+                'category' => 'Travel',
+                'description' => 'Taxi to the site',
+                'amount' => 2500,
+                'receipt' => '/media-objects/' . $receipt->getId(),
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+        $invoice = $client->request('POST', '/invoices/from-time-entries', [
+            'json' => ['engagement' => $bpIri],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $invoiceId = $invoice['id'];
+        $this->assertIsString($invoiceId);
+
+        // The renderer collects the image receipt as an embeddable data URI…
+        $em = static::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $entity = $em->getRepository(Invoice::class)->find($invoiceId);
+        $this->assertInstanceOf(Invoice::class, $entity);
+        $renderer = static::getContainer()->get(\App\Service\InvoicePdfRenderer::class);
+        $receipts = $renderer->receiptImages($entity);
+        $this->assertCount(1, $receipts);
+        $this->assertStringStartsWith('data:image/png;base64,', $receipts[0]['dataUri']);
+        $this->assertSame('Expense — Travel: Taxi to the site', $receipts[0]['caption']);
+
+        // …and the full PDF still renders.
+        $pdf = $client->request('GET', '/invoices/' . $invoiceId . '/pdf');
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertStringStartsWith('%PDF', $pdf->getContent());
+    }
+
     public function testDiscountAppliesBetweenSubtotalAndTax(): void
     {
         $admin = $this->createUser('admin@example.com');


### PR DESCRIPTION
Closes #672

## What
When an invoice line is backed by an expense (#650) that carries an **image** receipt, the invoice PDF now appends a **Receipts** section — a fresh page with one captioned image per line (caption = the line label, page-break-safe, capped height).

- `InvoicePdfRenderer::receiptImages()` collects them as **base64 data URIs** (dompdf runs with remote fetches disabled).
- **PDF-kind receipts are skipped** in v1 (dompdf can't inline a PDF into a PDF); unreadable bytes degrade to "no receipt" rather than failing the render.

## Tests
`ClientInvoiceTest::testPdfEmbedsImageReceiptsFromExpenseLines` — a real generated PNG receipt on an invoiced expense: `receiptImages()` returns one `data:image/png;base64,` entry with the line caption, and the full authenticated PDF route still streams `%PDF`.