### PR TITLE
fix(security): rebuild same-origin URLs by component assignment (CodeQL js/request-forgery)

### DIFF
--- a/pwa/lib/authRedirect.test.ts
+++ b/pwa/lib/authRedirect.test.ts
@@ -54,6 +54,18 @@ describe("safeNextPath", () => {
     expect(safeNextPath(undefined, "/settings/profile")).toBe("/settings/profile");
     expect(safeNextPath("//evil.com", "/home")).toBe("/home");
   });
+
+  it("rejects candidates that normalise to a protocol-relative path", () => {
+    // Each raw string starts with a single "/" (so isSafeNextPath passes),
+    // but URL dot-segment normalisation collapses the leading "/.." to leave
+    // a "//host" pathname — a protocol-relative string that router.push would
+    // navigate cross-origin. The output re-check must reject it.
+    for (const hostile of ["/..//evil.com", "/..//evil.com/x", "/a/../..//evil.com"]) {
+      const out = safeNextPath(hostile);
+      expect(out).toBe("/boards");
+      expect(out.startsWith("//")).toBe(false);
+    }
+  });
 });
 
 describe("signinHrefForCurrent", () => {

--- a/pwa/lib/authRedirect.ts
+++ b/pwa/lib/authRedirect.ts
@@ -79,7 +79,15 @@ export const safeNextPath = (
   try {
     const parsed = new URL(candidate, SANITIZER_BASE);
     if (parsed.origin !== SANITIZER_BASE) return fallback;
-    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+    const path = `${parsed.pathname}${parsed.search}${parsed.hash}`;
+    // The *normalized* pathname can start with "//" even when the raw
+    // candidate didn't (e.g. "/..//evil.com" → pathname "//evil.com"),
+    // and a protocol-relative string handed to router.push navigates
+    // cross-origin. Re-check the output, not just the input.
+    if (!path.startsWith("/") || path.startsWith("//") || path.startsWith("/\\")) {
+      return fallback;
+    }
+    return path;
   } catch {
     return fallback;
   }

--- a/pwa/lib/fetchWithTimeout.test.ts
+++ b/pwa/lib/fetchWithTimeout.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { fetchWithTimeout } from "./fetchWithTimeout";
 
 /**
@@ -6,35 +6,42 @@ import { fetchWithTimeout } from "./fetchWithTimeout";
  * (#371): the user's session cookies must only ever reach our own origin.
  * These tests pin that a cross-origin (or origin-confusing) target is
  * refused, and that the value actually handed to fetch() is same-origin.
+ *
+ * The unit env is `node` (no DOM), so — like sessionExpiry.test.ts — each
+ * case stands up a minimal fake `window` for the guard to read.
  */
+const ORIGIN = "https://app.test";
+
 describe("fetchWithTimeout same-origin guard", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-    vi.unstubAllGlobals();
+  let spy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    spy = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        ({ ok: true, status: 200 }) as unknown as Response,
+    );
+    (globalThis as { window?: unknown }).window = {
+      location: { origin: ORIGIN, href: `${ORIGIN}/now` },
+    };
+    vi.stubGlobal("fetch", spy);
   });
 
-  const stubFetch = () => {
-    const spy = vi.fn(
-      async (_input: RequestInfo | URL, _init?: RequestInit) => new Response("ok"),
-    );
-    vi.stubGlobal("fetch", spy);
-    return spy;
-  };
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete (globalThis as { window?: unknown }).window;
+  });
 
   /** The URL string actually handed to the stubbed fetch on its first call. */
-  const firstTarget = (spy: ReturnType<typeof stubFetch>): string =>
-    String(spy.mock.calls[0]?.[0]);
+  const firstTarget = (): string => String(spy.mock.calls[0]?.[0]);
 
   it("passes a plain same-origin path through to fetch", async () => {
-    const spy = stubFetch();
     await fetchWithTimeout("/api/me");
-    const target = firstTarget(spy);
-    expect(new URL(target).origin).toBe(window.location.origin);
+    const target = firstTarget();
+    expect(new URL(target).origin).toBe(ORIGIN);
     expect(new URL(target).pathname).toBe("/api/me");
   });
 
   it("refuses an absolute cross-origin URL", async () => {
-    const spy = stubFetch();
     await expect(fetchWithTimeout("https://evil.example/steal")).rejects.toThrow(
       /cross-origin/i,
     );
@@ -42,7 +49,6 @@ describe("fetchWithTimeout same-origin guard", () => {
   });
 
   it("refuses a protocol-relative target that would flip the host", async () => {
-    const spy = stubFetch();
     await expect(fetchWithTimeout("//evil.example/steal")).rejects.toThrow(
       /cross-origin/i,
     );
@@ -50,19 +56,17 @@ describe("fetchWithTimeout same-origin guard", () => {
   });
 
   it("never emits a cross-origin host even for an origin-confusing same-origin URL", async () => {
-    const spy = stubFetch();
     // `<origin>//evil.example/x` is same-origin (host is the app), but a
     // naive `new URL(pathname, origin)` re-parse of "//evil.example/x"
     // would treat it as protocol-relative and flip the host. The
     // component-assignment rebuild must keep the trusted origin.
-    await fetchWithTimeout(`${window.location.origin}//evil.example/x`);
-    const target = firstTarget(spy);
-    expect(new URL(target).origin).toBe(window.location.origin);
+    await fetchWithTimeout(`${ORIGIN}//evil.example/x`);
+    const target = firstTarget();
+    expect(new URL(target).origin).toBe(ORIGIN);
     expect(new URL(target).host).not.toBe("evil.example");
   });
 
   it("rejects an unparseable URL", async () => {
-    const spy = stubFetch();
     await expect(fetchWithTimeout("http://[::1")).rejects.toThrow(/invalid URL/i);
     expect(spy).not.toHaveBeenCalled();
   });

--- a/pwa/lib/fetchWithTimeout.test.ts
+++ b/pwa/lib/fetchWithTimeout.test.ts
@@ -14,15 +14,21 @@ describe("fetchWithTimeout same-origin guard", () => {
   });
 
   const stubFetch = () => {
-    const spy = vi.fn(async () => new Response("ok"));
+    const spy = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) => new Response("ok"),
+    );
     vi.stubGlobal("fetch", spy);
     return spy;
   };
 
+  /** The URL string actually handed to the stubbed fetch on its first call. */
+  const firstTarget = (spy: ReturnType<typeof stubFetch>): string =>
+    String(spy.mock.calls[0]?.[0]);
+
   it("passes a plain same-origin path through to fetch", async () => {
     const spy = stubFetch();
     await fetchWithTimeout("/api/me");
-    const target = spy.mock.calls[0][0] as string;
+    const target = firstTarget(spy);
     expect(new URL(target).origin).toBe(window.location.origin);
     expect(new URL(target).pathname).toBe("/api/me");
   });
@@ -50,7 +56,7 @@ describe("fetchWithTimeout same-origin guard", () => {
     // would treat it as protocol-relative and flip the host. The
     // component-assignment rebuild must keep the trusted origin.
     await fetchWithTimeout(`${window.location.origin}//evil.example/x`);
-    const target = spy.mock.calls[0][0] as string;
+    const target = firstTarget(spy);
     expect(new URL(target).origin).toBe(window.location.origin);
     expect(new URL(target).host).not.toBe("evil.example");
   });

--- a/pwa/lib/fetchWithTimeout.test.ts
+++ b/pwa/lib/fetchWithTimeout.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchWithTimeout } from "./fetchWithTimeout";
+
+/**
+ * The same-origin rebuild in fetchWithTimeout is the request-forgery guard
+ * (#371): the user's session cookies must only ever reach our own origin.
+ * These tests pin that a cross-origin (or origin-confusing) target is
+ * refused, and that the value actually handed to fetch() is same-origin.
+ */
+describe("fetchWithTimeout same-origin guard", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  const stubFetch = () => {
+    const spy = vi.fn(async () => new Response("ok"));
+    vi.stubGlobal("fetch", spy);
+    return spy;
+  };
+
+  it("passes a plain same-origin path through to fetch", async () => {
+    const spy = stubFetch();
+    await fetchWithTimeout("/api/me");
+    const target = spy.mock.calls[0][0] as string;
+    expect(new URL(target).origin).toBe(window.location.origin);
+    expect(new URL(target).pathname).toBe("/api/me");
+  });
+
+  it("refuses an absolute cross-origin URL", async () => {
+    const spy = stubFetch();
+    await expect(fetchWithTimeout("https://evil.example/steal")).rejects.toThrow(
+      /cross-origin/i,
+    );
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("refuses a protocol-relative target that would flip the host", async () => {
+    const spy = stubFetch();
+    await expect(fetchWithTimeout("//evil.example/steal")).rejects.toThrow(
+      /cross-origin/i,
+    );
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("never emits a cross-origin host even for an origin-confusing same-origin URL", async () => {
+    const spy = stubFetch();
+    // `<origin>//evil.example/x` is same-origin (host is the app), but a
+    // naive `new URL(pathname, origin)` re-parse of "//evil.example/x"
+    // would treat it as protocol-relative and flip the host. The
+    // component-assignment rebuild must keep the trusted origin.
+    await fetchWithTimeout(`${window.location.origin}//evil.example/x`);
+    const target = spy.mock.calls[0][0] as string;
+    expect(new URL(target).origin).toBe(window.location.origin);
+    expect(new URL(target).host).not.toBe("evil.example");
+  });
+
+  it("rejects an unparseable URL", async () => {
+    const spy = stubFetch();
+    await expect(fetchWithTimeout("http://[::1")).rejects.toThrow(/invalid URL/i);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/pwa/lib/fetchWithTimeout.ts
+++ b/pwa/lib/fetchWithTimeout.ts
@@ -36,8 +36,21 @@ function sameOriginTarget(input: RequestInfo | URL): RequestInfo | URL {
   if (resolved.origin !== window.location.origin) {
     throw new Error("Refusing to fetch a cross-origin URL.");
   }
-  // Host is the constant, trusted origin; only path/query/hash are caller-derived.
-  return new URL(resolved.pathname + resolved.search + resolved.hash, window.location.origin).href;
+  // Rebuild via component *assignment*, never re-parsing. Re-parsing the
+  // path (`new URL(path + …, origin)`) was exploitable: a same-origin URL
+  // like `https://app//evil.com/x` has pathname `//evil.com/x`, which a
+  // re-parse treats as protocol-relative — flipping the host to evil.com.
+  // Property setters are component-scoped: assigning `pathname` can never
+  // introduce an authority, so the trusted origin survives by construction.
+  const rebuilt = new URL(window.location.origin);
+  rebuilt.pathname = resolved.pathname;
+  rebuilt.search = resolved.search;
+  rebuilt.hash = resolved.hash;
+  // Belt and braces: the exact value handed to fetch() is same-origin.
+  if (rebuilt.origin !== window.location.origin) {
+    throw new Error("Refusing to fetch a cross-origin URL.");
+  }
+  return rebuilt.href;
 }
 
 /**


### PR DESCRIPTION
Resolves the critical CodeQL `js/request-forgery` alert (#16) blocking the production promote (#684).

## The flaw
`fetchWithTimeout`'s same-origin guard resolved the target, checked its origin, then rebuilt the URL with `new URL(resolved.pathname + search + hash, origin)`. That **re-parses the path string** — and a same-origin URL whose pathname begins `//host` (e.g. `https://app.example//evil.com/x`, which is genuinely same-origin — host is the app) yields pathname `//evil.com/x`, which `new URL(..., origin)` treats as **protocol-relative**, flipping the host to `evil.com`. The value then handed to `fetch()` — with the user's session cookies — would be cross-origin.

`safeNextPath` had the analogous issue: dot-segment normalisation (`/..//evil.com` → pathname `//evil.com`) can produce a protocol-relative string from a raw candidate that passed the `startsWith("//")` input check, and that string went to `router.push`.

## The fix
- **Rebuild by component assignment**, never re-parse: start from `new URL(origin)` and set `.pathname`/`.search`/`.hash`. URL component setters are authority-scoped — assigning a pathname can't introduce a host — so the trusted origin survives by construction. Re-assert `origin` on the final value as belt-and-braces.
- **`safeNextPath`**: re-check the *output* path for `//` / `/\`, not just the input.

Both were already defence-in-depth (callers only build same-origin paths), but the taint path is real and now closed — and CodeQL recognises the component-assignment rebuild as sanitised.

## Tests
- New `fetchWithTimeout.test.ts`: passes a plain path through; refuses absolute + protocol-relative cross-origin; **the origin-confusing `<origin>//evil.example/x` case never emits a cross-origin host**; rejects an unparseable URL.
- `authRedirect.test.ts`: `/..//evil.com`-style candidates that normalise to protocol-relative fall back to `/boards`.