### PR TITLE
fix(pages): serialize parent page as an IRI so the nav tree can nest

### DIFF
--- a/api/src/Entity/Page.php
+++ b/api/src/Entity/Page.php
@@ -5,6 +5,7 @@ namespace App\Entity;
 use ApiPlatform\Doctrine\Orm\Filter\OrderFilter;
 use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Get;
@@ -115,6 +116,9 @@ class Page
     #[ORM\ManyToOne(targetEntity: Page::class)]
     #[ORM\JoinColumn(nullable: true, onDelete: 'CASCADE')]
     #[Groups(['page:read', 'page:write'])]
+    // Serialize as an IRI, not an embedded object: the sidebar tree keys off
+    // the parent IRI, and embedding would recursively inline every ancestor.
+    #[ApiProperty(readableLink: false)]
     private ?Page $parent = null;
 
     /**


### PR DESCRIPTION
## What

`Page.parent` was serialized as an **embedded object** (recursively inlining every ancestor) instead of an IRI, because the relation shares the `page:read` group with the target's own fields.

The PWA sidebar's Pages tree keys off `parent` as an IRI string, so every page fell back to "root" → the tree rendered **flat**, and drag-to-nest never persisted (a nested drop rebuilt flat on refetch).

## Fix

Mark the relation `#[ApiProperty(readableLink: false)]` so it serializes as `/pages/{id}`, matching the frontend contract. Writes (drag-to-nest PATCH) are unaffected.

Verified against the running API — `parent` now returns `/pages/{uuid}` strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
