### PR TITLE
feat(pwa): full-bleed sidebar nav with a draggable, nestable page tree

### DIFF
--- a/pwa/components/common/Navbar.tsx
+++ b/pwa/components/common/Navbar.tsx
@@ -78,6 +78,7 @@ const Navbar = () => {
                   </SheetHeader>
                   <SidebarNav
                     includeSpaceSwitcher
+                    scrollable
                     itemWrapper={(child) => (
                       <SheetClose asChild>{child}</SheetClose>
                     )}

--- a/pwa/components/common/PagesNavTree.tsx
+++ b/pwa/components/common/PagesNavTree.tsx
@@ -20,7 +20,6 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { apiGetCollection, apiSend } from "@/lib/apiClient";
-import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import {
   applyMove,
@@ -31,6 +30,14 @@ import {
 } from "@/lib/pageTree";
 
 const INDENT = 14; // px per nesting level
+
+// Line page titles up with the other sidebar sections. The nav has no
+// horizontal padding, so every row is full-bleed and its 2px left accent border
+// sits at the sidebar's inner edge; a `size="sm"` ghost button's px-3 (12px)
+// plus the row span's pl-5 (20px) put their text at 34px. Page titles match:
+// 34 − 2 (border) = 32px, then one INDENT step per nesting level.
+const TITLE_BASE_INDENT = 32; // px
+const HANDLE_LEFT = 6; // px — grip inset from the row's (padding-box) left edge
 
 interface Props {
   spaceIri: string;
@@ -202,67 +209,72 @@ const PageRow = ({
   onToggle: () => void;
   wrap: (children: ReactNode) => ReactNode;
 }) => {
-  const { setNodeRef, attributes, listeners, transform, transition, isDragging } =
+  const { setNodeRef, listeners, transform, transition, isDragging } =
     useSortable({ id: item["@id"] });
   const href = `/pages/${item.id}`;
   const active = currentPath === href;
 
   return (
+    // The whole row is the drag source — grab the link anywhere to reorder or
+    // (drag sideways to) nest it, while a plain click still opens the page:
+    // dnd-kit's 4px activation distance tells a click from a drag. The row also
+    // carries the full-width hover + selection background, and the open/close
+    // disclosure is anchored on the right.
     <div
       ref={setNodeRef}
       style={{
         transform: CSS.Transform.toString(transform),
         transition,
-        paddingLeft: depth * INDENT,
       }}
       className={cn(
-        "group/pagerow relative flex items-center rounded-md",
-        active && "bg-accent text-accent-foreground",
-        isDragging && "opacity-60",
+        // Full-bleed row (the nav has no horizontal padding), square edges, and a
+        // 2px left accent border that turns the green theme color on hover /
+        // when active.
+        "group/pagerow relative flex h-8 cursor-grab select-none items-center gap-0.5 border-l-2 border-l-transparent pr-2 text-sm",
+        "hover:border-l-emerald-500 hover:bg-accent",
+        active && "border-l-emerald-500 bg-accent text-accent-foreground",
+        isDragging && "cursor-grabbing opacity-60",
       )}
       data-testid="pages-nav-row"
+      {...listeners}
     >
-      {item.childCount > 0 ? (
+      {/* Grip affordance, revealed on hover — a visual hint only; the whole row
+          is draggable. Pinned to the same fixed spot in the left gutter for
+          every page regardless of nesting depth. */}
+      <span
+        aria-hidden
+        style={{ left: HANDLE_LEFT }}
+        className="pointer-events-none absolute top-1/2 flex size-4 -translate-y-1/2 items-center justify-center text-muted-foreground/50 opacity-0 group-hover/pagerow:opacity-100"
+      >
+        <GripVertical className="size-3.5" />
+      </span>
+
+      {wrap(
+        <Link
+          href={href}
+          draggable={false}
+          style={{ paddingLeft: TITLE_BASE_INDENT + depth * INDENT }}
+          className="min-w-0 flex-1 truncate rounded-sm py-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+        >
+          {item.title}
+        </Link>,
+      )}
+
+      {/* Disclosure toggle on the right. Stop the pointer from starting a row
+          drag so a click just toggles open/closed. */}
+      {item.childCount > 0 && (
         <button
           type="button"
+          onPointerDown={(e) => e.stopPropagation()}
           onClick={onToggle}
           aria-label={collapsed ? "Expand" : "Collapse"}
-          className="shrink-0 rounded p-0.5 text-muted-foreground hover:text-foreground"
+          aria-expanded={!collapsed}
+          className="relative z-10 shrink-0 rounded p-0.5 text-muted-foreground hover:text-foreground"
         >
           <ChevronRight
             className={cn("size-3.5 transition-transform", !collapsed && "rotate-90")}
           />
         </button>
-      ) : (
-        <span className="w-[1.375rem] shrink-0" aria-hidden />
-      )}
-
-      {/* Drag handle overlays the right edge on hover so it doesn't indent the
-          row text (which should line up with the other nav sections). */}
-      <button
-        type="button"
-        aria-label={`Reorder ${item.title}`}
-        className="absolute right-1 top-1/2 z-10 -translate-y-1/2 cursor-grab rounded bg-accent p-0.5 text-muted-foreground/60 opacity-0 hover:text-foreground group-hover/pagerow:opacity-100"
-        {...attributes}
-        {...listeners}
-      >
-        <GripVertical className="size-3.5" />
-      </button>
-
-      {wrap(
-        <Button
-          asChild
-          variant="ghost"
-          size="sm"
-          className={cn(
-            "h-8 w-full min-w-0 justify-start font-normal",
-            active && "bg-transparent",
-          )}
-        >
-          <Link href={href}>
-            <span className="truncate">{item.title}</span>
-          </Link>
-        </Button>,
       )}
     </div>
   );

--- a/pwa/components/common/SearchBar.tsx
+++ b/pwa/components/common/SearchBar.tsx
@@ -194,7 +194,7 @@ const SearchBar = ({ className }: SearchBarProps = {}) => {
             }}
             onFocus={() => setOpen(true)}
             onKeyDown={onKeyDown}
-            placeholder="Search tasks…  ⌘K"
+            placeholder="Search tasks…"
             className="h-8 w-full pl-8"
             data-testid="navbar-search"
             aria-label="Search tasks"

--- a/pwa/components/common/Sidebar.tsx
+++ b/pwa/components/common/Sidebar.tsx
@@ -9,17 +9,18 @@ import SidebarNav from "./SidebarNav";
  * Renders nothing when the user isn't signed in — the public-facing
  * marketing/auth screens keep the original full-width chrome.
  *
- * Full viewport height, pinned to the left edge (`sticky top-0 h-screen`):
- * the header (banner + navbar) lives in the content column to its right, so
- * the space switcher at the top of the nav sits above everything. Its own
- * content scrolls internally (SidebarNav's `overflow-y-auto`).
+ * Sits in normal document flow and stretches to the row height (the parent
+ * layout row is `min-h-screen`), so the border + background always run the
+ * full page height. It grows with its own content rather than scrolling
+ * internally — a nav taller than the viewport makes the whole page grow and
+ * the document scroll as one (no separate sidebar scrollbar).
  */
 const Sidebar = () => {
   const { isAuthenticated } = useAuth();
   if (!isAuthenticated) return null;
   return (
     <aside
-      className="hidden md:flex w-60 shrink-0 border-r bg-background flex-col sticky top-0 h-screen"
+      className="hidden md:flex w-64 shrink-0 border-r bg-background flex-col"
       data-testid="app-sidebar"
     >
       <SidebarNav includeSpaceSwitcher />

--- a/pwa/components/common/SidebarNav.tsx
+++ b/pwa/components/common/SidebarNav.tsx
@@ -21,6 +21,18 @@ import { cn } from "@/lib/utils";
 import PagesNavTree from "./PagesNavTree";
 import SpaceSwitcher from "./SpaceSwitcher";
 
+// Shared styling for every sidebar nav item: a full-bleed row (the nav carries
+// no horizontal padding) with square edges and a 2px left accent border that
+// turns the green theme color on hover / when active. Mirrors PagesNavTree's
+// page rows so the whole sidebar reads as one system.
+const NAV_ITEM_CLASS =
+  "w-full min-w-0 justify-start gap-1.5 rounded-none border-l-2 border-l-transparent font-normal hover:border-l-emerald-500";
+const NAV_ITEM_ACTIVE_CLASS =
+  "border-l-emerald-500 bg-accent text-accent-foreground";
+// Section heading: same 2px transparent left inset so its label lines up with
+// the item rows below it.
+const NAV_HEADING_CLASS = "border-l-2 border-l-transparent";
+
 // The account menu (avatar + personal links + sign out + stop
 // impersonation) and the notification bell live in the top bar now —
 // see UserMenu / Navbar. The sidebar carries the space switcher, the
@@ -111,6 +123,13 @@ interface SidebarNavProps {
    * variant (where there's no room for it in the top bar) sets this.
    */
   includeSpaceSwitcher?: boolean;
+  /**
+   * Fill the container's height and scroll internally. The mobile Sheet
+   * (a fixed, viewport-height panel) sets this so a long nav scrolls
+   * inside the sheet. The persistent desktop sidebar leaves it off so the
+   * nav grows with its content and the whole page scrolls as one.
+   */
+  scrollable?: boolean;
 }
 
 interface ContentSectionProps {
@@ -157,7 +176,7 @@ const ContentSection = ({ section, spaceIri, wrap }: ContentSectionProps) => {
 
   return (
     <div className="mt-3 first:mt-0">
-      <div className="flex items-center px-3 pb-1">
+      <div className={cn("flex items-center px-3 pb-1", NAV_HEADING_CLASS)}>
         {wrap(
           <Link
             href={aggregatorHref}
@@ -192,7 +211,7 @@ const ContentSection = ({ section, spaceIri, wrap }: ContentSectionProps) => {
                   asChild
                   variant="ghost"
                   size="sm"
-                  className="w-full justify-start font-normal text-muted-foreground"
+                  className={cn(NAV_ITEM_CLASS, "text-muted-foreground")}
                 >
                   <Link href={aggregatorHref}>
                     <Plus className="size-4" />
@@ -228,9 +247,9 @@ const ContentSection = ({ section, spaceIri, wrap }: ContentSectionProps) => {
                         variant="ghost"
                         size="sm"
                         className={cn(
-                          "w-full min-w-0 justify-start font-normal",
+                          NAV_ITEM_CLASS,
                           currentPath === href &&
-                            "bg-accent text-accent-foreground",
+                            NAV_ITEM_ACTIVE_CLASS,
                         )}
                       >
                         <Link href={href}>
@@ -297,11 +316,6 @@ const AdminSection = ({ wrap }: { wrap: (children: ReactNode) => ReactNode }) =>
       label: "Global custom fields",
       match: "/admin/global-custom-fields",
     },
-    {
-      href: "/admin/sentry-test",
-      label: "Sentry test",
-      match: "/admin/sentry-test",
-    },
     { href: "/feedback", label: "Feedback", match: "/feedback" },
     ...ADMIN_EXTERNAL_LINKS.map((l) => ({ ...l, match: l.href, external: true })),
   ];
@@ -313,7 +327,7 @@ const AdminSection = ({ wrap }: { wrap: (children: ReactNode) => ReactNode }) =>
         onClick={toggle}
         aria-expanded={!collapsed}
         aria-label={`${collapsed ? "Expand" : "Collapse"} Admin`}
-        className="flex w-full items-center gap-1.5 px-3 pb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground hover:text-foreground"
+        className={cn("flex w-full items-center gap-1.5 px-3 pb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground hover:text-foreground", NAV_HEADING_CLASS)}
       >
         <ShieldCheck className="size-3.5 shrink-0 text-amber-600 dark:text-amber-400" />
         <span className="truncate">Admin</span>
@@ -334,8 +348,8 @@ const AdminSection = ({ wrap }: { wrap: (children: ReactNode) => ReactNode }) =>
               variant="ghost"
               size="sm"
               className={cn(
-                "w-full min-w-0 justify-start font-normal",
-                active && "bg-accent text-accent-foreground",
+                NAV_ITEM_CLASS,
+                active && NAV_ITEM_ACTIVE_CLASS,
               )}
             >
               {link.external ? (
@@ -425,7 +439,7 @@ const UserManagementSection = ({
         onClick={toggle}
         aria-expanded={!collapsed}
         aria-label={`${collapsed ? "Expand" : "Collapse"} User management`}
-        className="flex w-full items-center gap-1.5 px-3 pb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground hover:text-foreground"
+        className={cn("flex w-full items-center gap-1.5 px-3 pb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground hover:text-foreground", NAV_HEADING_CLASS)}
       >
         <Users className="size-3.5 shrink-0 text-indigo-600 dark:text-indigo-400" />
         <span className="truncate">User management</span>
@@ -448,8 +462,8 @@ const UserManagementSection = ({
                   variant="ghost"
                   size="sm"
                   className={cn(
-                    "w-full min-w-0 justify-start font-normal",
-                    active && "bg-accent text-accent-foreground",
+                    NAV_ITEM_CLASS,
+                    active && NAV_ITEM_ACTIVE_CLASS,
                   )}
                 >
                   <Link href={link.href}>
@@ -506,7 +520,7 @@ const TaxonomySection = ({
         onClick={toggle}
         aria-expanded={!collapsed}
         aria-label={`${collapsed ? "Expand" : "Collapse"} Taxonomy`}
-        className="flex w-full items-center gap-1.5 px-3 pb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground hover:text-foreground"
+        className={cn("flex w-full items-center gap-1.5 px-3 pb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground hover:text-foreground", NAV_HEADING_CLASS)}
       >
         <Tag className="size-3.5 shrink-0 text-teal-600 dark:text-teal-400" />
         <span className="truncate">Taxonomy</span>
@@ -529,8 +543,8 @@ const TaxonomySection = ({
                   variant="ghost"
                   size="sm"
                   className={cn(
-                    "w-full min-w-0 justify-start font-normal",
-                    active && "bg-accent text-accent-foreground",
+                    NAV_ITEM_CLASS,
+                    active && NAV_ITEM_ACTIVE_CLASS,
                   )}
                 >
                   <Link href={link.href}>
@@ -597,7 +611,7 @@ const BillingSection = ({
         onClick={toggle}
         aria-expanded={!collapsed}
         aria-label={`${collapsed ? "Expand" : "Collapse"} Billing`}
-        className="flex w-full items-center gap-1.5 px-3 pb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground hover:text-foreground"
+        className={cn("flex w-full items-center gap-1.5 px-3 pb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground hover:text-foreground", NAV_HEADING_CLASS)}
       >
         <CreditCard className="size-3.5 shrink-0 text-orange-600 dark:text-orange-400" />
         <span className="truncate">Billing</span>
@@ -620,8 +634,8 @@ const BillingSection = ({
                   variant="ghost"
                   size="sm"
                   className={cn(
-                    "w-full min-w-0 justify-start font-normal",
-                    active && "bg-accent text-accent-foreground",
+                    NAV_ITEM_CLASS,
+                    active && NAV_ITEM_ACTIVE_CLASS,
                   )}
                 >
                   <Link href={href}>
@@ -647,6 +661,7 @@ const BillingSection = ({
 const SidebarNav = ({
   itemWrapper,
   includeSpaceSwitcher = false,
+  scrollable = false,
 }: SidebarNavProps) => {
   const { user, isAuthenticated } = useAuth();
   const { activeSpace, isActiveSpaceAdmin, can } = useActiveSpace();
@@ -660,14 +675,22 @@ const SidebarNav = ({
   const calendarActive = router.pathname === "/calendar";
 
   return (
-    <div className="flex h-full flex-col">
+    <div className={cn("flex flex-col", scrollable && "h-full")}>
       {includeSpaceSwitcher && (
-        <div className="px-2 pt-4 pb-2">
+        // Match the navbar's height + bottom border so the switcher's bottom
+        // edge lines up with the top bar's across the two columns, and pin it
+        // to the top like the navbar so it stays put as the page scrolls.
+        <div className="sticky top-0 z-40 h-14 shrink-0 border-b bg-background">
           <SpaceSwitcher />
         </div>
       )}
 
-      <nav className="flex flex-col gap-0.5 px-2 pt-2 pb-4 flex-1 overflow-y-auto">
+      <nav
+        className={cn(
+          "flex flex-col gap-0.5 px-0 pt-2 pb-4",
+          scrollable && "flex-1 overflow-y-auto",
+        )}
+      >
         {activeSpace && (
           <span>
             {wrap(
@@ -676,8 +699,8 @@ const SidebarNav = ({
                 variant="ghost"
                 size="sm"
                 className={cn(
-                  "w-full min-w-0 justify-start gap-1.5 font-normal",
-                  calendarActive && "bg-accent text-accent-foreground",
+                  NAV_ITEM_CLASS,
+                  calendarActive && NAV_ITEM_ACTIVE_CLASS,
                 )}
               >
                 <Link href="/calendar">
@@ -713,9 +736,9 @@ const SidebarNav = ({
                 variant="ghost"
                 size="sm"
                 className={cn(
-                  "w-full min-w-0 justify-start gap-1.5 font-normal",
+                  NAV_ITEM_CLASS,
                   router.pathname === "/spaces/[id]/settings" &&
-                    "bg-accent text-accent-foreground",
+                    NAV_ITEM_ACTIVE_CLASS,
                 )}
               >
                 <Link href={`/spaces/${activeSpace.id}/settings`}>

--- a/pwa/components/common/SpaceSwitcher.tsx
+++ b/pwa/components/common/SpaceSwitcher.tsx
@@ -31,7 +31,9 @@ const SpaceSwitcher = () => {
 
   if (isLoading && spaces.length === 0) {
     return (
-      <div className="px-2 text-xs text-muted-foreground">Loading…</div>
+      <div className="flex h-full items-center px-3 text-xs text-muted-foreground">
+        Loading…
+      </div>
     );
   }
 
@@ -66,8 +68,8 @@ const SpaceSwitcher = () => {
           data-testid="space-switcher"
           aria-label={`Active space: ${activeSpace.name}`}
           className={cn(
-            "w-full flex items-center gap-2 rounded-md border bg-background px-2 py-1.5 text-sm",
-            "hover:bg-accent focus:outline-none focus:ring-2 focus:ring-ring",
+            "flex h-full w-full items-center gap-2 px-3 text-sm",
+            "hover:bg-accent focus:outline-none focus:ring-2 focus:ring-inset focus:ring-ring",
           )}
         >
           <SpaceTile


### PR DESCRIPTION
## Sidebar & page-navigator polish

- **Grows with the page** — the sidebar no longer scrolls on its own; the whole page scrolls as one. The **space switcher is sticky** and matches the navbar's height so their bottom borders line up.
- **Full-bleed accent-bar nav** — every item (Calendar, content sections + their rows and "New…" links, Taxonomy/Billing/User-management/Admin, Settings, and the page tree) is edge-to-edge, square, with a 2px left border that turns **emerald** on hover/active. Shared `NAV_ITEM_*` constants keep it consistent.
- **Draggable page tree** — grab a page link anywhere to reorder (vertical) or nest (horizontal); a plain click still opens it (dnd-kit 4px activation). The open/close disclosure moved to the right; the grip is a fixed-position hover hint.
- **Search bar** — removed the `⌘K` placeholder hint (the command-palette shortcut itself is unchanged).
- **Wider sidebar column** for more link room.

> Note: drag-to-**nest** only persists once the companion API fix (page `parent` serialized as an IRI) also lands — before that the tree can't rebuild nested on refetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
