### PR TITLE
chore(fixtures): seed all new billing surfaces in the everything space

### DIFF
--- a/api/src/DataFixtures/AdminDeskFixtures.php
+++ b/api/src/DataFixtures/AdminDeskFixtures.php
@@ -11,10 +11,16 @@ use App\Entity\CustomFieldValue;
 use App\Entity\Discussion;
 use App\Entity\Engagement;
 use App\Entity\EngagementCategory;
+use App\Entity\Estimate;
+use App\Entity\EstimateLineItem;
+use App\Entity\Expense;
+use App\Entity\ExpenseCategory;
 use App\Entity\Invoice;
 use App\Entity\InvoiceLineItem;
+use App\Entity\InvoicePayment;
 use App\Entity\MediaObject;
 use App\Entity\Page;
+use App\Entity\RetainerTransaction;
 use App\Entity\Space;
 use App\Entity\SpaceMembership;
 use App\Entity\Tag;
@@ -22,6 +28,7 @@ use App\Entity\Task;
 use App\Entity\TaskRelationship;
 use App\Entity\TaskSection;
 use App\Entity\TimeEntry;
+use App\Entity\TimesheetSubmission;
 use App\Entity\User;
 use App\Entity\UserGroup;
 use Doctrine\Bundle\FixturesBundle\Fixture;
@@ -37,9 +44,19 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
  *    every content type: a board (with task sections, tasks — one recurring
  *    with a reminder, a custom field & value, a task relationship, and task
  *    comments), a page with a sub-page and a page comment, a discussion +
- *    comment, tags, groups, and the full billing chain (client → engagement
- *    with a category/rate → a tracked time entry → a draft invoice). It also
- *    holds a second, deliberately **empty board** for the empty-state UI.
+ *    comment, tags, groups, and the **full billing chain**: client (with a
+ *    portal link + address) → engagement (with a fees budget) with a
+ *    category/rate → tracked time → a draft invoice, plus every
+ *    Harvest-parity surface — invoice branding (logo/terms/number series),
+ *    per-person cost rates, managed expense categories (incl. a unit-priced
+ *    mileage one), billable expenses with a receipt, a sent estimate, a
+ *    client retainer deposit, a sent invoice with a discount + per-line tax
+ *    + a partial payment, and a pending timesheet submission. It also holds
+ *    a second, deliberately **empty board** for the empty-state UI.
+ *
+ *    Testable public links (tokens are seeded, plaintext shown here):
+ *    `/portal/demo-portal-token`, `/i/demo-invoice-token`,
+ *    `/e/demo-estimate-token`.
  *  - **nothing** — a deliberately empty shared space, so the empty-space UI
  *    is reachable without deleting anything.
  *
@@ -84,11 +101,17 @@ class AdminDeskFixtures extends Fixture implements DependentFixtureInterface
         $manager->flush();
         $this->addReference(self::ADMIN_DESK_SPACE_REFERENCE, $desk);
 
-        // Members: Ada (admin) plus a few teammates.
-        $manager->persist((new SpaceMembership())->setSpace($desk)->setUser($ada)->setRole(Space::ROLE_ADMIN));
-        foreach ([$noah, $emma, $liam] as $member) {
+        // Members: Ada (admin) plus a few teammates. Each carries a per-person
+        // cost rate (#653) so the profitability report has real numbers.
+        $manager->persist(
+            (new SpaceMembership())->setSpace($desk)->setUser($ada)
+                ->setRole(Space::ROLE_ADMIN)->setCostRateAmount(9000),
+        );
+        $memberCostRates = [5000, 6500, 7000];
+        foreach ([$noah, $emma, $liam] as $i => $member) {
             $manager->persist(
-                (new SpaceMembership())->setSpace($desk)->setUser($member)->setRole(Space::ROLE_MEMBER),
+                (new SpaceMembership())->setSpace($desk)->setUser($member)
+                    ->setRole(Space::ROLE_MEMBER)->setCostRateAmount($memberCostRates[$i]),
             );
         }
 
@@ -260,6 +283,9 @@ class AdminDeskFixtures extends Fixture implements DependentFixtureInterface
         $engagement = (new Engagement())
             ->setSpace($desk)->setClient($client)->setCreatedBy($ada)
             ->setName('Acme website')->setCurrency('USD')
+            // Fees budget (#651): $10,000, with ~$2,400 tracked so the budget
+            // meter shows partial consumption (not empty, not over).
+            ->setBudgetType(Engagement::BUDGET_FEES)->setBudgetAmount(1000000)->setBudgetSpent(240000)
             ->setDescription(
                 "## Scope\n\nBuild + launch the Acme marketing site.\n\n"
                 . "- Net-30 terms\n- Weekly status call\n- Contract on file in the Files tab",
@@ -305,6 +331,151 @@ class AdminDeskFixtures extends Fixture implements DependentFixtureInterface
                 ->setQuantity(2.0)->setUnitAmount(12000)->setAmount(24000)->setPosition(0),
         );
         $manager->persist($invoice);
+
+        // --- New billing surfaces (Harvest-parity sprint) ---
+
+        // Invoice branding (#669): a seeded logo (avatar-kind media on the
+        // public /media route), default terms, and a per-space number series.
+        $logoImg = imagecreatetruecolor(160, 48);
+        if (false !== $logoImg) {
+            imagefilledrectangle($logoImg, 0, 0, 160, 48, (int) imagecolorallocate($logoImg, 13, 148, 136));
+            imagestring($logoImg, 5, 14, 16, 'ACME', (int) imagecolorallocate($logoImg, 255, 255, 255));
+            ob_start();
+            imagepng($logoImg);
+            $logoBytes = (string) ob_get_clean();
+            imagedestroy($logoImg);
+            $logoPath = 'avatars/fixture-acme-logo.png';
+            $this->storage->write($logoPath, $logoBytes);
+            $logo = (new MediaObject())
+                ->setOwner($ada)->setKind(MediaObject::KIND_AVATAR)
+                ->setVariants(['original' => $logoPath])
+                ->setOriginalName('acme-logo.png')->setMimeType('image/png')
+                ->setByteSize(\strlen($logoBytes));
+            $manager->persist($logo);
+            $desk->setInvoiceLogo($logo);
+        }
+        $desk
+            ->setInvoiceTerms("Payment due within 30 days. Thanks for your business!")
+            ->setInvoiceNumberPrefix('ACME-')->setInvoiceNumberNext(43);
+
+        // Client portal (#674) + a billing address. The token is stored
+        // sha256-hashed; visit /portal/demo-portal-token to open the portal.
+        $client->setAddress("123 Market St\nSpringfield, USA")
+            ->setPortalToken(hash('sha256', 'demo-portal-token'));
+
+        // Managed expense categories (#671) — incl. a unit-priced mileage one.
+        $catTravel = (new ExpenseCategory())->setSpace($desk)->setName('Travel');
+        $catSoftware = (new ExpenseCategory())->setSpace($desk)->setName('Software');
+        $catMileage = (new ExpenseCategory())->setSpace($desk)->setName('Mileage')->setUnitAmount(65);
+        foreach ([$catTravel, $catSoftware, $catMileage] as $cat) {
+            $manager->persist($cat);
+        }
+
+        // Expenses (#650) — a billable one with a receipt image + a category,
+        // and a non-billable one. The receipt rides the gated media download
+        // and embeds into the invoice PDF (#672).
+        $receiptImg = imagecreatetruecolor(200, 120);
+        $receiptPath = null;
+        if (false !== $receiptImg) {
+            imagefilledrectangle($receiptImg, 0, 0, 200, 120, (int) imagecolorallocate($receiptImg, 245, 245, 245));
+            imagestring($receiptImg, 4, 20, 50, 'RECEIPT $84.20', (int) imagecolorallocate($receiptImg, 30, 30, 30));
+            ob_start();
+            imagepng($receiptImg);
+            $receiptBytes = (string) ob_get_clean();
+            imagedestroy($receiptImg);
+            $receiptPath = 'attachments/fixture-hotel-receipt.png';
+            $this->storage->write($receiptPath, $receiptBytes);
+        }
+        $receipt = null;
+        if (null !== $receiptPath) {
+            $receipt = (new MediaObject())
+                ->setOwner($ada)->setKind(MediaObject::KIND_ATTACHMENT)
+                ->setVariants(['original' => $receiptPath])
+                ->setOriginalName('hotel-receipt.png')->setMimeType('image/png')
+                ->setByteSize(\strlen($receiptBytes));
+            $manager->persist($receipt);
+        }
+        $hotel = (new Expense())
+            ->setSpace($desk)->setEngagement($engagement)->setUser($ada)
+            ->setSpentOn(new \DateTimeImmutable('-4 days'))
+            ->setExpenseCategory($catTravel)->setDescription('Hotel — onsite kickoff')
+            ->setAmount(8420)->setCurrency('USD')->setBillable(true);
+        if (null !== $receipt) {
+            $hotel->setReceipt($receipt);
+        }
+        $manager->persist($hotel);
+        $manager->persist(
+            (new Expense())
+                ->setSpace($desk)->setEngagement($engagement)->setUser($ada)
+                ->setSpentOn(new \DateTimeImmutable('-3 days'))
+                ->setExpenseCategory($catSoftware)->setDescription('Figma seat')
+                ->setAmount(1500)->setCurrency('USD')->setBillable(false),
+        );
+
+        // An estimate (#652) — sent, awaiting the client's decision. Visit
+        // /e/demo-estimate-token for the public accept/decline page.
+        $estimate = (new Estimate())
+            ->setSpace($desk)->setClient($client)->setCreatedBy($ada)
+            ->setNumber('EST-0001')->setStatus(Estimate::STATUS_SENT)
+            ->setCurrency('USD')->setTaxRate(0)
+            ->setNotes('Ballpark for phase 2 — CMS migration + blog.')
+            ->setSubtotal(450000)->setTaxAmount(0)->setTotal(450000)
+            ->setPublicToken(hash('sha256', 'demo-estimate-token'))
+            ->setSentAt(new \DateTimeImmutable('-2 days'));
+        $estimate->addLineItem(
+            (new EstimateLineItem())->setDescription('CMS migration')
+                ->setQuantity(25.0)->setUnitAmount(12000)->setAmount(300000)->setPosition(0),
+        );
+        $estimate->addLineItem(
+            (new EstimateLineItem())->setDescription('Blog build-out')
+                ->setQuantity(12.5)->setUnitAmount(12000)->setAmount(150000)->setPosition(1),
+        );
+        $manager->persist($estimate);
+
+        // Client retainer (#673): a $2,000 deposit on the ledger, ready to
+        // draw down against an invoice from the invoice detail page.
+        $manager->persist(
+            (new RetainerTransaction())->setClient($client)
+                ->setType(RetainerTransaction::TYPE_DEPOSIT)->setAmount(200000)
+                ->setNote('Q3 retainer')->setCreatedBy($ada),
+        );
+
+        // A sent invoice exercising discounts (#648), per-line tax (#670), and
+        // a recorded partial payment (#648). $1,000 − 10% + tax on one line,
+        // half paid. Visit /i/demo-invoice-token for the public pay page.
+        $sentInvoice = (new Invoice())
+            ->setSpace($desk)->setClient($client)->setCreatedBy($ada)
+            ->setNumber('ACME-0042')->setCurrency('USD')->setStatus(Invoice::STATUS_SENT)
+            ->setIssueDate(new \DateTimeImmutable('-10 days'))
+            ->setDueDate(new \DateTimeImmutable('+20 days'))
+            ->setTaxRate(0)
+            ->setDiscountType(Invoice::DISCOUNT_PERCENT)->setDiscountValue(1000)
+            // subtotal 100000; −10% = 90000 taxable; line B taxed 8.75% on its
+            // discounted share (60000×0.9×0.0875 ≈ 4725); total ≈ 94725.
+            ->setSubtotal(100000)->setDiscountAmount(10000)->setTaxAmount(4725)->setTotal(94725)
+            ->setPublicToken(hash('sha256', 'demo-invoice-token'));
+        $sentInvoice->addLineItem(
+            (new InvoiceLineItem())->setDescription('Development — Discovery')
+                ->setQuantity(4.0)->setUnitAmount(10000)->setAmount(40000)->setPosition(0),
+        );
+        $sentInvoice->addLineItem(
+            (new InvoiceLineItem())->setDescription('Development — Build (taxable)')
+                ->setQuantity(5.0)->setUnitAmount(12000)->setAmount(60000)->setTaxRate(875)->setPosition(1),
+        );
+        $sentInvoice->addPayment(
+            (new InvoicePayment())->setAmount(47000)->setPaidOn(new \DateTimeImmutable('-5 days'))
+                ->setMethod(InvoicePayment::METHOD_MANUAL)->setNote('Bank transfer — deposit')
+                ->setCreatedBy($ada),
+        );
+        $manager->persist($sentInvoice);
+
+        // A pending timesheet submission (#654) awaiting Ada's approval, so
+        // the /approvals queue has a row.
+        $manager->persist(
+            (new TimesheetSubmission())->setSpace($desk)->setUser($noah)
+                ->setWeekStart(new \DateTimeImmutable('monday last week'))
+                ->setStatus(TimesheetSubmission::STATUS_PENDING),
+        );
 
         // A second, deliberately empty board — for exercising the empty-state UI.
         $emptyBoard = (new Board())


### PR DESCRIPTION
Expands `AdminDeskFixtures` so an admin sign-in demos every Harvest-parity feature shipped this sprint — invoice branding (logo/terms/number series), per-person cost rates, managed expense categories (incl. unit-priced mileage), billable expenses with a receipt, a sent estimate, a client retainer deposit, a sent invoice with discount + per-line tax + partial payment, a client portal token, and a pending timesheet submission.

Verified by CI's **Load fixtures** step in the E2E job (Docker won't run on my machine right now, so this is the load path).

Seeded public tokens for manual testing: `/portal/demo-portal-token`, `/i/demo-invoice-token`, `/e/demo-estimate-token`.