### PR TITLE
feat(invoices): recurrence end conditions + time-tracking docs (#598)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,7 @@ Developer docs:
 - `docs/developer/web-push.md` - Web Push (#100): PushSubscription, WebPushSender, the service worker + enable flow, VAPID key setup
 - `docs/developer/task-organization.md` - Task sections, the Kanban board view, and task relationships (entities, endpoints, validation, UI)
 - `docs/developer/billing.md` - Billing & the freemium gate: the Team plan, hybrid seat/usage caps, Stripe Checkout/Portal + webhook, enforcement flag, going-live setup
+- `docs/developer/time-tracking-invoicing.md` - Client-facing time tracking + invoicing: the Client→Project→Service→TimeEntry→Invoice chain, entities, endpoints, permission model, the payment-gateway registry, and the recurring/overdue jobs
 - `docs/developer/blog.md` - Public file-based blog: markdown posts + frontmatter, SSG rendering, SEO meta, generated sitemap, drafts
 
 User docs:

--- a/api/migrations/Version20260719120000.php
+++ b/api/migrations/Version20260719120000.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Recurring-invoice end conditions (#598): add nullable `recurrence_end_date`
+ * ("until" date) and `recurrence_count` ("after N invoices") to `invoice`. Both
+ * null = recurs forever; at most one may be set. Purely additive.
+ */
+final class Version20260719120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add recurrence_end_date + recurrence_count end conditions to invoice (#598).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE invoice ADD recurrence_end_date DATE DEFAULT NULL');
+        $this->addSql('ALTER TABLE invoice ADD recurrence_count INT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE invoice DROP recurrence_end_date');
+        $this->addSql('ALTER TABLE invoice DROP recurrence_count');
+    }
+}

--- a/api/src/Entity/Invoice.php
+++ b/api/src/Entity/Invoice.php
@@ -176,7 +176,10 @@ class Invoice
     /**
      * When set, this invoice is a recurring template: the sweep clones it into a
      * fresh draft each time {@see $nextIssueDate} arrives. One of weekly / monthly
-     * / yearly, repeated every {@see $recurrenceInterval}.
+     * / yearly, repeated every {@see $recurrenceInterval}. Recurrence runs forever
+     * unless an end condition is set — at most one of {@see $recurrenceEndDate}
+     * (stop once the next issue date passes it) or {@see $recurrenceCount}
+     * (remaining invoices to generate; decremented on each spawn).
      */
     #[ORM\Column(length: 10, nullable: true)]
     #[Assert\Choice(choices: self::FREQUENCIES, message: 'Invalid recurrence frequency.')]
@@ -191,6 +194,24 @@ class Invoice
     #[ORM\Column(type: 'date_immutable', nullable: true)]
     #[Groups(['invoice:read', 'invoice:write'])]
     private ?\DateTimeImmutable $nextIssueDate = null;
+
+    /**
+     * "Until" end condition: recurrence stops once the advanced next issue date
+     * would pass this date. Mutually exclusive with {@see $recurrenceCount}.
+     */
+    #[ORM\Column(type: 'date_immutable', nullable: true)]
+    #[Groups(['invoice:read', 'invoice:write'])]
+    private ?\DateTimeImmutable $recurrenceEndDate = null;
+
+    /**
+     * "After N invoices" end condition: the number of invoices still to be
+     * generated from this template. Decremented on each spawn; recurrence ends
+     * when it reaches zero. Mutually exclusive with {@see $recurrenceEndDate}.
+     */
+    #[ORM\Column(type: 'integer', nullable: true)]
+    #[Assert\Positive]
+    #[Groups(['invoice:read', 'invoice:write'])]
+    private ?int $recurrenceCount = null;
 
     /**
      * @var Collection<int, InvoiceLineItem>
@@ -330,6 +351,25 @@ class Invoice
                     ->atPath('nextIssueDate')
                     ->addViolation();
             }
+            if (null !== $this->recurrenceEndDate && null !== $this->recurrenceCount) {
+                $context->buildViolation('Choose one end condition: an end date or a number of invoices, not both.')
+                    ->atPath('recurrenceEndDate')
+                    ->addViolation();
+            }
+            if (
+                null !== $this->recurrenceEndDate && null !== $this->nextIssueDate
+                && $this->recurrenceEndDate < $this->nextIssueDate
+            ) {
+                $context->buildViolation('The recurrence end date must be on or after the next issue date.')
+                    ->atPath('recurrenceEndDate')
+                    ->addViolation();
+            }
+        } elseif (null !== $this->recurrenceEndDate || null !== $this->recurrenceCount) {
+            // End conditions are meaningless without a recurrence — reject rather
+            // than silently store dangling values.
+            $context->buildViolation('An end condition requires a recurrence frequency.')
+                ->atPath('recurrenceFrequency')
+                ->addViolation();
         }
     }
 
@@ -386,6 +426,46 @@ class Invoice
     public function setNextIssueDate(?\DateTimeImmutable $nextIssueDate): self
     {
         $this->nextIssueDate = $nextIssueDate;
+
+        return $this;
+    }
+
+    public function getRecurrenceEndDate(): ?\DateTimeImmutable
+    {
+        return $this->recurrenceEndDate;
+    }
+
+    public function setRecurrenceEndDate(?\DateTimeImmutable $recurrenceEndDate): self
+    {
+        $this->recurrenceEndDate = $recurrenceEndDate;
+
+        return $this;
+    }
+
+    public function getRecurrenceCount(): ?int
+    {
+        return $this->recurrenceCount;
+    }
+
+    public function setRecurrenceCount(?int $recurrenceCount): self
+    {
+        $this->recurrenceCount = $recurrenceCount;
+
+        return $this;
+    }
+
+    /**
+     * Stops recurrence: clears the frequency/interval/next-issue-date and both
+     * end conditions so the template drops out of the due-recurring sweep and
+     * reads as a plain (non-recurring) invoice.
+     */
+    public function endRecurrence(): self
+    {
+        $this->recurrenceFrequency = null;
+        $this->recurrenceInterval = null;
+        $this->nextIssueDate = null;
+        $this->recurrenceEndDate = null;
+        $this->recurrenceCount = null;
 
         return $this;
     }

--- a/api/src/Service/RecurringInvoiceSpawner.php
+++ b/api/src/Service/RecurringInvoiceSpawner.php
@@ -13,6 +13,11 @@ use Doctrine\ORM\EntityManagerInterface;
  * or its lines' time-entry links) — then advances the template's next issue date
  * by one interval. One clone + one advance per template per run; a template
  * still due after that is picked up on the next daily run.
+ *
+ * A template with an end condition (#598) stops after this spawn when its
+ * remaining count hits zero or the advanced next issue date would pass its end
+ * date — {@see Invoice::endRecurrence()} clears the recurrence so it drops out
+ * of the sweep.
  */
 final class RecurringInvoiceSpawner
 {
@@ -57,10 +62,7 @@ final class RecurringInvoiceSpawner
             $clone->setSubtotal($subtotal)->setTaxAmount($tax)->setTotal($subtotal + $tax);
             $this->em->persist($clone);
 
-            $next = $template->getNextIssueDate();
-            if (null !== $next) {
-                $template->setNextIssueDate($next->modify($step));
-            }
+            $this->advanceOrEnd($template, $step);
             ++$spawned;
         }
 
@@ -69,5 +71,41 @@ final class RecurringInvoiceSpawner
         }
 
         return $spawned;
+    }
+
+    /**
+     * Advances the template to its next issue date, or ends the recurrence when
+     * an end condition (#598) is now satisfied. The clone for the current run
+     * has already been produced by the caller, so this only decides whether the
+     * template keeps recurring.
+     */
+    private function advanceOrEnd(Invoice $template, string $step): void
+    {
+        $next = $template->getNextIssueDate();
+        $advanced = null === $next ? null : $next->modify($step);
+
+        // "After N invoices": this run consumed one occurrence.
+        $count = $template->getRecurrenceCount();
+        if (null !== $count) {
+            $remaining = $count - 1;
+            if ($remaining < 1) {
+                $template->endRecurrence();
+
+                return;
+            }
+            $template->setRecurrenceCount($remaining)->setNextIssueDate($advanced);
+
+            return;
+        }
+
+        // "Until" date: stop once the next occurrence would fall past it.
+        $end = $template->getRecurrenceEndDate();
+        if (null !== $end && null !== $advanced && $advanced > $end) {
+            $template->endRecurrence();
+
+            return;
+        }
+
+        $template->setNextIssueDate($advanced);
     }
 }

--- a/api/tests/Api/ClientInvoiceTest.php
+++ b/api/tests/Api/ClientInvoiceTest.php
@@ -627,6 +627,120 @@ class ClientInvoiceTest extends ApiTestCase
         $this->assertSame(2, $list['totalItems'] ?? null);
     }
 
+    public function testRecurringInvoiceStopsAfterCount(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $space = $this->createSharedSpace($admin);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $invoice = $client->request('POST', '/invoices', [
+            'json' => [
+                'space' => $spaceIri,
+                'client' => $clientRow['@id'],
+                'currency' => 'USD',
+                'recurrenceFrequency' => 'monthly',
+                'recurrenceInterval' => 1,
+                'nextIssueDate' => '2020-01-01',
+                'recurrenceCount' => 1,
+                'lineItems' => [['description' => 'Retainer', 'quantity' => 1, 'unitAmount' => 20000]],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $invoiceIri = $this->iri($invoice);
+
+        $spawner = static::getContainer()->get(\App\Service\RecurringInvoiceSpawner::class);
+        // First run spawns the one allowed occurrence and ends the recurrence.
+        $this->assertSame(1, $spawner->spawnDue(new \DateTimeImmutable('today')));
+        // Second run finds nothing — the template is no longer recurring.
+        $this->assertSame(0, $spawner->spawnDue(new \DateTimeImmutable('today')));
+
+        // Recurrence ended: the now-null fields are skipped from the read payload.
+        $template = $client->request('GET', $invoiceIri)->toArray();
+        $this->assertArrayNotHasKey('recurrenceFrequency', $template);
+        $this->assertArrayNotHasKey('recurrenceCount', $template);
+        $this->assertArrayNotHasKey('nextIssueDate', $template);
+
+        // Exactly one clone was produced (template + one draft).
+        $list = $client->request('GET', '/invoices?space=' . $spaceIri)->toArray();
+        $this->assertSame(2, $list['totalItems'] ?? null);
+    }
+
+    public function testRecurringInvoiceStopsAtEndDate(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $space = $this->createSharedSpace($admin);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        // Next issue 2020-01-01, ends 2020-01-15: after one monthly step the next
+        // occurrence (2020-02-01) falls past the end date, so recurrence stops.
+        $invoice = $client->request('POST', '/invoices', [
+            'json' => [
+                'space' => $spaceIri,
+                'client' => $clientRow['@id'],
+                'currency' => 'USD',
+                'recurrenceFrequency' => 'monthly',
+                'recurrenceInterval' => 1,
+                'nextIssueDate' => '2020-01-01',
+                'recurrenceEndDate' => '2020-01-15',
+                'lineItems' => [['description' => 'Retainer', 'quantity' => 1, 'unitAmount' => 20000]],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $invoiceIri = $this->iri($invoice);
+
+        $spawner = static::getContainer()->get(\App\Service\RecurringInvoiceSpawner::class);
+        $this->assertSame(1, $spawner->spawnDue(new \DateTimeImmutable('today')));
+        $this->assertSame(0, $spawner->spawnDue(new \DateTimeImmutable('today')));
+
+        // Recurrence ended: the now-null fields are skipped from the read payload.
+        $template = $client->request('GET', $invoiceIri)->toArray();
+        $this->assertArrayNotHasKey('recurrenceFrequency', $template);
+        $this->assertArrayNotHasKey('recurrenceEndDate', $template);
+    }
+
+    public function testRecurringInvoiceRejectsTwoEndConditions(): void
+    {
+        $admin = $this->createUser('admin@example.com');
+        $space = $this->createSharedSpace($admin);
+        $spaceIri = '/spaces/' . $space->getId();
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+        $clientRow = $client->request('POST', '/clients', [
+            'json' => ['space' => $spaceIri, 'name' => 'Acme Co', 'currency' => 'USD'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $client->request('POST', '/invoices', [
+            'json' => [
+                'space' => $spaceIri,
+                'client' => $clientRow['@id'],
+                'currency' => 'USD',
+                'recurrenceFrequency' => 'monthly',
+                'recurrenceInterval' => 1,
+                'nextIssueDate' => '2020-01-01',
+                'recurrenceEndDate' => '2020-06-01',
+                'recurrenceCount' => 3,
+                'lineItems' => [['description' => 'Retainer', 'quantity' => 1, 'unitAmount' => 20000]],
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+    }
+
     public function testInvoicePdfRenders(): void
     {
         $admin = $this->createUser('admin@example.com');

--- a/docs/developer/time-tracking-invoicing.md
+++ b/docs/developer/time-tracking-invoicing.md
@@ -1,0 +1,139 @@
+# Time tracking &amp; invoicing
+
+Madori's agency-style billing stack: track billable time and expenses against a
+client's project, then turn unbilled work into invoices (and quotes into
+estimates), collect payment online, and reconcile against retainers. The model
+mirrors Harvest — see the naming glossary in
+[`aura-board-engagement-rename`](../../CLAUDE.md) for the term mapping (Harvest
+"Task" = our **Service**).
+
+## The billing chain
+
+```
+Client → Project → Service (billing rate) → TimeEntry → Invoice
+                                              Expense  ↗
+```
+
+- **Client** (`App\Entity\Client`, `/clients`) — the company you bill. Carries
+  currency, address, and a default rate. Full CRUD incl. `Patch` (edit
+  name/email/address/currency/default rate).
+- **Project** (`App\Entity\Project`, `/projects`) — the billable unit time is
+  tracked against; belongs to a client, pins the currency, and is what invoices
+  are generated from. Carries an optional **budget** (hours or fees) with
+  threshold alerts.
+- **Service** (`App\Entity\Service`, `/services`) — a named line of billable
+  work inside a project (e.g. "Development") that fixes the **`billingRate`**.
+- **TimeEntry** (`App\Entity\TimeEntry`, `/time_entries`) — hours logged against
+  a project + service. Snapshots the rate at creation (`rateAmount`) so later
+  rate changes don't rewrite history. Supports a live timer (no `endedAt` yet).
+- **Expense** (`App\Entity\Expense`, `/expenses`) — a billable (or internal)
+  cost against a project, filed under an **ExpenseCategory**
+  (`/expense_categories`, supports a per-unit price for mileage-style entries),
+  with an optional receipt image that rides onto the invoice PDF.
+
+### Money out
+
+- **Invoice** (`App\Entity\Invoice`, `/invoices`) + **InvoiceLineItem** +
+  **InvoicePayment**. Generated from unbilled time/expenses; supports discounts
+  (percent or fixed), per-line and invoice-level tax, and partial payments. A
+  draft is editable; issuing/sending freezes it. Branding (logo, terms, number
+  prefix) comes from space settings and renders in
+  `templates/invoice/pdf.html.twig`.
+- **Estimate** (`App\Entity\Estimate`, `/estimates`) — a quote sent before work;
+  the client accepts/declines, then it **converts** to an invoice.
+- **RetainerTransaction** — a pre-paid client balance (deposit/draw ledger) that
+  invoices draw down against.
+
+### Rates
+
+- **Billing rate** — `Service.billingRate`, what the client is charged/hour.
+- **Cost rate** — `SpaceMembership.costRateAmount`, what a person costs; powers
+  the profitability report.
+- **Per-person rate** — `ProjectUserRate.rateAmount`, a rate override for a
+  specific member on a specific project.
+
+## Endpoints
+
+Standard API-Platform CRUD lives on each entity above (`/clients`,
+`/projects`, `/services`, `/time_entries`, `/invoices`, `/estimates`,
+`/expenses`, `/expense_categories`). The stateful transitions are custom
+controllers:
+
+| Route | Controller | Purpose |
+|---|---|---|
+| `POST /invoices/from-time-entries` | `InvoiceFromTimeController` | Preview + generate an invoice from selected unbilled time/expenses |
+| `POST /invoices/{id}/issue` | `InvoiceActionController` | Assign a number + issue date; freezes the draft |
+| `POST /invoices/{id}/send` | `InvoiceActionController` | Mint a fresh public token + email the client an `/i/{token}` link |
+| `POST /invoices/{id}/mark-paid` / `payments` | `InvoiceActionController` | Record a payment / full-paid |
+| `POST /invoices/{id}/void` | `InvoiceActionController` | Void an issued invoice |
+| `GET /invoices/{id}/pdf` | (PDF renderer) | Streamed invoice PDF |
+| `POST /estimates/{id}/send` / `convert` | `EstimateActionController` | Send a quote / convert an accepted one to an invoice |
+| `POST /clients/{id}/portal-link` | `ClientPortalController` | Mint a client-portal token |
+| `GET /portal/{token}` (+ `/invoices/{id}/pay`, `/estimates/{id}/accept\|decline`) | `ClientPortalController` | Public client portal: view + pay invoices, accept/decline estimates |
+
+Public, tokenised (unauthenticated) surfaces: `/i/{token}` (pay one invoice),
+`/e/{token}` (view/accept one estimate), `/portal/{token}` (the whole client
+portal). Tokens are sha256-hashed like password-reset tokens — the plaintext
+only ever leaves in the email/link.
+
+## Permission model
+
+Billing rides the space-role system (`App\Security\Permission\SpacePermission`).
+The **`invoices`** category (clients + invoices + estimates + expenses +
+retainers ride it) is **admin-reserved** by default — a plain member can't see
+or manage billing until an admin grants a role that includes it. Time tracking
+itself is member-level: members track their own time, and a **billed** entry is
+frozen (create/edit/delete 422) once it lands on an invoice. A
+[**timesheet approval**](./task-organization.md) (`App\Entity\TimesheetApproval`)
+freezes a whole submitted week the same way until an admin approves/rejects it.
+
+## Online payment: the gateway registry
+
+Invoice payment is provider-agnostic behind
+`App\Billing\Payment\PaymentGatewayInterface` + `PaymentGatewayRegistry`
+(mirrors `CalendarClientRegistry`). Each provider is one tagged class:
+
+- `StripePaymentGateway` — Stripe Checkout over Symfony HttpClient (no SDK),
+  env-gated on the Stripe keys; the webhook marks the invoice paid.
+- PayPal drops in as a second tagged class (`app.payment_gateway`) — tracked in
+  #597, interface + registry are ready.
+
+`PaymentGatewayRegistry::configuredKeys()` reports which providers are live; the
+public `/i/{token}` pay page offers whichever are configured.
+
+> Note: this is **client-facing** invoice payment (you collecting from your
+> clients) — entirely separate from the **subscription billing** that charges
+> for Madori itself (`App\Controller\BillingController`, `/me/billing`,
+> `docs/developer/billing.md`).
+
+## Recurring &amp; overdue jobs
+
+Both run on the shared worker via `App\Scheduler\MainScheduleProvider` (no system
+cron):
+
+- **Recurring invoices** — a template invoice sets `recurrenceFrequency`
+  (weekly/monthly/yearly) × `recurrenceInterval` + a `nextIssueDate`. The daily
+  `SpawnRecurringInvoices` job → `App\Service\RecurringInvoiceSpawner::spawnDue()`
+  clones each due template into a fresh draft (client/currency/tax/notes/line
+  items, **not** the recurrence or time-entry links) and advances the template.
+  **End conditions (#598):** set at most one of `recurrenceEndDate` ("until": stop
+  once the advanced next issue date passes it) or `recurrenceCount` ("after N
+  invoices": decremented each spawn). When the condition is met,
+  `Invoice::endRecurrence()` clears the recurrence so the template drops out of
+  the sweep and reads as a plain invoice. No end condition = recurs forever.
+- **Overdue invoices** — the daily `MarkOverdueInvoices` job
+  (`InvoiceRepository::markOverdue`) flips sent invoices past their due date to
+  `overdue` and emails the client a late-payment reminder (#649). Because
+  `send` only stores the token hash, the reminder **mints a fresh token** so the
+  `/i/{token}` link works.
+
+Both jobs also back console commands for manual runs, and `when@test` runs
+Messenger inline so the spawn/overdue logic is exercised synchronously in tests.
+
+## Tests
+
+`api/tests/Api/ClientInvoiceTest.php` covers the invoice lifecycle: generation
+from time, issue/send, PDF, discounts + partial payments, per-line tax, the
+public pay → webhook → paid flow, recurring spawn, and the recurrence end
+conditions. Estimates, expenses, budgets, retainers, and the client portal have
+their own suites under `api/tests/Api/`.

--- a/pwa/lib/invoiceTypes.ts
+++ b/pwa/lib/invoiceTypes.ts
@@ -73,6 +73,10 @@ export interface Invoice {
   recurrenceFrequency: "weekly" | "monthly" | "yearly" | null;
   recurrenceInterval: number | null;
   nextIssueDate: string | null;
+  /** Optional recurrence end: stop once the next issue date passes this. */
+  recurrenceEndDate: string | null;
+  /** Optional recurrence end: remaining invoices to generate. */
+  recurrenceCount: number | null;
   remindersEnabled: boolean;
   remindersSentAt: string[] | null;
   sentAt: string | null;

--- a/pwa/pages/invoices/[id].tsx
+++ b/pwa/pages/invoices/[id].tsx
@@ -53,6 +53,9 @@ const InvoiceDetailPage = () => {
   const [freq, setFreq] = useState("");
   const [interval, setInterval] = useState("1");
   const [nextIssue, setNextIssue] = useState("");
+  const [endMode, setEndMode] = useState<"" | "date" | "count">("");
+  const [endDate, setEndDate] = useState("");
+  const [endCount, setEndCount] = useState("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
@@ -99,6 +102,19 @@ const InvoiceDetailPage = () => {
     setFreq(invoice.recurrenceFrequency ?? "");
     setInterval(String(invoice.recurrenceInterval ?? 1));
     setNextIssue(invoice.nextIssueDate ?? "");
+    if (invoice.recurrenceEndDate) {
+      setEndMode("date");
+      setEndDate(invoice.recurrenceEndDate);
+      setEndCount("");
+    } else if (invoice.recurrenceCount !== null) {
+      setEndMode("count");
+      setEndCount(String(invoice.recurrenceCount));
+      setEndDate("");
+    } else {
+      setEndMode("");
+      setEndDate("");
+      setEndCount("");
+    }
   }, [invoice]);
 
   const preview = useMemo(() => {
@@ -166,6 +182,9 @@ const InvoiceDetailPage = () => {
           recurrenceFrequency: recurring ? freq : null,
           recurrenceInterval: recurring ? parseInt(interval, 10) || 1 : null,
           nextIssueDate: recurring ? nextIssue || null : null,
+          recurrenceEndDate: recurring && endMode === "date" ? endDate || null : null,
+          recurrenceCount:
+            recurring && endMode === "count" ? parseInt(endCount, 10) || null : null,
         },
       });
       setNotice("Saved.");
@@ -593,6 +612,49 @@ const InvoiceDetailPage = () => {
                         </>
                       )}
                     </div>
+                    {freq !== "" && (
+                      <div className="grid gap-4 sm:grid-cols-3">
+                        <div className="space-y-1.5">
+                          <Label htmlFor="inv-end-mode">Ends</Label>
+                          <select
+                            id="inv-end-mode"
+                            value={endMode}
+                            onChange={(e) =>
+                              setEndMode(e.target.value as "" | "date" | "count")
+                            }
+                            className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
+                          >
+                            <option value="">Never</option>
+                            <option value="date">On date</option>
+                            <option value="count">After N invoices</option>
+                          </select>
+                        </div>
+                        {endMode === "date" && (
+                          <div className="space-y-1.5">
+                            <Label htmlFor="inv-end-date">End date</Label>
+                            <Input
+                              id="inv-end-date"
+                              type="date"
+                              value={endDate}
+                              min={nextIssue || undefined}
+                              onChange={(e) => setEndDate(e.target.value)}
+                            />
+                          </div>
+                        )}
+                        {endMode === "count" && (
+                          <div className="space-y-1.5">
+                            <Label htmlFor="inv-end-count">Invoices</Label>
+                            <Input
+                              id="inv-end-count"
+                              type="number"
+                              min="1"
+                              value={endCount}
+                              onChange={(e) => setEndCount(e.target.value)}
+                            />
+                          </div>
+                        )}
+                      </div>
+                    )}
                     <Button onClick={() => void save()} disabled={saving}>
                       {saving ? "Saving…" : "Save"}
                     </Button>


### PR DESCRIPTION
Finishes two of the remaining #598 items.

## Recurrence "ends"
Recurring-invoice templates can now stop on an end condition (mirrors task recurrence):
- **`recurrenceEndDate`** — "until": stop once the advanced next issue date passes it.
- **`recurrenceCount`** — "after N invoices": decremented each spawn.

At most one may be set; both null = recurs forever. When met, the spawner calls `Invoice::endRecurrence()` so the template drops out of the daily sweep. Entity validation enforces mutual-exclusivity, end-date ≥ next-issue, and that an end condition requires a frequency. Migration `Version20260719120000` is additive.

PWA: an **Ends** control (Never / On date / After N invoices) on the invoice recurrence editor.

## Docs
New `docs/developer/time-tracking-invoicing.md` — the Client→Project→Service→TimeEntry→Invoice chain, entities, endpoints, permission model, the payment-gateway registry, and the recurring/overdue jobs. Indexed in CLAUDE.md.

## Tests
`ClientInvoiceTest`: count-based stop, date-based stop, two-end-conditions 422.

Local: schema:validate (dev+test) in sync, PHPStan + PHPCS clean, recurring invoice tests green.

Remaining on #598 (not in this PR): live manual browser click-through of the full pay flow.