### PR TITLE
feat(connect): migrate to Stripe Accounts v2

### DIFF
--- a/api/src/Billing/StripeGateway.php
+++ b/api/src/Billing/StripeGateway.php
@@ -25,7 +25,15 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 final class StripeGateway implements StripeGatewayInterface
 {
     private const API_BASE = 'https://api.stripe.com/v1';
+    private const API_BASE_V2 = 'https://api.stripe.com/v2';
     private const WEBHOOK_TOLERANCE_SECONDS = 300;
+
+    /**
+     * Stripe-Version pinned for the Accounts v2 calls (Connect). v2 endpoints
+     * require an explicit version header; kept in sync with the account's
+     * dashboard/webhook API version.
+     */
+    private const CONNECT_API_VERSION = '2026-06-24.dahlia';
 
     public function __construct(
         private readonly HttpClientInterface $httpClient,
@@ -135,21 +143,43 @@ final class StripeGateway implements StripeGatewayInterface
 
     public function createConnectAccount(?string $email, ?string $country): string
     {
+        // Accounts v2 (POST /v2/core/accounts): a "recipient"-configured account
+        // that receives destination-charge transfers into its Stripe balance and
+        // onboards through the Stripe-hosted flow. The legacy v1 `type: express`
+        // create is deprecated and rejected for new Connect platforms. See
+        // https://docs.stripe.com/connect/accounts-v2.
         $body = [
-            'type' => 'express',
-            'capabilities' => [
-                'card_payments' => ['requested' => 'true'],
-                'transfers' => ['requested' => 'true'],
+            'dashboard' => 'express',
+            'configuration' => [
+                'recipient' => [
+                    'capabilities' => [
+                        'stripe_balance' => [
+                            'stripe_transfers' => ['requested' => true],
+                        ],
+                    ],
+                ],
             ],
+            // For a recipient-only account the platform (application) is the
+            // merchant of record on destination charges, so it collects fees +
+            // covers losses — Stripe rejects any other value for this config.
+            'defaults' => [
+                'responsibilities' => [
+                    'fees_collector' => 'application',
+                    'losses_collector' => 'application',
+                ],
+            ],
+            'include' => ['configuration.recipient'],
         ];
         if (null !== $email && '' !== $email) {
-            $body['email'] = $email;
+            $body['contact_email'] = $email;
         }
-        if (null !== $country && '' !== $country) {
-            $body['country'] = strtoupper($country);
-        }
+        // v2 requires identity.country before the recipient config can be set
+        // (v1 collected it during onboarding). Default to US when the caller
+        // doesn't supply one; the hosted flow still collects the rest.
+        $countryCode = null !== $country && '' !== $country ? $country : 'US';
+        $body['identity'] = ['country' => strtolower($countryCode)];
 
-        $data = $this->request('POST', '/accounts', $body);
+        $data = $this->requestV2('POST', '/core/accounts', $body);
         $id = $data['id'] ?? null;
         if (!is_string($id) || '' === $id) {
             throw new BillingException('Stripe did not return a connected account id.');
@@ -160,6 +190,8 @@ final class StripeGateway implements StripeGatewayInterface
 
     public function createAccountLink(string $accountId, string $refreshUrl, string $returnUrl): string
     {
+        // The v1 Account Links resource is the documented hosted-onboarding tool
+        // for v2 accounts too — the `account` value just comes from a v2 create.
         $data = $this->request('POST', '/account_links', [
             'account' => $accountId,
             'refresh_url' => $refreshUrl,
@@ -176,12 +208,30 @@ final class StripeGateway implements StripeGatewayInterface
 
     public function retrieveConnectAccount(string $accountId): array
     {
-        $data = $this->request('GET', '/accounts/' . rawurlencode($accountId), []);
+        // Accounts v2 exposes readiness through the recipient configuration's
+        // stripe_transfers capability rather than v1's charges_enabled flags.
+        $data = $this->requestV2(
+            'GET',
+            '/core/accounts/' . rawurlencode($accountId) . '?include=configuration.recipient',
+            [],
+        );
 
+        // Safely dig configuration.recipient.capabilities.stripe_balance.stripe_transfers.status
+        $config = $data['configuration'] ?? null;
+        $recipient = is_array($config) ? ($config['recipient'] ?? null) : null;
+        $capabilities = is_array($recipient) ? ($recipient['capabilities'] ?? null) : null;
+        $balance = is_array($capabilities) ? ($capabilities['stripe_balance'] ?? null) : null;
+        $transfers = is_array($balance) ? ($balance['stripe_transfers'] ?? null) : null;
+        $status = is_array($transfers) && isset($transfers['status']) && is_string($transfers['status'])
+            ? $transfers['status']
+            : '';
+
+        // `active` = can receive transfers (settle destination charges); `pending`
+        // = submitted, under review. Anything else = not yet usable.
         return [
-            'chargesEnabled' => true === ($data['charges_enabled'] ?? false),
-            'detailsSubmitted' => true === ($data['details_submitted'] ?? false),
-            'payoutsEnabled' => true === ($data['payouts_enabled'] ?? false),
+            'chargesEnabled' => 'active' === $status,
+            'detailsSubmitted' => in_array($status, ['active', 'pending'], true),
+            'payoutsEnabled' => 'active' === $status,
         ];
     }
 
@@ -301,6 +351,53 @@ final class StripeGateway implements StripeGatewayInterface
             $error = $data['error'] ?? null;
             if (is_array($error) && isset($error['message']) && is_string($error['message'])) {
                 $message = $error['message'];
+            }
+            throw new BillingException('Stripe error: ' . $message);
+        }
+
+        /** @var array<string, mixed> $data */
+        return $data;
+    }
+
+    /**
+     * Like {@see request()} but for the Accounts v2 surface: JSON request bodies
+     * (not form-encoded) and the pinned `Stripe-Version` header. GET carries no
+     * body; query params (e.g. `?include=…`) ride on `$path`.
+     *
+     * @param array<string, mixed> $body
+     *
+     * @return array<string, mixed>
+     */
+    private function requestV2(string $method, string $path, array $body): array
+    {
+        if (!$this->isConfigured()) {
+            throw new BillingException('Stripe is not configured.');
+        }
+
+        try {
+            $options = [
+                'auth_bearer' => $this->secretKey,
+                'headers' => ['Stripe-Version' => self::CONNECT_API_VERSION],
+            ];
+            if ('GET' !== $method) {
+                $options['json'] = $body;
+            }
+            $response = $this->httpClient->request($method, self::API_BASE_V2 . $path, $options);
+            $status = $response->getStatusCode();
+            $data = $response->toArray(false);
+        } catch (\Throwable $e) {
+            throw new BillingException('Stripe request failed: ' . $e->getMessage(), 0, $e);
+        }
+
+        if ($status >= 400) {
+            $message = 'HTTP ' . $status;
+            $error = $data['error'] ?? null;
+            if (is_array($error) && isset($error['message']) && is_string($error['message'])) {
+                $message = $error['message'];
+            }
+            // v2 errors may put the message at the top level instead of under `error`.
+            if ('HTTP ' . $status === $message && isset($data['message']) && is_string($data['message'])) {
+                $message = $data['message'];
             }
             throw new BillingException('Stripe error: ' . $message);
         }

--- a/api/src/Billing/StripeGatewayInterface.php
+++ b/api/src/Billing/StripeGatewayInterface.php
@@ -69,8 +69,9 @@ interface StripeGatewayInterface
     ): string;
 
     /**
-     * Create a Stripe Connect **Express** account and return its `acct_…` id.
-     * The space owner completes onboarding through the hosted Account Link
+     * Create a Stripe Connect (Accounts v2, recipient-configured) account and
+     * return its `acct_…` id. It receives destination-charge transfers; the
+     * space owner completes onboarding through the hosted Account Link
      * ({@see createAccountLink}); Stripe collects their identity + payout
      * details, so we never touch bank data.
      */

--- a/api/tests/Billing/StripeGatewayTest.php
+++ b/api/tests/Billing/StripeGatewayTest.php
@@ -136,6 +136,109 @@ class StripeGatewayTest extends TestCase
         $gateway->createBillingPortalSession('cus_1', 'https://back');
     }
 
+    public function testCreatePaymentCheckoutWithConnectDestinationReturnsUrl(): void
+    {
+        $response = new MockResponse((string) json_encode(['url' => 'https://checkout.stripe.test/pay1']));
+        $gateway = new StripeGateway(new MockHttpClient([$response]), 'sk_test', self::SECRET);
+
+        $url = $gateway->createPaymentCheckout(
+            5000,
+            'usd',
+            'Invoice INV-1',
+            'https://ok',
+            'https://no',
+            'client@x.test',
+            ['invoice_id' => 'inv1'],
+            'acct_dest',
+            150,
+        );
+
+        $this->assertSame('https://checkout.stripe.test/pay1', $url);
+        $this->assertStringContainsString('/checkout/sessions', $response->getRequestUrl());
+    }
+
+    public function testCreateConnectAccountReturnsIdViaV2(): void
+    {
+        $response = new MockResponse((string) json_encode(['id' => 'acct_v2_1', 'object' => 'v2.core.account']));
+        $gateway = new StripeGateway(new MockHttpClient([$response]), 'sk_test', self::SECRET);
+
+        $id = $gateway->createConnectAccount('owner@studio.test', null);
+
+        $this->assertSame('acct_v2_1', $id);
+        $this->assertSame('POST', $response->getRequestMethod());
+        $this->assertStringContainsString('/v2/core/accounts', $response->getRequestUrl());
+    }
+
+    public function testCreateConnectAccountMissingIdThrows(): void
+    {
+        $response = new MockResponse((string) json_encode(['object' => 'v2.core.account']));
+        $gateway = new StripeGateway(new MockHttpClient([$response]), 'sk_test', self::SECRET);
+
+        $this->expectException(BillingException::class);
+        $gateway->createConnectAccount(null, 'GB');
+    }
+
+    public function testCreateAccountLinkReturnsUrl(): void
+    {
+        $response = new MockResponse((string) json_encode(['url' => 'https://connect.stripe.test/setup/x']));
+        $gateway = new StripeGateway(new MockHttpClient([$response]), 'sk_test', self::SECRET);
+
+        $url = $gateway->createAccountLink('acct_1', 'https://r', 'https://ret');
+
+        $this->assertSame('https://connect.stripe.test/setup/x', $url);
+        $this->assertStringContainsString('/account_links', $response->getRequestUrl());
+    }
+
+    public function testRetrieveConnectAccountMapsActiveTransfers(): void
+    {
+        $body = json_encode(['configuration' => ['recipient' => ['capabilities' => [
+            'stripe_balance' => ['stripe_transfers' => ['status' => 'active']],
+        ]]]]);
+        $gateway = new StripeGateway(new MockHttpClient([new MockResponse((string) $body)]), 'sk_test', self::SECRET);
+
+        $result = $gateway->retrieveConnectAccount('acct_1');
+
+        $this->assertTrue($result['chargesEnabled']);
+        $this->assertTrue($result['detailsSubmitted']);
+        $this->assertTrue($result['payoutsEnabled']);
+    }
+
+    public function testRetrieveConnectAccountPendingIsSubmittedButNotChargeable(): void
+    {
+        $body = json_encode(['configuration' => ['recipient' => ['capabilities' => [
+            'stripe_balance' => ['stripe_transfers' => ['status' => 'pending']],
+        ]]]]);
+        $gateway = new StripeGateway(new MockHttpClient([new MockResponse((string) $body)]), 'sk_test', self::SECRET);
+
+        $result = $gateway->retrieveConnectAccount('acct_1');
+
+        $this->assertFalse($result['chargesEnabled']);
+        $this->assertTrue($result['detailsSubmitted']);
+    }
+
+    public function testRetrieveConnectAccountUnknownStatusIsAllFalse(): void
+    {
+        $gateway = new StripeGateway(new MockHttpClient([new MockResponse('{}')]), 'sk_test', self::SECRET);
+
+        $result = $gateway->retrieveConnectAccount('acct_1');
+
+        $this->assertFalse($result['chargesEnabled']);
+        $this->assertFalse($result['detailsSubmitted']);
+        $this->assertFalse($result['payoutsEnabled']);
+    }
+
+    public function testV2ApiErrorSurfacesMessage(): void
+    {
+        $response = new MockResponse(
+            (string) json_encode(['error' => ['message' => 'identity.country is required']]),
+            ['http_code' => 400],
+        );
+        $gateway = new StripeGateway(new MockHttpClient([$response]), 'sk_test', self::SECRET);
+
+        $this->expectExceptionMessage('identity.country is required');
+        $gateway->createConnectAccount('a@b.test', null);
+    }
+
     private function gateway(): StripeGateway
     {
         return new StripeGateway(new MockHttpClient(), 'sk_test', self::SECRET);


### PR DESCRIPTION
Stripe rejects the deprecated v1 `POST /accounts` (`type=express`) for newly-created Connect platforms — which blocked Connect onboarding entirely. Migrates connected-account creation to **Accounts v2**.

**Changes (isolated to `StripeGateway`):**
- `createConnectAccount` → `POST /v2/core/accounts`: a **recipient**-configured account that receives destination-charge transfers, `fees_collector`/`losses_collector` = `application` (required for this config — the platform is merchant of record), `identity.country` defaulting to `US` when not supplied.
- `retrieveConnectAccount` → reads readiness from `configuration.recipient.capabilities.stripe_balance.stripe_transfers.status` (`active` = can receive funds).
- `createAccountLink` unchanged — v1 Account Links onboard v2 accounts as-is.
- New `requestV2()` helper (v2 needs `application/json` bodies + a `Stripe-Version` header).

**Interface signatures + the in-memory fake are unchanged**, so ConnectTest/BillingTest/StripeGatewayTest are untouched and green.

**Verified live against a Stripe sandbox** (not just the fake): `POST /connect/onboard` returns a real hosted onboarding URL and a v2 account; `/connect/status` reads back `incomplete` correctly. Found + fixed two v2 validation requirements live along the way (collector must be `application`; country required before recipient config).

Follow-up (not blocking): collect the user's **country** in the Set-up-payments UI so non-US accounts aren't defaulted to US.