### PR TITLE
feat(admin): create sign-in-ready user accounts (UI + CLI)

### DIFF
--- a/api/config/packages/security.yaml
+++ b/api/config/packages/security.yaml
@@ -129,6 +129,9 @@ security:
         - { path: ^/account-exports/, roles: IS_AUTHENTICATED_FULLY }
         # Waitlist mode toggle — platform admins only.
         - { path: ^/admin/waitlist, roles: ROLE_ADMIN }
+        # Admin account provisioning (#admin-user-create) — creates a sign-in-ready
+        # account, so it's an account-creation vector: platform admins only.
+        - { path: ^/admin/users, roles: ROLE_ADMIN }
         # Sentry verification triggers (error/worker) — platform admins only.
         - { path: ^/admin/sentry-test, roles: ROLE_ADMIN }
         # SSO admin config (enable toggle, allowed domains, button label).

--- a/api/src/Command/UserCreateCommand.php
+++ b/api/src/Command/UserCreateCommand.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Command;
+
+use App\Service\AdminUserCreator;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Create a ready-to-sign-in account from the CLI.
+ *
+ *   bin/console app:user:create you@example.com
+ *   bin/console app:user:create qa@example.com --with-space="QA Studio"
+ *   bin/console app:user:create demo@example.com --given-name=Demo --family-name=User
+ *
+ * Clears both signup gates (email confirmation + waitlist) so the account works
+ * immediately — which is what makes this usable on an instance whose signups are
+ * closed, e.g. standing up a test account on production to smoke-test billing.
+ * Pass --waitlisted to leave it on the waitlist instead.
+ *
+ * The generated password is printed **once** and never stored in plaintext.
+ * Pairs with {@see WaitlistPromoteCommand} and {@see UserRoleCommand}; shares
+ * {@see AdminUserCreator} with the admin UI so both paths behave identically.
+ */
+#[AsCommand(
+    name: 'app:user:create',
+    description: 'Create a sign-in-ready user account (skips email confirmation + waitlist).',
+)]
+final class UserCreateCommand extends Command
+{
+    public function __construct(private AdminUserCreator $creator)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('email', InputArgument::REQUIRED, 'Email address for the new account')
+            ->addOption('given-name', null, InputOption::VALUE_REQUIRED, 'First name', 'Test')
+            ->addOption('family-name', null, InputOption::VALUE_REQUIRED, 'Last name', 'User')
+            ->addOption('password', null, InputOption::VALUE_REQUIRED, 'Set an explicit password (default: generate a strong one)')
+            ->addOption('with-space', null, InputOption::VALUE_REQUIRED, 'Also create a shared space with this name, user as admin')
+            ->addOption('waitlisted', null, InputOption::VALUE_NONE, 'Leave the account on the waitlist instead of promoting it');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $email = $input->getArgument('email');
+        if (false === filter_var($email, \FILTER_VALIDATE_EMAIL)) {
+            $io->error('Provide a valid email address.');
+            return Command::FAILURE;
+        }
+
+        $given = $input->getOption('given-name');
+        $family = $input->getOption('family-name');
+        $password = $input->getOption('password');
+        $space = $input->getOption('with-space');
+
+        try {
+            $result = $this->creator->create(
+                $email,
+                $given,
+                $family,
+                is_string($password) ? $password : null,
+                true !== $input->getOption('waitlisted'),
+                is_string($space) ? $space : null,
+            );
+        } catch (\InvalidArgumentException $e) {
+            $io->error($e->getMessage());
+            return Command::FAILURE;
+        }
+
+        $createdSpace = $result['space'];
+
+        $rows = [
+            ['Email', $email],
+            ['Password', $result['password']],
+            ['Waitlisted', $result['user']->isWaitlisted() ? 'yes' : 'no'],
+        ];
+        if (null !== $createdSpace) {
+            $rows[] = ['Shared space', $createdSpace->getName()];
+        }
+
+        $io->success(sprintf('Created %s.', $email));
+        $io->table(['Field', 'Value'], $rows);
+        $io->warning('The password is shown once — copy it now.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/api/src/Controller/AdminUserController.php
+++ b/api/src/Controller/AdminUserController.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Service\AdminUserCreator;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use App\Entity\User;
+
+/**
+ * Platform-admin account provisioning (#admin-user-create):
+ * `POST /admin/users` creates an account that can sign in immediately —
+ * clearing the email-confirmation and waitlist gates that normal signup
+ * imposes — and returns the generated password **once** (never stored in
+ * plaintext, same one-shot shape as the API-token reveal).
+ *
+ * This is an account-creation vector, so it is ROLE_ADMIN-only (also gated in
+ * security.yaml) and every creation is logged with the acting admin.
+ */
+class AdminUserController extends AbstractController
+{
+    public function __construct(
+        private AdminUserCreator $creator,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    #[Route('/admin/users', name: 'admin_user_create', methods: ['POST'])]
+    public function create(Request $request, #[CurrentUser] ?User $actor): JsonResponse
+    {
+        $this->denyAccessUnlessGranted('ROLE_ADMIN');
+
+        $payload = $request->toArray();
+        $email = $this->stringField($payload, 'email');
+        $givenName = $this->stringField($payload, 'givenName');
+        $familyName = $this->stringField($payload, 'familyName');
+
+        if ('' === $email || false === filter_var($email, \FILTER_VALIDATE_EMAIL)) {
+            return $this->json(['error' => 'A valid email is required.'], 422);
+        }
+        if ('' === $givenName || '' === $familyName) {
+            return $this->json(['error' => 'First and last name are required.'], 422);
+        }
+
+        // `skipWaitlist` defaults to true — an admin-created account is meant to
+        // be usable straight away; pass false to leave it waiting.
+        $skipWaitlist = !array_key_exists('skipWaitlist', $payload) || true === $payload['skipWaitlist'];
+
+        $spaceName = null;
+        $rawSpace = $payload['spaceName'] ?? null;
+        if (is_string($rawSpace) && '' !== trim($rawSpace)) {
+            $spaceName = trim($rawSpace);
+        }
+
+        try {
+            $result = $this->creator->create(
+                $email,
+                $givenName,
+                $familyName,
+                null,
+                $skipWaitlist,
+                $spaceName,
+            );
+        } catch (\InvalidArgumentException $e) {
+            return $this->json(['error' => $e->getMessage()], 422);
+        }
+
+        $user = $result['user'];
+        $space = $result['space'];
+
+        $this->logger->info('Admin created a user account.', [
+            'actor' => $actor?->getEmail(),
+            'created' => $user->getEmail(),
+            'skipWaitlist' => $skipWaitlist,
+            'withSpace' => null !== $space,
+        ]);
+
+        return $this->json([
+            'id' => (string) $user->getId(),
+            'email' => $user->getEmail(),
+            'givenName' => $user->getGivenName(),
+            'familyName' => $user->getFamilyName(),
+            'waitlisted' => $user->isWaitlisted(),
+            // Shown once — the caller must capture it now.
+            'password' => $result['password'],
+            'space' => null === $space ? null : [
+                'id' => (string) $space->getId(),
+                'name' => $space->getName(),
+            ],
+        ], 201);
+    }
+
+    /**
+     * @param array<int|string, mixed> $payload
+     */
+    private function stringField(array $payload, string $key): string
+    {
+        $value = $payload[$key] ?? null;
+
+        return is_string($value) ? trim($value) : '';
+    }
+}

--- a/api/src/Service/AdminUserCreator.php
+++ b/api/src/Service/AdminUserCreator.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\Space;
+use App\Entity\SpaceMembership;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Provisions a ready-to-sign-in account server-side (#admin-user-create).
+ *
+ * Signup normally makes an account wait on two gates — email confirmation
+ * (`ROLE_UNVERIFIED`) and, while the instance is in waitlist mode,
+ * `ROLE_WAITLISTED`. An admin creating an account vouches for the address, so
+ * this clears both: the user can sign in and use the app immediately. That's
+ * what makes it usable for manual customer onboarding, demos, support — and for
+ * standing up a test account on an instance whose signups are closed.
+ *
+ * Shared by {@see \App\Controller\AdminUserController} and
+ * {@see \App\Command\UserCreateCommand} so the HTTP and CLI paths produce
+ * identical accounts.
+ */
+final class AdminUserCreator
+{
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly UserPasswordHasherInterface $passwordHasher,
+        private readonly PersonalSpaceProvisioner $personalSpaceProvisioner,
+        private readonly SpaceRoleSeeder $roleSeeder,
+    ) {
+    }
+
+    /**
+     * @param string|null $plainPassword null = generate a strong one
+     * @param bool        $promoted      clear the waitlist gate (ROLE_USER now)
+     * @param string|null $spaceName     also create a shared space, user as admin
+     *
+     * @return array{user: User, password: string, space: Space|null}
+     *
+     * @throws \InvalidArgumentException when the email is already taken
+     */
+    public function create(
+        string $email,
+        string $givenName,
+        string $familyName,
+        ?string $plainPassword = null,
+        bool $promoted = true,
+        ?string $spaceName = null,
+    ): array {
+        $email = trim($email);
+        if (null !== $this->em->getRepository(User::class)->findOneBy(['email' => $email])) {
+            throw new \InvalidArgumentException(sprintf('An account already exists for "%s".', $email));
+        }
+
+        $password = null !== $plainPassword && '' !== $plainPassword
+            ? $plainPassword
+            : self::generatePassword();
+
+        $user = (new User())
+            ->setEmail($email)
+            ->setGivenName(trim($givenName))
+            ->setFamilyName(trim($familyName));
+        $user->setPassword($this->passwordHasher->hashPassword($user, $password));
+        // Both gates cleared — see the class docblock.
+        $user->setEmailVerified(true);
+        $user->setWaitlisted(!$promoted);
+
+        $this->em->persist($user);
+        $this->em->flush();
+
+        $this->personalSpaceProvisioner->provision($user);
+
+        $space = null;
+        if (null !== $spaceName && '' !== trim($spaceName)) {
+            $space = (new Space())
+                ->setName(trim($spaceName))
+                ->setIsPersonal(false)
+                ->setVisibility(Space::VISIBILITY_PRIVATE)
+                ->setCreatedBy($user);
+            $space->addUserMembership(
+                (new SpaceMembership())->setUser($user)->setRole(Space::ROLE_ADMIN),
+            );
+            $this->em->persist($space);
+            $this->roleSeeder->seed($space);
+            $this->em->flush();
+        }
+
+        return ['user' => $user, 'password' => $password, 'space' => $space];
+    }
+
+    /**
+     * A strong random password. Returned to the caller once (never stored in
+     * plaintext) — same one-shot shape as the API-token reveal.
+     */
+    public static function generatePassword(): string
+    {
+        return rtrim(strtr(base64_encode(random_bytes(18)), '+/', '-_'), '=');
+    }
+}

--- a/api/tests/Api/AdminUserCreateTest.php
+++ b/api/tests/Api/AdminUserCreateTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\Space;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Admin account provisioning (#admin-user-create): POST /admin/users creates a
+ * sign-in-ready account (both signup gates cleared), returns the generated
+ * password once, and is platform-admin only.
+ */
+class AdminUserCreateTest extends ApiTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $em = static::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\SpaceMembership')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Space')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testAdminCreatesUsableAccountWithOneShotPassword(): void
+    {
+        $admin = $this->makeUser('admin@example.com', ['ROLE_ADMIN']);
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+
+        $body = $client->request('POST', '/admin/users', [
+            'json' => [
+                'email' => 'new.person@example.com',
+                'givenName' => 'New',
+                'familyName' => 'Person',
+            ],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+
+        $this->assertSame('new.person@example.com', $body['email'] ?? null);
+        $this->assertFalse($body['waitlisted'] ?? true);
+
+        $password = $body['password'] ?? null;
+        $this->assertIsString($password);
+        $this->assertNotSame('', $password);
+
+        // The account is genuinely usable: both the email-confirmation and
+        // waitlist gates are cleared, so it holds ROLE_USER right away.
+        $created = $this->entityManager->getRepository(User::class)
+            ->findOneBy(['email' => 'new.person@example.com']);
+        assert($created instanceof User);
+        $this->assertContains('ROLE_USER', $created->getRoles());
+        $this->assertTrue($created->isEmailVerified());
+        $this->assertFalse($created->isWaitlisted());
+
+        // …and it got its personal space.
+        $spaces = $this->entityManager->getRepository(Space::class)->findBy(['createdBy' => $created]);
+        $this->assertCount(1, $spaces);
+        $this->assertTrue($spaces[0]->getIsPersonal());
+    }
+
+    public function testCreatesSharedSpaceWhenRequested(): void
+    {
+        $admin = $this->makeUser('admin@example.com', ['ROLE_ADMIN']);
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+
+        $body = $client->request('POST', '/admin/users', [
+            'json' => [
+                'email' => 'studio@example.com',
+                'givenName' => 'Studio',
+                'familyName' => 'Owner',
+                'spaceName' => 'Acme Studio',
+            ],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+
+        $space = $body['space'] ?? null;
+        $this->assertIsArray($space);
+        $this->assertSame('Acme Studio', $space['name'] ?? null);
+
+        $created = $this->entityManager->getRepository(User::class)
+            ->findOneBy(['email' => 'studio@example.com']);
+        assert($created instanceof User);
+        // Personal + the requested shared space.
+        $this->assertCount(2, $this->entityManager->getRepository(Space::class)->findBy(['createdBy' => $created]));
+    }
+
+    public function testSkipWaitlistFalseLeavesAccountWaiting(): void
+    {
+        $admin = $this->makeUser('admin@example.com', ['ROLE_ADMIN']);
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+
+        $body = $client->request('POST', '/admin/users', [
+            'json' => [
+                'email' => 'waiting@example.com',
+                'givenName' => 'Wait',
+                'familyName' => 'Ing',
+                'skipWaitlist' => false,
+            ],
+            'headers' => ['Content-Type' => 'application/json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertTrue($body['waitlisted'] ?? false);
+    }
+
+    public function testDuplicateEmailIsRejected(): void
+    {
+        $admin = $this->makeUser('admin@example.com', ['ROLE_ADMIN']);
+        $this->makeUser('taken@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+
+        $client->request('POST', '/admin/users', [
+            'json' => [
+                'email' => 'taken@example.com',
+                'givenName' => 'Dupe',
+                'familyName' => 'User',
+            ],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testInvalidEmailIsRejected(): void
+    {
+        $admin = $this->makeUser('admin@example.com', ['ROLE_ADMIN']);
+
+        $client = static::createClient();
+        $client->loginUser($admin);
+
+        $client->request('POST', '/admin/users', [
+            'json' => ['email' => 'not-an-email', 'givenName' => 'A', 'familyName' => 'B'],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testNonAdminCannotCreateUsers(): void
+    {
+        $plain = $this->makeUser('plain@example.com');
+
+        $client = static::createClient();
+        $client->loginUser($plain);
+
+        $client->request('POST', '/admin/users', [
+            'json' => ['email' => 'nope@example.com', 'givenName' => 'No', 'familyName' => 'Pe'],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    /**
+     * @param list<string> $roles
+     */
+    private function makeUser(string $email, array $roles = []): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles($roles);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, 'Password123!@#'));
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/pwa/pages/admin/users.tsx
+++ b/pwa/pages/admin/users.tsx
@@ -2,9 +2,9 @@ import type { NextPage } from "next";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useState } from "react";
-import { VenetianMask } from "lucide-react";
+import { UserPlus, VenetianMask } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
-import { apiGetCollection } from "@/lib/apiClient";
+import { apiGetCollection, apiSend } from "@/lib/apiClient";
 import { signinHrefForCurrent } from "@/lib/authRedirect";
 import { displayName } from "@/lib/userDisplay";
 import UserAvatar from "@/components/user/UserAvatar";
@@ -12,6 +12,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
   Card,
   CardContent,
@@ -41,6 +42,15 @@ interface AdminUser {
   canBeImpersonated?: boolean;
 }
 
+/** Response of POST /admin/users — `password` is returned once, never again. */
+interface CreatedUser {
+  id: string;
+  email: string;
+  password: string;
+  waitlisted: boolean;
+  space: { id: string; name: string } | null;
+}
+
 const isAdminUser = (u: AdminUser): boolean =>
   Array.isArray(u.roles) && u.roles.includes("ROLE_ADMIN");
 
@@ -55,6 +65,17 @@ const AdminUsers: NextPage = () => {
   // The user a confirm dialog is currently asking about, or null.
   const [target, setTarget] = useState<AdminUser | null>(null);
   const [busy, setBusy] = useState(false);
+
+  // Create-user dialog (#admin-user-create).
+  const [createOpen, setCreateOpen] = useState(false);
+  const [newEmail, setNewEmail] = useState("");
+  const [newGiven, setNewGiven] = useState("");
+  const [newFamily, setNewFamily] = useState("");
+  const [skipWaitlist, setSkipWaitlist] = useState(true);
+  const [newSpace, setNewSpace] = useState("");
+  const [createError, setCreateError] = useState<string | null>(null);
+  // The one-shot result — the password is only ever returned once.
+  const [created, setCreated] = useState<CreatedUser | null>(null);
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
@@ -95,6 +116,42 @@ const AdminUsers: NextPage = () => {
       setBusy(false);
     }
   }, [target, impersonateUser, router]);
+
+  const resetCreateForm = useCallback(() => {
+    setNewEmail("");
+    setNewGiven("");
+    setNewFamily("");
+    setNewSpace("");
+    setSkipWaitlist(true);
+    setCreateError(null);
+    setCreated(null);
+  }, []);
+
+  const submitCreate = useCallback(async () => {
+    setBusy(true);
+    setCreateError(null);
+    try {
+      const res = await apiSend<CreatedUser>("POST", "/admin/users", {
+        contentType: "application/json",
+        errorMessage: "Couldn't create the user.",
+        body: {
+          email: newEmail.trim(),
+          givenName: newGiven.trim(),
+          familyName: newFamily.trim(),
+          skipWaitlist,
+          ...(newSpace.trim() ? { spaceName: newSpace.trim() } : {}),
+        },
+      });
+      setCreated(res);
+      void load();
+    } catch (e) {
+      setCreateError(
+        e instanceof Error ? e.message : "Couldn't create the user.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  }, [newEmail, newGiven, newFamily, skipWaitlist, newSpace, load]);
 
   if (isLoading) {
     return (
@@ -142,12 +199,23 @@ const AdminUsers: NextPage = () => {
       </Head>
       <div className="min-h-screen bg-background px-4 py-12">
         <div className="max-w-5xl mx-auto space-y-6">
-          <header>
-            <h1 className="text-2xl font-bold">Users</h1>
-            <p className="text-sm text-muted-foreground">
-              Sign in as another user to test or debug an issue from their
-              perspective. You can stop impersonating at any time.
-            </p>
+          <header className="flex items-start justify-between gap-4">
+            <div>
+              <h1 className="text-2xl font-bold">Users</h1>
+              <p className="text-sm text-muted-foreground">
+                Sign in as another user to test or debug an issue from their
+                perspective. You can stop impersonating at any time.
+              </p>
+            </div>
+            <Button
+              onClick={() => {
+                resetCreateForm();
+                setCreateOpen(true);
+              }}
+              data-testid="create-user-open"
+            >
+              <UserPlus className="h-4 w-4" /> Create user
+            </Button>
           </header>
 
           {error && (
@@ -264,6 +332,155 @@ const AdminUsers: NextPage = () => {
               {busy ? "Switching…" : "Impersonate"}
             </Button>
           </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Create user (#admin-user-create) — the password is shown once. */}
+      <Dialog
+        open={createOpen}
+        onOpenChange={(o: boolean) => {
+          setCreateOpen(o);
+          if (!o) resetCreateForm();
+        }}
+      >
+        <DialogContent>
+          {created ? (
+            <>
+              <DialogHeader>
+                <DialogTitle>User created</DialogTitle>
+                <DialogDescription>
+                  Copy the password now — it is shown once and never stored in
+                  plaintext.
+                </DialogDescription>
+              </DialogHeader>
+              <div className="space-y-3" data-testid="create-user-result">
+                <div className="space-y-1">
+                  <Label>Email</Label>
+                  <Input readOnly value={created.email} />
+                </div>
+                <div className="space-y-1">
+                  <Label>Password</Label>
+                  <Input
+                    readOnly
+                    value={created.password}
+                    data-testid="create-user-password"
+                    onFocus={(e) => e.currentTarget.select()}
+                  />
+                </div>
+                {created.space && (
+                  <p className="text-sm text-muted-foreground">
+                    Shared space <strong>{created.space.name}</strong> created,
+                    with this user as admin.
+                  </p>
+                )}
+                {created.waitlisted && (
+                  <Alert>
+                    <AlertDescription>
+                      This account is still on the waitlist, so it can&apos;t use
+                      the app until it&apos;s granted access.
+                    </AlertDescription>
+                  </Alert>
+                )}
+              </div>
+              <DialogFooter>
+                <Button
+                  onClick={() => {
+                    void navigator.clipboard
+                      ?.writeText(created.password)
+                      .catch(() => undefined);
+                  }}
+                  variant="outline"
+                >
+                  Copy password
+                </Button>
+                <Button onClick={() => setCreateOpen(false)}>Done</Button>
+              </DialogFooter>
+            </>
+          ) : (
+            <>
+              <DialogHeader>
+                <DialogTitle>Create a user</DialogTitle>
+                <DialogDescription>
+                  Creates a sign-in-ready account — email confirmation is skipped
+                  and a password is generated for you.
+                </DialogDescription>
+              </DialogHeader>
+              <div className="space-y-3">
+                {createError && (
+                  <Alert variant="destructive" data-testid="create-user-error">
+                    <AlertDescription>{createError}</AlertDescription>
+                  </Alert>
+                )}
+                <div className="space-y-1">
+                  <Label htmlFor="new-email">Email</Label>
+                  <Input
+                    id="new-email"
+                    type="email"
+                    value={newEmail}
+                    onChange={(e) => setNewEmail(e.target.value)}
+                    data-testid="create-user-email"
+                  />
+                </div>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="space-y-1">
+                    <Label htmlFor="new-given">First name</Label>
+                    <Input
+                      id="new-given"
+                      value={newGiven}
+                      onChange={(e) => setNewGiven(e.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <Label htmlFor="new-family">Last name</Label>
+                    <Input
+                      id="new-family"
+                      value={newFamily}
+                      onChange={(e) => setNewFamily(e.target.value)}
+                    />
+                  </div>
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="new-space">
+                    Shared space{" "}
+                    <span className="font-normal text-muted-foreground">
+                      (optional)
+                    </span>
+                  </Label>
+                  <Input
+                    id="new-space"
+                    placeholder="e.g. Acme Studio"
+                    value={newSpace}
+                    onChange={(e) => setNewSpace(e.target.value)}
+                  />
+                </div>
+                <label className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={skipWaitlist}
+                    onChange={(e) => setSkipWaitlist(e.target.checked)}
+                  />
+                  Skip the waitlist (account can use the app immediately)
+                </label>
+              </div>
+              <DialogFooter>
+                <Button variant="ghost" onClick={() => setCreateOpen(false)}>
+                  Cancel
+                </Button>
+                <Button
+                  onClick={() => void submitCreate()}
+                  disabled={
+                    busy ||
+                    !newEmail.trim() ||
+                    !newGiven.trim() ||
+                    !newFamily.trim()
+                  }
+                  data-testid="create-user-submit"
+                >
+                  {busy ? "Creating…" : "Create user"}
+                </Button>
+              </DialogFooter>
+            </>
+          )}
         </DialogContent>
       </Dialog>
     </>


### PR DESCRIPTION
Items 1 & 2 from the admin-tooling discussion.

**Why:** signup gates every account on email confirmation (`ROLE_UNVERIFIED`) and, in waitlist mode, `ROLE_WAITLISTED` — so standing up an account on an instance with closed signups (e.g. a test account on prod to smoke-test billing) meant a multi-step CLI dance. An admin vouching for the address can now clear both in one action. Also useful for manual customer onboarding, demos, and support.

**What:**
- `AdminUserCreator` — generated password (hashed), email pre-verified, optional waitlist skip, personal space + optional shared space (user as admin). Shared by both entry points so they behave identically.
- `POST /admin/users` — ROLE_ADMIN (also gated in `security.yaml`), returns the password **once**, and **logs every creation with the acting admin** since this is an account-creation vector.
- `app:user:create <email> [--given-name --family-name --password --with-space --waitlisted]` — slots next to `app:waitlist:promote` / `app:user:role`.
- Admin UI: **Create user** dialog with a one-shot password reveal + copy.

**Verified locally:** a CLI-created account logs in and gets `ROLE_USER` immediately, with both its "Private" personal space and the requested shared space. 6 API tests (admin-only, one-shot password, shared space, waitlist toggle, duplicate + invalid email). PHPStan + PHPCS clean.