### PR TITLE
fix(api): guard the remaining non-nullable env-injected params

### DIFF
--- a/api/src/Controller/ClientPortalController.php
+++ b/api/src/Controller/ClientPortalController.php
@@ -47,7 +47,10 @@ class ClientPortalController extends AbstractController
         private PaymentGatewayRegistry $gateways,
         private EstimateMailer $estimateMailer,
         private MailDispatcher $mail,
-        #[Autowire('%env(default::APP_FRONTEND_URL)%')]
+        // `string:` guards the non-nullable param: `default::` resolves an unset
+        // *or empty* env var to null, which would fatal on construction rather
+        // than degrade (same trap as the Stripe keys).
+        #[Autowire('%env(string:default::APP_FRONTEND_URL)%')]
         private string $frontendUrl,
     ) {
     }

--- a/api/src/Controller/ConnectController.php
+++ b/api/src/Controller/ConnectController.php
@@ -34,7 +34,10 @@ class ConnectController extends AbstractController
     public function __construct(
         private readonly EntityManagerInterface $em,
         private readonly StripeGatewayInterface $stripe,
-        #[Autowire('%env(default::APP_FRONTEND_URL)%')]
+        // `string:` guards the non-nullable param: `default::` resolves an unset
+        // *or empty* env var to null, which would fatal on construction rather
+        // than degrade (same trap as the Stripe keys).
+        #[Autowire('%env(string:default::APP_FRONTEND_URL)%')]
         private readonly string $frontendUrl,
     ) {
     }

--- a/api/src/Controller/PublicInvoiceController.php
+++ b/api/src/Controller/PublicInvoiceController.php
@@ -25,7 +25,10 @@ class PublicInvoiceController extends AbstractController
         private InvoiceRepository $invoices,
         private InvoicePdfRenderer $renderer,
         private PaymentGatewayRegistry $gateways,
-        #[Autowire('%env(default::APP_FRONTEND_URL)%')]
+        // `string:` guards the non-nullable param: `default::` resolves an unset
+        // *or empty* env var to null, which would fatal on construction rather
+        // than degrade (same trap as the Stripe keys).
+        #[Autowire('%env(string:default::APP_FRONTEND_URL)%')]
         private string $frontendUrl,
     ) {
     }


### PR DESCRIPTION
Follow-up to the fix in #743.

## The trap

Symfony's `default:` env processor treats an **empty string as unset**, so `%env(default::VAR)%` resolves to `null` — not `''` — whenever the var is blank. Injecting that into a non-nullable `string` constructor param throws a TypeError the moment the service is built.

In #743 this took down every container-starting CI job with nothing in the log but `container aura-php-1 is unhealthy`, because a new per-request listener made `StripeGateway` eager. This PR closes the remaining exposed sites.

## What's fixed

`APP_FRONTEND_URL` injected into a non-nullable `string $frontendUrl` in three controllers:

- `PublicInvoiceController` — the public invoice pay page
- `ConnectController` — Stripe Connect onboarding
- `ClientPortalController` — the client portal

It carries a non-empty fallback in both `api/.env` and `compose.yaml`, so it isn't blank in practice — but an explicit empty in the server's `/opt/aura/.env` would 500 exactly those three client-facing routes, and the failure mode (TypeError at construction) gives no useful signal.

## What's *not* fixed, deliberately

I audited every other `%env(default::` site. The `MAILER_FROM` params (`EmailChangeController`, `PasswordController`, `EmailVerificationService`, `MailDispatcher`, `NotificationDigestDispatcher`, `NotificationDispatcher`, `TaskReminderDispatcher`) and the `VAPID_*` params in `WebPushSender` are all declared `?string`, so they accept the null safely. No change needed.

## Verification

Reproduced the failure mode and confirmed the fix by recreating the `php` container with the var explicitly blank:

```
APP_FRONTEND_URL= docker compose up -d --force-recreate --renew-anon-volumes php
```

Container comes up healthy, and `GET /public/invoices/nope` returns **404** (the correct not-found) rather than 500 — which is the real evidence, since controllers are lazily constructed and a healthy `/docs` alone wouldn't prove it.

PHPStan L10 + strict-rules clean, PHPCS clean.