### PR TITLE
test(e2e): drive invoice generation through the UI; fix rename copy bugs

### DIFF
--- a/e2e/tests/invoicing.spec.js
+++ b/e2e/tests/invoicing.spec.js
@@ -52,4 +52,77 @@ test.describe("Invoicing", () => {
     await page.goto(`${BASE_URL}/invoices`);
     await expect(page.getByRole("heading", { name: "Invoices" })).toBeVisible();
   });
+
+  test("tracked time can be turned into a draft invoice from the UI", async ({ page }) => {
+    await registerAndSignIn(page, uniqueEmail());
+
+    // Seed the prerequisites over the API (page.request shares the signed-in
+    // session). Clicking through client → project → categories → time entry
+    // first would make this test mostly about *other* pages; what's under test
+    // here is the invoice composer.
+    const spaceIri = await personalSpaceIri(page);
+
+    const client = await postJson(page, "/clients", {
+      space: spaceIri,
+      name: `Acme ${Date.now()}`,
+      currency: "USD",
+    });
+
+    const project = await postJson(page, "/projects", {
+      space: spaceIri,
+      client: client["@id"],
+      name: "Acme Website",
+      currency: "USD",
+      categories: [{ name: "Dev", billingRate: 6000, position: 0 }],
+    });
+    const devCategory = project.categories[0];
+
+    // One billable hour → 6000 minor units.
+    await postJson(page, "/time_entries", {
+      space: spaceIri,
+      project: project["@id"],
+      category: devCategory["@id"],
+      startedAt: "2026-07-03T09:00:00+00:00",
+      endedAt: "2026-07-03T10:00:00+00:00",
+    });
+
+    // Now drive the composer: pick the project, preview, generate.
+    await page.goto(`${BASE_URL}/invoices`);
+    await page.getByRole("button", { name: /Generate invoice/ }).click();
+    await page.locator("#gen-project").selectOption(project["@id"]);
+    await page.getByRole("button", { name: /^Preview$/ }).click();
+
+    // The preview lists the tracked hour, so Generate becomes available.
+    const generate = page.getByRole("button", { name: /^Generate draft$/ });
+    await expect(generate).toBeEnabled();
+    await generate.click();
+
+    // The success notice names the entry count, and the new draft appears in
+    // the table under its client. (Asserting on the notice rather than any
+    // text containing "draft" — the Generate button says that too.)
+    await expect(
+      page.getByText("Draft invoice created from 1 time entry."),
+    ).toBeVisible();
+    await expect(page.getByText(client.name)).toBeVisible();
+  });
 });
+
+/** The signed-in user's personal space IRI — every seeded row hangs off it. */
+async function personalSpaceIri(page) {
+  const res = await page.request.get(`${BASE_URL}/spaces`, {
+    headers: { Accept: "application/ld+json" },
+  });
+  const body = await res.json();
+  const spaces = body.member ?? body["hydra:member"] ?? [];
+  expect(spaces.length, "the user should have a personal space").toBeGreaterThan(0);
+  return spaces[0]["@id"];
+}
+
+async function postJson(page, path, data) {
+  const res = await page.request.post(`${BASE_URL}${path}`, {
+    headers: { "Content-Type": "application/ld+json" },
+    data,
+  });
+  expect(res.status(), `POST ${path} -> ${await res.text()}`).toBe(201);
+  return res.json();
+}

--- a/pwa/pages/expenses/index.tsx
+++ b/pwa/pages/expenses/index.tsx
@@ -48,7 +48,7 @@ const openReceipt = async (receiptIri: string, onError: (m: string) => void) => 
 
 /**
  * Expense tracking (#650): inline-add list like /time — members log their
- * own expenses against an project, optionally attach a receipt, and
+ * own expenses against a project, optionally attach a receipt, and
  * invoice generation pulls the unbilled billable ones (billed = locked).
  */
 const ExpensesPage = () => {
@@ -237,7 +237,7 @@ const ExpensesPage = () => {
           {canCreate && noProjects && (
             <Alert className="mb-4">
               <AlertDescription>
-                You need an project to log expenses.{" "}
+                You need a project to log expenses.{" "}
                 <Link href="/projects" className="underline">
                   Set one up
                 </Link>{" "}

--- a/pwa/pages/invoices/index.tsx
+++ b/pwa/pages/invoices/index.tsx
@@ -335,7 +335,7 @@ const InvoicesPage = () => {
                                   }}
                                   className="h-9 w-64 max-w-full rounded-md border border-input bg-background px-3 text-sm"
                                 >
-                                  <option value="">Select an project…</option>
+                                  <option value="">Select a project…</option>
                                   {projects.map((eng) => (
                                     <option key={eng["@id"]} value={eng["@id"]}>
                                       {eng.name}

--- a/pwa/pages/projects/index.tsx
+++ b/pwa/pages/projects/index.tsx
@@ -140,7 +140,7 @@ const ProjectsPage = () => {
   const [loadError, setLoadError] = useState<string | null>(null);
 
   // Which project the side panel is showing: null (closed) | NEW (create) |
-  // an project IRI (view/edit that one).
+  // a project IRI (view/edit that one).
   const [sheetFor, setSheetFor] = useState<string | null>(null);
   const [name, setName] = useState("");
   const [clientIri, setClientIri] = useState("");
@@ -358,7 +358,7 @@ const ProjectsPage = () => {
         <PageHeader
           title="Projects"
           icon={<Briefcase className="h-6 w-6 text-orange-600 dark:text-orange-400" />}
-          subtitle="A project has a client and a set of categories, each with an hourly rate. Time is tracked against an project + category."
+          subtitle="A project has a client and a set of categories, each with an hourly rate. Time is tracked against a project + category."
         />
 
         {loadError && (

--- a/pwa/pages/time/index.tsx
+++ b/pwa/pages/time/index.tsx
@@ -496,7 +496,7 @@ const TimePage = () => {
                                   title={
                                     canTrack
                                       ? `Start a timer on ${projectName.get(projectIri) ?? "…"} · ${categoryName.get(categoryIri) ?? "…"} (change via Add time)`
-                                      : "Pick an project first"
+                                      : "Pick a project first"
                                   }
                                   className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
                                 >


### PR DESCRIPTION
The small follow-ups I could finish without your input.

## 1. Invoicing E2E depth (the #598 follow-up)

Extends the spec past client-creation to the step that actually matters: **turning tracked time into a draft invoice through the composer**.

Prerequisites (client → project → category → time entry) are **seeded over the API** via `page.request` rather than clicked through four more pages. Clicking them would make the test mostly about *those* pages; what's under test here is the composer. The seed helper surfaces the response body on failure, so a CI break is diagnosable in one round instead of a guessing game.

I verified the risky assumptions **before** pushing this time, rather than after:
- the preview auto-checks its entries (`setChecked(new Set(...))`), so "Generate draft" is genuinely enabled;
- `/spaces` orders `isPersonal DESC`, so the first row really is the personal space;
- the success notice — *"Draft invoice created from 1 time entry."* — is a precise assertion target. My first draft matched `/draft/i`, which would have matched the **"Generate draft" button itself** and passed for the wrong reason.

## 2. Copy bugs from the Engagement→Project rename

Six user-visible grammar leftovers, spotted while reading the composer:

- `Select an project…` → `Select a project…`
- `You need an project to log expenses.` → `a project`
- `Pick an project first` → `Pick a project first`
- `Time is tracked against an project + category.` → `a project`
- plus two doc comments

## Not done, and why

- **Live browser click-through** — still can't; my sandbox can't reach the app's localhost. That one needs you (or the testids below).
- **Cross-board subtask nesting on `/timeline`** — I listed this as a gap last time and it isn't one. Rows there are grouped *by board*, so a child on board B belongs under board B; nesting it beneath a parent on board A would pull it out of its own group. `nestByParent` already handles an off-group parent gracefully by treating it as a root. Leaving it alone rather than manufacturing churn.

## Verification

`pnpm typecheck` and `pnpm lint` clean (0 errors). The new E2E runs in CI.