### PR TITLE
test(e2e): dashboard widget round trip

### DIFF
--- a/e2e/tests/dashboard.spec.js
+++ b/e2e/tests/dashboard.spec.js
@@ -1,0 +1,81 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+const { BASE_URL, uniqueEmail: shared, registerAndSignIn } = require("./helpers");
+
+const uniqueEmail = () => shared("dashboard");
+
+/**
+ * Configurable dashboard (#759).
+ *
+ * The permission rules — who may see which widget, the admin-reserved
+ * categories, config-dependent categories — are covered at the API level by
+ * `App\Tests\Api\DashboardWidgetTest`, which can set up multi-user spaces far
+ * more cheaply than a browser can. What that can't tell us is whether the page
+ * actually drives any of it.
+ *
+ * So this covers the admin's full round trip through the UI: empty state → add
+ * from the catalog → configure → see the config render → remove. That's the
+ * path a plugin author's widget will travel, and it crosses a dialog, a drawer,
+ * and two optimistic refetches — the parts most likely to break silently.
+ *
+ * A freshly registered user is an admin of their own Private space, so no extra
+ * setup is needed to reach the editing controls.
+ */
+test.describe("Dashboard", () => {
+  test("unauthenticated visitors are redirected to sign in", async ({ page }) => {
+    await page.goto(`${BASE_URL}/dashboard`);
+    await expect(page).toHaveURL(/\/signin/);
+  });
+
+  test("an admin can add, configure, and remove a widget", async ({ page }) => {
+    await registerAndSignIn(page, uniqueEmail());
+
+    await page.goto(`${BASE_URL}/dashboard`);
+    await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();
+
+    // A brand-new space starts with nothing on it.
+    await expect(page.getByText("This dashboard is empty")).toBeVisible();
+
+    // --- add, from the server-driven catalog -------------------------------
+    await page.getByRole("button", { name: /Add your first widget/ }).click();
+    await expect(page.getByRole("heading", { name: "Add a widget" })).toBeVisible();
+
+    await page.getByTestId("add-widget-notes.markdown").click();
+
+    const note = page.getByTestId("widget-notes.markdown");
+    await expect(note).toBeVisible();
+    // The empty state is gone, so the layout actually re-read from the server.
+    await expect(page.getByText("This dashboard is empty")).toBeHidden();
+
+    // The picker stays open for adding several in a row.
+    await page.getByRole("button", { name: /^Done$/ }).click();
+
+    // --- configure ----------------------------------------------------------
+    await note.getByRole("button", { name: "Widget options" }).click();
+    await page.getByRole("menuitem", { name: /Configure/ }).click();
+
+    const heading = `Team note ${Date.now()}`;
+    await page.locator("#wcfg-title").fill(heading);
+    await page.locator("#wcfg-body").fill("We ship on Thursdays.");
+    await page.getByRole("button", { name: /^Save$/ }).click();
+
+    // Config round-tripped and the widget renders it — this is the whole
+    // point of the config being stored server-side rather than in the client.
+    await expect(note.getByText(heading)).toBeVisible();
+    await expect(note.getByText("We ship on Thursdays.")).toBeVisible();
+
+    // --- a second widget, to prove the catalog isn't a one-shot -------------
+    await page.getByRole("button", { name: /^Add widget$/ }).click();
+    await page.getByTestId("add-widget-boards.list").click();
+    await expect(page.getByTestId("widget-boards.list")).toBeVisible();
+    await page.getByRole("button", { name: /^Done$/ }).click();
+
+    // --- remove -------------------------------------------------------------
+    await note.getByRole("button", { name: "Widget options" }).click();
+    await page.getByRole("menuitem", { name: /Remove/ }).click();
+
+    await expect(page.getByTestId("widget-notes.markdown")).toHaveCount(0);
+    // The other widget is untouched — remove hit one row, not the layout.
+    await expect(page.getByTestId("widget-boards.list")).toBeVisible();
+  });
+});

--- a/pwa/components/dashboard/AddWidgetDialog.tsx
+++ b/pwa/components/dashboard/AddWidgetDialog.tsx
@@ -67,6 +67,7 @@ const AddWidgetDialog = ({ open, spaceId, adding, onAdd, onOpenChange }: Props) 
                       <button
                         key={entry.type}
                         type="button"
+                        data-testid={`add-widget-${entry.type}`}
                         disabled={adding !== null}
                         onClick={() => onAdd(entry)}
                         className="flex w-full items-start gap-3 rounded-md border p-3 text-left transition-colors hover:bg-accent disabled:opacity-60"

--- a/pwa/components/dashboard/WidgetConfigSheet.tsx
+++ b/pwa/components/dashboard/WidgetConfigSheet.tsx
@@ -41,12 +41,16 @@ const WidgetConfigSheet = ({ widget, saving, error, onSave, onClose }: Props) =>
   const [config, setConfig] = useState<Record<string, unknown>>({});
   const [width, setWidth] = useState(2);
   const [height, setHeight] = useState(2);
+  // Bumped on every open so the remount key below changes even when the same
+  // widget is configured twice in a row.
+  const [openSeq, setOpenSeq] = useState(0);
 
   useEffect(() => {
     if (widget) {
       setConfig(widget.config ?? {});
       setWidth(widget.width);
       setHeight(widget.height);
+      setOpenSeq((n) => n + 1);
     }
   }, [widget]);
 
@@ -149,9 +153,11 @@ const WidgetConfigSheet = ({ widget, saving, error, onSave, onClose }: Props) =>
         if (!open) onClose();
       }}
     >
-      {/* Remounted per widget: reusing a controlled Sheet mid-exit-animation
-          leaves it stuck closed. */}
-      <SheetContent key={widget?.id ?? "none"} className="w-full sm:max-w-md">
+      {/* Remounted on every open. Radix ≥1.6 leaves a reused controlled Sheet
+          stuck closed if it's reopened mid-exit-animation, and keying on the
+          widget id alone wouldn't change when the same widget is configured
+          twice in a row. */}
+      <SheetContent key={`${widget?.id ?? "none"}-${openSeq}`} className="w-full sm:max-w-md">
         <SheetHeader>
           <SheetTitle>{widget?.name ?? "Widget"}</SheetTitle>
         </SheetHeader>

--- a/pwa/components/dashboard/WidgetFrame.tsx
+++ b/pwa/components/dashboard/WidgetFrame.tsx
@@ -92,6 +92,7 @@ const WidgetFrame = ({ widget, canEdit, onConfigure, onRemove }: Props) => {
     <div
       ref={setNodeRef}
       style={style}
+      data-testid={`widget-${widget.type}`}
       className={`${WIDTH_CLASS[widget.width] ?? WIDTH_CLASS[2]} ${
         isDragging ? "z-10 opacity-70" : ""
       }`}

--- a/pwa/next-env.d.ts
+++ b/pwa/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.


### PR DESCRIPTION
Follow-up to #760. Adds the E2E coverage that PR was missing.

## What it covers

The admin's full round trip: empty state → add from the catalog → configure → see the config render → remove, plus the unauthenticated redirect. That's the path a plugin author's widget will travel, and it crosses a dialog, a drawer, and two refetches — the parts most likely to break silently.

Permissions stay at the API level (`DashboardWidgetTest`), where multi-user spaces are far cheaper to set up than in a browser. A freshly registered user is an admin of their own Private space, so the editing controls need no extra fixture.

## Two source changes it prompted

**Test ids on catalog buttons and widget frames.** The catalog button's accessible name concatenates a widget's name *and* its description, so text matching would have been fragile from day one.

**A latent Radix reopen bug.** The config sheet was keyed on the widget id, so configuring the same widget twice in a row reused the key — the exact pattern that leaves a controlled Sheet stuck closed if it reopens mid-exit-animation on radix-ui ≥1.6. Keyed per open now. Not something the E2E hits, but writing the drawer steps is what surfaced it.

## Honest note on verification

**I could not run this locally.** I tried properly — ran Playwright in the same container image CI uses, sharing the php container's network namespace so `https://localhost` resolved. The app answered, but this machine serves PHP requests in ~50s (dev container, `watch` mode), well past Playwright's 30s timeout. So CI is this spec's first real run.

To compensate I audited every selector against source rather than from memory: `PageHeader` renders `<h1>`, Radix `DialogTitle` renders `<h2>`, the options button's accessible name comes from an `sr-only` span, the config fields are `#wcfg-title` / `#wcfg-body` from `id={`wcfg-${key}`}`, and remove has no confirm step. The two new test ids exist to remove the remaining guesswork.

If it fails, I'll fix it rather than leave it red.
