### PR TITLE
fix(security): bump brace-expansion to 5.0.8 (CVE-2026-14257 DoS)

### DIFF
--- a/pwa/package.json
+++ b/pwa/package.json
@@ -85,7 +85,7 @@
   ],
   "pnpm": {
     "overrides": {
-      "brace-expansion@<1.1.16": "^1.1.16",
+      "brace-expansion@<5.0.8": "^5.0.8",
       "esbuild@<0.28.1": "^0.28.1",
       "fast-uri@<3.1.4": "^3.1.4",
       "js-yaml@<4.3.0": "^4.3.0",

--- a/pwa/pnpm-lock.yaml
+++ b/pwa/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion@<1.1.16: ^1.1.16
+  brace-expansion@<5.0.8: ^5.0.8
   esbuild@<0.28.1: ^0.28.1
   fast-uri@<3.1.4: ^3.1.4
   js-yaml@<4.3.0: ^4.3.0
@@ -2892,9 +2892,6 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -2909,12 +2906,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
-
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -3026,9 +3020,6 @@ packages:
 
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -8141,20 +8132,13 @@ snapshots:
 
   bail@2.0.2: {}
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.43: {}
 
   baseline-browser-mapping@2.11.1: {}
 
-  brace-expansion@1.1.16:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -8265,8 +8249,6 @@ snapshots:
   commander@2.20.3: {}
 
   commondir@1.0.1: {}
-
-  concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
 
@@ -9781,11 +9763,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## Description

Clears the current Dependabot alert — **brace-expansion DoS**, [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) / CVE-2026-14257 (unbounded expansion length → OOM crash, high severity), affecting `<=5.0.7`.

It flagged **both** brace-expansion instances in the tree:
- `1.1.16` via `eslint → minimatch@3.1.5`
- `5.0.7` via `@sentry/nextjs → glob → minimatch@10`

The 1.x line has **no patched release** (it tops out at the now-flagged 1.1.16), so the advisory's fix is `5.0.8`. I widened the existing `pnpm.overrides` entry from `brace-expansion@<1.1.16` to **`brace-expansion@<5.0.8` → `^5.0.8`**, so every path resolves to a single `brace-expansion@5.0.8`.

### Compatibility note
This jumps the eslint→`minimatch@3.1.5` path from brace-expansion 1.x to 5.x. Validated that minimatch@3 (eslint) and minimatch@10 (sentry bundler) both still work: `pnpm lint` passes (0 errors) and `pnpm build` is clean.

## Type of Change

- [x] Bug fix <!-- security remediation -->
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## Component

- [ ] API (PHP/Symfony)
- [x] PWA (Next.js)
- [ ] Infrastructure (Docker/Helm)
- [ ] E2E Tests
- [ ] Documentation

## How Has This Been Tested?

- `pnpm audit` — 0 vulnerabilities (from 2 high findings on brace-expansion 1.1.16 / 5.0.7)
- `pnpm lint` — 0 errors (exercises `minimatch@3` under eslint with brace-expansion 5.x)
- `pnpm build` — clean (exercises `minimatch@10` under the Sentry bundler)
- `pnpm typecheck` — clean
- `pnpm test` — 149 passing

## Checklist

- [x] My code follows the project's conventions
- [ ] I have added tests that prove my fix or feature works <!-- N/A: dependency remediation -->
- [x] New and existing tests pass locally (PHPUnit / `pnpm test:coverage`)
- [ ] New pure-logic helpers under `pwa/lib` are added to the coverage allowlist in `pwa/vitest.config.ts` <!-- N/A -->
- [x] I have updated documentation if needed <!-- N/A -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EunWErYhnkhsmAoAVsgJXK

---
_Generated by [Claude Code](https://claude.ai/code/session_01EunWErYhnkhsmAoAVsgJXK)_