### PR TITLE
promote: docs, home page, MCP automation tools + brace-expansion security bump

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,6 +274,8 @@ User docs:
 - `docs/user/two-factor-auth.md` - End-user guide for enabling, using, and recovering 2FA
 - `docs/user/password-reset.md` - End-user guide for resetting a forgotten password
 - `docs/user/data-export.md` - End-user guide for exporting your account data (GDPR)
+- `docs/user/automations.md` - End-user guide for board rules: reading a graph, building one, the run history, why a rule didn't fire
+- `docs/user/dashboards-and-reports.md` - End-user guide for the space dashboard widgets and the Reports charts
 
 ### GitHub Community Files (`.github/`)
 - `.github/CONTRIBUTING.md` - Contribution guidelines

--- a/api/src/Mcp/McpToolPolicy.php
+++ b/api/src/Mcp/McpToolPolicy.php
@@ -50,6 +50,11 @@ final class McpToolPolicy
         'create_board' => ['category' => 'boards', 'write' => true],
         'update_board' => ['category' => 'boards', 'write' => true],
         'delete_board' => ['category' => 'boards', 'write' => true],
+        // Automations are board configuration, so they ride the boards scope.
+        // Read-only by design — see ListAutomationsTool on why there is no
+        // create_automation.
+        'list_automations' => ['category' => 'boards', 'write' => false],
+        'get_automation_runs' => ['category' => 'boards', 'write' => false],
         // spaces — no dedicated AccessPolicy category; spaces are the
         // container for boards, so listing them rides the boards
         // read scope (it's read-only metadata either way).

--- a/api/src/Mcp/Tool/GetAutomationRunsTool.php
+++ b/api/src/Mcp/Tool/GetAutomationRunsTool.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Automation;
+use App\Entity\AutomationRun;
+use App\Entity\User;
+use App\Mcp\McpAuthorization;
+use App\Mcp\McpException;
+use App\Mcp\McpInputHelper;
+use App\Repository\AutomationRunRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Recent executions of one automation rule, step by step.
+ *
+ * The counterpart to {@see ListAutomationsTool}: that says what a rule *would*
+ * do, this says what it *did*. Together they answer "why did my task move?"
+ * without anyone opening the board.
+ *
+ * Skipped steps are included, not filtered out — a rule that fired and did
+ * nothing is the common case, and the condition that stopped it is the whole
+ * explanation.
+ */
+final class GetAutomationRunsTool implements McpToolInterface
+{
+    private const DEFAULT_LIMIT = 20;
+    private const MAX_LIMIT = 100;
+
+    public function __construct(
+        private EntityManagerInterface $em,
+        private AutomationRunRepository $runs,
+        private McpAuthorization $authz,
+        private McpInputHelper $input,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'get_automation_runs';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Show recent runs of one automation rule, including which conditions passed or skipped and which actions ran. Use to explain why a task changed by itself, or why a rule did not fire.';
+    }
+
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'automationId' => ['type' => 'string', 'description' => 'The rule to inspect (from list_automations).'],
+                'limit' => [
+                    'type' => 'integer',
+                    'description' => sprintf('Runs to return (1-%d, default %d).', self::MAX_LIMIT, self::DEFAULT_LIMIT),
+                ],
+            ],
+            'required' => ['automationId'],
+            'additionalProperties' => false,
+        ];
+    }
+
+    public function invoke(array $arguments, User $user): array
+    {
+        $id = $this->input->requireUuid('automationId', $arguments['automationId'] ?? null);
+        $rule = $this->em->getRepository(Automation::class)->find($id);
+
+        $board = $rule?->getBoard();
+        if (!$rule instanceof Automation || null === $board || !$this->authz->canReadBoard($board, $user)) {
+            throw McpException::notFound('No automation with that id.');
+        }
+
+        $limit = $this->input->optionalInt($arguments, 'limit') ?? self::DEFAULT_LIMIT;
+        $limit = max(1, min(self::MAX_LIMIT, $limit));
+
+        return [
+            'automation' => $rule->getName(),
+            'items' => array_map(
+                fn (AutomationRun $run) => [
+                    'status' => $run->getStatus(),
+                    'task' => $run->getTaskTitle(),
+                    'taskId' => null === $run->getTask() ? null : (string) $run->getTask()->getId(),
+                    // Non-zero means another rule caused this one to fire —
+                    // the first thing to check when rules look like they're
+                    // fighting each other.
+                    'causedByAnotherRule' => $run->getDepth() > 0,
+                    'steps' => $run->getSteps(),
+                    'ranAt' => $run->getRanAt()->format(\DATE_ATOM),
+                ],
+                $this->runs->recentFor($rule, $limit),
+            ),
+        ];
+    }
+}

--- a/api/src/Mcp/Tool/ListAutomationsTool.php
+++ b/api/src/Mcp/Tool/ListAutomationsTool.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Automation;
+use App\Entity\Board;
+use App\Entity\User;
+use App\Mcp\McpAuthorization;
+use App\Mcp\McpException;
+use App\Mcp\McpInputHelper;
+use App\Repository\AutomationRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Lists a board's automation rules, flattened into readable when/if/then form.
+ *
+ * **Read-only, deliberately.** There is no create_automation companion: a rule
+ * edits *other people's* tasks on a schedule nobody is watching, which is a far
+ * bigger grant than the per-item writes the other MCP tools make. Letting a
+ * model author one would hand it durable authority over a board rather than a
+ * single reversible action. Writing rules stays a space admin in the UI.
+ *
+ * The value here is explanatory — "why did this task move?" is answerable by
+ * reading the rules plus {@see GetAutomationRunsTool}, and that's exactly the
+ * question a model gets asked.
+ */
+final class ListAutomationsTool implements McpToolInterface
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private AutomationRepository $automations,
+        private McpAuthorization $authz,
+        private McpInputHelper $input,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'list_automations';
+    }
+
+    public function getDescription(): string
+    {
+        return 'List the automation rules on a board, each summarised as when/if/then. Read-only. Use with get_automation_runs to explain why a task changed on its own.';
+    }
+
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'boardId' => ['type' => 'string', 'description' => 'The board whose rules to list.'],
+            ],
+            'required' => ['boardId'],
+            'additionalProperties' => false,
+        ];
+    }
+
+    public function invoke(array $arguments, User $user): array
+    {
+        $boardId = $this->input->requireUuid('boardId', $arguments['boardId'] ?? null);
+        $board = $this->em->getRepository(Board::class)->find($boardId);
+
+        // Existence-hiding, same as every other board-scoped surface.
+        if (!$board instanceof Board || !$this->authz->canReadBoard($board, $user)) {
+            throw McpException::notFound('No board with that id.');
+        }
+
+        $rules = $this->automations->findBy(['board' => $board], ['createdAt' => 'ASC']);
+
+        return [
+            'items' => array_map(
+                fn (Automation $rule) => [
+                    'id' => (string) $rule->getId(),
+                    'name' => $rule->getName(),
+                    'enabled' => $rule->isEnabled(),
+                    'trigger' => $rule->getTriggerEvent(),
+                    'summary' => $this->summarise($rule),
+                    // Surfaced because a rule the server switched off after
+                    // repeated failures looks identical to one someone paused.
+                    'lastError' => $rule->getLastError(),
+                    'lastRunAt' => $rule->getLastRunAt()?->format(\DATE_ATOM),
+                ],
+                $rules,
+            ),
+        ];
+    }
+
+    /**
+     * Flattens the graph into "when X, only if Y, then Z" — a shape a model can
+     * actually reason about, rather than raw nodes and edges.
+     */
+    private function summarise(Automation $rule): string
+    {
+        $graph = $rule->getGraph();
+        $nodes = $graph['nodes'] ?? [];
+        if (!is_array($nodes)) {
+            return 'This rule could not be read.';
+        }
+
+        $by = ['trigger' => [], 'condition' => [], 'action' => []];
+        foreach ($nodes as $node) {
+            if (!is_array($node)) {
+                continue;
+            }
+            $kind = is_string($node['kind'] ?? null) ? $node['kind'] : '';
+            $type = is_string($node['type'] ?? null) ? $node['type'] : '';
+            if (isset($by[$kind]) && '' !== $type) {
+                $by[$kind][] = $type;
+            }
+        }
+
+        $parts = [];
+        if ([] !== $by['trigger']) {
+            $parts[] = 'when ' . implode(', ', $by['trigger']);
+        }
+        if ([] !== $by['condition']) {
+            $parts[] = 'only if ' . implode(' and ', $by['condition']);
+        }
+        if ([] !== $by['action']) {
+            $parts[] = 'then ' . implode(', ', $by['action']);
+        }
+
+        return [] === $parts ? 'Empty rule.' : implode('; ', $parts);
+    }
+}

--- a/api/tests/Api/McpTest.php
+++ b/api/tests/Api/McpTest.php
@@ -645,6 +645,80 @@ class McpTest extends ApiTestCase
         $this->assertTrue($body['result']['isError'] ?? null);
     }
 
+    public function testListAutomationsFlattensARuleIntoWhenIfThen(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $board = $this->makeProject($alice, [], 'Automated');
+
+        $rule = new \App\Entity\Automation();
+        $rule->setBoard($board)
+            ->setName('Tag on completion')
+            ->setTriggerEvent(\App\Automation\AutomationEvents::TASK_COMPLETED)
+            ->setGraph([
+                'nodes' => [
+                    ['id' => 't', 'kind' => 'trigger', 'type' => 'task.completed', 'config' => []],
+                    ['id' => 'c', 'kind' => 'condition', 'type' => 'task.has_tag', 'config' => ['tag' => 'urgent']],
+                    ['id' => 'a', 'kind' => 'action', 'type' => 'task.add_tag', 'config' => ['tag' => 'done']],
+                ],
+                'edges' => [['from' => 't', 'to' => 'c'], ['from' => 'c', 'to' => 'a']],
+            ])
+            ->setCreatedBy($alice);
+        $this->entityManager->persist($rule);
+        $this->entityManager->flush();
+
+        $plain = $this->mintToken($alice, 'CLI');
+        $client = static::createClient();
+
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_automations',
+            'arguments' => ['boardId' => (string) $board->getId()],
+        ]);
+        $this->assertFalse($body['result']['isError'] ?? null);
+
+        $structured = $body['result']['structuredContent'] ?? null;
+        $this->assertIsArray($structured);
+        $items = $structured['items'];
+        $this->assertIsArray($items);
+        $this->assertCount(1, $items);
+        $this->assertIsArray($items[0]);
+
+        // Flattened rather than handing back raw nodes and edges — a model can
+        // reason about a sentence, not an adjacency list.
+        $summary = $items[0]['summary'];
+        $this->assertIsString($summary);
+        $this->assertStringContainsString('when task.completed', $summary);
+        $this->assertStringContainsString('only if task.has_tag', $summary);
+        $this->assertStringContainsString('then task.add_tag', $summary);
+
+        // The runs tool reads the same rule cleanly with no history yet.
+        $runs = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'get_automation_runs',
+            'arguments' => ['automationId' => (string) $rule->getId()],
+        ]);
+        $this->assertFalse($runs['result']['isError'] ?? null);
+        $runsStructured = $runs['result']['structuredContent'] ?? null;
+        $this->assertIsArray($runsStructured);
+        $this->assertSame([], $runsStructured['items']);
+    }
+
+    public function testAutomationToolsHideAnotherUsersBoard(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $bob = $this->createUser('bob@example.com');
+        $board = $this->makeProject($bob, [], "Bob's board");
+
+        $plain = $this->mintToken($alice, 'CLI');
+        $client = static::createClient();
+
+        $body = $this->callMcp($client, $plain, 'tools/call', [
+            'name' => 'list_automations',
+            'arguments' => ['boardId' => (string) $board->getId()],
+        ]);
+
+        // Existence-hiding, same as every other board-scoped tool.
+        $this->assertTrue($body['result']['isError'] ?? null);
+    }
+
     public function testEveryRegisteredToolHasAPolicyMapping(): void
     {
         // Guards against a new MCP tool silently defaulting to "allowed under

--- a/docs/developer/mcp-server.md
+++ b/docs/developer/mcp-server.md
@@ -64,6 +64,7 @@ Tokens authenticate via `Authorization: Bearer` on both the `/mcp` firewall and 
 | Task        | `create_task`, `get_task`, `update_task`, `delete_task`, `list_tasks`, `search_tasks` |
 | Relationships| `link_tasks`, `unlink_tasks`, `list_task_relationships` (subtasks / dependencies / links) |
 | Board       | `create_board`, `get_board`, `update_board`, `delete_board`, `list_boards` |
+| Automations | `list_automations`, `get_automation_runs` — **read-only** |
 | Space       | `list_spaces`                                                                   |
 | Page        | `create_page`, `get_page`, `update_page`, `delete_page`, `list_pages`          |
 | Assignment  | `assign_task`, `unassign_task`, `get_my_tasks`                                 |
@@ -119,6 +120,21 @@ time- and expense-tracking loop.
 tracking concern like logging time (everyone records their own), distinct from
 seeing what the business bills. `list_estimates`, by contrast, rides `invoices`.
 This mirrors the REST `security:` expressions exactly.
+
+### Automations are read-only on purpose
+
+`list_automations` and `get_automation_runs` expose board rules, but there is
+deliberately **no `create_automation`**.
+
+Every other write tool here makes one reversible change to one item. A rule is
+different in kind: it edits *other people's* tasks, repeatedly, on a schedule
+nobody is watching. Letting a model author one would hand it durable authority
+over a board rather than a single action a human would notice going wrong.
+
+The read side is where the value is anyway — "why did this task move on its
+own?" is answerable from the rules plus their run history, and that's precisely
+what a model gets asked. Authoring rules stays a space admin in the UI. See
+[board-automations.md](board-automations.md).
 
 ### Analytics
 

--- a/docs/user/automations.md
+++ b/docs/user/automations.md
@@ -1,0 +1,91 @@
+# Automating a board
+
+A rule does something automatically when something happens on a board — reassign a task when it's completed, tag anything that goes overdue, post a comment when work moves to review.
+
+You'll find them on the **Automations** tab of any board.
+
+## Reading a rule
+
+Every rule is three kinds of step:
+
+- **When** — the thing that starts it. Every rule has exactly one.
+- **Only if** — an optional check. Steps hanging below it run only when it passes.
+- **Then** — what actually happens.
+
+They're drawn as connected boxes:
+
+```
+When a task is completed
+      ├──▶ Only if it's tagged "urgent" ──▶ Then notify the lead
+      └──▶ Then move it to "Done"
+```
+
+Both branches come off the trigger, so completing a task always moves it to Done — but only urgent ones notify the lead.
+
+**"Only if" is a gate, not a fork.** There's no "otherwise" path. If you want two different outcomes, add two checks off the same box.
+
+## Building one
+
+1. Open a board → **Automations** → **New rule**.
+2. Pick what starts it.
+3. Click a step in the palette to add it, then drag from the dot on one box to the dot on the next to connect them.
+4. Click any box to set it up in the panel on the right.
+5. **Save**, then switch it on.
+
+New rules start **switched off**, so nothing happens while you're still building.
+
+The canvas will tell you when a rule can't be saved yet — a step that isn't connected to anything, or a loop where two steps point at each other.
+
+### On a phone
+
+You can read rules on a small screen, but not edit them. Dragging boxes and drawing connections needs more room than a phone gives.
+
+## What can start a rule
+
+- A task is **created**
+- A task is **completed**
+- A task **moves to a section**
+- A task's **assignee changes**
+- A task's **due date passes**
+
+Overdue is checked hourly, so a rule on it runs within the hour rather than at midnight exactly.
+
+## Why did my task change?
+
+Open the rule and switch to **History**. Every run is listed with each step and what it did:
+
+- **matched** — the check passed
+- **skipped** — the check didn't pass, so nothing below it ran
+- **did** — the action ran
+- **failed** — something went wrong; the reason is shown
+
+Skipped steps are shown on purpose. A rule that fired and did nothing is normal, and the skipped check is the explanation.
+
+If a run is labelled **triggered by another rule**, one rule's change set off another. That's the first thing to look at when rules seem to be fighting.
+
+Anyone who can see the board can read the history, even if they can't edit rules. History is kept for 30 days.
+
+## Rules that stop themselves
+
+A few things are deliberately capped:
+
+- A rule can't loop back on itself — that's refused when you draw it.
+- Rules can set off other rules, but only a few steps deep. A chain that keeps going gets cut, and the history says so.
+- A rule that keeps failing is switched off automatically, with the reason shown on the rule. Fix it and switch it back on.
+
+These exist so a mistake costs you one confused afternoon, not a thousand notifications overnight.
+
+## Who can do what
+
+- **Editing rules** is limited to space admins, because a rule changes other people's tasks.
+- **Reading rules and their history** is open to anyone who can see the board — usually the person asking why their task moved isn't the person who wrote the rule.
+
+## When a rule doesn't fire
+
+Worth checking, in order:
+
+1. **Is it switched on?** New rules start off.
+2. **Does the trigger match what actually happened?** "Moved to a section" doesn't fire when a task is created already in one.
+3. **Look at History.** If runs are listed but everything is *skipped*, a check is stopping it — that's your answer.
+4. **No runs at all?** The trigger never fired. A rule on one board doesn't see another board's tasks.
+5. **Is there an error on the rule?** Repeated failures switch it off.

--- a/docs/user/dashboards-and-reports.md
+++ b/docs/user/dashboards-and-reports.md
@@ -1,0 +1,62 @@
+# Dashboards and reports
+
+Two different views of how things are going: a **dashboard** you arrange yourself, and **reports** that chart your money and time.
+
+## Your space dashboard
+
+**Dashboard** in the sidebar is a grid you build from widgets. It starts empty.
+
+A space admin arranges it, and **everyone in the space sees the same layout** — it's the team's shared view, not a personal one.
+
+### Adding widgets
+
+**Add widget** opens the catalog:
+
+| Widget | Shows |
+|---|---|
+| Metric chart | One number over time, as a chart |
+| Metric total | One headline figure with its change |
+| Engagements | Client work and how much of each budget is used |
+| My tasks | Your own open tasks — each person sees their own |
+| Boards | Boards in the space, with open task counts |
+| Note | Free text — announcements, links, conventions |
+
+Drag the handle on a widget to rearrange. The `…` menu configures or removes it.
+
+**"My tasks" is per person.** One widget, but everyone sees their own work — you don't need one per teammate.
+
+### Why your dashboard might look shorter than a colleague's
+
+Widgets only appear if you're allowed to see what's in them. Anything showing money needs invoicing access, which a space admin grants. You'll see the rest of the dashboard normally — the parts you can't read are simply left out.
+
+## Reports
+
+**Reports** has three tabs.
+
+**Dashboard** charts five numbers over a period you choose:
+
+- **Invoiced** — what you've billed, by invoice date. Drafts and voided invoices don't count.
+- **Collected** — what's actually been paid, by payment date.
+- **Tracked time** — everything logged.
+- **Billable time** — just the billable part.
+- **Unbilled value** — billable work you haven't invoiced yet, priced at its rate.
+
+**Invoiced and Collected are deliberately different dates.** The gap between the two lines is how long clients take to pay you.
+
+**Unbilled value** is the one to watch: it goes up as you work and drops when you invoice. If it keeps climbing, you're behind on billing.
+
+**Time summary** and **Uninvoiced** are tables, both exportable as CSV.
+
+### Multiple currencies
+
+If you bill in more than one currency, each gets its own line. They're never added together, since a total mixing dollars and euros would be meaningless.
+
+### Gaps in a chart
+
+A gap means no activity was recorded in that period — not zero. A month you didn't invoice is a break in the line, not a drop to the bottom.
+
+## Who sees what
+
+- The **Dashboard tab in Reports** needs no special access — it drops the money charts for anyone without invoicing access and keeps the time ones.
+- **Time summary** and **Uninvoiced** need invoicing access.
+- The **space dashboard** is readable by everyone; only admins can rearrange it.

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -85,7 +85,7 @@
   ],
   "pnpm": {
     "overrides": {
-      "brace-expansion@<1.1.16": "^1.1.16",
+      "brace-expansion@<5.0.8": "^5.0.8",
       "esbuild@<0.28.1": "^0.28.1",
       "fast-uri@<3.1.4": "^3.1.4",
       "js-yaml@<4.3.0": "^4.3.0",

--- a/pwa/pages/index.tsx
+++ b/pwa/pages/index.tsx
@@ -22,7 +22,9 @@ import {
   Plus,
   Receipt,
   Repeat,
+  LayoutDashboard,
   Search,
+  Workflow,
   ShieldCheck,
   SlidersHorizontal,
   Users,
@@ -601,6 +603,16 @@ const FEATURES: { icon: LucideIcon; title: string; desc: string }[] = [
     icon: Receipt,
     title: "Time & invoicing",
     desc: "Track time and expenses against clients, then turn them into branded invoices, estimates, and retainers — with reports and approvals.",
+  },
+  {
+    icon: Workflow,
+    title: "Automations",
+    desc: "Rules on a board, drawn as a graph: when a task is completed, if it's tagged urgent, then reassign it and post a comment. Every run is logged so you can see why something changed.",
+  },
+  {
+    icon: LayoutDashboard,
+    title: "Dashboards & analytics",
+    desc: "Build a space dashboard from widgets, and chart the numbers that matter — revenue invoiced and collected, hours tracked, and work you haven't billed yet.",
   },
   {
     icon: Search,

--- a/pwa/pnpm-lock.yaml
+++ b/pwa/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion@<1.1.16: ^1.1.16
+  brace-expansion@<5.0.8: ^5.0.8
   esbuild@<0.28.1: ^0.28.1
   fast-uri@<3.1.4: ^3.1.4
   js-yaml@<4.3.0: ^4.3.0
@@ -2892,9 +2892,6 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -2909,12 +2906,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
-
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -3026,9 +3020,6 @@ packages:
 
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -8141,20 +8132,13 @@ snapshots:
 
   bail@2.0.2: {}
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.43: {}
 
   baseline-browser-mapping@2.11.1: {}
 
-  brace-expansion@1.1.16:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -8265,8 +8249,6 @@ snapshots:
   commander@2.20.3: {}
 
   commondir@1.0.1: {}
-
-  concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
 
@@ -9781,11 +9763,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
Promotes 2 commits.

- **#778** — home page feature cards, two user guides, and two read-only MCP automation tools
- **#777** — `brace-expansion` bumped to 5.0.8 (CVE-2026-14257, ReDoS)

## Deploy notes

**No migration.** Nothing schema-touching in either commit — this is the first promote in a while without one.

**No env vars, no config, no new scheduled jobs.**

### What changes for a user

Only the home page. Two feature cards added for automations and dashboards/analytics, since the page still described the product as it was before this session's work.

The two new user guides publish to `/guides` automatically — that page renders the repo `docs/` tree at build time, so they appear with the PWA image.

### The security bump

`brace-expansion` is a transitive dependency, pinned through the existing `pnpm.overrides` block rather than a direct dependency change. Verified the lockfile now resolves a single `brace-expansion@5.0.8` across the whole tree, so there's no older copy left behind for another package to pull in.

ReDoS in a build-time dependency, so the practical exposure was low — but it's a clean, isolated bump worth carrying.

### MCP

Two new tools, both read-only: `list_automations` and `get_automation_runs`. They widen what a token can *read* about a board, gated on the existing `boards` category — no new permission surface, and deliberately no rule-authoring tool.

## Risk

Low. The API changes are two additive read endpoints; the PWA change is copy plus two markdown files. Nothing already running behaves differently.

Waitlist stays on; Stripe stays in test mode.
