### PR TITLE
feat(timeline): turn Timeline on from the Timeline tab

### DIFF
--- a/pwa/components/boards/BoardTimeline.tsx
+++ b/pwa/components/boards/BoardTimeline.tsx
@@ -8,6 +8,7 @@ import {
 } from "react";
 import { CalendarRange, CornerDownRight } from "lucide-react";
 import { ENTRYPOINT } from "@/config/entrypoint";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { valuePairDefinitionIri } from "@/components/tasks/CustomFieldValueList";
 import { analyseSchedule, edgeKey, nestByParent } from "@/lib/timelineAnalysis";
@@ -81,6 +82,16 @@ interface BoardTimelineProps<T extends TimelineTask> {
    * the field arrives.
    */
   startFieldIri: string | null;
+  /**
+   * Whether this viewer may switch Timeline on. Mirrors the server's
+   * `space.boards.update` check — offering a button that 403s is worse than
+   * not offering one.
+   */
+  canEnable?: boolean;
+  /** Turn Timeline on from here. Omitted on the cross-board view. */
+  onEnable?: () => void | Promise<void>;
+  /** True while the enable request is in flight, so the button can say so. */
+  enabling?: boolean;
   onOpenTask: (task: T) => void;
   /** Persist a new due date (ISO) or clear it. */
   onMoveDue: (task: T, dueIso: string | null) => void;
@@ -146,6 +157,9 @@ const BoardTimeline = <T extends TimelineTask>({
   readOnly = false,
   enabled,
   startFieldIri,
+  canEnable = false,
+  onEnable,
+  enabling = false,
   onOpenTask,
   onMoveDue,
   onMoveStart,
@@ -353,14 +367,39 @@ const BoardTimeline = <T extends TimelineTask>({
   }, [zoom]);
 
   if (!enabled) {
+    // Turn it on from here when the viewer is allowed to. Sending someone to
+    // Settings for a one-field toggle is a pointless detour, and telling
+    // someone who *can't* change it to go there is worse than pointless.
+    const offerButton = canEnable === true && typeof onEnable === "function";
+
     return (
       <div className="flex flex-col items-center justify-center gap-2 rounded-md border border-dashed py-16 text-center">
         <CalendarRange className="h-8 w-8 text-muted-foreground" aria-hidden />
         <p className="font-medium">Timeline isn&apos;t turned on</p>
         <p className="max-w-sm text-sm text-muted-foreground">
-          Enable Timeline in the board&apos;s Settings to plan tasks on a Gantt
-          chart. Each bar runs from its Start date to its due date.
+          {offerButton
+            ? "Plan this board's tasks on a Gantt chart. Each bar runs from its Start date to its due date."
+            : "Someone who can manage this board needs to turn Timeline on before it can be used here."}
         </p>
+
+        {offerButton && (
+          <>
+            <Button
+              className="mt-2"
+              data-testid="timeline-enable-button"
+              disabled={enabling}
+              onClick={() => void onEnable?.()}
+            >
+              {enabling ? "Turning on…" : "Turn on Timeline"}
+            </Button>
+            {/* Says what else the switch does before it's flipped, rather than
+                leaving the new field to be discovered afterwards. */}
+            <p className="max-w-sm text-xs text-muted-foreground">
+              This adds the shared <strong>Start date</strong> field to the
+              board. It can&apos;t be removed while Timeline is on.
+            </p>
+          </>
+        )}
       </div>
     );
   }

--- a/pwa/pages/boards/[id].tsx
+++ b/pwa/pages/boards/[id].tsx
@@ -197,13 +197,14 @@ interface NewTaskDraft {
 
 const BoardDetail = () => {
   const { user, isAuthenticated, isLoading: authLoading } = useAuth();
-  const { spaces } = useActiveSpace();
+  const { spaces, activeSpace, can } = useActiveSpace();
   const router = useRouter();
   const { id } = router.query;
   const boardId = typeof id === "string" ? id : null;
   const currentUserIri = user ? `/users/${user.id}` : null;
 
   const [board, setBoard] = useState<Board | null>(null);
+  const [enablingTimeline, setEnablingTimeline] = useState(false);
   const [tasks, setTasks] = useState<BoardTask[]>([]);
   // Bumped to nudge the Calendar tab to refetch after drawer/list edits.
   const [calendarRefresh, setCalendarRefresh] = useState(0);
@@ -919,9 +920,26 @@ const BoardDetail = () => {
   // Timeline (#timeline): flip the feature on/off. Enabling attaches the
   // canonical global "Start date" field server-side (BoardTimelineProcessor),
   // so a reload of the board's field set is needed to pick it up.
+  /**
+   * Whether to offer "Turn on Timeline" in the Timeline tab's empty state.
+   *
+   * Mirrors the server's `space.boards.update` check. `can()` answers for the
+   * **active** space, so it's only trustworthy when that's the space this board
+   * actually lives in — otherwise we'd be reading someone's permissions in the
+   * wrong space. When they differ we withhold the button rather than guess:
+   * Settings still has the switch, and a button that 403s is worse than one
+   * that isn't there.
+   */
+  const canEnableTimeline = useMemo(() => {
+    if (!board || !activeSpace) return false;
+    if (boardSpaceIri(board) !== activeSpace["@id"]) return false;
+    return can("boards", "update");
+  }, [board, activeSpace, can]);
+
   const handleSetTimelineEnabled = useCallback(
     async (enabled: boolean) => {
       if (!board) return;
+      setEnablingTimeline(true);
       try {
         const res = await fetch(`${ENTRYPOINT}/boards/${encodeURIComponent(board.id)}`, {
           method: "PATCH",
@@ -937,6 +955,8 @@ const BoardDetail = () => {
         await load();
       } catch (err) {
         setError(err instanceof Error ? err.message : "Failed to update Timeline.");
+      } finally {
+        setEnablingTimeline(false);
       }
     },
     [board, load],
@@ -1779,6 +1799,9 @@ const BoardDetail = () => {
                     sections={sections}
                     enabled={board.timelineEnabled ?? false}
                     startFieldIri={timelineStartFieldIri}
+                    canEnable={canEnableTimeline}
+                    enabling={enablingTimeline}
+                    onEnable={() => handleSetTimelineEnabled(true)}
                     onOpenTask={(t) => openTaskDetail(t)}
                     onMoveDue={(t, iso) => void patchTask(t, { dueDate: iso })}
                     onMoveStart={(t, dateStr) =>


### PR DESCRIPTION
Small UX fix, split out from the automations work so each can be reviewed on its own.

## The problem

The Timeline tab's empty state said "Enable Timeline in the board's Settings" — to **everyone**, including people with no permission to change it. For them that's a trip to a page where they'd find nothing they can do.

## The change

The button is on the tab, and only for viewers who can actually flip it. Everyone else gets an honest message instead of a dead-end instruction.

The permission check mirrors the server's `space.boards.update`, and is deliberately narrow:

```
can("boards", "update")   // answers for the ACTIVE space
```

A board can belong to a space that isn't the active one, in which case that answer is about the wrong space. When they differ I **withhold the button** rather than guess — Settings still has the switch, and a button that 403s is worse than one that isn't there.

Also says up front that enabling attaches the shared **Start date** field and that it can't be removed while Timeline is on, rather than leaving that to be discovered after the fact.

## Verification

PWA typecheck and production build. `BoardTimeline`'s new props are optional, so the cross-board `/timeline` view (which passes neither) is unaffected — enabling belongs on the owning board, not a read-only aggregate.

**Not verified in a browser.** The empty state's layout with a button and two lines of text is worth a glance.
