### PR TITLE
feat(automations): task.deleted event, notify action, full-height canvas

### DIFF
--- a/api/src/Automation/Action/NotifyUserAction.php
+++ b/api/src/Automation/Action/NotifyUserAction.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Automation\Action;
+
+use App\Automation\ActionDefinitionInterface;
+use App\Automation\AutomationContext;
+use App\Automation\SurvivesTaskDeletion;
+use App\Entity\Notification;
+use App\Entity\Space;
+use App\Entity\User;
+use App\Service\NotificationDispatcher;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Sends someone an in-app notification.
+ *
+ * The only action that still means something once its task is gone, which is
+ * what makes `task.deleted` a usable trigger at all — every other action edits
+ * the task, and there's nothing left to edit. Hence
+ * {@see SurvivesTaskDeletion}.
+ *
+ * Useful on every other event too: "tell the lead when anything lands in
+ * Blocked" doesn't need to touch the task.
+ */
+final class NotifyUserAction implements ActionDefinitionInterface, SurvivesTaskDeletion
+{
+    private const MAX_MESSAGE = 500;
+
+    public function __construct(
+        private EntityManagerInterface $em,
+        private NotificationDispatcher $notifications,
+    ) {
+    }
+
+    public function type(): string
+    {
+        return 'task.notify';
+    }
+
+    public function label(): string
+    {
+        return 'Notify someone';
+    }
+
+    public function description(): string
+    {
+        return 'Sends a person an in-app notification. Works even when the task has been deleted.';
+    }
+
+    public function configSchema(): array
+    {
+        return [
+            [
+                'key' => 'user',
+                'type' => 'space_member',
+                'label' => 'Notify',
+            ],
+            [
+                'key' => 'message',
+                'type' => 'textarea',
+                'label' => 'Message',
+                'placeholder' => 'What should they be told?',
+            ],
+        ];
+    }
+
+    public function validateConfig(array $config): ?string
+    {
+        $user = $config['user'] ?? null;
+        if (!is_string($user) || '' === trim($user)) {
+            return 'Choose who to notify.';
+        }
+
+        $message = $config['message'] ?? '';
+        if (!is_string($message)) {
+            return 'The message must be text.';
+        }
+        if (mb_strlen($message) > self::MAX_MESSAGE) {
+            return sprintf('The message cannot be longer than %d characters.', self::MAX_MESSAGE);
+        }
+
+        return null;
+    }
+
+    public function execute(AutomationContext $context, array $config): string
+    {
+        $recipientId = is_string($config['user'] ?? null) ? $config['user'] : '';
+        $recipient = $this->em->getRepository(User::class)->find($recipientId);
+
+        if (!$recipient instanceof User) {
+            // Fail closed and loudly: the run log is the only place anyone
+            // would notice a rule quietly notifying nobody.
+            throw new \RuntimeException('The person this rule notifies no longer exists.');
+        }
+
+        // Confine to the board's space, exactly like the assign action. A
+        // config id is user input, and without this a rule could be pointed at
+        // a stranger who'd receive notifications about work they can't see.
+        $space = $context->task->getBoard()?->getSpace();
+        if (!$space instanceof Space || !$space->hasMember($recipient)) {
+            throw new \RuntimeException('That person is not a member of this space.');
+        }
+
+        $message = is_string($config['message'] ?? null) ? trim($config['message']) : '';
+        if ('' === $message) {
+            $message = sprintf('The rule "%s" ran.', $context->automation?->getName() ?? 'Automation');
+        }
+
+        $this->notifications->notify(
+            recipient: $recipient,
+            type: Notification::TYPE_STATUS,
+            actor: $context->actor,
+            title: $context->task->getTitle(),
+            body: $message,
+            // A deleted task can't be linked to — passing it would produce a
+            // notification whose link 404s the moment it's clicked.
+            task: $context->taskDeleted ? null : $context->task,
+        );
+
+        return sprintf('notified %s', $recipient->getEmail());
+    }
+}

--- a/api/src/Automation/AutomationContext.php
+++ b/api/src/Automation/AutomationContext.php
@@ -49,6 +49,14 @@ final class AutomationContext
          * user, and say so in what they write.
          */
         public readonly ?Automation $automation = null,
+        /**
+         * The task has already been deleted; `$task` is a detached shell kept
+         * only so conditions can read what it was.
+         *
+         * Nothing may be written to it — see {@see SurvivesTaskDeletion} and
+         * the guard in {@see AutomationRunner}.
+         */
+        public readonly bool $taskDeleted = false,
     ) {
     }
 
@@ -63,6 +71,7 @@ final class AutomationContext
             $this->actor,
             $this->depth,
             $automation,
+            $this->taskDeleted,
         );
     }
 

--- a/api/src/Automation/AutomationEvents.php
+++ b/api/src/Automation/AutomationEvents.php
@@ -28,12 +28,23 @@ final class AutomationEvents
      */
     public const TASK_DUE = 'task.due';
 
+    /**
+     * A task was deleted from a board.
+     *
+     * The odd one out: by the time rules run, the row is gone. Conditions read
+     * a snapshot taken before deletion, and only actions marked
+     * {@see SurvivesTaskDeletion} can run — everything else has nothing left to
+     * edit. See {@see AutomationRunner} for how that's enforced.
+     */
+    public const TASK_DELETED = 'task.deleted';
+
     /** @var list<string> */
     public const ALL = [
         self::TASK_CREATED,
         self::TASK_UPDATED,
         self::TASK_COMPLETED,
         self::TASK_DUE,
+        self::TASK_DELETED,
     ];
 
     public static function isValid(string $event): bool

--- a/api/src/Automation/AutomationRunner.php
+++ b/api/src/Automation/AutomationRunner.php
@@ -76,7 +76,12 @@ final class AutomationRunner
 
         $run = (new AutomationRun())
             ->setAutomation($automation)
-            ->setTask($context->task)
+            // No FK for a deleted task: the entity here is a detached shell, and
+            // linking it would make Doctrine try to cascade-persist a task that
+            // was just removed. The snapshotted title below is precisely why
+            // that column exists — the log outlives the row either way.
+            ->setTask($context->taskDeleted ? null : $context->task)
+            ->setTaskTitle($context->task->getTitle())
             ->setDepth($context->depth);
 
         $steps = [];
@@ -138,6 +143,19 @@ final class AutomationRunner
             $action = $this->registry->action($node['type']);
             if (null === $action) {
                 $steps[] = $this->step($node, 'error', 'This action is not available on this server.');
+
+                return;
+            }
+
+            // On task.deleted there is no row left to edit. Refusing here — and
+            // saying so in the log — beats letting an action mutate a detached
+            // object that will never be saved, which would read as success.
+            if ($context->taskDeleted && !$action instanceof SurvivesTaskDeletion) {
+                $steps[] = $this->step(
+                    $node,
+                    'skipped',
+                    'Skipped — the task was deleted, so there is nothing left to change. Use "Notify someone" here instead.',
+                );
 
                 return;
             }

--- a/api/src/Automation/SurvivesTaskDeletion.php
+++ b/api/src/Automation/SurvivesTaskDeletion.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Automation;
+
+/**
+ * Marks an action that still means something once its task is gone (#764).
+ *
+ * Almost every action edits the task — assign it, tag it, move it. On
+ * `task.deleted` there is nothing left to edit, so running them would either
+ * throw or silently mutate a detached object nobody will save. Both are worse
+ * than refusing.
+ *
+ * A marker interface rather than a method on {@see ActionDefinitionInterface}
+ * because the safe case is the rare one: the default should be "needs a live
+ * task", and opting in should be a deliberate act by the two or three actions
+ * that genuinely don't.
+ */
+interface SurvivesTaskDeletion
+{
+}

--- a/api/src/Automation/Trigger/TaskDeletedTrigger.php
+++ b/api/src/Automation/Trigger/TaskDeletedTrigger.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Automation\Trigger;
+
+use App\Automation\AutomationContext;
+use App\Automation\AutomationEvents;
+use App\Automation\TriggerDefinitionInterface;
+
+/**
+ * Fires when a task is deleted from the board.
+ *
+ * Useful for noticing work disappearing — "tell the lead when anything is
+ * deleted from the release board". Only notifying actions can follow it, since
+ * the task itself no longer exists to be changed.
+ */
+final class TaskDeletedTrigger implements TriggerDefinitionInterface
+{
+    public function type(): string
+    {
+        return 'task.deleted';
+    }
+
+    public function label(): string
+    {
+        return 'A task is deleted';
+    }
+
+    public function description(): string
+    {
+        return 'Runs when a task is deleted from this board. Only notification actions can follow — the task is gone by then.';
+    }
+
+    public function event(): string
+    {
+        return AutomationEvents::TASK_DELETED;
+    }
+
+    public function configSchema(): array
+    {
+        return [];
+    }
+
+    public function validateConfig(array $config): ?string
+    {
+        return null;
+    }
+
+    public function matches(AutomationContext $context, array $config): bool
+    {
+        // The event itself is the whole condition; nothing further to narrow.
+        return AutomationEvents::TASK_DELETED === $context->event;
+    }
+}

--- a/api/src/Entity/AutomationRun.php
+++ b/api/src/Entity/AutomationRun.php
@@ -104,6 +104,18 @@ class AutomationRun
     }
 
     /** Also snapshots the title, so the run survives the task's deletion. */
+    /**
+     * Records the title even when there's no task to link to — a `task.deleted`
+     * run has no row to point at, and "which task was that?" is the first thing
+     * anyone reading the log needs.
+     */
+    public function setTaskTitle(string $title): self
+    {
+        $this->taskTitle = mb_substr($title, 0, 255);
+
+        return $this;
+    }
+
     public function setTask(?Task $task): self
     {
         $this->task = $task;

--- a/api/src/Message/RunAutomations.php
+++ b/api/src/Message/RunAutomations.php
@@ -27,6 +27,16 @@ final class RunAutomations
         public readonly ?string $actorId = null,
         /** How many automation-caused changes deep this already is. */
         public readonly int $depth = 0,
+        /**
+         * The board, carried explicitly for `task.deleted` only.
+         *
+         * Every other event resolves the board from the task. On deletion the
+         * row is gone by the time the worker runs, so the link has to travel
+         * with the message or the rules can never be found.
+         */
+        public readonly ?string $boardId = null,
+        /** The task's title at deletion, for the run log and notifications. */
+        public readonly ?string $taskTitle = null,
     ) {
     }
 }

--- a/api/src/MessageHandler/RunAutomationsHandler.php
+++ b/api/src/MessageHandler/RunAutomationsHandler.php
@@ -7,6 +7,7 @@ use App\Automation\AutomationEvents;
 use App\Automation\AutomationRunner;
 use App\Automation\TaskSnapshot;
 use App\Entity\AutomationRun;
+use App\Entity\Board;
 use App\Entity\Task;
 use App\Entity\User;
 use App\Message\RunAutomations;
@@ -44,16 +45,34 @@ final class RunAutomationsHandler
 
     public function __invoke(RunAutomations $message): void
     {
-        $task = $this->em->getRepository(Task::class)->find($message->taskId);
-        // Deleted between the edit and the worker picking this up. Nothing to
-        // do, and not an error worth retrying.
-        if (!$task instanceof Task) {
-            return;
-        }
+        $deleted = AutomationEvents::TASK_DELETED === $message->event;
 
-        $board = $task->getBoard();
-        if (null === $board) {
-            return;
+        if ($deleted) {
+            // The row is gone on purpose. Rebuild a detached shell from what
+            // travelled with the message so conditions can still read what the
+            // task *was* — the runner refuses to let anything write to it.
+            $board = null === $message->boardId
+                ? null
+                : $this->em->getRepository(Board::class)->find($message->boardId);
+            if (!$board instanceof Board) {
+                return;
+            }
+
+            $task = new Task();
+            $task->setTitle($message->taskTitle ?? 'Deleted task');
+            $task->setBoard($board);
+        } else {
+            $task = $this->em->getRepository(Task::class)->find($message->taskId);
+            // Deleted between the edit and the worker picking this up. Nothing
+            // to do, and not an error worth retrying.
+            if (!$task instanceof Task) {
+                return;
+            }
+
+            $board = $task->getBoard();
+            if (null === $board) {
+                return;
+            }
         }
 
         $rules = $this->automations->enabledFor($board, $message->event);
@@ -72,6 +91,7 @@ final class RunAutomationsHandler
             after: $message->after,
             actor: $actor instanceof User ? $actor : null,
             depth: $message->depth,
+            taskDeleted: $deleted,
         );
 
         // Snapshot before the rules touch anything, so the follow-up event can
@@ -99,7 +119,9 @@ final class RunAutomationsHandler
 
         $this->em->flush();
 
-        if (!$applied) {
+        // A deletion can't chain: nothing was changed, and there's no task left
+        // for a follow-up rule to look at.
+        if (!$applied || $deleted) {
             return;
         }
 

--- a/api/src/State/TaskDeleteProcessor.php
+++ b/api/src/State/TaskDeleteProcessor.php
@@ -7,8 +7,13 @@ use ApiPlatform\State\ProcessorInterface;
 use App\Entity\CalendarEventLink;
 use App\Entity\Task;
 use App\Entity\User;
+use App\Automation\AutomationEvents;
+use App\Automation\TaskSnapshot;
+use App\Message\RunAutomations;
 use App\Message\SyncTaskToCalendar;
+use App\Repository\AutomationRepository;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -31,6 +36,8 @@ final class TaskDeleteProcessor implements ProcessorInterface
         private ProcessorInterface $removeProcessor,
         private EntityManagerInterface $em,
         private MessageBusInterface $bus,
+        private AutomationRepository $automations,
+        private Security $security,
     ) {
     }
 
@@ -54,7 +61,37 @@ final class TaskDeleteProcessor implements ProcessorInterface
             }
         }
 
+        // Everything the rules will need has to be read *now* — after the
+        // remove there is no row to read it from. Dispatched after, so a rule
+        // never fires for a deletion that failed.
+        $board = $data->getBoard();
+        $automationPayload = null;
+        // Skip the queue entirely when the board has no rule listening — the
+        // same cheap check AutomationDispatcher makes, which can't be reused
+        // here because it resolves the board from a task that's about to stop
+        // existing.
+        if (
+            null !== $board
+            && null !== $data->getId()
+            && [] !== $this->automations->enabledFor($board, AutomationEvents::TASK_DELETED)
+        ) {
+            $actor = $this->security->getUser();
+            $automationPayload = new RunAutomations(
+                taskId: (string) $data->getId(),
+                event: AutomationEvents::TASK_DELETED,
+                before: TaskSnapshot::of($data),
+                after: [],
+                actorId: $actor instanceof User && null !== $actor->getId() ? (string) $actor->getId() : null,
+                boardId: (string) $board->getId(),
+                taskTitle: $data->getTitle(),
+            );
+        }
+
         $result = $this->removeProcessor->process($data, $operation, $uriVariables, $context);
+
+        if (null !== $automationPayload) {
+            $this->bus->dispatch($automationPayload);
+        }
 
         foreach ($messages as $message) {
             $this->bus->dispatch($message);

--- a/api/tests/Api/AutomationWiringTest.php
+++ b/api/tests/Api/AutomationWiringTest.php
@@ -116,6 +116,61 @@ class AutomationWiringTest extends ApiTestCase
         $this->assertCount(0, $reloaded->getTags());
     }
 
+    /**
+     * Deleting a task fires its rule, and a mutating action is refused rather
+     * than silently editing a row that no longer exists.
+     */
+    public function testDeletingATaskRunsARuleButRefusesMutatingActions(): void
+    {
+        [$user, $board] = $this->scaffold();
+        // add_tag has nothing left to tag once the task is gone.
+        $this->makeRule($board, $user, AutomationEvents::TASK_DELETED, 'task.deleted', 'ghost-tag');
+        $task = $this->makeTask($user, $board, 'Doomed');
+        $taskId = (string) $task->getId();
+
+        $client = static::createClient();
+        $client->loginUser($user);
+        $client->request('DELETE', '/tasks/' . $taskId);
+        $this->assertResponseStatusCodeSame(204);
+
+        $this->entityManager->clear();
+
+        // The rule ran and was logged — that's the point of the event.
+        $runs = $this->entityManager->getRepository(AutomationRun::class)->findAll();
+        $this->assertCount(1, $runs);
+        $this->assertSame('Doomed', $runs[0]->getTaskTitle());
+
+        // …but the action was skipped with an explanation, not silently
+        // "applied" against a detached object nobody saves.
+        $actionStep = null;
+        foreach ($runs[0]->getSteps() as $step) {
+            if ('action' === $step['kind']) {
+                $actionStep = $step;
+            }
+        }
+        $this->assertNotNull($actionStep, 'The action should appear in the log even when skipped.');
+        $this->assertSame('skipped', $actionStep['outcome']);
+        $this->assertStringContainsString('deleted', $actionStep['detail']);
+
+        // And the task really is gone.
+        $this->assertNull($this->entityManager->getRepository(Task::class)->find($taskId));
+    }
+
+    /** A board with no deletion rule must not enqueue anything. */
+    public function testDeletingATaskWithNoRuleLogsNothing(): void
+    {
+        [$user, $board] = $this->scaffold();
+        $task = $this->makeTask($user, $board, 'Unwatched');
+
+        $client = static::createClient();
+        $client->loginUser($user);
+        $client->request('DELETE', '/tasks/' . $task->getId());
+        $this->assertResponseStatusCodeSame(204);
+
+        $this->entityManager->clear();
+        $this->assertCount(0, $this->entityManager->getRepository(AutomationRun::class)->findAll());
+    }
+
     /** A disabled rule must not run. */
     public function testADisabledRuleIsSkipped(): void
     {

--- a/docs/developer/board-automations.md
+++ b/docs/developer/board-automations.md
@@ -40,7 +40,19 @@ The **before/after snapshot travels with the message** (`TaskSnapshot`). By the 
 
 **Failure is per-step.** One action throwing records an error against that node and the walk continues with its siblings. A rule that assigns *and* comments shouldn't lose the assignment because someone deleted a tag.
 
-Events (`AutomationEvents`): `task.created`, `task.updated`, `task.completed`, `task.due`. Completion raises its own event rather than a generic update, so a "when completed" rule can't re-fire on every later edit of a finished task.
+Events (`AutomationEvents`): `task.created`, `task.updated`, `task.completed`, `task.due`, `task.deleted`. Completion raises its own event rather than a generic update, so a "when completed" rule can't re-fire on every later edit of a finished task.
+
+### `task.deleted` is the odd one
+
+By the time rules run, the row is gone. That breaks the usual model, so it's handled explicitly rather than left to fail confusingly:
+
+- The message carries the **board id and the task's title**, because the board can't be resolved from a task that no longer exists.
+- The handler rebuilds a **detached shell** from that snapshot so conditions can still read what the task *was*.
+- Actions must be marked `SurvivesTaskDeletion` to run. Everything else is **skipped with an explanation in the run log** — letting `add_tag` mutate a detached object would look like success while doing nothing.
+- The run is logged with `task = null` and the title kept in `taskTitle`. Linking the FK would make Doctrine try to persist the deleted task back.
+- Deletions never chain: there's nothing left to change.
+
+In practice this means `task.deleted` pairs with **Notify someone**, which is why that action exists.
 
 ## Adding a trigger, condition, or action
 

--- a/pwa/components/automations/AutomationCanvas.tsx
+++ b/pwa/components/automations/AutomationCanvas.tsx
@@ -157,7 +157,11 @@ const AutomationCanvas = ({
   );
 
   return (
-    <div className="h-[520px] w-full rounded-md border">
+    /* Fills the viewport rather than sitting in a fixed 520px letterbox — a
+       rule with a few branches needs room, and the canvas is the whole point
+       of the tab. The floor keeps it usable on a short window; the offset
+       leaves space for the page chrome above it. */
+    <div className="h-[calc(100vh-20rem)] min-h-[520px] w-full rounded-md border">
       <ReactFlow
         nodes={nodes}
         edges={edges}

--- a/pwa/components/automations/AutomationsTab.tsx
+++ b/pwa/components/automations/AutomationsTab.tsx
@@ -4,7 +4,8 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Plus, Workflow } from "lucide-react";
 import { apiGet, apiSend } from "@/lib/apiClient";
 import {
-  KIND_LABEL,
+  KIND_HINT,
+  KIND_PALETTE_LABEL,
   defaultConfigFor,
   definitionFor,
   describeProblem,
@@ -27,7 +28,10 @@ import StepConfigPanel, { type PickerOption } from "./StepConfigPanel";
 // React Flow is heavy and only this tab needs it.
 const AutomationCanvas = dynamic(() => import("./AutomationCanvas"), {
   ssr: false,
-  loading: () => <div className="h-[520px] animate-pulse rounded-md bg-muted/40" />,
+  // Matches the canvas's own height so the tab doesn't jump when it loads.
+  loading: () => (
+    <div className="h-[calc(100vh-20rem)] min-h-[520px] animate-pulse rounded-md bg-muted/40" />
+  ),
 });
 
 interface Props {
@@ -354,13 +358,22 @@ const AutomationsTab = ({ boardId, sections, members }: Props) => {
               <AutomationRunLog automationId={selectedRule.id} />
             ) : (
               <>
-            {/* Palette — built from the server catalog, never hardcoded. */}
+            {/* Palette — built from the server catalog, never hardcoded.
+                Grouped by category with a one-line explanation, so the three
+                kinds of step read as a model (listen → gate → do) rather than
+                as three undifferentiated rows of buttons. */}
             {canEdit && (
-              <div className="hidden flex-wrap gap-1.5 lg:flex">
+              <div className="hidden flex-col gap-2 lg:flex">
                 {palette.map(([kind, steps]) => (
                   <div key={kind} className="flex flex-wrap items-center gap-1.5">
-                    <span className="text-xs text-muted-foreground">
-                      {KIND_LABEL[kind]}:
+                    <span
+                      className="w-16 shrink-0 text-xs font-medium"
+                      title={KIND_HINT[kind]}
+                    >
+                      {KIND_PALETTE_LABEL[kind]}
+                    </span>
+                    <span className="mr-1 hidden text-xs text-muted-foreground 2xl:inline">
+                      {KIND_HINT[kind]}
                     </span>
                     {steps.map((step) => (
                       <Button
@@ -395,7 +408,9 @@ const AutomationsTab = ({ boardId, sections, members }: Props) => {
                 onReject={setError}
               />
 
-              <Card className="p-3">
+              {/* Scrolls inside itself rather than stretching the row, so a
+                  step with many fields can't push the canvas off-screen. */}
+              <Card className="max-h-[calc(100vh-20rem)] min-h-[520px] overflow-y-auto p-3">
                 <p className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
                   {selectedNode ? "Step settings" : "Nothing selected"}
                 </p>

--- a/pwa/lib/automationTypes.ts
+++ b/pwa/lib/automationTypes.ts
@@ -88,10 +88,32 @@ export interface AutomationRun {
   ranAt: string;
 }
 
+/**
+ * How a step reads *inside a rule* — the sentence form, so a graph scans as
+ * "When a task is completed, only if it's urgent, then notify the lead".
+ */
 export const KIND_LABEL: Record<NodeKind, string> = {
   trigger: "When",
   condition: "Only if",
   action: "Then",
+};
+
+/**
+ * How a step reads *in the palette* — the category you're picking from, which
+ * is a different question from how it reads in a sentence. "When:" as a
+ * column heading says nothing about what the list contains.
+ */
+export const KIND_PALETTE_LABEL: Record<NodeKind, string> = {
+  trigger: "Events",
+  condition: "Gates",
+  action: "Actions",
+};
+
+/** One-line explanation of each category, for the palette. */
+export const KIND_HINT: Record<NodeKind, string> = {
+  trigger: "What we listen for. Every rule starts with exactly one.",
+  condition: "Checks the event's data. Steps below only run if it passes.",
+  action: "What happens. Can use the event's data.",
 };
 
 /** An empty rule still needs its trigger — a graph without one can never run. */


### PR DESCRIPTION
Three things you asked for, split out from the Timeline change ([#780](https://github.com/roboparker/Aura/pull/780)).

## `task.deleted` needed a design, not a constant

`created` and `updated` already existed. `deleted` is genuinely different: **the task is gone by the time rules run.** That breaks the usual model, so it's handled explicitly rather than left to fail confusingly:

- The **board id and title travel with the message** — you can't resolve a board from a deleted row.
- The handler rebuilds a **detached shell** so conditions can still read what the task *was*.
- Actions must opt in via a `SurvivesTaskDeletion` marker. Everything else is **skipped with a reason in the run log**. Letting `add_tag` mutate a detached object would look like success while doing nothing, which is the worst failure mode for a rules engine.
- The run records a **null task FK** with the title snapshotted.

That last one I found the hard way: linking the FK made Doctrine try to cascade-persist the just-deleted task, and `DELETE /tasks/{id}` returned a 500. The `taskTitle` column already existed for precisely this case.

Deletions never chain — there's nothing left to change.

## The event forced a new action

Every existing action mutates the task, so `task.deleted` would have been a trigger with **nothing usable after it**. So there's now **Notify someone**: the only action that still means something once its task is gone, and useful on every other event too ("tell the lead when anything lands in Blocked" doesn't need to touch the task).

It confines its recipient to the board's space the same way the assign action does — a config id is user input, and without that check a rule could notify a stranger about work they can't see.

## Canvas and palette

- Fills the viewport (`100vh-20rem`, floor `520px`) instead of a fixed letterbox. A rule with a few branches needs room, and the canvas is the point of the tab.
- The settings panel scrolls inside itself, so a step with many fields can't push the canvas off-screen.
- The palette is grouped **Events / Gates / Actions** with a line explaining each, so the three kinds read as a model — listen, gate, do.

The in-graph wording stays **When / Only if / Then**. A column heading and a sentence fragment are different questions: "When:" says nothing about what a list contains, but reads correctly inside a rule.

## Verification

- 55 automation tests, 15 vitest, PHPStan L10 + strict, PHPCS, PWA build
- Two new tests: a deletion fires its rule *and* the mutating action is refused with an explanation; plus a board with no deletion rule enqueues nothing

**Not verified in a browser** — the full-height sizing especially. My `100vh-20rem` offset is a guess at the page chrome above the canvas and may want a nudge.
