### PR TITLE
fix: resolve the critical and high-severity findings from the UI/UX audit

### DIFF
--- a/api/migrations/Version20260727120000.php
+++ b/api/migrations/Version20260727120000.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use App\Service\AvatarColorService;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Snap `tag.color` onto the WCAG-AA avatar palette.
+ *
+ * `Tag.color` previously accepted any `#RRGGBB` value, and tag chips render
+ * their label over that colour — seeded tags reached only 2.15:1 against the
+ * white text the chip hardcoded. The entity now constrains the column with
+ * `Assert\Choice(AvatarColorService::PALETTE)`, matching Space and UserGroup.
+ *
+ * Without this backfill that constraint would be a latent break rather than a
+ * fix: API Platform validates the *whole* entity on PATCH, so a pre-existing
+ * out-of-palette tag would 422 on an unrelated title edit.
+ *
+ * Colours are matched by **hue**, not RGB distance, so a tag keeps its colour
+ * family: teal-600 becomes teal-700 rather than the numerically-nearer
+ * cyan-700. Desaturated values (any grey, black, white) have no meaningful hue
+ * and collapse to the palette's neutral slate.
+ *
+ * Irreversible by nature — the original arbitrary colours aren't recoverable
+ * once mapped, and `down()` would have nothing to restore them from.
+ */
+final class Version20260727120000 extends AbstractMigration
+{
+    /** Below this saturation a colour has no useful hue; use the neutral. */
+    private const NEUTRAL_SATURATION = 0.15;
+    private const NEUTRAL = '#334155'; // slate-700
+
+    public function getDescription(): string
+    {
+        return 'Snap tag.color onto the WCAG-AA avatar palette (hue-matched).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $colors = $this->connection->fetchFirstColumn(
+            'SELECT DISTINCT color FROM tag',
+        );
+
+        foreach ($colors as $color) {
+            if (!is_string($color) || in_array($color, AvatarColorService::PALETTE, true)) {
+                continue;
+            }
+
+            $this->addSql(
+                'UPDATE tag SET color = :new WHERE color = :old',
+                ['new' => $this->snapToPalette($color), 'old' => $color],
+            );
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException(
+            'Original tag colours are not recoverable once snapped to the palette.',
+        );
+    }
+
+    /** Nearest palette entry by circular hue distance, with a neutral fallback. */
+    private function snapToPalette(string $color): string
+    {
+        [$hue, $saturation] = $this->toHueSaturation($color);
+
+        if (null === $hue || $saturation < self::NEUTRAL_SATURATION) {
+            return self::NEUTRAL;
+        }
+
+        $best = self::NEUTRAL;
+        $bestDistance = PHP_FLOAT_MAX;
+
+        foreach (AvatarColorService::PALETTE as $candidate) {
+            if (self::NEUTRAL === $candidate) {
+                continue; // reserved for the desaturated case above
+            }
+
+            [$candidateHue] = $this->toHueSaturation($candidate);
+            if (null === $candidateHue) {
+                continue;
+            }
+
+            $distance = abs($hue - $candidateHue);
+            $distance = min($distance, 360.0 - $distance);
+
+            if ($distance < $bestDistance) {
+                $bestDistance = $distance;
+                $best = $candidate;
+            }
+        }
+
+        return $best;
+    }
+
+    /**
+     * @return array{0: float|null, 1: float} hue in degrees (null when grey), saturation 0..1
+     */
+    private function toHueSaturation(string $hex): array
+    {
+        $hex = ltrim($hex, '#');
+        if (6 !== strlen($hex) || 1 !== preg_match('/^[0-9a-fA-F]{6}$/', $hex)) {
+            return [null, 0.0];
+        }
+
+        $r = hexdec(substr($hex, 0, 2)) / 255;
+        $g = hexdec(substr($hex, 2, 2)) / 255;
+        $b = hexdec(substr($hex, 4, 2)) / 255;
+
+        $max = max($r, $g, $b);
+        $min = min($r, $g, $b);
+        $delta = $max - $min;
+        $lightness = ($max + $min) / 2;
+
+        if (0.0 === $delta) {
+            return [null, 0.0];
+        }
+
+        $saturation = $lightness > 0.5
+            ? $delta / (2 - $max - $min)
+            : $delta / ($max + $min);
+
+        if ($max === $r) {
+            $hue = fmod(($g - $b) / $delta, 6);
+        } elseif ($max === $g) {
+            $hue = ($b - $r) / $delta + 2;
+        } else {
+            $hue = ($r - $g) / $delta + 4;
+        }
+
+        $hue *= 60;
+        if ($hue < 0) {
+            $hue += 360;
+        }
+
+        return [$hue, $saturation];
+    }
+}

--- a/api/src/DataFixtures/AdminDeskFixtures.php
+++ b/api/src/DataFixtures/AdminDeskFixtures.php
@@ -116,7 +116,7 @@ class AdminDeskFixtures extends Fixture implements DependentFixtureInterface
 
         // Tags (space-scoped, owned by Ada).
         $tags = [];
-        foreach (['ops' => '#0d9488', 'finance' => '#f59e0b'] as $title => $color) {
+        foreach (['ops' => '#0f766e', 'finance' => '#854d0e'] as $title => $color) {
             $tag = (new Tag())->setOwner($ada)->setSpace($desk)->setTitle($title)->setColor($color);
             $manager->persist($tag);
             $tags[$title] = $tag;

--- a/api/src/DataFixtures/BoardFixtures.php
+++ b/api/src/DataFixtures/BoardFixtures.php
@@ -59,10 +59,10 @@ class BoardFixtures extends Fixture implements DependentFixtureInterface
         // Tags are scoped to a space (#tags): create them in the launch space
         // whose tasks attach them. Owner = Uma (the space admin).
         $tagDefinitions = [
-            'urgent' => '#dc2626',
-            'design' => '#7c3aed',
-            'backend' => '#0d9488',
-            'docs' => '#f59e0b',
+            'urgent' => '#b91c1c',
+            'design' => '#6d28d9',
+            'backend' => '#0f766e',
+            'docs' => '#854d0e',
         ];
         $tags = [];
         foreach ($tagDefinitions as $title => $color) {

--- a/api/src/Entity/Tag.php
+++ b/api/src/Entity/Tag.php
@@ -11,6 +11,7 @@ use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
 use App\Repository\TagRepository;
+use App\Service\AvatarColorService;
 use App\State\TagOwnerProcessor;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -86,15 +87,21 @@ class Tag
     /**
      * Hex color for badge rendering. Stored as lowercase `#RRGGBB` so the
      * PWA can drop it straight into an inline style.
+     *
+     * Constrained to the same WCAG-AA palette as user avatars, spaces and
+     * groups. Before this, any of the 16.7M hex values passed the regex, and
+     * chips render their label over this colour — seeded tags reached only
+     * 2.15:1. The PWA picker already offered just the palette; the API is
+     * what accepted anything.
      */
     #[ORM\Column(length: 7)]
     #[Assert\NotBlank(message: 'Color is required.')]
-    #[Assert\Regex(
-        pattern: '/^#[0-9a-fA-F]{6}$/',
-        message: 'Color must be a hex value like #22c55e.',
+    #[Assert\Choice(
+        choices: AvatarColorService::PALETTE,
+        message: 'Color must be one of the supported avatar palette values.',
     )]
     #[Groups(['tag:read', 'tag:write', 'task:read'])]
-    private string $color = '#6b7280';
+    private string $color = '#334155';
 
     /**
      * Inverse side of the Task↔Tag relation. The Task entity owns the join

--- a/api/src/Mcp/Tool/CreateTagTool.php
+++ b/api/src/Mcp/Tool/CreateTagTool.php
@@ -7,6 +7,7 @@ use App\Entity\User;
 use App\Mcp\McpEntitySerializer;
 use App\Mcp\McpInputHelper;
 use App\Mcp\McpSpaceResolver;
+use App\Service\AvatarColorService;
 use Doctrine\ORM\EntityManagerInterface;
 
 /**
@@ -31,7 +32,7 @@ final class CreateTagTool implements McpToolInterface
 
     public function getDescription(): string
     {
-        return 'Create a tag in a space. Pass a spaceId (from list_spaces) for a shared space, or omit it for your personal space. Color is a #RRGGBB hex (defaults to grey).';
+        return 'Create a tag in a space. Pass a spaceId (from list_spaces) for a shared space, or omit it for your personal space. Color must be one of the supported palette values (defaults to slate).';
     }
 
     public function getInputSchema(): array
@@ -41,7 +42,15 @@ final class CreateTagTool implements McpToolInterface
             'properties' => [
                 'title' => ['type' => 'string', 'description' => 'Tag label (required).'],
                 'spaceId' => ['type' => 'string', 'description' => 'UUID of a space the user belongs to. Omit for the personal space.'],
-                'color' => ['type' => 'string', 'description' => 'Hex color like #22c55e. Defaults to #6b7280.'],
+                // Enumerated rather than free-form: the entity constrains this
+                // to the WCAG-AA palette, so advertising an arbitrary hex would
+                // just produce validation errors the model has to guess its
+                // way out of.
+                'color' => [
+                    'type' => 'string',
+                    'enum' => AvatarColorService::PALETTE,
+                    'description' => 'Tag color. Must be one of the listed palette values. Defaults to #334155 (slate).',
+                ],
                 'description' => ['type' => 'string', 'description' => 'Optional note.'],
             ],
             'required' => ['title'],

--- a/api/tests/Api/McpTest.php
+++ b/api/tests/Api/McpTest.php
@@ -418,13 +418,13 @@ class McpTest extends ApiTestCase
         $client = static::createClient();
         $body = $this->callMcp($client, $plain, 'tools/call', [
             'name' => 'create_tag',
-            'arguments' => ['title' => 'urgent', 'color' => '#ef4444'],
+            'arguments' => ['title' => 'urgent', 'color' => '#b91c1c'],
         ]);
         $this->assertFalse($body['result']['isError'] ?? null);
         $structured = $body['result']['structuredContent'] ?? null;
         $this->assertIsArray($structured);
         $this->assertSame('urgent', $structured['title']);
-        $this->assertSame('#ef4444', $structured['color']);
+        $this->assertSame('#b91c1c', $structured['color']);
 
         $body = $this->callMcp($client, $plain, 'tools/call', [
             'name' => 'list_tags',

--- a/api/tests/Api/TagTest.php
+++ b/api/tests/Api/TagTest.php
@@ -8,6 +8,7 @@ use App\Entity\SpaceMembership;
 use App\Entity\Tag;
 use App\Entity\Task;
 use App\Entity\User;
+use App\Service\AvatarColorService;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
@@ -54,7 +55,7 @@ class TagTest extends ApiTestCase
             'json' => [
                 'title' => 'Urgent',
                 'description' => 'Needs doing today',
-                'color' => '#ef4444',
+                'color' => '#b91c1c',
                 'space' => '/spaces/' . $space->getId(),
             ],
             'headers' => ['Content-Type' => 'application/ld+json'],
@@ -65,7 +66,7 @@ class TagTest extends ApiTestCase
             '@type' => 'Tag',
             'title' => 'Urgent',
             'description' => 'Needs doing today',
-            'color' => '#ef4444',
+            'color' => '#b91c1c',
         ]);
 
         $tag = $this->reloadTagByTitle('Urgent');
@@ -85,7 +86,7 @@ class TagTest extends ApiTestCase
         $client->request('POST', '/tags', [
             'json' => [
                 'title' => 'Sneaky',
-                'color' => '#22c55e',
+                'color' => '#15803d',
                 'space' => '/spaces/' . $space->getId(),
                 'owner' => '/users/' . $bob->getId(),
             ],
@@ -108,7 +109,7 @@ class TagTest extends ApiTestCase
         $client->request('POST', '/tags', [
             'json' => [
                 'title' => 'Trespass',
-                'color' => '#22c55e',
+                'color' => '#15803d',
                 'space' => '/spaces/' . $bobsSpace->getId(),
             ],
             'headers' => ['Content-Type' => 'application/ld+json'],
@@ -125,7 +126,7 @@ class TagTest extends ApiTestCase
         $client->loginUser($user);
 
         $client->request('POST', '/tags', [
-            'json' => ['title' => 'No space', 'color' => '#22c55e'],
+            'json' => ['title' => 'No space', 'color' => '#15803d'],
             'headers' => ['Content-Type' => 'application/ld+json'],
         ]);
         // securityPostDenormalize rejects a tag with no (accessible) space.
@@ -140,7 +141,7 @@ class TagTest extends ApiTestCase
         $client->loginUser($user);
 
         $client->request('POST', '/tags', [
-            'json' => ['title' => '', 'color' => '#22c55e', 'space' => '/spaces/' . $space->getId()],
+            'json' => ['title' => '', 'color' => '#15803d', 'space' => '/spaces/' . $space->getId()],
             'headers' => ['Content-Type' => 'application/ld+json'],
         ]);
         $this->assertResponseStatusCodeSame(422);
@@ -158,6 +159,47 @@ class TagTest extends ApiTestCase
             'headers' => ['Content-Type' => 'application/ld+json'],
         ]);
         $this->assertResponseStatusCodeSame(422);
+    }
+
+    /**
+     * A well-formed hex outside the WCAG-AA palette is rejected. Tag chips
+     * render their label over this colour, and an unconstrained hex let
+     * seeded tags reach 2.15:1 against white — well under the 4.5:1 floor.
+     */
+    public function testCreateTagRejectsColorOutsideThePalette(): void
+    {
+        $user = $this->createUser('alice@example.com');
+        $space = $this->createSpace($user, 'Alice space');
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        $client->request('POST', '/tags', [
+            // amber-500: valid hex, 2.15:1 against white.
+            'json' => ['title' => 'Low contrast', 'color' => '#f59e0b', 'space' => '/spaces/' . $space->getId()],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    /** Every palette entry is accepted, so the constraint can't drift from the list. */
+    public function testCreateTagAcceptsEveryPaletteColor(): void
+    {
+        $user = $this->createUser('alice@example.com');
+        $space = $this->createSpace($user, 'Alice space');
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        foreach (AvatarColorService::PALETTE as $index => $color) {
+            $client->request('POST', '/tags', [
+                'json' => [
+                    'title' => 'Palette ' . $index,
+                    'color' => $color,
+                    'space' => '/spaces/' . $space->getId(),
+                ],
+                'headers' => ['Content-Type' => 'application/ld+json'],
+            ]);
+            $this->assertResponseStatusCodeSame(201, sprintf('palette colour %s should be accepted', $color));
+        }
     }
 
     public function testListTagsOnlyShowsTagsInSpacesYouBelongTo(): void
@@ -218,13 +260,13 @@ class TagTest extends ApiTestCase
         $client = static::createClient();
         $client->loginUser($member);
         $client->request('PATCH', '/tags/' . $tag->getId(), [
-            'json' => ['title' => 'After', 'color' => '#3b82f6'],
+            'json' => ['title' => 'After', 'color' => '#1d4ed8'],
             'headers' => ['Content-Type' => 'application/merge-patch+json'],
         ]);
 
         $this->assertResponseIsSuccessful();
         $reloaded = $this->reloadTagByTitle('After');
-        $this->assertSame('#3b82f6', $reloaded->getColor());
+        $this->assertSame('#1d4ed8', $reloaded->getColor());
     }
 
     public function testDeleteTagInOwnSpace(): void
@@ -244,7 +286,7 @@ class TagTest extends ApiTestCase
         $alice = $this->createUser('alice@example.com');
         $space = $this->createSpace($alice, 'Alice space');
         $task = $this->createTask($alice, 'Write docs');
-        $tag = $this->createTag($alice, $space, 'Writing', '#3b82f6');
+        $tag = $this->createTag($alice, $space, 'Writing', '#1d4ed8');
 
         $client = static::createClient();
         $client->loginUser($alice);
@@ -269,8 +311,8 @@ class TagTest extends ApiTestCase
         $alice = $this->createUser('alice@example.com');
         $space = $this->createSpace($alice, 'Alice space');
         $task = $this->createTask($alice, 'Write docs');
-        $keep = $this->createTag($alice, $space, 'Keep', '#22c55e');
-        $drop = $this->createTag($alice, $space, 'Drop', '#ef4444');
+        $keep = $this->createTag($alice, $space, 'Keep', '#15803d');
+        $drop = $this->createTag($alice, $space, 'Drop', '#b91c1c');
         $task->addTag($keep);
         $task->addTag($drop);
         $this->entityManager->flush();
@@ -348,7 +390,7 @@ class TagTest extends ApiTestCase
         $alice = $this->createUser('alice@example.com');
         $space = $this->createSpace($alice, 'Alice space');
         $task = $this->createTask($alice, 'Has a tag');
-        $tag = $this->createTag($alice, $space, 'Temp', '#ef4444');
+        $tag = $this->createTag($alice, $space, 'Temp', '#b91c1c');
         $task->addTag($tag);
         $this->entityManager->flush();
 

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -7,9 +7,9 @@
     "": {
       "name": "e2e",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "AGPL-3.0-only",
       "devDependencies": {
-        "@playwright/test": "^1.50.0",
+        "@playwright/test": "^1.59.1",
         "@types/node": "^22.9.0"
       }
     },

--- a/e2e/tests/boards.spec.js
+++ b/e2e/tests/boards.spec.js
@@ -180,7 +180,7 @@ test.describe("Boards", () => {
     // Seed a tag so the tags combobox has something to pick.
     const tagRes = await page.request.post(`${BASE_URL}/tags`, {
       headers: { "Content-Type": "application/ld+json" },
-      data: { title: `urgent-${Date.now()}`, color: "#ef4444", space: spaceIri },
+      data: { title: `urgent-${Date.now()}`, color: "#b91c1c", space: spaceIri },
     });
     expect(tagRes.ok()).toBeTruthy();
     const tag = await tagRes.json();

--- a/pwa/components/dev/registry.ts
+++ b/pwa/components/dev/registry.ts
@@ -42,6 +42,7 @@ export const componentRegistry: RegistryEntry[] = [
   { slug: "popover", name: "Popover", category: "Overlay", description: "Floating content anchored to a trigger." },
   { slug: "separator", name: "Separator", category: "Primitive", description: "Horizontal or vertical divider." },
   { slug: "sheet", name: "Sheet", category: "Overlay", description: "Side-anchored drawer." },
+  { slug: "sonner", name: "Toaster (sonner)", category: "Feedback", description: "App-wide transient toasts, including undoable actions. Mounted once in _app.tsx." },
   { slug: "switch", name: "Switch", category: "Form", description: "On/off toggle built on @base-ui/react." },
   { slug: "table", name: "Table", category: "Data", description: "Styled HTML table primitives." },
   { slug: "comments-panel", name: "CommentsPanel", category: "Data", description: "Flat chronological comment thread with composer, inline edit/delete, and a lockable composer." },

--- a/pwa/components/tasks/TagsCombobox.tsx
+++ b/pwa/components/tasks/TagsCombobox.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { X } from "lucide-react";
+import { readableForeground } from "@/lib/contrast";
 import { cn } from "@/lib/utils";
 import {
   Combobox,
@@ -105,8 +106,11 @@ const TagsCombobox = ({
               <ComboboxChip
                 key={tag["@id"]}
                 aria-label={tag.title}
-                className="px-2 text-white [&_[data-slot=combobox-chip-remove]]:hover:!bg-transparent"
-                style={{ backgroundColor: tag.color }}
+                className="px-2 [&_[data-slot=combobox-chip-remove]]:hover:!bg-transparent"
+                style={{
+                  backgroundColor: tag.color,
+                  color: readableForeground(tag.color),
+                }}
                 showRemove={elevation !== 0}
                 data-testid="task-tag"
               >

--- a/pwa/components/tasks/TaskRow.tsx
+++ b/pwa/components/tasks/TaskRow.tsx
@@ -353,24 +353,30 @@ const TaskRow = ({
           />
         </TableCell>
         <TableCell className="align-top text-right whitespace-nowrap">
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={() => onOpenDetail(task)}
-            aria-label={`Open details for "${task.title}"`}
-            data-testid="task-open-detail"
-          >
-            <PanelRight className="h-4 w-4" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={() => onDelete(task)}
-            aria-label={`Delete "${task.title}"`}
-            className="text-destructive hover:text-destructive"
-          >
-            <Trash2 className="h-4 w-4" />
-          </Button>
+          {/* The benign action and the destructive one are deliberately not
+              adjacent: a divider plus a gap separates them so a slipped click
+              on "Open details" can't land on Delete. */}
+          <div className="flex items-center justify-end gap-1">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => onOpenDetail(task)}
+              aria-label={`Open details for "${task.title}"`}
+              data-testid="task-open-detail"
+            >
+              <PanelRight className="h-4 w-4" />
+            </Button>
+            <span aria-hidden="true" className="mx-1 h-5 w-px bg-border" />
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => onDelete(task)}
+              aria-label={`Delete "${task.title}"`}
+              className="text-destructive hover:text-destructive"
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </div>
         </TableCell>
       </TableRow>
       <TableRow

--- a/pwa/components/ui/sonner.tsx
+++ b/pwa/components/ui/sonner.tsx
@@ -1,0 +1,38 @@
+import { Toaster as SonnerToaster } from "sonner";
+
+/**
+ * App-wide toast host. Mounted once in `_app.tsx`.
+ *
+ * Madori ships a single dark theme (see `styles/globals.css`), so the theme is
+ * pinned rather than read from a provider. Colours come from the design tokens
+ * instead of Sonner's defaults so toasts match cards and dialogs.
+ *
+ * Toasts are for transient confirmation of an action the user just took —
+ * especially ones offering an `action` such as Undo. They are not a substitute
+ * for inline error state on a form.
+ */
+const Toaster = ({ ...props }: React.ComponentProps<typeof SonnerToaster>) => (
+  <SonnerToaster
+    theme="dark"
+    position="bottom-right"
+    // Sonner defaults to visible-on-hover only; keep the close button always
+    // available so a toast offering Undo can be dismissed without waiting.
+    closeButton
+    toastOptions={{
+      classNames: {
+        toast:
+          "group flex items-center gap-3 rounded-md border border-border bg-card p-4 text-sm text-card-foreground shadow-lg",
+        description: "text-muted-foreground",
+        actionButton:
+          "rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90",
+        cancelButton:
+          "rounded-md bg-muted px-3 py-1.5 text-xs font-medium text-muted-foreground hover:bg-muted/80",
+        closeButton: "border-border bg-card text-muted-foreground hover:text-foreground",
+        error: "border-destructive/50",
+      },
+    }}
+    {...props}
+  />
+);
+
+export { Toaster };

--- a/pwa/lib/contrast.test.ts
+++ b/pwa/lib/contrast.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { AVATAR_PALETTE } from "./avatarPalette";
+import { contrastRatio, meetsAA, parseHex, readableForeground, relativeLuminance } from "./contrast";
+
+describe("parseHex", () => {
+  it("parses 6-digit hex with and without the hash", () => {
+    expect(parseHex("#ff8800")).toEqual({ r: 255, g: 136, b: 0 });
+    expect(parseHex("ff8800")).toEqual({ r: 255, g: 136, b: 0 });
+  });
+
+  it("expands 3-digit shorthand", () => {
+    expect(parseHex("#f80")).toEqual({ r: 255, g: 136, b: 0 });
+  });
+
+  it("returns null for junk", () => {
+    for (const bad of ["", "#", "#12345", "rgb(1,2,3)", "#gggggg", "nonsense"]) {
+      expect(parseHex(bad)).toBeNull();
+    }
+  });
+});
+
+describe("relativeLuminance / contrastRatio", () => {
+  it("anchors on the spec's endpoints", () => {
+    expect(relativeLuminance("#000000")).toBeCloseTo(0, 5);
+    expect(relativeLuminance("#ffffff")).toBeCloseTo(1, 5);
+    expect(contrastRatio("#ffffff", "#000000")).toBeCloseTo(21, 2);
+  });
+
+  it("is symmetric and self-referentially 1", () => {
+    expect(contrastRatio("#0d9488", "#ffffff")).toBeCloseTo(contrastRatio("#ffffff", "#0d9488"), 10);
+    expect(contrastRatio("#4d7c0f", "#4d7c0f")).toBeCloseTo(1, 10);
+  });
+
+  it("reproduces the ratios measured in the audit", () => {
+    // amber-500 and teal-600 against white — the two failing seeded tags.
+    expect(contrastRatio("#ffffff", "#f59e0b")).toBeCloseTo(2.15, 1);
+    expect(contrastRatio("#ffffff", "#0d9488")).toBeCloseTo(3.74, 1);
+  });
+});
+
+describe("readableForeground", () => {
+  it("picks dark text on light backgrounds", () => {
+    expect(readableForeground("#f59e0b")).toBe("#111317"); // amber-500
+    expect(readableForeground("#ffffff")).toBe("#111317");
+  });
+
+  it("picks white on dark backgrounds", () => {
+    expect(readableForeground("#334155")).toBe("#ffffff"); // slate-700
+    expect(readableForeground("#000000")).toBe("#ffffff");
+  });
+
+  it("falls back to white when the colour is unparseable", () => {
+    expect(readableForeground("not-a-colour")).toBe("#ffffff");
+  });
+
+  it("lifts every previously-failing seeded tag colour to AA", () => {
+    // These are the real values in the seeded database. Each failed at
+    // 2.15 / 3.74 against the old hardcoded white.
+    for (const bad of ["#f59e0b", "#0d9488", "#dc2626", "#7c3aed"]) {
+      expect(meetsAA(bad)).toBe(true);
+    }
+  });
+});
+
+describe("AVATAR_PALETTE", () => {
+  it("is entirely AA-legible under the chosen foreground", () => {
+    for (const color of AVATAR_PALETTE) {
+      expect(meetsAA(color), `${color} should reach AA`).toBe(true);
+    }
+  });
+
+  it("still resolves to white, as its comment claims", () => {
+    // The palette documents itself as verified against *white* text — guard
+    // that, so a future palette edit can't silently flip entries to dark.
+    for (const color of AVATAR_PALETTE) {
+      expect(readableForeground(color), `${color} should keep white text`).toBe("#ffffff");
+    }
+  });
+});

--- a/pwa/lib/contrast.ts
+++ b/pwa/lib/contrast.ts
@@ -1,0 +1,67 @@
+/**
+ * WCAG contrast helpers.
+ *
+ * Used where a foreground has to sit on a colour we don't control at build
+ * time — a user-picked tag or group colour dropped into an inline style. The
+ * palette in `avatarPalette.ts` is pre-verified against white, but values can
+ * also arrive from the API, from fixtures, or from rows created before a
+ * constraint existed, so rendering has to stay legible regardless.
+ */
+
+const WHITE = "#ffffff";
+/** Near-black rather than pure black: softer on light chips, same AA maths. */
+const NEAR_BLACK = "#111317";
+
+/** Parses `#rgb` / `#rrggbb` into 0-255 channels. Returns null if unparseable. */
+export function parseHex(hex: string): { r: number; g: number; b: number } | null {
+  const m = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(hex.trim());
+  if (!m) return null;
+  let h = m[1];
+  if (h.length === 3) {
+    h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
+  }
+  return {
+    r: parseInt(h.slice(0, 2), 16),
+    g: parseInt(h.slice(2, 4), 16),
+    b: parseInt(h.slice(4, 6), 16),
+  };
+}
+
+/** WCAG 2.x relative luminance. */
+export function relativeLuminance(hex: string): number {
+  const c = parseHex(hex);
+  if (!c) return 0;
+  const channel = (v: number) => {
+    const s = v / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * channel(c.r) + 0.7152 * channel(c.g) + 0.0722 * channel(c.b);
+}
+
+/** WCAG contrast ratio between two hex colours, 1..21. */
+export function contrastRatio(a: string, b: string): number {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+}
+
+/**
+ * Picks whichever of white / near-black reads better on `background`.
+ *
+ * Deliberately compares the two candidates rather than testing lightness
+ * against a fixed threshold: a mid-tone like amber-500 is a coin toss by
+ * lightness but decisively better with dark text (2.15:1 white vs 8.9:1
+ * near-black). Falls back to white on an unparseable value, matching the
+ * previous hardcoded behaviour.
+ */
+export function readableForeground(background: string): string {
+  if (!parseHex(background)) return WHITE;
+  return contrastRatio(WHITE, background) >= contrastRatio(NEAR_BLACK, background)
+    ? WHITE
+    : NEAR_BLACK;
+}
+
+/** True when `background` can carry normal-size body text at AA (4.5:1). */
+export function meetsAA(background: string, foreground = readableForeground(background)): boolean {
+  return contrastRatio(foreground, background) >= 4.5;
+}

--- a/pwa/lib/notificationPrefs.test.ts
+++ b/pwa/lib/notificationPrefs.test.ts
@@ -3,6 +3,7 @@ import {
   allOnMatrix,
   DEFAULT_NOTIFICATION_MATRIX,
   NOTIFICATION_ROWS,
+  PUSH_PERMISSION_COPY,
 } from "./notificationPrefs";
 
 describe("notification preference defaults", () => {
@@ -30,5 +31,25 @@ describe("allOnMatrix", () => {
     for (const channel of Object.values(matrix)) {
       expect(channel).toEqual({ inApp: true, email: true });
     }
+  });
+});
+
+describe("PUSH_PERMISSION_COPY", () => {
+  it("covers every state the push helper can report", () => {
+    for (const state of ["default", "granted", "denied", "unsupported"] as const) {
+      expect(PUSH_PERMISSION_COPY[state]).toBeTruthy();
+    }
+  });
+
+  it("never leaks the raw spec vocabulary to the user", () => {
+    // "default" in particular reads as "nothing to do" when it means the
+    // opposite, which is the whole reason this map exists.
+    for (const copy of Object.values(PUSH_PERMISSION_COPY)) {
+      expect(copy).not.toMatch(/\b(default|granted|denied)\b/);
+    }
+  });
+
+  it("tells the user what to do when push is blocked", () => {
+    expect(PUSH_PERMISSION_COPY.denied).toMatch(/site settings/i);
   });
 });

--- a/pwa/lib/notificationPrefs.ts
+++ b/pwa/lib/notificationPrefs.ts
@@ -50,7 +50,7 @@ export const NOTIFICATION_ROWS: NotificationRow[] = [
   {
     key: "budgets",
     label: "Budget alerts",
-    description: "An project you administer crosses 80% or 100% of its budget.",
+    description: "A project you administer crosses 80% or 100% of its budget.",
   },
 ];
 
@@ -70,3 +70,23 @@ export const allOnMatrix = (): Record<string, NotificationChannel> =>
   Object.fromEntries(
     NOTIFICATION_ROWS.map((r) => [r.key, { inApp: true, email: true }]),
   );
+
+/**
+ * Human copy for each browser push-permission state.
+ *
+ * The Notification API's own vocabulary can't be shown to users as-is:
+ * `"default"` is a spec term meaning *permission has not been requested yet*,
+ * but it reads as "this is the normal setting, nothing to do" — exactly
+ * inverting the one state that needs the user to act. Each state is phrased as
+ * what it means for the user, and `default` is paired with an Enable control at
+ * the call site.
+ */
+export const PUSH_PERMISSION_COPY: Record<
+  NotificationPermission | "unsupported",
+  string
+> = {
+  default: "Push isn't enabled yet.",
+  granted: "Push is allowed in this browser.",
+  denied: "Push is blocked — re-enable it in your browser's site settings.",
+  unsupported: "This browser doesn't support push notifications.",
+};

--- a/pwa/lib/useUndoableDelete.ts
+++ b/pwa/lib/useUndoableDelete.ts
@@ -1,0 +1,112 @@
+import { useCallback, useEffect, useRef } from "react";
+import { toast } from "sonner";
+
+/** How long the user gets to undo before the delete is actually sent. */
+export const UNDO_WINDOW_MS = 7000;
+
+interface PendingDelete {
+  timer: ReturnType<typeof setTimeout>;
+  /** Fires the real request. Called by the timer, or early on flush. */
+  commit: () => void;
+}
+
+export interface UndoableDeleteOptions<T> {
+  /** Stable identity for the item — used to key the pending delete. */
+  keyOf: (item: T) => string;
+  /** Remove the item from local state. Runs immediately, before any request. */
+  remove: (item: T) => void;
+  /** Put the item back exactly where it was. Runs when the user undoes. */
+  restore: (item: T) => void;
+  /** Issue the actual delete. Should throw/reject on failure. */
+  request: (item: T) => Promise<void>;
+  /** Toast copy. */
+  message: (item: T) => string;
+  /** Called when the delete ultimately fails, after the item is restored. */
+  onError?: (item: T, error: unknown) => void;
+}
+
+/**
+ * Optimistic delete with a real undo window.
+ *
+ * The row disappears immediately and the network request is *deferred* for
+ * `UNDO_WINDOW_MS`. Undo cancels the request outright, so undoing costs nothing
+ * and needs no restore endpoint on the API.
+ *
+ * The subtle part is what happens when the user leaves before the window
+ * closes. If we simply dropped the timer, the task would quietly come back —
+ * the user watched it vanish and would have every reason to believe it was
+ * gone. So any still-pending delete is *flushed* (sent immediately) on unmount
+ * and on `pagehide`. Leaving the page therefore confirms the delete rather than
+ * cancelling it, which matches what the user was last shown.
+ */
+export function useUndoableDelete<T>({
+  keyOf,
+  remove,
+  restore,
+  request,
+  message,
+  onError,
+}: UndoableDeleteOptions<T>) {
+  const pending = useRef(new Map<string, PendingDelete>());
+
+  const flushAll = useCallback(() => {
+    // Copy first: commit() deletes from the map as it goes.
+    for (const entry of [...pending.current.values()]) {
+      clearTimeout(entry.timer);
+      entry.commit();
+    }
+    pending.current.clear();
+  }, []);
+
+  useEffect(() => {
+    const onPageHide = () => flushAll();
+    window.addEventListener("pagehide", onPageHide);
+    return () => {
+      window.removeEventListener("pagehide", onPageHide);
+      flushAll();
+    };
+  }, [flushAll]);
+
+  return useCallback(
+    (item: T) => {
+      const key = keyOf(item);
+
+      // Guard against a double-click queueing two deletes for one row.
+      if (pending.current.has(key)) return;
+
+      remove(item);
+
+      let settled = false;
+      const commit = () => {
+        if (settled) return;
+        settled = true;
+        pending.current.delete(key);
+        void request(item).catch((err: unknown) => {
+          // The request failed, so the item still exists server-side. Put it
+          // back rather than leaving the UI lying about it.
+          restore(item);
+          onError?.(item, err);
+        });
+      };
+
+      const timer = setTimeout(commit, UNDO_WINDOW_MS);
+      pending.current.set(key, { timer, commit });
+
+      toast(message(item), {
+        duration: UNDO_WINDOW_MS,
+        action: {
+          label: "Undo",
+          onClick: () => {
+            const entry = pending.current.get(key);
+            if (!entry) return; // already committed — too late to undo
+            settled = true;
+            clearTimeout(entry.timer);
+            pending.current.delete(key);
+            restore(item);
+          },
+        },
+      });
+    },
+    [keyOf, remove, restore, request, message, onError],
+  );
+}

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -55,6 +55,7 @@
     "react-markdown": "^10.1.0",
     "recharts": "^3.10.1",
     "remark-gfm": "^4.0.1",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.3",
     "tw-animate-css": "^1.4.0"

--- a/pwa/pages/_app.tsx
+++ b/pwa/pages/_app.tsx
@@ -4,6 +4,7 @@ import "../styles/globals.css"
 import { useEffect } from "react"
 import Script from "next/script"
 import Layout from "../components/common/Layout"
+import { Toaster } from "../components/ui/sonner"
 import { UMAMI_SCRIPT_SRC, UMAMI_WEBSITE_ID } from "../lib/analytics"
 import { registerPushServiceWorker } from "../lib/push"
 import type { AppProps } from "next/app"
@@ -30,6 +31,7 @@ function MyApp({ Component, pageProps }: AppProps<{dehydratedState: DehydratedSt
     <Layout dehydratedState={pageProps.dehydratedState}>
       <Component {...pageProps} />
     </Layout>
+    <Toaster />
   </>
 }
 

--- a/pwa/pages/dev/components/sonner.tsx
+++ b/pwa/pages/dev/components/sonner.tsx
@@ -1,0 +1,73 @@
+import { toast } from "sonner";
+
+import ComponentDoc from "@/components/dev/ComponentDoc";
+import { Button } from "@/components/ui/button";
+
+const SonnerPage = () => (
+  <ComponentDoc
+    name="Toaster (sonner)"
+    description="App-wide transient notifications. Mounted once in `_app.tsx`; call the `toast()` function from anywhere. Theme is pinned to dark and the palette is overridden to the app's design tokens, so toasts match cards and dialogs. Use a toast to confirm an action the user just took — especially one that offers Undo. It is not a replacement for inline form errors, which must stay next to the field they describe."
+    importPath={`import { toast } from "sonner";`}
+    examples={[
+      {
+        title: "Undoable action",
+        code: `toast("Deleted “Draft onboarding email”", {
+  duration: 7000,
+  action: { label: "Undo", onClick: () => restore() },
+})`,
+        preview: (
+          <Button
+            variant="outline"
+            onClick={() =>
+              toast("Deleted “Draft onboarding email”", {
+                duration: 7000,
+                action: { label: "Undo", onClick: () => toast.success("Restored") },
+              })
+            }
+          >
+            Show undo toast
+          </Button>
+        ),
+      },
+      {
+        title: "Status variants",
+        code: `toast.success("Saved")
+toast.error("Could not reach the server")
+toast("Plain message")`,
+        preview: (
+          <div className="flex flex-wrap gap-3">
+            <Button variant="outline" onClick={() => toast.success("Saved")}>
+              Success
+            </Button>
+            <Button variant="outline" onClick={() => toast.error("Could not reach the server")}>
+              Error
+            </Button>
+            <Button variant="outline" onClick={() => toast("Plain message")}>
+              Plain
+            </Button>
+          </div>
+        ),
+      },
+      {
+        title: "With a description",
+        code: `toast("Export started", {
+  description: "We'll email you a link when it's ready.",
+})`,
+        preview: (
+          <Button
+            variant="outline"
+            onClick={() =>
+              toast("Export started", {
+                description: "We'll email you a link when it's ready.",
+              })
+            }
+          >
+            Show
+          </Button>
+        ),
+      },
+    ]}
+  />
+);
+
+export default SonnerPage;

--- a/pwa/pages/settings/notifications.tsx
+++ b/pwa/pages/settings/notifications.tsx
@@ -1,14 +1,16 @@
+import { useEffect, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { usePreferencePersist } from "@/lib/usePreferencePersist";
 import { useSettingsSection } from "@/lib/useSettingsSection";
-import { enablePush } from "@/lib/push";
-import { DEFAULT_NOTIFICATION_MATRIX } from "@/lib/notificationPrefs";
+import { enablePush, pushPermission } from "@/lib/push";
+import { DEFAULT_NOTIFICATION_MATRIX, PUSH_PERMISSION_COPY } from "@/lib/notificationPrefs";
 import SettingsShell from "@/components/settings/SettingsShell";
 import SaveIndicator from "@/components/settings/SaveIndicator";
 import SectionSaveBar from "@/components/settings/SectionSaveBar";
 import NotificationMatrix from "@/components/settings/NotificationMatrix";
 import EmailDigestControl from "@/components/settings/EmailDigestControl";
 import QuietHoursControl from "@/components/settings/QuietHoursControl";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
@@ -19,10 +21,11 @@ const NotificationsPage = () => {
   const prefs = user?.preferences;
   const disabled = !user;
 
-  const pushPermission =
-    typeof window !== "undefined" && "Notification" in window
-      ? Notification.permission
-      : "default";
+  // Read in an effect, not during render: the server has no Notification API
+  // and would always emit "default", so deriving it inline mismatches on
+  // hydration for anyone who has already granted or blocked push.
+  const [permission, setPermission] = useState<NotificationPermission | "unsupported" | null>(null);
+  useEffect(() => setPermission(pushPermission()), []);
 
   const matrix = prefs?.notificationMatrix ?? DEFAULT_NOTIFICATION_MATRIX;
   const digest = prefs?.emailDigest ?? { mode: "realtime", hour: 8 };
@@ -144,13 +147,37 @@ const NotificationsPage = () => {
               />
             </div>
           </div>
-          <p className="text-xs text-muted-foreground">
-            Browser permission:{" "}
-            <span className="font-medium" data-testid="push-permission">
-              {pushPermission}
-            </span>
-            .
-          </p>
+          {/* The browser's own permission vocabulary is misleading here:
+              "default" is a spec term meaning *not yet asked*, but reads as
+              "this is the normal setting, nothing to do" — so the one state
+              that needs action looked like the one that didn't. Each state is
+              stated as intent, and the actionable one carries its control. */}
+          {permission !== null && (
+            <p className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+              <span data-testid="push-permission" data-permission={permission}>
+                {PUSH_PERMISSION_COPY[permission]}
+              </span>
+              {permission === "default" && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-6 px-2 text-xs"
+                  disabled={disabled}
+                  onClick={() => {
+                    void enablePush().then((result) => {
+                      setPermission(pushPermission());
+                      if (result.ok) {
+                        void push.persist({ pushNotificationsEnabled: true });
+                      }
+                    });
+                  }}
+                  data-testid="push-enable"
+                >
+                  Enable
+                </Button>
+              )}
+            </p>
+          )}
         </CardContent>
       </Card>
     </SettingsShell>

--- a/pwa/pages/tags.tsx
+++ b/pwa/pages/tags.tsx
@@ -16,6 +16,7 @@ import ColorSwatchPicker from "@/components/common/ColorSwatchPicker";
 import ConfirmDialog from "@/components/common/ConfirmDialog";
 import PageHeader from "@/components/common/PageHeader";
 import { AVATAR_PALETTE } from "@/lib/avatarPalette";
+import { readableForeground } from "@/lib/contrast";
 import { ENTRYPOINT } from "@/config/entrypoint";
 
 interface Tag {
@@ -296,8 +297,11 @@ const Tags = () => {
                       >
                         <td className="px-4 py-2 align-middle">
                           <span
-                            className="inline-block rounded px-2 py-1 text-sm font-semibold whitespace-nowrap text-white"
-                            style={{ backgroundColor: tag.color }}
+                            className="inline-block rounded px-2 py-1 text-sm font-semibold whitespace-nowrap"
+                            style={{
+                              backgroundColor: tag.color,
+                              color: readableForeground(tag.color),
+                            }}
                           >
                             {tag.title}
                           </span>

--- a/pwa/pages/tasks.tsx
+++ b/pwa/pages/tasks.tsx
@@ -25,6 +25,7 @@ import { ENTRYPOINT } from "@/config/entrypoint";
 import { trackEvent } from "@/lib/analytics";
 import { signinHrefForCurrent } from "@/lib/authRedirect";
 import { type CommentLiveEvent } from "@/lib/useCommentLiveUpdates";
+import { useUndoableDelete } from "@/lib/useUndoableDelete";
 import MarkdownEditor from "@/components/editor/MarkdownEditor";
 import AssigneesCombobox, {
   type AssigneeOption,
@@ -467,9 +468,31 @@ const Tasks = () => {
     }
   };
 
-  const handleDelete = async (task: Task) => {
-    setError(null);
-    try {
+  // Where each optimistically-removed task sat, so Undo restores it to its
+  // original position instead of dropping it at the end of the list.
+  const deletedIndex = useRef(new Map<string, number>());
+
+  const handleDelete = useUndoableDelete<Task>({
+    keyOf: (task) => task["@id"],
+    remove: (task) => {
+      setError(null);
+      const index = tasks.findIndex((t) => t["@id"] === task["@id"]);
+      if (index !== -1) {
+        deletedIndex.current.set(task["@id"], index);
+      }
+      setTasks((prev) => prev.filter((t) => t["@id"] !== task["@id"]));
+    },
+    restore: (task) => {
+      setTasks((prev) => {
+        if (prev.some((t) => t["@id"] === task["@id"])) return prev;
+        const next = [...prev];
+        const index = deletedIndex.current.get(task["@id"]) ?? next.length;
+        next.splice(Math.min(index, next.length), 0, task);
+        return next;
+      });
+      deletedIndex.current.delete(task["@id"]);
+    },
+    request: async (task) => {
       const res = await fetch(`${ENTRYPOINT}${task["@id"]}`, {
         method: "DELETE",
         credentials: "include",
@@ -477,11 +500,13 @@ const Tasks = () => {
       if (!res.ok) {
         throw new Error("Failed to delete task.");
       }
-      await loadData();
-    } catch (err) {
+      deletedIndex.current.delete(task["@id"]);
+    },
+    message: (task) => `Deleted “${task.title}”`,
+    onError: (_task, err) => {
       setError(err instanceof Error ? err.message : "Failed to delete task.");
-    }
-  };
+    },
+  });
 
   const handleTitleChange = async (task: Task, nextTitle: string) => {
     // Optimistic title update — input has already returned to read mode.

--- a/pwa/pnpm-lock.yaml
+++ b/pwa/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -4815,6 +4818,12 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -10510,6 +10519,11 @@ snapshots:
       side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
+
+  sonner@2.0.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
   source-map-js@1.2.1: {}
 

--- a/pwa/styles/globals.css
+++ b/pwa/styles/globals.css
@@ -20,7 +20,12 @@
     --popover-foreground:    #e9e9e6;
 
     --muted:                 #1d2025;
-    --muted-foreground:      #7a7e83;
+    /* Carries most of the app's secondary text, so it has to clear WCAG AA
+       (4.5:1) against every ground it can land on, not just the page
+       background. The previous #7a7e83 only passed on --background (4.73)
+       and failed on --card (4.35), --muted (4.00) and --accent (3.67).
+       #93979c passes all four with headroom — worst case 5.11 on --accent. */
+    --muted-foreground:      #93979c;
 
     --accent:                #23272d;            /* hover bg */
     --accent-foreground:     #e9e9e6;

--- a/pwa/vitest.config.ts
+++ b/pwa/vitest.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
       include: [
         "lib/authRedirect.ts",
         "lib/avatarPalette.ts",
+        "lib/contrast.ts",
         "lib/currencies.ts",
         "lib/landingDestination.ts",
         "lib/notificationPrefs.ts",


### PR DESCRIPTION
## Description

Fixes the top-tier findings from a UI/UX audit of the signed-in app — the one Critical, two of the High-severity contrast issues, and both Copy findings — plus one unrelated chore spotted along the way.

Full audit (22 findings): https://claude.ai/code/artifact/a026ca5a-2135-492f-9c27-822820100ca3

**C-01 — task deletion was unguarded (Critical).** The `/tasks` row trash button fired `DELETE` immediately: no confirmation, no toast, no undo, with the button sitting directly beside "Open details". Deleting the *same task* from the detail drawer already routed through `ConfirmDialog`, as do tags, boards, roles and API keys — the list row was the one unguarded path and the highest-traffic one.

Rather than add another modal to the most repeated action in the app, delete is now optimistic with a real undo window: the row goes at once and the request is deferred, so undo costs nothing and needs no restore endpoint. Leaving the page mid-window **flushes** the pending delete rather than cancelling it — the user watched the row vanish, so finding it alive later would be the surprising outcome. Undo restores the row to its original index.

**H-03 — `--muted-foreground` failed AA on 3 of 4 grounds.** `#7a7e83` cleared 4.5:1 only against `--background`; it failed on `--card` (4.35), `--muted` (4.00) and `--accent` (3.67). One token carries most of the app's secondary text. Raised to `#93979c` (worst case 5.11).

**H-02 — tag chips were illegible and unconstrained.** Chips hardcoded `text-white` over a user-picked hex while `Tag.color` was validated only as a hex regex, so seeded tags reached **2.15:1**. Two halves: chip foreground is now derived from background luminance (so *any* stored colour renders legibly), and `Tag.color` takes `Assert\Choice` against `AvatarColorService::PALETTE`, matching Space and UserGroup.

The constraint needed a backfill to be a fix rather than a latent break — API Platform validates the whole entity on PATCH, so a pre-existing out-of-palette tag would have 422'd on an unrelated title edit. The migration snaps by **hue**, not RGB distance, so tags keep their colour family (teal-600 → teal-700, not the numerically-nearer cyan-700).

**L-18 / L-19 — copy.** "An project" → "A project". And the Push card printed `Notification.permission` verbatim: in the spec `"default"` means *not yet asked*, but it reads as *nothing to do* — the one state needing action looked like the one that didn't. Each state now reads as intent and the actionable one carries an Enable button. That read also ran during render behind a `typeof window` guard (SSR "default" vs client actual), so it additionally fixes a hydration mismatch.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## Component

- [x] API (PHP/Symfony)
- [x] PWA (Next.js)
- [ ] Infrastructure (Docker/Helm)
- [x] E2E Tests
- [ ] Documentation

## How Has This Been Tested?

Driven in a real browser against a running stack, not only typechecked.

**Undo delete** — row disappears with **0** DELETEs in flight; toast shows `Deleted "…" | Undo`; undo restores to the *original index* (2 → 2) and genuinely cancels (still 0 DELETEs after the window elapses); no-undo commits exactly **1** DELETE that survives a reload; navigating away mid-window still sends it. Button gap 0px → 17px plus a divider.

**Contrast** — measured across five routes, resolving each element's effective background through transparent ancestors with alpha compositing:

| Route | Before | After |
|---|---:|---:|
| `/settings/security` | 70 | 0 |
| `/tasks` | 36 | 0 |
| `/settings/notifications` | 23 | 0 |
| `/spaces` | 18 | 0 |
| `/boards` | 1 | 0 |
| **Total** | **148** | **0** |

**Migration** — run against real data: 6 tags across 4 distinct colours, every one staying in family.

**Copy** — renders "Push isn't enabled yet." with an Enable button, no raw spec word, and no hydration warnings.

Suites: `TagTest` 19/19 · `McpTest` 36/36 · `TaskTest`+`BoardTest`+`SpaceTest` 79/79 · vitest 164/164 (19 files) · PHPStan level 10 clean over 801 files · PHPCS clean over 803 · `doctrine:schema:validate` in sync · all 360 Playwright specs parse.

## Checklist

- [x] My code follows the project's conventions
- [x] I have added tests that prove my fix or feature works
- [x] New and existing tests pass locally (PHPUnit / `pnpm test:coverage`)
- [x] New pure-logic helpers under `pwa/lib` are added to the coverage allowlist in `pwa/vitest.config.ts`
- [x] I have updated documentation if needed

## Notes for the reviewer

Two corrections to the audit report itself, worth knowing since it's the record:

- The report's contrast counts (19 on `/tasks`, 25 on `/settings/security`) were **undercounts**; stricter measurement gives 36 and 70. The finding was right, its size was understated.
- The report implied the tag *picker* was unconstrained. It wasn't — it already fed `AVATAR_PALETTE` via `ColorSwatchPicker`. The real hole was the API accepting any hex, plus fixtures seeding out-of-palette values.

Deliberately **not** included, as they change look-and-feel or have wide blast radius and deserve their own review: de-muting completed task styling (part of H-03's fix), and the remaining 17 findings (H-04 through L-22).

New reusable component `components/ui/sonner.tsx` ships with its dev-docs page at `/dev/components/sonner` and a registry entry, per `CLAUDE.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_011c8hAeLnvvpgeaEqPzcTjS)_