### PR TITLE
fix(a11y): announce and focus validation errors, and name the task drawer

### DIFF
--- a/e2e/tests/auth.spec.js
+++ b/e2e/tests/auth.spec.js
@@ -42,10 +42,26 @@ test.describe("Authentication", () => {
     await page.goto(`${BASE_URL}/signup`);
 
     // Submit empty form → top-of-form summary + inline messages.
+    // Each message appears twice by design (once in the summary, once beside
+    // its field), so assert against each location specifically rather than a
+    // bare text match.
     await page.getByRole("button", { name: "Create account" }).click();
-    await expect(page.getByTestId("signup-error-summary")).toBeVisible();
-    await expect(page.locator("text=Email is required")).toBeVisible();
-    await expect(page.locator("text=Password is required")).toBeVisible();
+
+    const summary = page.getByTestId("signup-error-summary");
+    await expect(summary).toBeVisible();
+    await expect(summary).toContainText("Email is required");
+    await expect(summary).toContainText("Password is required");
+
+    // Inline messages, associated with their input via aria-describedby.
+    await expect(page.locator("#email-error")).toBeVisible();
+    await expect(page.locator("#password-error")).toBeVisible();
+    await expect(page.locator('input[name="email"]')).toHaveAttribute(
+      "aria-describedby",
+      "email-error",
+    );
+
+    // A failed submit must move focus to the summary, not leave it on <body>.
+    await expect(summary).toBeFocused();
   });
 
   test("sign in with valid credentials", async ({ page }) => {

--- a/pwa/components/auth/SignInForm.tsx
+++ b/pwa/components/auth/SignInForm.tsx
@@ -11,6 +11,7 @@ import { landingPathFor, readLanding } from "@/lib/landingDestination";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { FormikField } from "@/components/ui/formik-field";
+import { FormikFocusError } from "@/components/ui/formik-focus-error";
 import SsoButtons from "@/components/auth/SsoButtons";
 
 interface SignInValues {
@@ -112,6 +113,9 @@ const SignInForm = ({ next, registered, reset, expired, onTwoFactorRequired }: P
       >
         {({ isSubmitting, status }) => (
           <Form className="space-y-5" noValidate>
+            {/* Two fields and no summary, so this focuses the first invalid
+                input directly. */}
+            <FormikFocusError />
             {status && (() => {
               const isCreds = /invalid credentials/i.test(status);
               const title = isCreds ? "Invalid email or password" : status;
@@ -139,6 +143,7 @@ const SignInForm = ({ next, registered, reset, expired, onTwoFactorRequired }: P
             })()}
 
             <FormikField
+              required
               name="email"
               type="email"
               label="Email"
@@ -148,6 +153,7 @@ const SignInForm = ({ next, registered, reset, expired, onTwoFactorRequired }: P
             />
 
             <FormikField
+              required
               name="password"
               type="password"
               label="Password"

--- a/pwa/components/auth/SignUpForm.tsx
+++ b/pwa/components/auth/SignUpForm.tsx
@@ -6,6 +6,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import SsoButtons from "@/components/auth/SsoButtons";
 import { FormikField } from "@/components/ui/formik-field";
+import { FormikFocusError, findFieldControl } from "@/components/ui/formik-focus-error";
 import {
   MIN_PASSWORD_LENGTH,
   MIN_PASSWORD_STRENGTH,
@@ -213,8 +214,21 @@ const SignUpForm = ({ inviteToken, onCollected, submitLabel = "Create account" }
 
           return (
             <Form className="space-y-4" noValidate>
+              <FormikFocusError />
               {visibleErrors.length > 0 && (
-                <Alert variant="destructive" data-testid="signup-error-summary">
+                // Focus lands here after a failed submit (see FormikFocusError),
+                // so the user hears the whole picture before being dropped into
+                // a single field. tabIndex={-1} makes it programmatically
+                // focusable without adding a tab stop; role="alert" announces it
+                // if it appears while focus is elsewhere.
+                <Alert
+                  variant="destructive"
+                  data-testid="signup-error-summary"
+                  data-error-summary=""
+                  tabIndex={-1}
+                  role="alert"
+                  className="focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
                   <AlertDescription>
                     <p className="font-semibold">Fix the highlighted fields</p>
                     <p className="text-xs mt-1">
@@ -222,18 +236,41 @@ const SignUpForm = ({ inviteToken, onCollected, submitLabel = "Create account" }
                       {visibleErrors.length === 1 ? "" : "s"} to resolve before you can
                       continue.
                     </p>
+                    <ul className="mt-2 space-y-0.5 text-xs">
+                      {visibleErrors.map((key) => (
+                        <li key={key}>
+                          {/* A button, not an anchor: this moves focus, it
+                              doesn't navigate. Resolution is by `name`, not
+                              `id` — id schemes vary per control (the consent
+                              checkbox renders as `consent-acceptTerms`), so an
+                              id-based href would silently be a dead link. */}
+                          <button
+                            type="button"
+                            className="text-left underline underline-offset-2"
+                            onClick={(e) => {
+                              const form = e.currentTarget.closest("form");
+                              if (form) findFieldControl(form, key)?.focus();
+                            }}
+                          >
+                            {errors[key]}
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
                   </AlertDescription>
                 </Alert>
               )}
 
               <div className="grid grid-cols-2 gap-3">
                 <FormikField
+                  required
                   name="givenName"
                   type="text"
                   autoComplete="given-name"
                   label="Given name"
                 />
                 <FormikField
+                  required
                   name="familyName"
                   type="text"
                   autoComplete="family-name"
@@ -242,6 +279,7 @@ const SignUpForm = ({ inviteToken, onCollected, submitLabel = "Create account" }
               </div>
 
               <FormikField
+                required
                 name="email"
                 type="email"
                 label="Work email"
@@ -255,6 +293,7 @@ const SignUpForm = ({ inviteToken, onCollected, submitLabel = "Create account" }
               />
 
               <FormikField
+                required
                 name="password"
                 type="password"
                 label="Password"

--- a/pwa/components/auth/TermsConsentField.tsx
+++ b/pwa/components/auth/TermsConsentField.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { useField } from "formik";
 import { Checkbox } from "@/components/ui/checkbox";
+import { FIELD_NAME_ATTR } from "@/components/ui/formik-focus-error";
 import { cn } from "@/lib/utils";
 
 /**
@@ -23,6 +24,12 @@ const TermsConsentField = ({ name = "acceptTerms" }: { name?: string }) => {
       <div className="flex items-start gap-2.5">
         <Checkbox
           id={id}
+          // Makes this field addressable by its Formik name, like every
+          // FormikField — the error summary and focus-on-failed-submit both
+          // resolve targets that way. It can't be found by `name` (Radix puts
+          // that on a hidden proxy input, so focus would land somewhere
+          // invisible) and its id is `consent-acceptTerms`, not the field name.
+          {...{ [FIELD_NAME_ATTR]: name }}
           checked={field.value}
           onCheckedChange={(checked) => {
             // Mark touched without validating against the stale snapshot, then

--- a/pwa/components/dev/registry.ts
+++ b/pwa/components/dev/registry.ts
@@ -32,6 +32,7 @@ export const componentRegistry: RegistryEntry[] = [
   { slug: "dialog", name: "Dialog", category: "Overlay", description: "Modal dialog with title, body, and actions." },
   { slug: "dropdown-menu", name: "Dropdown Menu", category: "Overlay", description: "Anchored menu with items, separators, and submenus." },
   { slug: "formik-field", name: "FormikField", category: "Form", description: "Formik-aware label + input + error wrapper." },
+  { slug: "formik-focus-error", name: "FormikFocusError", category: "Form", description: "Moves focus to the error summary or first invalid field after a failed submit." },
   { slug: "input", name: "Input", category: "Form", description: "Single-line text input." },
   { slug: "input-group", name: "InputGroup", category: "Form", description: "Compose an input with leading/trailing addons." },
   { slug: "input-otp", name: "InputOTP", category: "Form", description: "Segmented one-time-code input (slots + separator) built on input-otp." },

--- a/pwa/components/tasks/TaskDetailDrawer.tsx
+++ b/pwa/components/tasks/TaskDetailDrawer.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { CheckCircle2, Repeat, Trash2 } from "lucide-react";
 import { ENTRYPOINT } from "@/config/entrypoint";
-import { Sheet, SheetContent } from "@/components/ui/sheet";
+import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
 import ConfirmDialog from "@/components/common/ConfirmDialog";
 import MarkdownEditor from "@/components/editor/MarkdownEditor";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -399,6 +399,22 @@ const TaskDetailDrawer = ({
           }
         }}
       >
+        {/* The dialog's accessible name. Visually hidden because the visible
+            title is an editable <input> and can't double as the heading; without
+            this the drawer announced only "dialog", so in a list of similar rows
+            there was no way to confirm the right task had opened. Rendering it
+            through SheetTitle (Radix's Dialog.Title) is what wires
+            aria-labelledby, and it gives the dialog its one heading.
+
+            Deliberately NOT aria-modal: this Sheet is modal={false} so its
+            comboboxes and popovers portal outside the dialog subtree and stay
+            interactive (see the onInteractOutside guard above). Claiming
+            modality would tell assistive tech that everything outside the
+            drawer is unavailable — hiding exactly those controls. Focus is
+            already trapped, which is the part that matters functionally. */}
+        <SheetTitle className="sr-only">
+          {task ? `Task details: ${task.title}` : "Task details"}
+        </SheetTitle>
         {loading && (
           <p className="p-6 text-sm text-muted-foreground">Loading…</p>
         )}

--- a/pwa/components/ui/formik-field.tsx
+++ b/pwa/components/ui/formik-field.tsx
@@ -31,6 +31,18 @@ export function FormikField({
   const fieldId = id ?? name;
   const [, meta] = useField(name);
   const isInvalid = meta.touched && Boolean(meta.error);
+
+  // The error and description are only useful to a screen reader if the input
+  // points at them. Without this the field announces "invalid" with no reason
+  // given, and the user has to hunt the form to find out which rule they broke.
+  // Only reference ids that are actually rendered.
+  const errorId = `${fieldId}-error`;
+  const descriptionId = `${fieldId}-description`;
+  const describedBy =
+    [description ? descriptionId : null, isInvalid ? errorId : null]
+      .filter(Boolean)
+      .join(" ") || undefined;
+
   return (
     <div className={cn("space-y-1.5", containerClassName)}>
       {labelAddon ? (
@@ -46,13 +58,22 @@ export function FormikField({
         id={fieldId}
         name={name}
         aria-invalid={isInvalid || undefined}
+        aria-describedby={describedBy}
         className={inputClassName}
         {...inputProps}
       />
       {description && (
-        <p className="text-xs text-muted-foreground">{description}</p>
+        <p id={descriptionId} className="text-xs text-muted-foreground">
+          {description}
+        </p>
       )}
-      <ErrorMessage name={name} component="p" className="text-sm text-destructive" />
+      <ErrorMessage name={name}>
+        {(message) => (
+          <p id={errorId} className="text-sm text-destructive">
+            {message}
+          </p>
+        )}
+      </ErrorMessage>
     </div>
   );
 }

--- a/pwa/components/ui/formik-focus-error.tsx
+++ b/pwa/components/ui/formik-focus-error.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useRef } from "react";
+import { useFormikContext } from "formik";
+
+/** Marks the element a failed submit should focus, in preference to a field. */
+export const ERROR_SUMMARY_ATTR = "data-error-summary";
+
+/**
+ * Opt-in marker for controls that can't be found by `name`.
+ *
+ * Design-system controls (Radix Checkbox, Switch, …) render a visible button
+ * plus a *hidden* proxy input that carries the `name` for form submission.
+ * Resolving by name alone therefore finds the hidden one and focus lands
+ * somewhere invisible — worse than not moving it at all. Put this attribute on
+ * the visible control instead.
+ */
+export const FIELD_NAME_ATTR = "data-field-name";
+
+const NAMED_CONTROL = "input,select,textarea,[contenteditable='true']";
+
+/** Focusable and actually perceivable — excludes Radix's hidden proxy inputs. */
+function isVisibleControl(el: HTMLElement): boolean {
+  if (el.getAttribute("aria-hidden") === "true") return false;
+  if (el.getAttribute("tabindex") === "-1") return false;
+  const rect = el.getBoundingClientRect();
+  return rect.width > 0 && rect.height > 0;
+}
+
+/** Sorts field names into the order their controls appear on screen. */
+function orderedByDom(form: HTMLElement, names: string[]): string[] {
+  return [...names].sort((a, b) => {
+    const ea = findFieldControl(form, a);
+    const eb = findFieldControl(form, b);
+    if (!ea || !eb) return 0;
+    // DOCUMENT_POSITION_FOLLOWING = b comes after a.
+    return ea.compareDocumentPosition(eb) & Node.DOCUMENT_POSITION_FOLLOWING
+      ? -1
+      : 1;
+  });
+}
+
+/**
+ * Resolves a Formik field name to the control the user should be focused on.
+ * Exported so an error summary and the focus-on-submit behaviour can't drift.
+ */
+export function findFieldControl(
+  form: HTMLElement,
+  name: string,
+): HTMLElement | null {
+  const tagged = form.querySelector<HTMLElement>(
+    `[${FIELD_NAME_ATTR}="${CSS.escape(name)}"]`,
+  );
+  if (tagged && isVisibleControl(tagged)) return tagged;
+
+  for (const el of form.querySelectorAll<HTMLElement>(NAMED_CONTROL)) {
+    if (el.getAttribute("name") === name && isVisibleControl(el)) return el;
+  }
+  return null;
+}
+
+/**
+ * Moves focus after a failed submit.
+ *
+ * Without this, submitting an invalid form leaves focus on `<body>`: the
+ * errors appear but the caret is nowhere near them, so a keyboard user re-tabs
+ * the whole form and a screen-reader user gets no announcement at all.
+ *
+ * Two targets, in order of preference:
+ *
+ * 1. An error **summary** (any element carrying `data-error-summary`). When a
+ *    form has one, that's the better landing spot than the first bad field —
+ *    the user hears how many problems there are before being dropped into one
+ *    of them. This is the GOV.UK error-summary pattern.
+ * 2. Otherwise the first invalid control **in DOM order** — not in `errors`
+ *    key order, which follows the validator and can differ from what the user
+ *    sees.
+ *
+ * Runs only on a *new* failed submit (tracked by `submitCount`) and only once
+ * the attempt has settled, so it can't fight Formik's re-render or steal focus
+ * while the user is typing a correction.
+ */
+export function FormikFocusError() {
+  const { submitCount, isSubmitting, errors } = useFormikContext<
+    Record<string, unknown>
+  >();
+  const anchorRef = useRef<HTMLSpanElement>(null);
+  const handledSubmit = useRef(0);
+
+  useEffect(() => {
+    if (submitCount === 0 || submitCount === handledSubmit.current) return;
+    // Wait for the submit attempt to settle; focusing mid-flight would be
+    // undone by the re-render that follows.
+    if (isSubmitting) return;
+
+    const names = Object.keys(errors);
+    if (names.length === 0) {
+      // A clean submit still counts as handled, so a later failure re-fires.
+      handledSubmit.current = submitCount;
+      return;
+    }
+    handledSubmit.current = submitCount;
+
+    const form = anchorRef.current?.closest("form");
+    if (!form) return;
+
+    const summary = form.querySelector<HTMLElement>(`[${ERROR_SUMMARY_ATTR}]`);
+    if (summary) {
+      summary.focus();
+      return;
+    }
+
+    // First invalid control in DOM order — not in `errors` key order, which
+    // follows the validator and can differ from what the user sees.
+    for (const name of orderedByDom(form, names)) {
+      const target = findFieldControl(form, name);
+      if (target) {
+        target.focus();
+        return;
+      }
+    }
+  }, [submitCount, isSubmitting, errors]);
+
+  return <span ref={anchorRef} aria-hidden="true" className="hidden" />;
+}

--- a/pwa/pages/dev/components/formik-focus-error.tsx
+++ b/pwa/pages/dev/components/formik-focus-error.tsx
@@ -1,0 +1,152 @@
+import { Formik, Form } from "formik";
+
+import ComponentDoc from "@/components/dev/ComponentDoc";
+import { Button } from "@/components/ui/button";
+import { FormikField } from "@/components/ui/formik-field";
+import {
+  FormikFocusError,
+  findFieldControl,
+} from "@/components/ui/formik-focus-error";
+
+const errorsFor = (values: { email: string; password: string }) => {
+  const errors: Record<string, string> = {};
+  if (!values.email) errors.email = "Email is required.";
+  if (!values.password) errors.password = "Password is required.";
+  return errors;
+};
+
+const PlainDemo = () => (
+  <Formik
+    initialValues={{ email: "", password: "" }}
+    validate={errorsFor}
+    onSubmit={() => {
+      // no-op for the docs preview
+    }}
+  >
+    <Form className="space-y-4" noValidate>
+      <FormikFocusError />
+      <FormikField required name="email" label="Email" type="email" />
+      <FormikField required name="password" label="Password" type="password" />
+      <Button type="submit" size="sm">
+        Submit empty — focus lands on Email
+      </Button>
+    </Form>
+  </Formik>
+);
+
+const SummaryDemo = () => (
+  <Formik
+    initialValues={{ email: "", password: "" }}
+    validate={errorsFor}
+    onSubmit={() => {
+      // no-op for the docs preview
+    }}
+  >
+    {({ errors, submitCount }) => (
+      <Form className="space-y-4" noValidate>
+        <FormikFocusError />
+        {submitCount > 0 && Object.keys(errors).length > 0 && (
+          <div
+            data-error-summary=""
+            tabIndex={-1}
+            role="alert"
+            className="rounded-md border border-destructive/50 p-3 text-sm"
+          >
+            <p className="font-semibold text-destructive">
+              Fix the highlighted fields
+            </p>
+            <ul className="mt-1 space-y-0.5 text-xs">
+              {Object.keys(errors).map((key) => (
+                <li key={key}>
+                  <button
+                    type="button"
+                    className="underline underline-offset-2"
+                    onClick={(e) => {
+                      const form = e.currentTarget.closest("form");
+                      if (form) findFieldControl(form, key)?.focus();
+                    }}
+                  >
+                    {String(errors[key as keyof typeof errors])}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        <FormikField required name="email" label="Email" type="email" />
+        <FormikField required name="password" label="Password" type="password" />
+        <Button type="submit" size="sm">
+          Submit empty — focus lands on the summary
+        </Button>
+      </Form>
+    )}
+  </Formik>
+);
+
+const FormikFocusErrorPage = () => (
+  <ComponentDoc
+    name="FormikFocusError"
+    description="Moves focus after a failed submit. Without it, submitting an invalid form leaves focus on <body>: the errors appear but the caret is nowhere near them, so a keyboard user re-tabs the whole form and a screen-reader user gets no announcement at all. Render it once inside a <Form>. It prefers an error summary (any element carrying `data-error-summary`) and otherwise focuses the first invalid control in DOM order — not in `errors` key order, which follows the validator rather than what the user sees. It fires only on a new failed submit and only once the attempt settles, so it can't fight Formik's re-render or steal focus mid-correction."
+    importPath={`import { FormikFocusError, findFieldControl, FIELD_NAME_ATTR } from "@/components/ui/formik-focus-error";`}
+    examples={[
+      {
+        title: "No summary — focuses the first invalid field",
+        code: `<Form noValidate>
+  <FormikFocusError />
+  <FormikField required name="email" label="Email" />
+  <FormikField required name="password" label="Password" />
+  <Button type="submit">Sign in</Button>
+</Form>`,
+        preview: <PlainDemo />,
+      },
+      {
+        title: "With an error summary — focuses the summary",
+        code: `{/* Any element carrying data-error-summary wins over the first
+    field: the user hears how many problems there are before being
+    dropped into one of them (the GOV.UK error-summary pattern).
+    tabIndex={-1} makes it focusable without adding a tab stop. */}
+<div data-error-summary tabIndex={-1} role="alert">
+  <ul>
+    {Object.keys(errors).map((key) => (
+      <li key={key}>
+        <button
+          type="button"
+          onClick={(e) => {
+            const form = e.currentTarget.closest("form")
+            if (form) findFieldControl(form, key)?.focus()
+          }}
+        >
+          {errors[key]}
+        </button>
+      </li>
+    ))}
+  </ul>
+</div>`,
+        preview: <SummaryDemo />,
+      },
+      {
+        title: "Controls that can't be found by name",
+        code: `{/* Radix Checkbox/Switch render a visible button plus a HIDDEN
+    proxy input that carries the name. Resolving by name alone finds
+    the hidden one, so focus lands somewhere invisible — worse than
+    not moving it. Mark the visible control instead. */}
+<Checkbox {...{ [FIELD_NAME_ATTR]: name }} id={id} />
+
+{/* Then findFieldControl(form, name) returns the visible button, and
+    both the summary and FormikFocusError resolve it the same way. */}`,
+        preview: (
+          <p className="text-sm text-muted-foreground">
+            <code>findFieldControl</code> skips anything{" "}
+            <code>aria-hidden</code>, <code>tabindex=&quot;-1&quot;</code>, or
+            zero-sized, so a hidden proxy input can never be the focus target.
+            Use <code>FIELD_NAME_ATTR</code> on design-system controls that
+            don&apos;t carry a <code>name</code> of their own — see{" "}
+            <code>TermsConsentField</code>.
+          </p>
+        ),
+      },
+    ]}
+  />
+);
+
+export default FormikFocusErrorPage;


### PR DESCRIPTION
## Description

Fixes **H-04** and **H-05** from the UI/UX audit, completing the accessibility pass begun in [#784](https://github.com/roboparker/Aura/pull/784). That change made the app *navigable*; these two make its interactive parts *usable*.

Full audit: https://claude.ai/code/artifact/a026ca5a-2135-492f-9c27-822820100ca3

**H-04 — validation errors were shown but never announced or focused.** Submitting sign-in empty set `aria-invalid` on both inputs but left `aria-describedby` **null**, so the visible "Email is required." was never associated with its field — a screen reader announced "invalid" with no reason given. Focus stayed on `<body>`, so on sign-up five errors appeared with the caret nowhere near any of them.

The association is fixed in **`FormikField`**, which every Formik form shares (14 files), so it lands once rather than per form. Only ids that are actually rendered get referenced — a dangling `aria-describedby` announces nothing, which is worse than omitting it.

New **`FormikFocusError`** moves focus after a failed submit. It prefers an error summary when the form has one (the user hears how many problems there are before being dropped into one of them — the GOV.UK pattern), and otherwise focuses the first invalid control **in DOM order**, not `errors` key order, which follows the validator rather than what the user sees. It fires only on a *new* failed submit and only once the attempt settles, so it can't fight Formik's re-render or steal focus mid-correction.

**H-05 — the task drawer was an unnamed dialog.** It announced only "dialog", with `aria-label`, `aria-labelledby` and any heading all absent, so in a list of similar rows there was no way to confirm the right task had opened. It now renders a visually-hidden `SheetTitle` ("Task details: <title>"); the visible title is an editable `<input>` and can't double as the heading. Radix wires `aria-labelledby` from it.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## Component

- [ ] API (PHP/Symfony)
- [x] PWA (Next.js)
- [ ] Infrastructure (Docker/Helm)
- [x] E2E Tests
- [ ] Documentation

## How Has This Been Tested?

Driven in a real browser:

| | Before | After |
|---|---|---|
| Drawer `aria-labelledby` | `null` | `"Task details: Draft onboarding email"` |
| Headings inside drawer | 0 | 1 |
| Sign-in fields with resolving `aria-describedby` | 0/2 | **2/2** |
| Focus after failed sign-in submit | `<body>` | first invalid input |
| Focus after failed sign-up submit | `<body>` | the summary (`role=alert`) |
| Summary entries landing on a **visible** control | n/a | **5/5** |

Focus trapping in the drawer was **verified, not assumed** — 50 tabs against 25 focusables, never escaping.

`tsc` clean · `pnpm lint` 0 errors · vitest 164/164 · e2e `auth.spec.js` 7/7, `tasks`+`boards` 14/15 (the one failure is the pre-existing keyboard-drag test, see below).

## Checklist

- [x] My code follows the project's conventions
- [x] I have added tests that prove my fix or feature works
- [x] New and existing tests pass locally (PHPUnit / `pnpm test:coverage`)
- [x] New pure-logic helpers under `pwa/lib` are added to the coverage allowlist in `pwa/vitest.config.ts`
- [x] I have updated documentation if needed

## Notes for the reviewer

**I deviated from the audit on `aria-modal`.** The report said to add it "to match the actual trapping behaviour". I didn't, deliberately: this Sheet is `modal={false}` *precisely so* its comboboxes and popovers can portal outside the dialog and stay interactive (there's an `onInteractOutside` guard for it). Claiming modality would tell assistive tech everything outside the drawer is unavailable — hiding exactly those controls. Focus is already trapped, which is the part that matters functionally. This is the one judgement call worth a second opinion.

**Two defects I introduced and then caught by driving the real form,** both worth knowing because they'd have looked fine in review:

1. Linking summary entries by `id` was silently dead for the consent checkbox, whose id is `consent-acceptTerms`, not its field name. Id schemes vary per control; field names don't.
2. Switching to `name` then focused Radix's **hidden proxy input** rather than the visible checkbox — focus landing somewhere invisible is worse than not moving it at all. `findFieldControl` now skips `aria-hidden`, `tabindex="-1"` and zero-sized elements, and `FIELD_NAME_ATTR` marks controls carrying no name of their own. The summary and the focus behaviour resolve targets through the same function so they can't drift.

**The e2e assertion was tightened, not relaxed.** Each message now appears twice by design (summary + inline), which tripped the old unanchored `text=` locator. Rather than loosen it, the test now asserts each location specifically *and* additionally pins the `aria-describedby` wiring and that focus lands on the summary.

**On local e2e, stated plainly:** a full-suite run showed 9 failures, but I could not reproduce any of them in isolation either with **or** without these changes (15/15 both ways), and the failing set differed between full-suite runs. That's the signature of flakiness in my long-running native harness under sustained load, not a regression — CI runs a fresh Docker stack with Mailpit and is the authority here. The one consistent local failure, `tasks.spec.js:286` (keyboard drag), reproduces on unmodified `main` and passed in CI on #784.

**Not included:** H-06 (targets below the 24px minimum) — the remaining High — plus the nine Mediums and three Lows.

---
_Generated by [Claude Code](https://claude.ai/code/session_011c8hAeLnvvpgeaEqPzcTjS)_