### PR TITLE
fix(ui): add pressed states to every button, and retire the raw checkboxes

### DIFF
--- a/e2e/tests/tasks.spec.js
+++ b/e2e/tests/tasks.spec.js
@@ -52,14 +52,14 @@ test.describe("Tasks", () => {
     // explicit toBeChecked / not.toBeChecked assertions auto-wait until
     // the controlled input matches the expected DOM state, which is
     // the actual sync point we care about.
-    const checkbox = item.locator('input[type="checkbox"]');
+    const checkbox = item.getByTestId("task-done");
     const completeResponse = page.waitForResponse(
       (res) =>
         res.request().method() === "PATCH" &&
         res.url().includes("/tasks/") &&
         res.ok(),
     );
-    await checkbox.check();
+    await checkbox.click();
     await completeResponse;
     await expect(checkbox).toBeChecked();
     // Completed tasks read as muted (no strikethrough).
@@ -72,7 +72,7 @@ test.describe("Tasks", () => {
         res.url().includes("/tasks/") &&
         res.ok(),
     );
-    await checkbox.uncheck();
+    await checkbox.click();
     await uncompleteResponse;
     await expect(checkbox).not.toBeChecked();
     await expect(item.locator(`text=${title}`)).not.toHaveClass(/text-muted-foreground/);
@@ -153,7 +153,7 @@ test.describe("Tasks", () => {
 
     // Complete the task — backend clones the next occurrence; frontend
     // refetches because the toggled task carries a recurrence rule.
-    await item.locator('input[type="checkbox"]').check();
+    await item.getByTestId("task-done").click();
 
     // Two rows now share the title — one completed (the original) and one
     // pending (the next occurrence, due 14 days after the original date).
@@ -163,7 +163,7 @@ test.describe("Tasks", () => {
     // The new row also shows the recurrence icon (rule carries over).
     await expect(
       allRows
-        .filter({ hasNot: page.locator("input[type=checkbox]:checked") })
+        .filter({ hasNot: page.locator('[data-testid="task-done"][data-state="checked"]') })
         .locator('[data-testid="task-due-date-repeat-icon"]'),
     ).toBeVisible();
   });
@@ -230,7 +230,7 @@ test.describe("Tasks", () => {
     // would yank the row out of view and time the check out.
     await filter.click();
     await expect(todayItem).toBeVisible();
-    await overdueItem.locator('input[type="checkbox"]').check();
+    await overdueItem.getByTestId("task-done").click();
     await expect(overdueCell).toHaveAttribute("data-status", "none");
   });
 

--- a/pwa/components/auth/InviteSignup.tsx
+++ b/pwa/components/auth/InviteSignup.tsx
@@ -520,7 +520,7 @@ const AcceptInviteCard = ({
 
               <TermsConsentField />
 
-              <Button type="submit" disabled={isSubmitting} className="w-full">
+              <Button type="submit" loading={isSubmitting} className="w-full">
                 {isSubmitting ? "Creating account…" : "Accept & create account"}
               </Button>
             </Form>

--- a/pwa/components/auth/SignInForm.tsx
+++ b/pwa/components/auth/SignInForm.tsx
@@ -173,7 +173,7 @@ const SignInForm = ({ next, registered, reset, expired, onTwoFactorRequired }: P
             <div className="space-y-3 pt-2">
               <Button
                 type="submit"
-                disabled={isSubmitting}
+                loading={isSubmitting}
                 className="w-full h-12 text-base font-semibold"
               >
                 {isSubmitting ? "Signing in..." : "Sign in"}

--- a/pwa/components/auth/SignUpForm.tsx
+++ b/pwa/components/auth/SignUpForm.tsx
@@ -314,7 +314,7 @@ const SignUpForm = ({ inviteToken, onCollected, submitLabel = "Create account" }
 
               <TermsConsentField />
 
-              <Button type="submit" disabled={isSubmitting} className="w-full">
+              <Button type="submit" loading={isSubmitting} className="w-full">
                 {submitLabel}
               </Button>
               <SsoButtons verb="Sign up" />

--- a/pwa/components/auth/TwoFactorRecoveryInterstitial.tsx
+++ b/pwa/components/auth/TwoFactorRecoveryInterstitial.tsx
@@ -246,7 +246,7 @@ const ReenrollPasswordStep = ({ onCancel, onStarted }: ReenrollPasswordStepProps
             </Button>
             <Button
               type="submit"
-              disabled={isSubmitting}
+              loading={isSubmitting}
               className="flex-1"
               data-testid="2fa-recovery-password-submit"
             >
@@ -416,7 +416,7 @@ const DisableStep = ({ onCancel, onDone }: DisableStepProps) => (
             <Button
               type="submit"
               variant="destructive"
-              disabled={isSubmitting}
+              loading={isSubmitting}
               className="flex-1"
               data-testid="2fa-recovery-disable-submit"
             >

--- a/pwa/components/tasks/TaskRow.tsx
+++ b/pwa/components/tasks/TaskRow.tsx
@@ -24,6 +24,7 @@ import AttachmentsPanel, {
 import DueDateCell from "@/components/tasks/DueDateCell";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { TableCell, TableRow } from "@/components/ui/table";
 import {
@@ -287,12 +288,12 @@ const TaskRow = ({
               a bigger target is faster for everyone and materially easier with
               a tremor or a touch screen. `before:` grows the *hit area* to
               24x24 without changing how the checkbox looks. */}
-          <input
-            type="checkbox"
+          <Checkbox
             checked={!!task.completedOn}
-            onChange={() => onToggle(task)}
+            onCheckedChange={() => onToggle(task)}
             aria-label={`Mark "${task.title}" as ${task.completedOn ? "incomplete" : "complete"}`}
-            className="relative mt-1 h-4 w-4 shrink-0 cursor-pointer before:absolute before:-inset-1 before:content-['']"
+            data-testid="task-done"
+            className="relative mt-1 shrink-0 before:absolute before:-inset-1 before:content-['']"
           />
         </TableCell>
         <TableCell className="align-top pl-0">

--- a/pwa/components/ui/button.tsx
+++ b/pwa/components/ui/button.tsx
@@ -5,20 +5,29 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  // `transition-colors` widened to include `transform` so the active-press
+  // scale animates rather than snapping. The scale is suppressed under
+  // prefers-reduced-motion; the colour step still lands, so the press is
+  // never *only* communicated by movement.
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium cursor-pointer transition-[color,background-color,border-color,opacity,transform] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 active:scale-[.98] motion-reduce:active:scale-100 disabled:pointer-events-none disabled:opacity-50 aria-busy:cursor-progress [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
+      // Every variant carries an `active:` step. On touch there is no hover,
+      // so the pressed state is the ONLY confirmation that a tap registered —
+      // without it users re-tap, which is exactly the input pattern that turns
+      // a slow request into a double submit.
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow-sm hover:bg-primary/90",
+          "bg-primary text-primary-foreground shadow-sm hover:bg-primary/90 active:bg-primary/80",
         destructive:
-          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90 active:bg-destructive/80",
         outline:
-          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground active:bg-accent/70",
         secondary:
-          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80 active:bg-secondary/70",
+        ghost:
+          "hover:bg-accent hover:text-accent-foreground active:bg-accent/70",
+        link: "text-primary underline-offset-4 hover:underline active:opacity-70",
       },
       size: {
         default: "h-9 px-4 py-2",
@@ -41,15 +50,27 @@ export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
+  /**
+   * The button's action is in flight. Sets `aria-busy` and disables the
+   * button, so the pending state is exposed programmatically rather than
+   * only through a swapped label like "Signing in…".
+   *
+   * Callers keep owning the label swap — this is about semantics, not copy.
+   */
+  loading?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
+  ({ className, variant, size, asChild = false, loading, disabled, ...props }, ref) => {
     const Comp = asChild ? Slot : "button";
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
+        // A busy button must not be re-triggerable; `disabled` alone doesn't
+        // say *why* it's inert, and `aria-busy` alone would leave it clickable.
+        aria-busy={loading || undefined}
+        disabled={disabled ?? (loading || undefined)}
         {...props}
       />
     );

--- a/pwa/eslint.config.mjs
+++ b/pwa/eslint.config.mjs
@@ -22,4 +22,24 @@ export default [
       "react-hooks/set-state-in-effect": "off",
     },
   },
+  {
+    // A bare <input type="checkbox"> paints the browser's default blue, which
+    // reads as unfinished next to the app's teal primary, and it can't carry
+    // the shared focus-ring or disabled conventions. Use components/ui/checkbox.
+    // Scoped to app code — the primitive itself is allowed to use the native
+    // element, and the dev-docs pages demonstrate it.
+    files: ["components/**/*.tsx", "pages/**/*.tsx"],
+    ignores: ["components/ui/**", "pages/dev/**"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            'JSXOpeningElement[name.name="input"] > JSXAttribute[name.name="type"][value.value="checkbox"]',
+          message:
+            "Use <Checkbox> from @/components/ui/checkbox instead of a raw <input type=\"checkbox\">.",
+        },
+      ],
+    },
+  },
 ];

--- a/pwa/pages/admin/users.tsx
+++ b/pwa/pages/admin/users.tsx
@@ -11,6 +11,7 @@ import UserAvatar from "@/components/user/UserAvatar";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -454,10 +455,9 @@ const AdminUsers: NextPage = () => {
                   />
                 </div>
                 <label className="flex items-center gap-2 text-sm">
-                  <input
-                    type="checkbox"
+                  <Checkbox
                     checked={skipWaitlist}
-                    onChange={(e) => setSkipWaitlist(e.target.checked)}
+                    onCheckedChange={(c) => setSkipWaitlist(c === true)}
                   />
                   Skip the waitlist (account can use the app immediately)
                 </label>

--- a/pwa/pages/approvals/index.tsx
+++ b/pwa/pages/approvals/index.tsx
@@ -10,6 +10,7 @@ import { signinHrefForCurrent } from "@/lib/authRedirect";
 import PageHeader from "@/components/common/PageHeader";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Card } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 
@@ -119,10 +120,9 @@ const ApprovalsPage = () => {
 
               <div className="mb-3 flex justify-end">
                 <label className="flex items-center gap-2 text-sm text-muted-foreground">
-                  <input
-                    type="checkbox"
+                  <Checkbox
                     checked={showAll}
-                    onChange={(e) => setShowAll(e.target.checked)}
+                    onCheckedChange={(c) => setShowAll(c === true)}
                   />
                   Show decided weeks
                 </label>

--- a/pwa/pages/boards/[id].tsx
+++ b/pwa/pages/boards/[id].tsx
@@ -1500,11 +1500,9 @@ const BoardDetail = () => {
                                   {isCopying ? "Copying…" : "Copy"}
                                 </Button>
                                 <label className="flex items-center gap-1.5 text-xs text-muted-foreground select-none">
-                                  <input
-                                    type="checkbox"
+                                  <Checkbox
                                     checked={copyIncludeTasks}
-                                    onChange={(e) => setCopyIncludeTasks(e.target.checked)}
-                                    className="h-3.5 w-3.5"
+                                    onCheckedChange={(c) => setCopyIncludeTasks(c === true)}
                                     data-testid="board-copy-include-tasks"
                                   />
                                   include tasks

--- a/pwa/pages/dev/components/button.tsx
+++ b/pwa/pages/dev/components/button.tsx
@@ -50,6 +50,51 @@ const ButtonPage = () => (
         code: `<Button disabled>Saving…</Button>`,
         preview: <Button disabled>Saving…</Button>,
       },
+      {
+        title: "Loading (`loading`)",
+        code: `{/* Sets aria-busy AND disables, so the pending state is exposed
+    programmatically rather than only via the swapped label.
+    You keep owning the label — this is semantics, not copy. */}
+<Button loading>Signing in…</Button>`,
+        preview: (
+          <div className="space-y-2">
+            <Button loading>Signing in…</Button>
+            <p className="text-sm text-muted-foreground">
+              A <code>disabled</code> button says it can&apos;t be used;{" "}
+              <code>loading</code> says why. Passing <code>disabled</code>{" "}
+              explicitly still wins, so an already-invalid form stays disabled
+              without claiming to be busy.
+            </p>
+          </div>
+        ),
+      },
+      {
+        title: "Pressed state",
+        code: `{/* Every variant has an active: step. Press and hold to see it. */}
+<Button>Default</Button>
+<Button variant="secondary">Secondary</Button>
+<Button variant="outline">Outline</Button>
+<Button variant="destructive">Destructive</Button>`,
+        preview: (
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <Button>Default</Button>
+              <Button variant="secondary">Secondary</Button>
+              <Button variant="outline">Outline</Button>
+              <Button variant="destructive">Destructive</Button>
+              <Button variant="ghost">Ghost</Button>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              On touch there is no hover, so the pressed state is the{" "}
+              <em>only</em> confirmation a tap registered — without it users
+              re-tap, which is what turns a slow request into a double submit.
+              The colour step carries the signal; the{" "}
+              <code>scale-[.98]</code> is suppressed under{" "}
+              <code>prefers-reduced-motion</code>.
+            </p>
+          </div>
+        ),
+      },
     ]}
   />
 );

--- a/pwa/pages/expenses/index.tsx
+++ b/pwa/pages/expenses/index.tsx
@@ -16,6 +16,7 @@ import PageHeader from "@/components/common/PageHeader";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -397,10 +398,9 @@ const ExpensesPage = () => {
                               </div>
                               <div className="flex flex-wrap items-center gap-4">
                                 <label className="flex items-center gap-2 text-sm">
-                                  <input
-                                    type="checkbox"
+                                  <Checkbox
                                     checked={billable}
-                                    onChange={(e) => setBillable(e.target.checked)}
+                                    onCheckedChange={(c) => setBillable(c === true)}
                                   />
                                   Billable
                                 </label>
@@ -649,10 +649,9 @@ const EditExpenseRow = ({
             />
           </div>
           <label className="flex items-center gap-2 text-sm">
-            <input
-              type="checkbox"
+            <Checkbox
               checked={eBillable}
-              onChange={(e) => setEBillable(e.target.checked)}
+              onCheckedChange={(c) => setEBillable(c === true)}
             />
             Billable
           </label>

--- a/pwa/pages/invoices/index.tsx
+++ b/pwa/pages/invoices/index.tsx
@@ -12,6 +12,7 @@ import { Invoice, STATUS_META, clientName, formatMoney } from "@/lib/invoiceType
 import PageHeader from "@/components/common/PageHeader";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Card } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
@@ -423,10 +424,9 @@ const InvoicesPage = () => {
                                           )}
                                         >
                                           <td className="px-3 py-1.5">
-                                            <input
-                                              type="checkbox"
+                                            <Checkbox
                                               checked={checked.has(entry["@id"])}
-                                              onChange={() => toggleChecked(entry["@id"])}
+                                              onCheckedChange={() => toggleChecked(entry["@id"])}
                                               aria-label="Include this entry"
                                             />
                                           </td>
@@ -471,10 +471,9 @@ const InvoicesPage = () => {
                                           )}
                                         >
                                           <td className="px-3 py-1.5">
-                                            <input
-                                              type="checkbox"
+                                            <Checkbox
                                               checked={checkedExpenses.has(expense["@id"])}
-                                              onChange={() =>
+                                              onCheckedChange={() =>
                                                 toggleCheckedExpense(expense["@id"])
                                               }
                                               aria-label="Include this expense"

--- a/pwa/pages/projects/index.tsx
+++ b/pwa/pages/projects/index.tsx
@@ -12,6 +12,7 @@ import AttachmentsPanel, { type Attachment } from "@/components/tasks/Attachment
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -695,12 +696,11 @@ const ProjectsPage = () => {
                     const checked = assigned.includes(p["@id"]);
                     return (
                       <label key={p["@id"]} className="flex items-center gap-2 text-sm">
-                        <input
-                          type="checkbox"
+                        <Checkbox
                           checked={checked}
-                          onChange={(e) =>
+                          onCheckedChange={(c) =>
                             setAssigned((prev) =>
-                              e.target.checked ? [...prev, p["@id"]] : prev.filter((x) => x !== p["@id"]),
+                              c === true ? [...prev, p["@id"]] : prev.filter((x) => x !== p["@id"]),
                             )
                           }
                         />


### PR DESCRIPTION
## Description

Addresses **M-16** and **M-10** from the UI/UX audit. Split out of [#792](https://github.com/roboparker/Aura/pull/792) so each finding lands on its own. Follows [#783](https://github.com/roboparker/Aura/pull/783), [#784](https://github.com/roboparker/Aura/pull/784), [#786](https://github.com/roboparker/Aura/pull/786), [#790](https://github.com/roboparker/Aura/pull/790), [#792](https://github.com/roboparker/Aura/pull/792).

Full audit: https://claude.ai/code/artifact/a026ca5a-2135-492f-9c27-822820100ca3

### M-16 — no button had a pressed state

Zero `active:` utilities existed anywhere in `components/ui/`, and `aria-busy` appeared **nowhere** in the codebase. All six variants now carry an `active:` step plus a `scale-[.98]` press.

This matters most on touch: there is no hover, so the pressed state is the **only** confirmation that a tap registered. Without it users re-tap — which is exactly the input pattern that turns a slow request into a double submit.

The scale is suppressed under `prefers-reduced-motion`, and the colour step lands regardless, so the press is never communicated by movement alone. `transition-colors` widened to include `transform` so it animates rather than snapping.

`Button` also gains a **`loading`** prop that sets `aria-busy` and disables. A `disabled` button says it can't be used; `loading` says *why*. An explicit `disabled` still wins, so an invalid form stays disabled without claiming to be busy.

### M-10 — 9 raw checkboxes bypassed the design system

`<input type="checkbox">` across 7 files painted the browser's default blue next to the app's teal primary, and couldn't carry the shared focus-ring or disabled conventions. All 9 now use `components/ui/checkbox`.

An **ESLint rule** (`no-restricted-syntax`, scoped to `components/` and `pages/`, excluding `components/ui/` and the dev-docs) bans the raw element so this can't regress.

`TaskRow`'s 24×24 hit area from #790 is preserved on the new control.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## Component

- [ ] API (PHP/Symfony)
- [x] PWA (Next.js)
- [ ] Infrastructure (Docker/Helm)
- [x] E2E Tests
- [ ] Documentation

## How Has This Been Tested?

Measured in a real browser:

| Check | Result |
|---|---|
| Button press | rest → hover (α .9) → **pressed (α .8)** — distinct from both |
| Press scale | `scale: 0.98`, rendered width **446 → 437px** |
| Task checkbox | `BUTTON[role=checkbox]`, `--primary` border + fill, toggles correctly |
| ESLint guard | **verified it fires** on a deliberate violation |

`tsc` clean · `pnpm lint` 0 errors · vitest 164/164 · e2e tasks+boards+auth+invoicing **25/26** (the one failure is the pre-existing keyboard-drag test that reproduces on unmodified `main`). Re-verified after rebasing onto the post-#792 `main`.

## Checklist

- [x] My code follows the project's conventions
- [x] I have added tests that prove my fix or feature works
- [x] New and existing tests pass locally (PHPUnit / `pnpm test:coverage`)
- [x] New pure-logic helpers under `pwa/lib` are added to the coverage allowlist in `pwa/vitest.config.ts`
- [x] I have updated documentation if needed

## Notes for the reviewer

**Four e2e selectors had to move off `input[type="checkbox"]`.** Radix renders a visible `role=checkbox` button **plus a hidden proxy input**, so the old selectors would have silently resolved to the hidden one and `.check()` would fail on it.

I found three on the first pass and **missed a fourth** — a `hasNot` filter using the CSS `:checked` pseudo — because my grep pattern was subtly wrong (`input\[type=.checkbox` requires a character between `=` and `checkbox`, so it never matched the unquoted form). The suite caught it. All four now key off `data-testid="task-done"` / `data-state`.

**`loading` is deliberately partial.** Adopted on the five auth submit buttons — the highest-traffic async actions and the report's named example — not on all ~33 label-swapping buttons. Retrofitting the rest is mechanical but wide, and a swapped label ("Signing in…") is already announced to assistive tech, so this is an enhancement rather than a defect.

**Also verified the guard, not just the fix.** A lint rule that never fires is worse than none — it reads as protection while protecting nothing. I introduced a deliberate violation to confirm it errors, then removed it.

**Remaining after this:** M-12, M-13, M-14, M-15, M-17 and L-20 → L-22. **M-09 is dismissed as intentional** per the maintainer — `/tasks` is a list view, the board is a board view, and their fields are configured separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_011c8hAeLnvvpgeaEqPzcTjS)_