### PR TITLE
fix(ui): stop flagging fields the user only tabbed through

### DIFF
--- a/e2e/tests/auth.spec.js
+++ b/e2e/tests/auth.spec.js
@@ -64,6 +64,35 @@ test.describe("Authentication", () => {
     await expect(summary).toBeFocused();
   });
 
+  test("tabbing through empty fields does not flag them as errors", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE_URL}/signup`);
+
+    // Walk the form the way someone orienting on it does: focus the first
+    // field and tab onward without typing. Formik marks each field touched on
+    // blur, so the naive `touched && error` render told the user off for
+    // fields they hadn't reached a decision on yet.
+    await page.focus("#givenName");
+    for (let i = 0; i < 4; i++) await page.keyboard.press("Tab");
+
+    await expect(page.locator("#givenName-error")).toHaveCount(0);
+    await expect(page.locator("#email-error")).toHaveCount(0);
+    await expect(page.locator("#password-error")).toHaveCount(0);
+    await expect(page.locator('[aria-invalid="true"]')).toHaveCount(0);
+
+    // But typing something genuinely wrong and leaving SHOULD complain — this
+    // is "reward early, punish late", not "never validate before submit".
+    await page.fill("#email", "not-an-email");
+    await page.keyboard.press("Tab");
+    await expect(page.locator("#email-error")).toBeVisible();
+    await expect(page.locator("#email-error")).toContainText("Invalid email");
+
+    // ...and only for that field. The still-empty password is untouched by
+    // the user's mistake and must stay quiet.
+    await expect(page.locator("#password-error")).toHaveCount(0);
+  });
+
   test("sign in with valid credentials", async ({ page }) => {
     // Register first via API
     const email = uniqueEmail();

--- a/pwa/components/auth/TermsConsentField.tsx
+++ b/pwa/components/auth/TermsConsentField.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { useField } from "formik";
+import { useField, useFormikContext } from "formik";
 import { Checkbox } from "@/components/ui/checkbox";
 import { FIELD_NAME_ATTR } from "@/components/ui/formik-focus-error";
 import { cn } from "@/lib/utils";
@@ -16,7 +16,12 @@ import { cn } from "@/lib/utils";
  */
 const TermsConsentField = ({ name = "acceptTerms" }: { name?: string }) => {
   const [field, meta, helpers] = useField<boolean>(name);
-  const showError = Boolean(meta.error) && meta.touched;
+  const { submitCount } = useFormikContext();
+  // Submit-gated, matching FormikField. A checkbox has no half-filled state to
+  // judge — it's ticked or it isn't — so blur is never evidence the user has
+  // decided. Erroring on it means tabbing toward the Terms link to read them
+  // tells you off for not having agreed yet.
+  const showError = Boolean(meta.error) && submitCount > 0;
   const id = `consent-${name}`;
 
   return (

--- a/pwa/components/ui/formik-field.tsx
+++ b/pwa/components/ui/formik-field.tsx
@@ -1,4 +1,4 @@
-import { Field, ErrorMessage, useField } from "formik";
+import { Field, useField, useFormikContext } from "formik";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
@@ -30,7 +30,25 @@ export function FormikField({
 }: FormikFieldProps) {
   const fieldId = id ?? name;
   const [, meta] = useField(name);
-  const isInvalid = meta.touched && Boolean(meta.error);
+  const { submitCount } = useFormikContext();
+
+  // "Reward early, punish late." Formik marks a field touched on *blur*, so
+  // rendering on `touched` alone tells someone their email is required for the
+  // crime of tabbing past it on the way to read the form — the error arrives
+  // before they've had a chance to do the thing it's complaining about.
+  //
+  // An error is shown once either of these is true:
+  //   - they've submitted (submitCount > 0), so every problem is fair game; or
+  //   - they typed something and left, so there's real input to judge.
+  //
+  // Blurring a field that's still empty says nothing, because "I haven't
+  // filled this in yet" is not a mistake. Clearing a field back to empty
+  // before submit returns it to that same not-yet-answered state.
+  const value: unknown = meta.value;
+  const hasEntry =
+    typeof value === "string" ? value.trim() !== "" : Boolean(value);
+  const isInvalid =
+    Boolean(meta.error) && (submitCount > 0 || (meta.touched && hasEntry));
 
   // The error and description are only useful to a screen reader if the input
   // points at them. Without this the field announces "invalid" with no reason
@@ -67,13 +85,15 @@ export function FormikField({
           {description}
         </p>
       )}
-      <ErrorMessage name={name}>
-        {(message) => (
-          <p id={errorId} className="text-sm text-destructive">
-            {message}
-          </p>
-        )}
-      </ErrorMessage>
+      {/* Not Formik's <ErrorMessage>: it renders on `touched` alone, which is
+          the blur-too-early behaviour above. Gate on the same `isInvalid` the
+          input's aria-invalid uses, so the visible message and the announced
+          state can't disagree. */}
+      {isInvalid && typeof meta.error === "string" && (
+        <p id={errorId} className="text-sm text-destructive">
+          {meta.error}
+        </p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Audit finding **M-14**.

## The bug

Formik marks a field touched on **blur**, and `FormikField` rendered its error on `touched && error`. So walking the form to read it — focus the first field, tab onward — told you "Email is required." before you had any chance to type one.

Measured on `/signup` with no typing and no submit:

| action | before | after |
|---|---|---|
| tab past 1 empty field | `Email is required.` + `aria-invalid` | nothing |
| tab past 2 empty fields | `Email is required.`, `Password is required.` + 2× `aria-invalid` | nothing |

Being told off for a field you haven't reached a decision about is both wrong and desensitising: by the time a real error appears, the user has learned the red text is noise.

## The rule

"Reward early, punish late." An error shows when either:
- the user has **submitted** (`submitCount > 0`) — every problem is fair game then; or
- they **typed something and moved on** — there's real input to judge.

Blurring a field that's still empty says nothing, because *"I haven't filled this in yet"* is not a mistake. Clearing a field back to empty before submit returns it to that same not-yet-answered state.

**This is not "don't validate until submit".** Typing an invalid email and tabbing away still complains immediately — and only about that field:

| action | before | after |
|---|---|---|
| type `not-an-email`, tab on | `Invalid email address.` **+ `Password is required.`** | `Invalid email address.` only |
| submit empty | all 5 errors incl. consent | **unchanged** — all 5 |

That middle row is the whole fix: the password was never touched by the user's mistake, so it stays quiet.

## Scope

Wider than the finding suggests. It's not sign-in-specific — this is the shared primitive behind **14 forms** (sign in, sign up, invite, forgot/reset password, profile, change password, email change, 2FA), so all of them stop pre-blaming.

`TermsConsentField` carried its own copy of the same rule and is fixed too, gated on submit **alone**: a checkbox has no half-filled state to judge, so blur is never evidence the user has decided. Tabbing toward the Terms link to read it shouldn't tell you off for not having agreed yet.

`SignUpForm`'s error summary already gated on `submitCount`, so it was already consistent — no change needed.

## Notes

- The message now renders from the same `isInvalid` the input's `aria-invalid` uses, replacing Formik's `<ErrorMessage>` (which has the blur behaviour baked in), so the visible message and the announced state can't disagree.
- `FormikFocusError` is unaffected — it reads Formik's `errors`, not DOM `aria-invalid`, so focus-on-failed-submit still lands correctly.

## Verification

New e2e test tabs through the signup form asserting nothing is flagged, then types an invalid email and asserts that one field — and only that field — complains. **Confirmed it fails without the fix** (`#givenName-error` count 1 ≠ 0), so it's a real guard rather than a vacuous one.

`tsc --noEmit` clean · `pnpm lint` 0 errors · vitest 164/164 · `auth.spec.js` 8/8, including the existing "sign up shows validation errors" unchanged (it submits, so it's unaffected by design).

---
_Generated by [Claude Code](https://claude.ai/code/session_011c8hAeLnvvpgeaEqPzcTjS)_