### PR TITLE
fix(a11y): make overflowing tables reachable by keyboard, and say they scroll

### DIFF
--- a/pwa/components/ui/table.tsx
+++ b/pwa/components/ui/table.tsx
@@ -2,17 +2,101 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-function Table({ className, ...props }: React.ComponentProps<"table">) {
+/**
+ * Tracks whether the scroll container actually overflows, and whether it's
+ * scrolled to the end. Re-measures on resize of both the container and the
+ * table (columns and rows change width as data loads), and on scroll.
+ */
+function useHorizontalOverflow(ref: React.RefObject<HTMLDivElement | null>) {
+  const [state, setState] = React.useState({ scrollable: false, atEnd: true })
+
+  React.useEffect(() => {
+    const el = ref.current
+    if (!el) return
+
+    const measure = () => {
+      const scrollable = el.scrollWidth > el.clientWidth + 1
+      const atEnd = el.scrollLeft + el.clientWidth >= el.scrollWidth - 1
+      setState((prev) =>
+        prev.scrollable === scrollable && prev.atEnd === atEnd
+          ? prev
+          : { scrollable, atEnd },
+      )
+    }
+
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(el)
+    // The table's own width changes independently of the container's — a
+    // column appearing is exactly when a previously-fitting table starts to
+    // overflow, and the container never resizes for it.
+    if (el.firstElementChild) observer.observe(el.firstElementChild)
+    el.addEventListener("scroll", measure, { passive: true })
+
+    return () => {
+      observer.disconnect()
+      el.removeEventListener("scroll", measure)
+    }
+  }, [ref])
+
+  return state
+}
+
+function Table({
+  className,
+  scrollRegionLabel = "Scrollable table",
+  ...props
+}: React.ComponentProps<"table"> & {
+  /**
+   * Names the scroll region for screen readers. Worth overriding when a page
+   * has more than one table, so the landmarks are distinguishable.
+   */
+  scrollRegionLabel?: string
+}) {
+  const ref = React.useRef<HTMLDivElement>(null)
+  const { scrollable, atEnd } = useHorizontalOverflow(ref)
+
   return (
-    <div
-      data-slot="table-container"
-      className="relative w-full overflow-x-auto"
-    >
-      <table
-        data-slot="table"
-        className={cn("w-full caption-bottom text-sm", className)}
-        {...props}
-      />
+    <div className="relative">
+      <div
+        ref={ref}
+        data-slot="table-container"
+        // Keyboard access is the real defect here, not the missing cue. An
+        // `overflow-x-auto` div is scrollable by mouse wheel and touch but is
+        // not focusable, so a keyboard-only user cannot scroll it at all — on
+        // a phone-width task list that put four columns, including Actions,
+        // permanently out of reach (WCAG 2.1.1).
+        //
+        // Applied only while it actually overflows: an unconditional tab stop
+        // on all ~115 tables would be ~115 pointless stops on the ones that
+        // fit. A focusable region needs a name, hence role + label.
+        {...(scrollable
+          ? { tabIndex: 0, role: "region", "aria-label": scrollRegionLabel }
+          : {})}
+        className={cn(
+          "w-full overflow-x-auto",
+          scrollable &&
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        )}
+      >
+        <table
+          data-slot="table"
+          className={cn("w-full caption-bottom text-sm", className)}
+          {...props}
+        />
+      </div>
+      {/* A shadow rather than a colour fade: these tables sit on `bg-card` in
+          some places and `bg-background` in others, and a gradient keyed to
+          either one shows as a smudge on the other. Hidden once there's
+          nothing further right, so it never lies about content that isn't
+          there. Decorative — the region label carries the meaning. */}
+      {scrollable && !atEnd && (
+        <div
+          data-scroll-cue=""
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-y-0 right-0 w-6 bg-gradient-to-l from-black/25 to-transparent dark:from-black/50"
+        />
+      )}
     </div>
   )
 }

--- a/pwa/pages/dev/components/table.tsx
+++ b/pwa/pages/dev/components/table.tsx
@@ -18,7 +18,7 @@ const rows = [
 const TablePage = () => (
   <ComponentDoc
     name="Table"
-    description="Styled wrappers for the native HTML table primitives."
+    description="Styled wrappers for the native HTML table primitives. When the table is wider than its container it becomes a keyboard-focusable scroll region and shows an edge shadow — both applied only while it actually overflows."
     importPath={`import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell, TableCaption } from "@/components/ui/table";`}
     examples={[
       {
@@ -66,6 +66,55 @@ const TablePage = () => (
               ))}
             </TableBody>
           </Table>
+        ),
+      },
+      {
+        title: "Horizontal overflow",
+        code: `{/* Nothing to opt into: when the table outgrows its container it
+    gains tabindex=0 + role="region" so a keyboard user can scroll it,
+    plus a right-edge shadow that retracts at the end.
+
+    The keyboard part is the point. An overflow-x-auto div scrolls by
+    wheel and touch but is not focusable, so keyboard-only users could
+    not reach off-screen columns at all (WCAG 2.1.1).
+
+    Both are conditional on actually overflowing — an unconditional
+    tabindex would put a dead tab stop on every table that fits.
+
+    Override the region's name when a page has several tables: */}
+<Table scrollRegionLabel="Invoice line items">…</Table>`,
+        preview: (
+          <div className="max-w-sm">
+            <Table scrollRegionLabel="Example task table">
+              <TableHeader>
+                <TableRow>
+                  <TableHead>ID</TableHead>
+                  <TableHead>Title</TableHead>
+                  <TableHead>Owner</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Assignees</TableHead>
+                  <TableHead>Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map((row) => (
+                  <TableRow key={row.id}>
+                    <TableCell>{row.id}</TableCell>
+                    <TableCell>{row.title}</TableCell>
+                    <TableCell>{row.owner}</TableCell>
+                    <TableCell>{row.status}</TableCell>
+                    <TableCell>ada, lin</TableCell>
+                    <TableCell>Edit</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Tab to the table above, then use the arrow keys. Constrained to{" "}
+              <code>max-w-sm</code> here so it overflows; the first example on
+              this page fits and so stays out of the tab order entirely.
+            </p>
+          </div>
         ),
       },
     ]}


### PR DESCRIPTION
Audit finding **M-15**.

## What's actually wrong

At 375px the task list is a **957px table inside a 341px container**. Due, Tags, Assignees and Actions all sit off-screen. Two problems follow, and only one is cosmetic.

**The real one:** an `overflow-x-auto` div scrolls by wheel and touch but is **not focusable**, so a keyboard-only user cannot scroll it at all. Those four columns — including the row's **Actions** — weren't merely hard to find, they were unreachable. That's WCAG 2.1.1.

## Measured, before → after

| at 375px | before | after |
|---|---|---|
| `tabindex` | `null` | `0` |
| keyboard-focusable | **false** | true |
| ArrowRight → `scrollLeft` | n/a | 0 → **480** |
| accessible name | none | `role="region"`, "Scrollable table" |
| edge cue | none | shown, **retracts at the end** |

| at 1600px (table fits) | after |
|---|---|
| `tabindex` / `role` / cue | `null` / `null` / none |

That last row matters: this component backs **~115 tables** and most fit. An unconditional `tabindex` would scatter that many dead tab stops through the app — trading one keyboard problem for another. Both the tab stop and the cue are conditional on real overflow.

## The finding's stated mechanism is wrong, which changes the fix

**Nothing is hidden.** There is no responsive column-hiding anywhere in the codebase, and no column computes to `display: none` (`hiddenColumns: []`). The table always scrolled — it just never *said* so, and couldn't be scrolled without a pointer.

So the suggested "drop the table for a stacked card layout below `md:`" would be a redesign of the busiest screen in the app to solve a problem that isn't the one occurring. Not in this PR.

The sticky-first-column half of the alternative is also not here: it competes with the sticky *header* already on these tables, and the edge cue plus keyboard access covers the actual defect.

## Notes

- The cue is a **shadow, not a colour fade** — these tables sit on `bg-card` in some places and `bg-background` in others, so a gradient keyed to either token shows as a smudge on the other.
- `/tags` is unaffected: it builds its own raw `<table>` rather than using this component, and fits at 375px anyway. Worth a follow-up so it stops missing `Table` improvements, but that's a refactor, not this finding.

## Verification

The change introduces a positioned wrapper around the scroll container, and both `/tasks` and the board detail have **sticky headers inside it** — the one real regression risk. After a 600px scroll both still pin (title bar 88→56, column header 204→148; they'd be at −512 and −396 if stickiness had broken).

`tasks.spec.js` + `boards.spec.js` 15/15 · `tsc --noEmit` clean · `pnpm lint` 0 errors · vitest 164/164. Docs page updated for the new `scrollRegionLabel` prop, per CLAUDE.md.

---
_Generated by [Claude Code](https://claude.ai/code/session_011c8hAeLnvvpgeaEqPzcTjS)_