### PR TITLE
fix(ui): name colour swatches, unify page titles, un-orphan the sidebar

### DIFF
--- a/e2e/tests/auth.spec.js
+++ b/e2e/tests/auth.spec.js
@@ -10,7 +10,7 @@ test.describe("Authentication", () => {
     const email = uniqueEmail();
 
     await page.goto(`${BASE_URL}/signup`);
-    await expect(page).toHaveTitle("Sign Up - Madori");
+    await expect(page).toHaveTitle("Sign Up — Madori");
 
     // Step 1 — form. The redesigned signup no longer has a confirm
     // field; the strength meter does the safety work instead.
@@ -104,7 +104,7 @@ test.describe("Authentication", () => {
 
     // Sign in via UI
     await page.goto(`${BASE_URL}/signin`);
-    await expect(page).toHaveTitle("Sign In - Madori");
+    await expect(page).toHaveTitle("Sign In — Madori");
 
     await page.fill("#email", email);
     await page.fill("#password", "Password123!@#");

--- a/e2e/tests/boards.spec.js
+++ b/e2e/tests/boards.spec.js
@@ -20,7 +20,7 @@ test.describe("Boards", () => {
     await registerAndSignIn(page, email);
 
     await page.goto(`${BASE_URL}/boards`);
-    await expect(page).toHaveTitle("Boards - Madori");
+    await expect(page).toHaveTitle("Boards — Madori");
     await expect(page.locator("text=No boards yet")).toBeVisible();
 
     // Create — the form lives behind the "New board" toggle now.

--- a/e2e/tests/tags.spec.js
+++ b/e2e/tests/tags.spec.js
@@ -44,7 +44,7 @@ test.describe("Tags", () => {
     await registerAndSignIn(page, uniqueEmail());
 
     await page.goto(`${BASE_URL}/tags`);
-    await expect(page).toHaveTitle("Tags - Madori");
+    await expect(page).toHaveTitle("Tags — Madori");
     await expect(page.locator("text=No tags yet")).toBeVisible();
 
     const title = `Urgent-${Date.now()}`;

--- a/e2e/tests/tasks.spec.js
+++ b/e2e/tests/tasks.spec.js
@@ -26,7 +26,7 @@ test.describe("Tasks", () => {
     await registerAndSignIn(page, uniqueEmail());
 
     await page.goto(`${BASE_URL}/tasks`);
-    await expect(page).toHaveTitle("Tasks - Madori");
+    await expect(page).toHaveTitle("Tasks — Madori");
     // Empty state: only the new-task input row, no real task rows.
     await expect(page.locator('[data-testid="task-item"]')).toHaveCount(0);
 

--- a/pwa/components/common/ColorSwatchPicker.tsx
+++ b/pwa/components/common/ColorSwatchPicker.tsx
@@ -1,4 +1,4 @@
-import { AVATAR_PALETTE } from "@/lib/avatarPalette";
+import { AVATAR_PALETTE, colorName } from "@/lib/avatarPalette";
 import { cn } from "@/lib/utils";
 
 /**
@@ -50,7 +50,9 @@ const ColorSwatchPicker = ({
             type="button"
             role="radio"
             aria-checked={isSelected}
-            aria-label={color}
+            // Named, not hex: the rest of this picker is wired correctly, so
+            // the label was the only thing making it unusable without sight.
+            aria-label={colorName(color)}
             disabled={disabled}
             onClick={() => onChange(color)}
             className={cn(

--- a/pwa/components/common/SidebarNav.tsx
+++ b/pwa/components/common/SidebarNav.tsx
@@ -9,6 +9,7 @@ import {
   ChevronDown,
   CreditCard,
   FlaskConical,
+  KeyRound,
   Plus,
   Settings,
   ShieldCheck,
@@ -402,11 +403,20 @@ const AdminSection = ({ wrap }: { wrap: (children: ReactNode) => ReactNode }) =>
 };
 
 /**
- * Space membership + access management (Users, Roles, API keys) as a
- * collapsible nav group, mirroring {@see AdminSection}. Users + Roles are
- * space-admin only; API keys is gated on the `api_keys` read capability
- * (admins have it by default, a role can grant it to a member too). The
- * "General" space settings live in a standalone link above this group.
+ * Space membership management (Users, Roles) as a collapsible nav group,
+ * mirroring {@see AdminSection}. Space-admin only.
+ *
+ * API keys deliberately does *not* live here, even though it is adjacent
+ * access-management. It is gated on the `api_keys` capability rather than on
+ * admin, so a member granted that one capability used to see the whole "User
+ * management" heading standing over a single "API keys" child — a category
+ * label promising user management and delivering one unrelated item, which
+ * reads as a permissions bug and sends members hunting for controls they will
+ * never have. Hiding the header on a child count would have been the wrong
+ * cure: the mismatch is semantic, not numeric, and a count rule would also
+ * swallow a section that legitimately has one child. So API keys is a
+ * top-level item instead — the shape Tags and Custom fields already use — and
+ * it sits in the same place for every role.
  */
 const UserManagementSection = ({
   wrap,
@@ -414,7 +424,7 @@ const UserManagementSection = ({
   wrap: (children: ReactNode) => ReactNode;
 }) => {
   const router = useRouter();
-  const { activeSpace, isActiveSpaceAdmin, can } = useActiveSpace();
+  const { activeSpace, isActiveSpaceAdmin } = useActiveSpace();
 
   const storageKey = "madori.navCollapsed.userManagement";
   const [collapsed, setCollapsed] = useState(false);
@@ -446,15 +456,6 @@ const UserManagementSection = ({
             href: `/spaces/${activeSpace.id}/roles`,
             label: "Roles",
             match: "/spaces/[id]/roles",
-          },
-        ]
-      : []),
-    ...(activeSpace && can("api_keys", "read")
-      ? [
-          {
-            href: `/spaces/${activeSpace.id}/api-keys`,
-            label: "API keys",
-            match: "/spaces/[id]/api-keys",
           },
         ]
       : []),
@@ -802,6 +803,32 @@ const SidebarNav = ({
         {activeSpace && <BillingSection wrap={wrap} canInvoices={canInvoices} />}
 
         <UserManagementSection wrap={wrap} />
+
+        {/* Top-level rather than inside User management: it's gated on the
+            `api_keys` capability, not on admin, so grouping it under that
+            heading left a member with only this one item standing under a
+            "User management" label. Same place for every role now. */}
+        {activeSpace && can("api_keys", "read") && (
+          <div className="mt-3">
+            {wrap(
+              <Button
+                asChild
+                variant="ghost"
+                size="sm"
+                className={cn(
+                  NAV_ITEM_CLASS,
+                  router.pathname === "/spaces/[id]/api-keys" &&
+                    NAV_ITEM_ACTIVE_CLASS,
+                )}
+              >
+                <Link href={`/spaces/${activeSpace.id}/api-keys`}>
+                  <KeyRound className="size-3.5 shrink-0 text-amber-600 dark:text-amber-400" />
+                  <span className="truncate">API keys</span>
+                </Link>
+              </Button>,
+            )}
+          </div>
+        )}
 
         {activeSpace && isActiveSpaceAdmin && (
           <div className="mt-3">

--- a/pwa/components/settings/SettingsShell.tsx
+++ b/pwa/components/settings/SettingsShell.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/router";
 import { useAuth } from "@/contexts/AuthContext";
 import { signinHrefForCurrent } from "@/lib/authRedirect";
 import SettingsNav, { type SettingsSectionKey } from "./SettingsNav";
+import { pageTitle } from "@/lib/pageTitle";
 
 interface SettingsShellProps {
   active: SettingsSectionKey;
@@ -46,7 +47,7 @@ const SettingsShell = ({
   return (
     <>
       <Head>
-        <title>{title} · Settings - Madori</title>
+        <title>{pageTitle(title, "Settings")}</title>
       </Head>
       <div className="min-h-screen bg-muted">
         <div className="mx-auto max-w-5xl px-4 py-10">

--- a/pwa/lib/avatarPalette.test.ts
+++ b/pwa/lib/avatarPalette.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   AVATAR_PALETTE,
+  PALETTE_NAMES,
+  colorName,
   deterministicPaletteColor,
   resolveGroupColor,
   resolveSpaceColor,
@@ -51,5 +53,32 @@ describe("resolveGroupColor", () => {
     expect(resolveGroupColor({ color: null, spaceSummary: { color: null } })).toBe(
       AVATAR_PALETTE[0],
     );
+  });
+});
+
+describe("colorName", () => {
+  // The drift guard: a colour added to the palette without a name would
+  // silently go back to announcing itself as a hex code, which is the exact
+  // defect this map exists to fix.
+  it("names every palette entry", () => {
+    for (const hex of AVATAR_PALETTE) {
+      expect(PALETTE_NAMES[hex], `no name for ${hex}`).toBeTruthy();
+      expect(colorName(hex)).not.toMatch(/^#/);
+    }
+  });
+
+  it("gives each palette entry a distinct name", () => {
+    const names = AVATAR_PALETTE.map(colorName);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("is case- and whitespace-insensitive", () => {
+    expect(colorName("#0F766E")).toBe("Teal");
+    expect(colorName("  #0f766e  ")).toBe("Teal");
+  });
+
+  it("falls back to the hex for an off-palette colour", () => {
+    // No worse than the old behaviour, and the app offers nothing off-palette.
+    expect(colorName("#123456")).toBe("#123456");
   });
 });

--- a/pwa/lib/avatarPalette.ts
+++ b/pwa/lib/avatarPalette.ts
@@ -22,6 +22,43 @@ export const AVATAR_PALETTE: readonly string[] = [
 ];
 
 /**
+ * Speakable names for the palette, keyed by hex.
+ *
+ * The colours were already named in the comments above; this makes the name
+ * addressable so a swatch can label itself "Teal" instead of handing a screen
+ * reader a hex code to read out as "hash three three four one five five".
+ * Shade suffixes are dropped — "slate-700" is an implementation detail, and
+ * the palette holds one shade per hue, so "Slate" is unambiguous.
+ */
+export const PALETTE_NAMES: Readonly<Record<string, string>> = {
+  "#334155": "Slate",
+  "#b91c1c": "Red",
+  "#c2410c": "Orange",
+  "#b45309": "Amber",
+  "#854d0e": "Yellow",
+  "#4d7c0f": "Lime",
+  "#15803d": "Green",
+  "#047857": "Emerald",
+  "#0f766e": "Teal",
+  "#0e7490": "Cyan",
+  "#0369a1": "Sky",
+  "#1d4ed8": "Blue",
+  "#4338ca": "Indigo",
+  "#6d28d9": "Violet",
+  "#7e22ce": "Purple",
+  "#be185d": "Pink",
+};
+
+/**
+ * Human name for a palette colour, falling back to the hex for anything
+ * off-palette. The fallback is no worse than the previous behaviour, and
+ * every colour the app actually offers is in the map.
+ */
+export function colorName(hex: string): string {
+  return PALETTE_NAMES[hex.trim().toLowerCase()] ?? hex;
+}
+
+/**
  * Deterministic palette pick keyed on a string (name, id — anything
  * stable for the entity in question). Use for surfaces that need a
  * persistent color but don't have a `personalizedColor` column to read

--- a/pwa/lib/pageTitle.test.ts
+++ b/pwa/lib/pageTitle.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { PRODUCT_NAME, pageTitle } from "./pageTitle";
+
+describe("pageTitle", () => {
+  it("appends the product name after an em dash", () => {
+    expect(pageTitle("Boards")).toBe("Boards — Madori");
+  });
+
+  it("joins multiple parts with a middle dot", () => {
+    expect(pageTitle("Roles", "Launch team")).toBe("Roles · Launch team — Madori");
+  });
+
+  it("drops nullish and empty parts rather than emitting a stray separator", () => {
+    // The common case: a title rendered while its subject is still loading.
+    expect(pageTitle("Board", null)).toBe("Board — Madori");
+    expect(pageTitle(undefined, "Board")).toBe("Board — Madori");
+    expect(pageTitle("Board", "")).toBe("Board — Madori");
+    expect(pageTitle("Board", "   ")).toBe("Board — Madori");
+  });
+
+  it("trims parts", () => {
+    expect(pageTitle("  Boards  ")).toBe("Boards — Madori");
+  });
+
+  it("falls back to the bare product name when given nothing usable", () => {
+    expect(pageTitle()).toBe(PRODUCT_NAME);
+    expect(pageTitle(null, undefined, "")).toBe(PRODUCT_NAME);
+  });
+
+  it("never emits the old hyphen separator", () => {
+    expect(pageTitle("Boards")).not.toContain(" - ");
+  });
+});

--- a/pwa/lib/pageTitle.ts
+++ b/pwa/lib/pageTitle.ts
@@ -1,0 +1,32 @@
+/** Product name, as it appears in the browser tab. */
+export const PRODUCT_NAME = "Madori";
+
+/**
+ * Builds a document title.
+ *
+ * There were three shapes shipping side by side — `Boards - Madori` (28
+ * pages), `Dashboard — Madori` (24), and `Roles · Launch team` (which omitted
+ * the product name entirely). Tab strips, bookmarks, history and search
+ * results all put those next to each other, which is exactly where a product's
+ * consistency is on display for free.
+ *
+ * One rule now: parts are joined with a middle dot, then the product name is
+ * appended after an em dash. The two separators do different jobs — the dot
+ * separates page context, the dash separates the page from the product — so
+ * the title stays parseable at a glance no matter how many parts it has.
+ *
+ *   pageTitle("Boards")              → "Boards — Madori"
+ *   pageTitle("Roles", "Launch team") → "Roles · Launch team — Madori"
+ *
+ * Empty and nullish parts are dropped, so a caller can pass a value that is
+ * still loading without emitting a stray separator.
+ */
+export function pageTitle(...parts: Array<string | null | undefined>): string {
+  const named = parts
+    .map((p) => (typeof p === "string" ? p.trim() : ""))
+    .filter((p) => p.length > 0);
+
+  return named.length > 0
+    ? `${named.join(" · ")} — ${PRODUCT_NAME}`
+    : PRODUCT_NAME;
+}

--- a/pwa/pages/account-exports/[token].tsx
+++ b/pwa/pages/account-exports/[token].tsx
@@ -8,6 +8,7 @@ import { ENTRYPOINT } from "@/config/entrypoint";
 import { signinHrefForCurrent } from "@/lib/authRedirect";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { pageTitle } from "@/lib/pageTitle";
 
 interface ExportStatus {
   status: "ready" | "expired";
@@ -157,7 +158,7 @@ const AccountExportDownloadPage = () => {
   return (
     <>
       <Head>
-        <title>Data export - Madori</title>
+        <title>{pageTitle("Data export")}</title>
       </Head>
       <div className="container mx-auto max-w-lg px-4 py-16">
         <Card>

--- a/pwa/pages/admin/global-custom-fields.tsx
+++ b/pwa/pages/admin/global-custom-fields.tsx
@@ -7,6 +7,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { signinHrefForCurrent } from "@/lib/authRedirect";
 import CustomFieldsManager from "@/components/custom-fields/CustomFieldsManager";
 import PageHeader from "@/components/common/PageHeader";
+import { pageTitle } from "@/lib/pageTitle";
 
 /**
  * Admin-only manager for instance-wide GLOBAL custom fields
@@ -41,7 +42,7 @@ const AdminGlobalCustomFields: NextPage = () => {
     return (
       <>
         <Head>
-          <title>Access Denied - Madori</title>
+          <title>{pageTitle("Access Denied")}</title>
         </Head>
         <div className="min-h-screen flex items-center justify-center bg-muted px-4">
           <div className="text-center">
@@ -60,7 +61,7 @@ const AdminGlobalCustomFields: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Global custom fields - Madori</title>
+        <title>{pageTitle("Global custom fields")}</title>
       </Head>
       <div className="min-h-screen bg-background px-4 py-8">
         <div className="mx-auto w-full max-w-4xl">

--- a/pwa/pages/admin/growth.tsx
+++ b/pwa/pages/admin/growth.tsx
@@ -23,6 +23,7 @@ import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
+import { pageTitle } from "@/lib/pageTitle";
 
 const FunnelChart = dynamic(() => import("@/components/admin/FunnelChart"), {
   ssr: false,
@@ -101,7 +102,7 @@ const GrowthPage = () => {
     return (
       <>
         <Head>
-          <title>Access Denied - Madori</title>
+          <title>{pageTitle("Access Denied")}</title>
         </Head>
         <div className="flex min-h-screen items-center justify-center bg-muted px-4">
           <div className="text-center">
@@ -125,7 +126,7 @@ const GrowthPage = () => {
   return (
     <>
       <Head>
-        <title>Growth — Madori</title>
+        <title>{pageTitle("Growth")}</title>
       </Head>
       <div className="min-h-screen bg-background px-4 py-12">
         <div className="mx-auto max-w-5xl">

--- a/pwa/pages/admin/segments/[id].tsx
+++ b/pwa/pages/admin/segments/[id].tsx
@@ -32,6 +32,7 @@ import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { ArrowLeft, X } from "lucide-react";
+import { pageTitle } from "@/lib/pageTitle";
 
 const AdminSegmentDetail: NextPage = () => {
   const { user, isAuthenticated, isLoading } = useAuth();
@@ -248,7 +249,7 @@ const AdminSegmentDetail: NextPage = () => {
   return (
     <>
       <Head>
-        <title>{segment.name} - Madori Segments</title>
+        <title>{pageTitle(segment.name, "Segments", "Admin")}</title>
       </Head>
       <div className="min-h-screen bg-background px-4 py-12">
         <div className="max-w-5xl mx-auto space-y-6">

--- a/pwa/pages/admin/segments/index.tsx
+++ b/pwa/pages/admin/segments/index.tsx
@@ -44,6 +44,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { MoreHorizontal } from "lucide-react";
+import { pageTitle } from "@/lib/pageTitle";
 
 const AdminSegments: NextPage = () => {
   const { user, isAuthenticated, isLoading } = useAuth();
@@ -190,7 +191,7 @@ const AdminSegments: NextPage = () => {
     return (
       <>
         <Head>
-          <title>Access Denied - Madori</title>
+          <title>{pageTitle("Access Denied")}</title>
         </Head>
         <div className="min-h-screen flex items-center justify-center bg-muted px-4">
           <div className="text-center">
@@ -207,7 +208,7 @@ const AdminSegments: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Segments - Madori Admin</title>
+        <title>{pageTitle("Segments", "Admin")}</title>
       </Head>
       <div className="min-h-screen bg-background px-4 py-12">
         <div className="max-w-5xl mx-auto space-y-6">

--- a/pwa/pages/admin/sentry-test.tsx
+++ b/pwa/pages/admin/sentry-test.tsx
@@ -15,6 +15,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { pageTitle } from "@/lib/pageTitle";
 
 // Admin-only page to verify Sentry captures errors on each surface once the
 // DSNs are configured (see docs/developer/monitoring.md). Nothing here is
@@ -110,7 +111,7 @@ const AdminSentryTest: NextPage = () => {
     return (
       <>
         <Head>
-          <title>Access Denied - Madori</title>
+          <title>{pageTitle("Access Denied")}</title>
         </Head>
         <div className="min-h-screen flex items-center justify-center bg-muted px-4">
           <div className="text-center">
@@ -127,7 +128,7 @@ const AdminSentryTest: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Sentry test - Madori Admin</title>
+        <title>{pageTitle("Sentry test", "Admin")}</title>
       </Head>
       <div className="min-h-screen bg-background px-4 py-12">
         <div className="max-w-3xl mx-auto space-y-6">

--- a/pwa/pages/admin/sso.tsx
+++ b/pwa/pages/admin/sso.tsx
@@ -12,6 +12,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
+import { pageTitle } from "@/lib/pageTitle";
 
 interface FieldSpec {
   key: string;
@@ -222,7 +223,7 @@ const SsoAdminPage: NextPage = () => {
   return (
     <>
       <Head>
-        <title>SSO - Madori Admin</title>
+        <title>{pageTitle("SSO", "Admin")}</title>
       </Head>
       <div className="min-h-screen bg-background px-4 py-12">
         <div className="mx-auto max-w-5xl space-y-6">

--- a/pwa/pages/admin/users.tsx
+++ b/pwa/pages/admin/users.tsx
@@ -29,6 +29,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { pageTitle } from "@/lib/pageTitle";
 
 interface AdminUser {
   id: string;
@@ -170,7 +171,7 @@ const AdminUsers: NextPage = () => {
     return (
       <>
         <Head>
-          <title>Access Denied - Madori</title>
+          <title>{pageTitle("Access Denied")}</title>
         </Head>
         <div className="min-h-screen flex items-center justify-center bg-muted px-4">
           <div className="text-center">
@@ -196,7 +197,7 @@ const AdminUsers: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Users - Madori Admin</title>
+        <title>{pageTitle("Users", "Admin")}</title>
       </Head>
       <div className="min-h-screen bg-background px-4 py-12">
         <div className="max-w-5xl mx-auto space-y-6">

--- a/pwa/pages/admin/waitlist.tsx
+++ b/pwa/pages/admin/waitlist.tsx
@@ -24,6 +24,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Switch } from "@/components/ui/switch";
+import { pageTitle } from "@/lib/pageTitle";
 
 interface WaitlistUser {
   id: string;
@@ -185,7 +186,7 @@ const AdminWaitlist: NextPage = () => {
     return (
       <>
         <Head>
-          <title>Access Denied - Madori</title>
+          <title>{pageTitle("Access Denied")}</title>
         </Head>
         <div className="min-h-screen flex items-center justify-center bg-muted px-4">
           <div className="text-center">
@@ -204,7 +205,7 @@ const AdminWaitlist: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Waitlist - Madori Admin</title>
+        <title>{pageTitle("Waitlist", "Admin")}</title>
       </Head>
       <div className="min-h-screen bg-background px-4 py-12">
         <div className="max-w-5xl mx-auto space-y-6">

--- a/pwa/pages/approvals/index.tsx
+++ b/pwa/pages/approvals/index.tsx
@@ -13,6 +13,7 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Card } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
+import { pageTitle } from "@/lib/pageTitle";
 
 interface ApprovalRow {
   id: string;
@@ -95,7 +96,7 @@ const ApprovalsPage = () => {
   return (
     <>
       <Head>
-        <title>Approvals — Madori</title>
+        <title>{pageTitle("Approvals")}</title>
       </Head>
       <div className="min-h-screen bg-background px-4 py-12">
         <div className="mx-auto max-w-4xl">

--- a/pwa/pages/blog/[slug].tsx
+++ b/pwa/pages/blog/[slug].tsx
@@ -7,6 +7,7 @@ import { ChevronLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { formatBlogDate, type BlogPost } from "@/lib/blogTypes";
 import { getAllPosts, getPostBySlug, siteUrl } from "@/lib/blog";
+import { pageTitle } from "@/lib/pageTitle";
 
 interface Props {
   post: BlogPost;
@@ -21,7 +22,7 @@ const BlogPostPage: NextPage<Props> = ({ post, origin }) => {
   return (
     <>
       <Head>
-        <title>{`${post.title} — Madori`}</title>
+        <title>{pageTitle(post.title)}</title>
         <meta name="description" content={description} />
         <link rel="canonical" href={canonical} />
         {post.draft ? <meta name="robots" content="noindex" /> : null}

--- a/pwa/pages/blog/index.tsx
+++ b/pwa/pages/blog/index.tsx
@@ -3,13 +3,14 @@ import Head from "next/head";
 import Link from "next/link";
 import { formatBlogDate, type BlogPostSummary } from "@/lib/blogTypes";
 import { getPostSummaries, siteUrl } from "@/lib/blog";
+import { pageTitle } from "@/lib/pageTitle";
 
 interface Props {
   posts: BlogPostSummary[];
   origin: string;
 }
 
-const PAGE_TITLE = "Blog — Madori";
+const PAGE_TITLE = pageTitle("Blog");
 const PAGE_DESCRIPTION =
   "Tips, tricks, and progress updates from the team building Madori — the API-first workspace for tasks, docs, and boards.";
 

--- a/pwa/pages/boards/[id].tsx
+++ b/pwa/pages/boards/[id].tsx
@@ -110,6 +110,7 @@ import { Label } from "@/components/ui/label";
 import MarkdownEditor from "@/components/editor/MarkdownEditor";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
+import { pageTitle } from "@/lib/pageTitle";
 
 interface Member {
   "@id": string;
@@ -1270,7 +1271,7 @@ const BoardDetail = () => {
   return (
     <>
       <Head>
-        <title>{board ? `${board.title} - Madori` : "Board - Madori"}</title>
+        <title>{pageTitle(board?.title ?? "Board")}</title>
       </Head>
       <div className="min-h-screen bg-background px-4 py-8">
         <div className="w-full">

--- a/pwa/pages/boards/index.tsx
+++ b/pwa/pages/boards/index.tsx
@@ -21,6 +21,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { SkeletonList } from "@/components/ui/skeleton";
+import { pageTitle } from "@/lib/pageTitle";
 
 interface Member {
   "@id": string;
@@ -195,7 +196,7 @@ const Boards = () => {
   return (
     <>
       <Head>
-        <title>Boards - Madori</title>
+        <title>{pageTitle("Boards")}</title>
       </Head>
       <div className="min-h-screen bg-background px-4 py-12">
         <div className="max-w-5xl mx-auto">

--- a/pwa/pages/calendar.tsx
+++ b/pwa/pages/calendar.tsx
@@ -9,6 +9,7 @@ import CalendarView from "@/components/calendar/CalendarView";
 import TaskDetailDrawer from "@/components/tasks/TaskDetailDrawer";
 import { type AssigneeOption } from "@/components/tasks/AssigneesCombobox";
 import { type TagOption } from "@/components/tasks/TagsCombobox";
+import { pageTitle } from "@/lib/pageTitle";
 
 interface Collection<T> {
   member?: T[];
@@ -89,7 +90,7 @@ const CalendarPage = () => {
   return (
     <>
       <Head>
-        <title>Calendar - Madori</title>
+        <title>{pageTitle("Calendar")}</title>
       </Head>
       <div className="min-h-screen bg-background">
         <div className="w-full px-4 py-8">

--- a/pwa/pages/clients/index.tsx
+++ b/pwa/pages/clients/index.tsx
@@ -16,6 +16,7 @@ import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { pageTitle } from "@/lib/pageTitle";
 
 const SELECT_CLASS = "h-9 w-full rounded-md border border-input bg-background px-3 text-sm";
 
@@ -202,7 +203,7 @@ const ClientsPage = () => {
   return (
     <>
       <Head>
-        <title>Clients — Madori</title>
+        <title>{pageTitle("Clients")}</title>
       </Head>
       <div className="min-h-screen bg-background px-4 py-12">
         <div className="mx-auto max-w-4xl">

--- a/pwa/pages/confirm-email-change.tsx
+++ b/pwa/pages/confirm-email-change.tsx
@@ -7,6 +7,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { pageTitle } from "@/lib/pageTitle";
 
 type State =
   | { status: "idle" }
@@ -73,7 +74,7 @@ const ConfirmEmailChange = () => {
   return (
     <>
       <Head>
-        <title>Confirm Email Change - Madori</title>
+        <title>{pageTitle("Confirm Email Change")}</title>
       </Head>
       <div className="min-h-screen flex items-center justify-center bg-muted px-4 py-12">
         <Card className="w-full max-w-md">

--- a/pwa/pages/custom-fields.tsx
+++ b/pwa/pages/custom-fields.tsx
@@ -8,6 +8,7 @@ import { signinHrefForCurrent } from "@/lib/authRedirect";
 import CustomFieldsManager from "@/components/custom-fields/CustomFieldsManager";
 import PageHeader from "@/components/common/PageHeader";
 import { Card, CardContent } from "@/components/ui/card";
+import { pageTitle } from "@/lib/pageTitle";
 
 /**
  * Space-level custom-field manager (#custom-fields-space). Defines the field
@@ -38,7 +39,7 @@ const CustomFields = () => {
   return (
     <>
       <Head>
-        <title>Custom fields - Madori</title>
+        <title>{pageTitle("Custom fields")}</title>
       </Head>
       <div className="min-h-screen bg-background px-4 py-8">
         <div className="mx-auto w-full max-w-4xl">

--- a/pwa/pages/dashboard.tsx
+++ b/pwa/pages/dashboard.tsx
@@ -36,6 +36,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { pageTitle } from "@/lib/pageTitle";
 
 /**
  * The configurable space dashboard (#759).
@@ -180,7 +181,7 @@ const DashboardPage = () => {
   return (
     <>
       <Head>
-        <title>Dashboard — Madori</title>
+        <title>{pageTitle("Dashboard")}</title>
       </Head>
       <div className="min-h-screen bg-background px-4 py-12">
         <div className="mx-auto max-w-6xl">

--- a/pwa/pages/dev/components/index.tsx
+++ b/pwa/pages/dev/components/index.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { componentRegistry } from "@/components/dev/registry";
+import { pageTitle } from "@/lib/pageTitle";
 
 const categories = [
   "Primitive",
@@ -20,7 +21,7 @@ const categories = [
 const ComponentsIndex = () => (
   <>
     <Head>
-      <title>Components · Dev</title>
+      <title>{pageTitle("Components", "Dev")}</title>
     </Head>
     <div className="mx-auto max-w-5xl px-6 py-10">
       <header className="mb-8">

--- a/pwa/pages/e/[token].tsx
+++ b/pwa/pages/e/[token].tsx
@@ -8,6 +8,7 @@ import { ESTIMATE_STATUS_META, EstimateStatus } from "@/lib/estimateTypes";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
+import { pageTitle } from "@/lib/pageTitle";
 
 interface PublicLine {
   description: string;
@@ -236,7 +237,7 @@ const PublicEstimatePage = () => {
   return (
     <>
       <Head>
-        <title>Estimate — Madori</title>
+        <title>{pageTitle("Estimate")}</title>
       </Head>
       <div className="container mx-auto max-w-2xl px-4 py-16">
         <Card>

--- a/pwa/pages/estimates/[id].tsx
+++ b/pwa/pages/estimates/[id].tsx
@@ -16,6 +16,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
+import { pageTitle } from "@/lib/pageTitle";
 
 const MERGE_PATCH = "application/merge-patch+json";
 
@@ -158,7 +159,7 @@ const EstimateDetailPage = () => {
   return (
     <>
       <Head>
-        <title>Estimate — Madori</title>
+        <title>{pageTitle("Estimate")}</title>
       </Head>
       <div className="min-h-screen bg-background px-4 py-12">
         <div className="mx-auto max-w-3xl">

--- a/pwa/pages/estimates/index.tsx
+++ b/pwa/pages/estimates/index.tsx
@@ -22,6 +22,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { pageTitle } from "@/lib/pageTitle";
 
 interface ClientLite {
   "@id": string;
@@ -133,7 +134,7 @@ const EstimatesPage = () => {
   return (
     <>
       <Head>
-        <title>Estimates — Madori</title>
+        <title>{pageTitle("Estimates")}</title>
       </Head>
       <div className="min-h-screen bg-background px-4 py-12">
         <div className="mx-auto max-w-4xl">

--- a/pwa/pages/expenses/index.tsx
+++ b/pwa/pages/expenses/index.tsx
@@ -20,6 +20,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { pageTitle } from "@/lib/pageTitle";
 
 const MERGE_PATCH = "application/merge-patch+json";
 
@@ -226,7 +227,7 @@ const ExpensesPage = () => {
   return (
     <>
       <Head>
-        <title>Expenses — Madori</title>
+        <title>{pageTitle("Expenses")}</title>
       </Head>
       <div className="min-h-screen bg-background px-4 py-12">
         <div className="mx-auto max-w-5xl">

--- a/pwa/pages/exports/[token].tsx
+++ b/pwa/pages/exports/[token].tsx
@@ -8,6 +8,7 @@ import { ENTRYPOINT } from "@/config/entrypoint";
 import { signinHrefForCurrent } from "@/lib/authRedirect";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { pageTitle } from "@/lib/pageTitle";
 
 interface ExportStatus {
   status: "ready" | "expired";
@@ -161,7 +162,7 @@ const ExportDownloadPage = () => {
   return (
     <>
       <Head>
-        <title>Space export - Madori</title>
+        <title>{pageTitle("Space export")}</title>
       </Head>
       <div className="container mx-auto max-w-lg px-4 py-16">
         <Card>

--- a/pwa/pages/faq.tsx
+++ b/pwa/pages/faq.tsx
@@ -1,5 +1,6 @@
 import Head from "next/head";
 import Link from "next/link";
+import { pageTitle } from "@/lib/pageTitle";
 
 interface QA {
   q: string;
@@ -161,7 +162,7 @@ const SECTIONS: Section[] = [
 const Faq = () => (
   <>
     <Head>
-      <title>FAQ — Madori</title>
+      <title>{pageTitle("FAQ")}</title>
       <meta
         name="description"
         content="Frequently asked questions about Madori — plans and billing, your data, the API, and support."

--- a/pwa/pages/feedback/[id].tsx
+++ b/pwa/pages/feedback/[id].tsx
@@ -32,6 +32,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
+import { pageTitle } from "@/lib/pageTitle";
 
 const FeedbackDetailPage = () => {
   const { user, isAuthenticated, isLoading: authLoading } = useAuth();
@@ -231,9 +232,7 @@ const FeedbackDetailPage = () => {
   return (
     <>
       <Head>
-        <title>
-          {ticket ? `${ticket.title} - Madori` : "Feedback - Madori"}
-        </title>
+        <title>{pageTitle(ticket?.title ?? "Feedback")}</title>
       </Head>
       <div className="min-h-screen bg-background">
         <div className="max-w-5xl mx-auto px-4 py-8 space-y-4">

--- a/pwa/pages/feedback/index.tsx
+++ b/pwa/pages/feedback/index.tsx
@@ -20,6 +20,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
+import { pageTitle } from "@/lib/pageTitle";
 
 type TypeFilter = FeedbackType | "all";
 type StatusFilter = FeedbackStatus | "all";
@@ -95,7 +96,7 @@ const FeedbackBoardPage = () => {
   return (
     <>
       <Head>
-        <title>Feedback - Madori</title>
+        <title>{pageTitle("Feedback")}</title>
       </Head>
       <div className="min-h-screen bg-background">
         <div className="max-w-5xl mx-auto px-4 py-8 space-y-6">

--- a/pwa/pages/feedback/new.tsx
+++ b/pwa/pages/feedback/new.tsx
@@ -19,6 +19,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
+import { pageTitle } from "@/lib/pageTitle";
 
 const NewFeedbackPage = () => {
   const { user, isAuthenticated, isLoading: authLoading } = useAuth();
@@ -70,7 +71,7 @@ const NewFeedbackPage = () => {
   return (
     <>
       <Head>
-        <title>New feedback - Madori</title>
+        <title>{pageTitle("New feedback")}</title>
       </Head>
       <div className="min-h-screen bg-background">
         <div className="max-w-5xl mx-auto px-4 py-8 space-y-4">

--- a/pwa/pages/forgot-password.tsx
+++ b/pwa/pages/forgot-password.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/card";
 import { FormikField } from "@/components/ui/formik-field";
 import MadoriWordmark from "@/components/auth/MadoriWordmark";
+import { pageTitle } from "@/lib/pageTitle";
 
 interface ForgotPasswordValues {
   email: string;
@@ -81,7 +82,7 @@ const ForgotPassword = () => {
   return (
     <>
       <Head>
-        <title>Reset your password — Madori</title>
+        <title>{pageTitle("Reset your password")}</title>
       </Head>
       <div className="min-h-screen flex flex-col items-center justify-center bg-background px-4 py-10 gap-8">
         <MadoriWordmark />

--- a/pwa/pages/groups/[id].tsx
+++ b/pwa/pages/groups/[id].tsx
@@ -28,6 +28,7 @@ import DeleteGroupDialog from "@/components/groups/DeleteGroupDialog";
 import GroupTile from "@/components/groups/GroupTile";
 import SpaceTile from "@/components/spaces/SpaceTile";
 import UserAvatar from "@/components/user/UserAvatar";
+import { pageTitle } from "@/lib/pageTitle";
 
 const formatDate = (iso: string): string => {
   const d = new Date(iso);
@@ -310,7 +311,7 @@ const GroupDetail = () => {
   return (
     <>
       <Head>
-        <title>{group ? `${group.title} - Madori` : "Group - Madori"}</title>
+        <title>{pageTitle(group?.title ?? "Group")}</title>
       </Head>
       <div className="px-6 py-8 max-w-6xl mx-auto">
         {isLoading || !group ? (

--- a/pwa/pages/groups/new.tsx
+++ b/pwa/pages/groups/new.tsx
@@ -17,6 +17,7 @@ import MarkdownEditor from "@/components/editor/MarkdownEditor";
 import ColorSwatchPicker from "@/components/common/ColorSwatchPicker";
 import EmailChipInput from "@/components/common/EmailChipInput";
 import GroupTile from "@/components/groups/GroupTile";
+import { pageTitle } from "@/lib/pageTitle";
 
 const MAX_INVITES = 50;
 
@@ -158,7 +159,7 @@ const NewGroupPage = () => {
   return (
     <>
       <Head>
-        <title>Create a group — Madori</title>
+        <title>{pageTitle("Create a group")}</title>
       </Head>
 
       <div className="px-4 py-10 max-w-5xl mx-auto">

--- a/pwa/pages/guides/[...slug].tsx
+++ b/pwa/pages/guides/[...slug].tsx
@@ -8,6 +8,7 @@ import { ChevronLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import CodeFence from "@/components/editor/CodeFence";
 import { getAllDocs, loadDoc, type LoadedDoc } from "@/lib/docs";
+import { pageTitle } from "@/lib/pageTitle";
 
 // `<pre>` override: react-markdown wraps a fenced code block as
 // `<pre><code className="language-xxx">{code}</code></pre>`. Unwrap it
@@ -41,7 +42,7 @@ const SECTION_LABELS: Record<string, string> = {
 const GuidePage = ({ doc, sectionLabel }: Props) => (
   <>
     <Head>
-      <title>{`${doc.title} — Madori guides`}</title>
+      <title>{pageTitle(doc.title, "Guides")}</title>
       <meta
         name="description"
         content={`${doc.title} — ${sectionLabel} documentation for Madori.`}

--- a/pwa/pages/guides/index.tsx
+++ b/pwa/pages/guides/index.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { getDocSections, type DocSection } from "@/lib/docs";
+import { pageTitle } from "@/lib/pageTitle";
 
 interface Props {
   sections: DocSection[];
@@ -12,7 +13,7 @@ interface Props {
 const GuidesIndex = ({ sections }: Props) => (
   <>
     <Head>
-      <title>Guides — Madori</title>
+      <title>{pageTitle("Guides")}</title>
       <meta
         name="description"
         content="User and developer documentation for Madori."

--- a/pwa/pages/i/[token].tsx
+++ b/pwa/pages/i/[token].tsx
@@ -7,6 +7,7 @@ import { formatMoney, InvoiceStatus, STATUS_META } from "@/lib/invoiceTypes";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
+import { pageTitle } from "@/lib/pageTitle";
 
 interface PublicLine {
   description: string;
@@ -312,7 +313,7 @@ const PublicInvoicePage = () => {
   return (
     <>
       <Head>
-        <title>Invoice — Madori</title>
+        <title>{pageTitle("Invoice")}</title>
       </Head>
       <div className="container mx-auto max-w-2xl px-4 py-16">
         <Card>

--- a/pwa/pages/invoices/[id].tsx
+++ b/pwa/pages/invoices/[id].tsx
@@ -21,6 +21,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
+import { pageTitle } from "@/lib/pageTitle";
 
 const MERGE_PATCH = "application/merge-patch+json";
 
@@ -315,7 +316,7 @@ const InvoiceDetailPage = () => {
   return (
     <>
       <Head>
-        <title>Invoice — Madori</title>
+        <title>{pageTitle("Invoice")}</title>
       </Head>
       <div className="min-h-screen bg-background px-4 py-12">
         <div className="mx-auto max-w-3xl">

--- a/pwa/pages/invoices/index.tsx
+++ b/pwa/pages/invoices/index.tsx
@@ -23,6 +23,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { pageTitle } from "@/lib/pageTitle";
 
 type InvoiceAction = "issue" | "send" | "mark-paid" | "void";
 
@@ -284,7 +285,7 @@ const InvoicesPage = () => {
   return (
     <>
       <Head>
-        <title>Invoices — Madori</title>
+        <title>{pageTitle("Invoices")}</title>
       </Head>
       <div className="min-h-screen bg-background px-4 py-12">
         <div className="mx-auto max-w-4xl">

--- a/pwa/pages/notifications/index.tsx
+++ b/pwa/pages/notifications/index.tsx
@@ -16,6 +16,7 @@ import NotificationRow from "@/components/notifications/NotificationRow";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
+import { pageTitle } from "@/lib/pageTitle";
 
 const GROUP_ORDER: TimeGroup[] = ["Today", "This week", "Earlier"];
 
@@ -113,7 +114,7 @@ const NotificationsPage = () => {
   return (
     <>
       <Head>
-        <title>Notifications - Madori</title>
+        <title>{pageTitle("Notifications")}</title>
       </Head>
       <div className="min-h-screen bg-background">
         <div className="mx-auto max-w-5xl space-y-5 px-4 py-8">

--- a/pwa/pages/organizations/[id].tsx
+++ b/pwa/pages/organizations/[id].tsx
@@ -31,6 +31,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
+import { pageTitle } from "@/lib/pageTitle";
 
 // Roles an admin can assign from the member row. Owner transfer is a heavier
 // action (kept out of the quick menu until a dedicated flow exists).
@@ -155,7 +156,7 @@ const OrganizationDetail = () => {
   return (
     <>
       <Head>
-        <title>{org ? `${org.name} - Madori` : "Organization - Madori"}</title>
+        <title>{pageTitle(org?.name ?? "Organization")}</title>
       </Head>
 
       <div className="px-6 py-8 max-w-4xl mx-auto">

--- a/pwa/pages/organizations/[id]/settings.tsx
+++ b/pwa/pages/organizations/[id]/settings.tsx
@@ -9,6 +9,7 @@ import { apiGet, ApiError } from "@/lib/apiClient";
 import { type Organization } from "@/lib/organizationTypes";
 import { Button } from "@/components/ui/button";
 import AccountBillingCard from "@/components/billing/AccountBillingCard";
+import { pageTitle } from "@/lib/pageTitle";
 
 const OrganizationSettings = () => {
   const { isAuthenticated, isLoading: authLoading } = useAuth();
@@ -65,7 +66,7 @@ const OrganizationSettings = () => {
   return (
     <>
       <Head>
-        <title>{org ? `${org.name} settings - Madori` : "Organization settings - Madori"}</title>
+        <title>{pageTitle(org ? `${org.name} settings` : "Organization settings")}</title>
       </Head>
 
       <div className="px-6 py-8 max-w-3xl mx-auto">

--- a/pwa/pages/organizations/index.tsx
+++ b/pwa/pages/organizations/index.tsx
@@ -25,6 +25,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import PageHeader from "@/components/common/PageHeader";
+import { pageTitle } from "@/lib/pageTitle";
 
 const OrganizationsIndex = () => {
   const { user, isAuthenticated, isLoading: authLoading } = useAuth();
@@ -109,7 +110,7 @@ const OrganizationsIndex = () => {
   return (
     <>
       <Head>
-        <title>Organizations - Madori</title>
+        <title>{pageTitle("Organizations")}</title>
       </Head>
 
       <div className="px-6 py-8 max-w-5xl mx-auto">

--- a/pwa/pages/pages/[pageId].tsx
+++ b/pwa/pages/pages/[pageId].tsx
@@ -44,6 +44,7 @@ import CommentsPanel, {
   type Comment as PageCommentRow,
 } from "@/components/common/CommentsPanel";
 import { useCommentLiveUpdates } from "@/lib/useCommentLiveUpdates";
+import { pageTitle } from "@/lib/pageTitle";
 
 interface ChildPage {
   "@id": string;
@@ -302,7 +303,7 @@ const PageDetailView = () => {
   return (
     <>
       <Head>
-        <title>{page ? `${page.title} - Madori` : "Page - Madori"}</title>
+        <title>{pageTitle(page?.title ?? "Page")}</title>
       </Head>
       <div className="min-h-screen bg-background">
         <div className="max-w-5xl mx-auto px-4 py-8 space-y-6">

--- a/pwa/pages/pages/index.tsx
+++ b/pwa/pages/pages/index.tsx
@@ -19,6 +19,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { pageTitle } from "@/lib/pageTitle";
 
 interface SpaceRef {
   "@id": string;
@@ -132,7 +133,7 @@ const PagesIndex = () => {
   return (
     <>
       <Head>
-        <title>Pages - Madori</title>
+        <title>{pageTitle("Pages")}</title>
       </Head>
       <div className="min-h-screen bg-background">
         <div className="max-w-4xl mx-auto px-4 py-8 space-y-6">

--- a/pwa/pages/portal/[token].tsx
+++ b/pwa/pages/portal/[token].tsx
@@ -8,6 +8,7 @@ import { ESTIMATE_STATUS_META, EstimateStatus } from "@/lib/estimateTypes";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
+import { pageTitle } from "@/lib/pageTitle";
 
 interface PortalInvoice {
   id: string;
@@ -325,7 +326,7 @@ const ClientPortalPage = () => {
   return (
     <>
       <Head>
-        <title>Billing portal — Madori</title>
+        <title>{pageTitle("Billing portal")}</title>
       </Head>
       <div className="flex min-h-screen items-start justify-center bg-muted px-4 py-12">
         <Card className="w-full max-w-3xl">

--- a/pwa/pages/pricing.tsx
+++ b/pwa/pages/pricing.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { pageTitle } from "@/lib/pageTitle";
 
 /**
  * Public pricing page.
@@ -97,7 +98,7 @@ const Pricing = () => {
   return (
     <>
       <Head>
-        <title>Pricing — Madori</title>
+        <title>{pageTitle("Pricing")}</title>
         <meta
           name="description"
           content="Madori pricing — a free plan for individuals, plus Pro, Business, and Enterprise tiers for teams."

--- a/pwa/pages/privacy.tsx
+++ b/pwa/pages/privacy.tsx
@@ -1,12 +1,13 @@
 import Head from "next/head";
 import Link from "next/link";
+import { pageTitle } from "@/lib/pageTitle";
 
 const LAST_UPDATED = "June 9, 2026";
 
 const Privacy = () => (
   <>
     <Head>
-      <title>Privacy Policy — Madori</title>
+      <title>{pageTitle("Privacy Policy")}</title>
       <meta
         name="description"
         content="How Madori collects, uses, and protects your personal data."

--- a/pwa/pages/projects/index.tsx
+++ b/pwa/pages/projects/index.tsx
@@ -24,6 +24,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
+import { pageTitle } from "@/lib/pageTitle";
 
 const SELECT_CLASS =
   "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
@@ -353,7 +354,7 @@ const ProjectsPage = () => {
   return (
     <>
       <Head>
-        <title>Projects — Madori</title>
+        <title>{pageTitle("Projects")}</title>
       </Head>
       <div className="mx-auto max-w-4xl px-6 py-8">
         <PageHeader

--- a/pwa/pages/reports/index.tsx
+++ b/pwa/pages/reports/index.tsx
@@ -16,6 +16,7 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { pageTitle } from "@/lib/pageTitle";
 
 type ReportTab = "dashboard" | "summary" | "uninvoiced";
 
@@ -172,7 +173,7 @@ const ReportsPage = () => {
   return (
     <>
       <Head>
-        <title>Reports — Madori</title>
+        <title>{pageTitle("Reports")}</title>
       </Head>
       <div className="min-h-screen bg-background px-4 py-12">
         {/* The dashboard lays out two chart columns and wants the extra room;

--- a/pwa/pages/reset-password.tsx
+++ b/pwa/pages/reset-password.tsx
@@ -26,6 +26,7 @@ import {
   MIN_PASSWORD_STRENGTH,
   estimatePasswordStrength,
 } from "@/lib/passwordStrength";
+import { pageTitle } from "@/lib/pageTitle";
 
 interface ResetPasswordValues {
   newPassword: string;
@@ -346,7 +347,7 @@ const ResetPassword = () => {
   return (
     <>
       <Head>
-        <title>Set a new password — Madori</title>
+        <title>{pageTitle("Set a new password")}</title>
       </Head>
       <PageShell>{renderBody()}</PageShell>
     </>

--- a/pwa/pages/revert-email-change.tsx
+++ b/pwa/pages/revert-email-change.tsx
@@ -7,6 +7,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { pageTitle } from "@/lib/pageTitle";
 
 type State =
   | { status: "idle" }
@@ -68,7 +69,7 @@ const RevertEmailChange = () => {
   return (
     <>
       <Head>
-        <title>Undo Email Change - Madori</title>
+        <title>{pageTitle("Undo Email Change")}</title>
       </Head>
       <div className="min-h-screen flex items-center justify-center bg-muted px-4 py-12">
         <Card className="w-full max-w-md">

--- a/pwa/pages/search.tsx
+++ b/pwa/pages/search.tsx
@@ -22,6 +22,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
+import { pageTitle } from "@/lib/pageTitle";
 
 // ---- Types ----
 type Status = "" | "open" | "completed";
@@ -284,7 +285,7 @@ const SearchPage = () => {
   return (
     <>
       <Head>
-        <title>{filters.q ? `Search: ${filters.q}` : "Search"} - Madori</title>
+        <title>{pageTitle(filters.q ? `Search: ${filters.q}` : "Search")}</title>
       </Head>
       <div className="min-h-screen bg-background">
         <div className="mx-auto max-w-5xl space-y-5 px-4 py-8">

--- a/pwa/pages/signin.tsx
+++ b/pwa/pages/signin.tsx
@@ -1,10 +1,11 @@
 import Head from "next/head";
 import AuthCard from "@/components/auth/AuthCard";
+import { pageTitle } from "@/lib/pageTitle";
 
 const SignIn = () => (
   <>
     <Head>
-      <title>Sign In - Madori</title>
+      <title>{pageTitle("Sign In")}</title>
     </Head>
     <AuthCard defaultTab="signin" />
   </>

--- a/pwa/pages/signup.tsx
+++ b/pwa/pages/signup.tsx
@@ -1,10 +1,11 @@
 import Head from "next/head";
 import AuthCard from "@/components/auth/AuthCard";
+import { pageTitle } from "@/lib/pageTitle";
 
 const SignUp = () => (
   <>
     <Head>
-      <title>Sign Up - Madori</title>
+      <title>{pageTitle("Sign Up")}</title>
     </Head>
     <AuthCard defaultTab="signup" />
   </>

--- a/pwa/pages/spaces/[id].tsx
+++ b/pwa/pages/spaces/[id].tsx
@@ -39,6 +39,7 @@ import {
 } from "@/components/spaces/SpaceContentTabs";
 import SpaceTile from "@/components/spaces/SpaceTile";
 import UserAvatar, { type AvatarUser } from "@/components/user/UserAvatar";
+import { pageTitle } from "@/lib/pageTitle";
 
 interface BoardOwner {
   email: string;
@@ -359,7 +360,7 @@ const SpaceDetail = () => {
   return (
     <>
       <Head>
-        <title>{space ? `${space.name} - Madori` : "Space - Madori"}</title>
+        <title>{pageTitle(space?.name ?? "Space")}</title>
       </Head>
       <div className="min-h-screen bg-background px-4 py-8">
         <div className="max-w-6xl mx-auto">

--- a/pwa/pages/spaces/[id]/api-keys.tsx
+++ b/pwa/pages/spaces/[id]/api-keys.tsx
@@ -29,6 +29,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import PageHeader from "@/components/common/PageHeader";
 import ConfirmDialog from "@/components/common/ConfirmDialog";
+import { pageTitle } from "@/lib/pageTitle";
 
 interface SpaceApiKey {
   id: string;
@@ -216,7 +217,7 @@ const SpaceApiKeys = () => {
   return (
     <>
       <Head>
-        <title>API keys · {space.name}</title>
+        <title>{pageTitle("API keys", space.name)}</title>
       </Head>
       <div className="mx-auto max-w-5xl px-4 py-8">
         <PageHeader

--- a/pwa/pages/spaces/[id]/roles.tsx
+++ b/pwa/pages/spaces/[id]/roles.tsx
@@ -31,6 +31,7 @@ import PageHeader from "@/components/common/PageHeader";
 import ColorSwatchPicker from "@/components/common/ColorSwatchPicker";
 import ConfirmDialog from "@/components/common/ConfirmDialog";
 import RolePermissionMatrix from "@/components/spaces/RolePermissionMatrix";
+import { pageTitle } from "@/lib/pageTitle";
 
 const SpaceRoles = () => {
   const { user, isAuthenticated, isLoading: authLoading } = useAuth();
@@ -222,7 +223,7 @@ const SpaceRoles = () => {
   return (
     <>
       <Head>
-        <title>Roles · {space.name}</title>
+        <title>{pageTitle("Roles", space.name)}</title>
       </Head>
       <div className="mx-auto max-w-5xl px-4 py-8">
         <PageHeader

--- a/pwa/pages/spaces/[id]/settings.tsx
+++ b/pwa/pages/spaces/[id]/settings.tsx
@@ -22,6 +22,7 @@ import InvoiceBrandingCard from "@/components/spaces/InvoiceBrandingCard";
 import ExpenseCategoriesCard from "@/components/spaces/ExpenseCategoriesCard";
 import DeleteSpaceDialog from "@/components/spaces/DeleteSpaceDialog";
 import ChangeVisibilityDialog from "@/components/spaces/ChangeVisibilityDialog";
+import { pageTitle } from "@/lib/pageTitle";
 
 // Billing (Stripe) is off until a real payment system is wired up. Flip
 // NEXT_PUBLIC_BILLING_ENABLED=true (and configure the Stripe env) to surface
@@ -281,7 +282,7 @@ const SpaceSettings = () => {
   return (
     <>
       <Head>
-        <title>Space settings · {space.name}</title>
+        <title>{pageTitle("Space settings", space.name)}</title>
       </Head>
       <div className="mx-auto max-w-5xl px-4 py-8 pb-24">
         <div className="mb-6">

--- a/pwa/pages/spaces/[id]/users.tsx
+++ b/pwa/pages/spaces/[id]/users.tsx
@@ -35,6 +35,7 @@ import { Input } from "@/components/ui/input";
 import PageHeader from "@/components/common/PageHeader";
 import GroupTile from "@/components/groups/GroupTile";
 import UserAvatar, { type AvatarUser } from "@/components/user/UserAvatar";
+import { pageTitle } from "@/lib/pageTitle";
 
 type Role = "admin" | "member";
 
@@ -489,7 +490,7 @@ const SpaceUsers = () => {
   return (
     <>
       <Head>
-        <title>Users · {space.name}</title>
+        <title>{pageTitle("Users", space.name)}</title>
       </Head>
       <div className="mx-auto max-w-5xl px-4 py-8">
         <PageHeader

--- a/pwa/pages/spaces/index.tsx
+++ b/pwa/pages/spaces/index.tsx
@@ -19,6 +19,7 @@ import { SkeletonList } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import PageHeader from "@/components/common/PageHeader";
 import SpaceCard from "@/components/spaces/SpaceCard";
+import { pageTitle } from "@/lib/pageTitle";
 
 type FilterKey = "all" | "shared" | "personal" | "owned";
 type SortKey = "recent" | "name" | "members";
@@ -126,7 +127,7 @@ const SpacesIndex = () => {
   return (
     <>
       <Head>
-        <title>Spaces - Madori</title>
+        <title>{pageTitle("Spaces")}</title>
       </Head>
 
       <div className="px-6 py-8 max-w-7xl mx-auto">

--- a/pwa/pages/spaces/new.tsx
+++ b/pwa/pages/spaces/new.tsx
@@ -18,6 +18,7 @@ import MarkdownEditor from "@/components/editor/MarkdownEditor";
 import ColorSwatchPicker from "@/components/common/ColorSwatchPicker";
 import EmailChipInput from "@/components/common/EmailChipInput";
 import SpaceTile from "@/components/spaces/SpaceTile";
+import { pageTitle } from "@/lib/pageTitle";
 
 const MAX_INVITES = 50;
 
@@ -169,7 +170,7 @@ const NewSpacePage = () => {
   return (
     <>
       <Head>
-        <title>Create a space — Madori</title>
+        <title>{pageTitle("Create a space")}</title>
       </Head>
 
       <div className="px-4 py-10 max-w-5xl mx-auto">

--- a/pwa/pages/tags.tsx
+++ b/pwa/pages/tags.tsx
@@ -19,6 +19,7 @@ import PageHeader from "@/components/common/PageHeader";
 import { AVATAR_PALETTE } from "@/lib/avatarPalette";
 import { readableForeground } from "@/lib/contrast";
 import { ENTRYPOINT } from "@/config/entrypoint";
+import { pageTitle } from "@/lib/pageTitle";
 
 interface Tag {
   "@id": string;
@@ -200,7 +201,7 @@ const Tags = () => {
   return (
     <>
       <Head>
-        <title>Tags - Madori</title>
+        <title>{pageTitle("Tags")}</title>
       </Head>
       <div className="min-h-screen bg-background px-4 py-12">
         <div className="max-w-5xl mx-auto">

--- a/pwa/pages/tasks.tsx
+++ b/pwa/pages/tasks.tsx
@@ -73,6 +73,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
+import { pageTitle as buildPageTitle } from "@/lib/pageTitle";
 
 interface BoardMembership {
   "@id": string;
@@ -1107,7 +1108,7 @@ const Tasks = () => {
   return (
     <>
       <Head>
-        <title>{pageTitle} - Madori</title>
+        <title>{buildPageTitle(pageTitle)}</title>
       </Head>
       <div className="min-h-screen bg-background px-4 py-12">
         <div className="max-w-7xl mx-auto">

--- a/pwa/pages/terms.tsx
+++ b/pwa/pages/terms.tsx
@@ -1,12 +1,13 @@
 import Head from "next/head";
 import Link from "next/link";
+import { pageTitle } from "@/lib/pageTitle";
 
 const LAST_UPDATED = "June 9, 2026";
 
 const Terms = () => (
   <>
     <Head>
-      <title>Terms and Conditions — Madori</title>
+      <title>{pageTitle("Terms and Conditions")}</title>
       <meta
         name="description"
         content="The terms and conditions that govern your use of Madori."

--- a/pwa/pages/time/index.tsx
+++ b/pwa/pages/time/index.tsx
@@ -25,6 +25,7 @@ import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { pageTitle } from "@/lib/pageTitle";
 
 const MERGE_PATCH = "application/merge-patch+json";
 
@@ -321,7 +322,7 @@ const TimePage = () => {
   return (
     <>
       <Head>
-        <title>Time — Madori</title>
+        <title>{pageTitle("Time")}</title>
       </Head>
       <div className="min-h-screen bg-background px-4 py-12">
         <div className="mx-auto max-w-5xl">

--- a/pwa/pages/timeline.tsx
+++ b/pwa/pages/timeline.tsx
@@ -11,6 +11,7 @@ import TaskDetailDrawer from "@/components/tasks/TaskDetailDrawer";
 import { type AssigneeOption } from "@/components/tasks/AssigneesCombobox";
 import { type TagOption } from "@/components/tasks/TagsCombobox";
 import { type CustomFieldValuePair } from "@/components/tasks/CustomFieldValueList";
+import { pageTitle } from "@/lib/pageTitle";
 
 /**
  * `/timeline` — the cross-board Gantt for the active space (#timeline).
@@ -178,7 +179,7 @@ const TimelinePage = () => {
   return (
     <>
       <Head>
-        <title>Timeline - Madori</title>
+        <title>{pageTitle("Timeline")}</title>
       </Head>
       <div className="min-h-screen bg-background">
         <div className="w-full px-4 py-8">

--- a/pwa/pages/verify-email.tsx
+++ b/pwa/pages/verify-email.tsx
@@ -16,6 +16,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { pageTitle } from "@/lib/pageTitle";
 
 type ConfirmStatus = "verifying" | "success" | "error";
 type ResendStatus = "idle" | "sending" | "sent" | "error";
@@ -107,7 +108,7 @@ const VerifyEmail: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Confirm your email - Madori</title>
+        <title>{pageTitle("Confirm your email")}</title>
       </Head>
       <div className="min-h-screen flex flex-col items-center justify-center bg-background px-4 py-10 gap-8">
         <MadoriWordmark />

--- a/pwa/pages/waitlist.tsx
+++ b/pwa/pages/waitlist.tsx
@@ -18,6 +18,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { pageTitle } from "@/lib/pageTitle";
 
 /**
  * Landing page for waitlisted accounts. The WaitlistGate (mounted in Layout)
@@ -67,7 +68,7 @@ const Waitlist: NextPage = () => {
   return (
     <>
       <Head>
-        <title>You&apos;re on the waitlist - Madori</title>
+        <title>{pageTitle("You&apos;re on the waitlist")}</title>
       </Head>
       <div className="min-h-screen flex flex-col items-center justify-center bg-background px-4 py-10 gap-8">
         <MadoriWordmark />


### PR DESCRIPTION
Audit findings **L-20, L-21, L-22** — the remaining Low tier.

## Two of the five needed no work

**L-18** and **L-19** were already fixed in #783, which swept them alongside the Critical/High items. `notificationPrefs.ts:53` — the exact line cited — already reads "**A** project you administer…", and a repo-wide search for `An <consonant>` returns nothing. The push-permission block already maps the three browser states to intent with an Enable button on the actionable one. Verified before writing anything.

## L-20 — swatches announced themselves as hex

`aria-label={color}` made a screen reader say *"radio, hash three three four one five five"*, so choosing an avatar colour was impossible without sight — in a picker whose `role="radiogroup"` and `aria-checked` wiring is otherwise correct. The label was the only weak link.

The palette was already named in code comments; those names are now a real map.

| | before | after |
|---|---|---|
| swatch labels | `#334155`, `#0f766e`, … | `Slate`, `Teal`, … |
| any hex label | yes | **no** (0 of 16) |

Off-palette colours fall back to the hex — no worse than before, and unreachable in practice since no caller passes a custom palette.

## L-21 — three title shapes, not two

The finding reported two (46 hyphen / 26 em dash). Measured, there were **three**, and the counts differ:

- `Boards - Madori` — 28 pages
- `Dashboard — Madori` — 24 pages
- `Roles · Launch team` — omitted the product name entirely

One `pageTitle()` helper builds all of them. The two separators do different jobs — a middle dot separates page context, an em dash separates the page from the product — so a title stays parseable however many parts it has. `Profile · Settings — Madori` is the shape that needed both.

Verified across 12 routes: all end `— Madori`, zero hyphen separators, none missing the product name.

The marketing homepage keeps its bespoke SEO title, since it leads with the product name rather than following the page-title pattern.

## L-22 — the orphan section

A member granted the `api_keys` capability saw the **"User management"** heading standing over a single **"API keys"** child.

I did **not** implement the suggested "hide a section header when its visible children drop below two". That rule would also swallow a section that legitimately has one child, and the mismatch here isn't numeric — it's that "User management" was never the right home for a capability-gated API keys link, which is why it's the one item that survives the admin gate.

Promoting it to a top-level item — the shape Tags and Custom fields already use — puts it in the same place for every role and leaves the group as admin-only Users + Roles, where an orphan is **impossible by construction** rather than suppressed by a heuristic.

| sidebar | before | after |
|---|---|---|
| as a member | `User management: [API keys]` | no heading; `API keys` top-level |
| as an admin | `User management: [Users, Roles, API keys]` | `User management: [Users, Roles]`; `API keys` top-level |

Note the repro is narrower than reported: `links.length === 0` already returned null, so a member *without* the capability saw no heading at all.

## Verification

All three confirmed in the running app (browser probe, signed in, both spaces).

**Six e2e assertions pinned the old hyphen titles** (`toHaveTitle("Boards - Madori")` and friends) — they'd have failed CI, and are updated.

`tsc --noEmit` clean · `pnpm lint` 0 errors · vitest **174/174** (new coverage for `colorName` and `pageTitle`, including a drift guard asserting every palette entry has a distinct name — a colour added without one would silently go back to announcing a hex code) · e2e 36/37.

The one e2e failure is `tasks.spec.js:286` keyboard-drag. I stashed these changes and re-ran it against a clean tree, where it fails identically — pre-existing local flakiness, and it passed in CI on #796, #797 and #798.

---
_Generated by [Claude Code](https://claude.ai/code/session_011c8hAeLnvvpgeaEqPzcTjS)_