### PR TITLE
fix(a11y): keyboard-operable colour picker, /tags on the Table primitive

### DIFF
--- a/e2e/tests/tasks.spec.js
+++ b/e2e/tests/tasks.spec.js
@@ -306,18 +306,34 @@ test.describe("Tasks", () => {
 
     // Grab the grip on the top item (C) and move it down twice to position 3.
     // Use locator.press() to focus+press atomically (more reliable in CI than
-    // focus() + keyboard.press), and wait briefly between keys so dnd-kit's
-    // drag state has time to update between Space/Arrow events.
+    // focus() + keyboard.press).
+    //
+    // Each key is followed by a wait for dnd-kit to *announce* the move rather
+    // than a fixed sleep. dnd-kit names the droppable it moved over in its own
+    // live region, so the announcement changing is proof the key was processed.
+    // A fixed delay is a guess, and on a loaded machine 100ms was sometimes
+    // short enough that the second ArrowDown landed before the first had
+    // settled — the drop then committed one position early, leaving B, C, A
+    // instead of B, A, C. That produced a failure at the very last assertion,
+    // which read as flake but was really "we stopped measuring too soon".
+    // dnd-kit's own region, matched by its generated id. Not `role="status"`
+    // broadly — the toaster and the loading skeletons are live regions too.
+    const dragAnnouncement = page.locator('[id^="DndLiveRegion"]');
+    const pressAndSettle = async (press) => {
+      const before = await dragAnnouncement.textContent();
+      await press();
+      await expect
+        .poll(() => dragAnnouncement.textContent(), { timeout: 5000 })
+        .not.toBe(before);
+    };
+
     const topGrip = page
       .locator('[data-testid="task-item"]')
       .first()
       .getByRole("button", { name: /Drag to reorder/ });
-    await topGrip.press("Space");
-    await page.waitForTimeout(100);
-    await page.keyboard.press("ArrowDown");
-    await page.waitForTimeout(100);
-    await page.keyboard.press("ArrowDown");
-    await page.waitForTimeout(100);
+    await pressAndSettle(() => topGrip.press("Space"));
+    await pressAndSettle(() => page.keyboard.press("ArrowDown"));
+    await pressAndSettle(() => page.keyboard.press("ArrowDown"));
     await page.keyboard.press("Space");
 
     // Now the order should be B, A, C — verify via the top item

--- a/pwa/components/common/ColorSwatchPicker.tsx
+++ b/pwa/components/common/ColorSwatchPicker.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, type KeyboardEvent } from "react";
 import { AVATAR_PALETTE, colorName } from "@/lib/avatarPalette";
 import { cn } from "@/lib/utils";
 
@@ -35,13 +36,76 @@ const ColorSwatchPicker = ({
   ariaLabel,
   className,
 }: Props) => {
+  const refs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  // A radiogroup is one tab stop, not one per option. Without a roving
+  // tabindex these 16 swatches were 16 stops on the way past the picker, and
+  // the arrow keys — the only way a radiogroup is meant to be operated — did
+  // nothing. The selected swatch holds the stop; if the current value isn't in
+  // the palette (nothing selected), the first one does, so the group is always
+  // reachable.
+  const selectedIndex = options.indexOf(value);
+  const tabbableIndex = selectedIndex >= 0 ? selectedIndex : 0;
+
+  // Where focus belongs once the pending render settles.
+  //
+  // Focusing inline doesn't survive: callers disable the whole group while the
+  // change saves (AvatarSection passes `disabled={!!savingColor}`), and a
+  // disabled button cannot hold focus — the browser drops it to <body>, which
+  // ends keyboard traversal after a single arrow press. Recording the intent
+  // and applying it from an effect means focus lands as soon as the group is
+  // interactive again, whether that's this render or the one after the save.
+  const pendingFocus = useRef<number | null>(null);
+
+  useEffect(() => {
+    const index = pendingFocus.current;
+    if (index === null) return;
+    const el = refs.current[index];
+    if (el && !el.disabled) {
+      el.focus();
+      pendingFocus.current = null;
+    }
+    // Still disabled: stay pending. `disabled` is a dependency, so this reruns
+    // the moment the save finishes.
+  }, [disabled, value]);
+
+  // Linear traversal with wrap, which is the radiogroup pattern regardless of
+  // how the options are laid out visually. Deliberately not column-aware: the
+  // grid is a `className` the caller can override, so inferring a row width
+  // from it would be a guess that breaks the moment someone restyles it.
+  const move = (to: number) => {
+    pendingFocus.current = to;
+    onChange(options[to]);
+  };
+
+  const onKeyDown = (event: KeyboardEvent, index: number) => {
+    if (disabled) return;
+    const jump: Record<string, number> = {
+      ArrowRight: 1,
+      ArrowDown: 1,
+      ArrowLeft: -1,
+      ArrowUp: -1,
+    };
+    if (event.key in jump) {
+      // Arrow keys select as they move — that's what makes it a radiogroup
+      // rather than a toolbar, and it's why the group only needs one stop.
+      event.preventDefault();
+      move((index + jump[event.key] + options.length) % options.length);
+      return;
+    }
+    if (event.key === "Home" || event.key === "End") {
+      event.preventDefault();
+      move(event.key === "Home" ? 0 : options.length - 1);
+    }
+  };
+
   return (
     <div
       role="radiogroup"
       aria-label={ariaLabel}
       className={cn("grid w-fit grid-cols-8 gap-2", className)}
     >
-      {options.map((color) => {
+      {options.map((color, index) => {
         const isSelected = value === color;
         const isSaving = savingColor === color;
         return (
@@ -49,12 +113,17 @@ const ColorSwatchPicker = ({
             key={color}
             type="button"
             role="radio"
+            ref={(el) => {
+              refs.current[index] = el;
+            }}
             aria-checked={isSelected}
             // Named, not hex: the rest of this picker is wired correctly, so
             // the label was the only thing making it unusable without sight.
             aria-label={colorName(color)}
+            tabIndex={index === tabbableIndex ? 0 : -1}
             disabled={disabled}
             onClick={() => onChange(color)}
+            onKeyDown={(e) => onKeyDown(e, index)}
             className={cn(
               "h-8 w-8 rounded-md transition focus:outline-none focus:ring-2 focus:ring-ring disabled:cursor-not-allowed",
               isSelected

--- a/pwa/pages/dev/components/color-swatch-picker.tsx
+++ b/pwa/pages/dev/components/color-swatch-picker.tsx
@@ -28,7 +28,7 @@ const Saving = () => {
 const ColorSwatchPickerPage = () => (
   <ComponentDoc
     name="ColorSwatchPicker"
-    description="Stateless `radiogroup` row of round color swatches — the picker shape used for avatar color in account settings and reused on the create/edit space + group surfaces. The caller owns `value` and is notified via `onChange`. Defaults to `AVATAR_PALETTE`; pass `options` to override. `savingColor` pulses the in-flight swatch and `disabled` short-circuits all interaction so a form can stop the user racing an async save."
+    description="Stateless `radiogroup` row of round color swatches — the picker shape used for avatar color in account settings and reused on the create/edit space + group surfaces. The caller owns `value` and is notified via `onChange`. Defaults to `AVATAR_PALETTE`; pass `options` to override. `savingColor` pulses the in-flight swatch and `disabled` short-circuits all interaction so a form can stop the user racing an async save. Keyboard support follows the WAI radiogroup pattern: the group is a single tab stop and the arrow keys move the selection."
     importPath={`import ColorSwatchPicker from "@/components/common/ColorSwatchPicker";`}
     examples={[
       {
@@ -42,6 +42,15 @@ const ColorSwatchPickerPage = () => (
   onChange={setColor}
   ariaLabel="Avatar color"
 />`,
+        preview: <Basic />,
+      },
+      {
+        title: "Keyboard",
+        description:
+          "A radiogroup is one tab stop, not one per option — Tab enters the group at the selected swatch, and the arrow keys move the selection from there (wrapping at both ends; Home/End jump to the first/last). Before this, all 16 swatches sat in the tab order and the arrow keys did nothing, which made the picker unusable without a mouse.",
+        code: `{/* Nothing to opt into — the roving tabindex is internal.
+    Tab to the picker below, then press the arrow keys. */}
+<ColorSwatchPicker value={color} onChange={setColor} ariaLabel="Avatar color" />`,
         preview: <Basic />,
       },
       {

--- a/pwa/pages/tags.tsx
+++ b/pwa/pages/tags.tsx
@@ -12,6 +12,14 @@ import MarkdownView from "@/components/editor/MarkdownView";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { SkeletonList } from "@/components/ui/skeleton";
 import ColorSwatchPicker from "@/components/common/ColorSwatchPicker";
 import ConfirmDialog from "@/components/common/ConfirmDialog";
@@ -230,33 +238,26 @@ const Tags = () => {
             </div>
           ) : (
             <div className="overflow-hidden rounded-lg border bg-card" data-testid="tag-list">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b text-xs uppercase tracking-wide text-muted-foreground">
-                    <th className="px-4 py-2 text-left font-medium">Tag</th>
-                    <th className="px-4 py-2 text-left font-medium">Description</th>
-                    <th className="px-4 py-2" />
-                  </tr>
-                </thead>
-                <tbody>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Tag</TableHead>
+                    <TableHead>Description</TableHead>
+                    <TableHead />
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
                   {tags.length === 0 && !creating && (
-                    <tr data-testid="tag-empty">
-                      <td
-                        colSpan={3}
-                        className="px-4 py-6 text-center text-muted-foreground"
-                      >
+                    <TableRow data-testid="tag-empty">
+                      <TableCell colSpan={3} className="py-6 text-center whitespace-normal text-muted-foreground">
                         No tags yet — add one to start grouping tasks across boards.
-                      </td>
-                    </tr>
+                      </TableCell>
+                    </TableRow>
                   )}
                   {tags.map((tag) =>
                     editingId === tag["@id"] ? (
-                      <tr
-                        key={tag["@id"]}
-                        data-testid="tag-item"
-                        className="border-b last:border-0"
-                      >
-                        <td colSpan={3} className="px-4 py-3">
+                      <TableRow key={tag["@id"]} data-testid="tag-item">
+                        <TableCell colSpan={3} className="py-3 whitespace-normal">
                           <form
                             onSubmit={(e) => handleUpdate(e, tag)}
                             className="space-y-3"
@@ -293,15 +294,11 @@ const Tags = () => {
                               </Button>
                             </div>
                           </form>
-                        </td>
-                      </tr>
+                        </TableCell>
+                      </TableRow>
                     ) : (
-                      <tr
-                        key={tag["@id"]}
-                        data-testid="tag-item"
-                        className="border-b last:border-0 hover:bg-accent/40"
-                      >
-                        <td className="px-4 py-2 align-middle">
+                      <TableRow key={tag["@id"]} data-testid="tag-item">
+                        <TableCell>
                           <span
                             className="inline-block rounded px-2 py-1 text-sm font-semibold whitespace-nowrap"
                             style={{
@@ -311,15 +308,15 @@ const Tags = () => {
                           >
                             {tag.title}
                           </span>
-                        </td>
-                        <td className="min-w-0 px-4 py-2 align-middle">
+                        </TableCell>
+                        <TableCell className="min-w-0 whitespace-normal">
                           {tag.description ? (
                             <MarkdownView source={tag.description} />
                           ) : (
                             <span className="text-muted-foreground/50">—</span>
                           )}
-                        </td>
-                        <td className="px-4 py-2 text-right align-middle whitespace-nowrap">
+                        </TableCell>
+                        <TableCell className="text-right">
                           <Button
                             variant="ghost"
                             size="icon"
@@ -337,13 +334,13 @@ const Tags = () => {
                           >
                             <Trash2 className="h-4 w-4" />
                           </Button>
-                        </td>
-                      </tr>
+                        </TableCell>
+                      </TableRow>
                     ),
                   )}
                   {creating && (
-                    <tr data-testid="tag-create-row" className="border-b last:border-0">
-                      <td colSpan={3} className="px-4 py-3">
+                    <TableRow data-testid="tag-create-row">
+                      <TableCell colSpan={3} className="py-3 whitespace-normal">
                         <form onSubmit={handleCreate} className="space-y-3">
                           <Input
                             type="text"
@@ -386,11 +383,11 @@ const Tags = () => {
                             </Button>
                           </div>
                         </form>
-                      </td>
-                    </tr>
+                      </TableCell>
+                    </TableRow>
                   )}
-                </tbody>
-              </table>
+                </TableBody>
+              </Table>
               {can("tags", "create") && !creating && (
                 <button
                   type="button"


### PR DESCRIPTION
Three follow-ups spotted while closing out the UI/UX audit. None were audit findings — all three were noticed while working nearby.

## 1. `ColorSwatchPicker` wasn't keyboard-operable as a radiogroup

Sixteen swatches each carried their own tab stop, so the picker was **16 stops to tab past**, and the arrow keys — the only way a radiogroup is meant to be driven — did nothing.

Now uses a roving tabindex: one tab stop, entered at the selected swatch, arrows move the selection (wrapping; Home/End jump to the ends). Traversal is linear rather than column-aware **on purpose** — the grid is a `className` callers can override, so inferring a row width from it would break the moment someone restyles it. Linear is also what the WAI radiogroup pattern specifies.

**Driving it in a browser turned up a second defect behind the first.** Focusing inline doesn't survive the change, because callers disable the whole group while it saves (`AvatarSection` passes `disabled={!!savingColor}`) and **a disabled button can't hold focus** — the browser drops it to `<body>`. So one arrow press worked and every subsequent one was swallowed. Focus intent is now recorded and applied from an effect keyed on `disabled`, so it lands as soon as the group is interactive again.

Measured:

| step | selected | focused | tabbable |
|---|---|---|---|
| enter group | 8 Emerald | 8 | 1 |
| → | 9 Cyan | 9 | 1 |
| → | 10 Sky | 10 | 1 |
| ← | 9 Cyan | 9 | 1 |
| End | 15 Pink | 15 | 1 |
| → (wrap) | 0 Slate | 0 | 1 |

Before the focus fix, step 2 gave `focused: -1` and everything after it was inert.

## 2. `/tags` hand-rolled its own `<table>`

It bypassed the `Table` primitive entirely, so it silently missed the keyboard scroll region added for M-15 — and would miss anything added to `Table` in future. No live bug (it fits at 375px), but a gap that would widen.

The real risk in converting: `TableCell` now defaults to `whitespace-nowrap` for tabular data, which would have stopped the markdown description wrapping and blown the column sideways. The description cell and the two full-width form rows opt back into `whitespace-normal`.

Verified with a long description: description cell computes `normal`, the tag chip stays `nowrap`, row wraps to 70px, and neither the scroll container nor the page overflows.

## 3. The keyboard-drag e2e test was failing — and it was the test's fault

Not a product bug. It slept a fixed **100ms** between keys. On a loaded machine that was sometimes short enough that the second `ArrowDown` landed before the first had settled, so the drop committed one position early — leaving **B, C, A** instead of **B, A, C**. That surfaced only at the very last assertion, which read as flake but was really *"we stopped measuring too soon"*.

Stepping the drag manually confirmed it — at 250ms every move lands and dnd-kit announces each one:

```
after Space      → moved over <self>
after ArrowDown  → moved over <task 2>
after ArrowDown  → moved over <task 3>
after Space      → dropped over <task 3>
```

So the sleeps are replaced by waiting for **dnd-kit's own live region to change**, which is proof the key was processed rather than a guess about how long it takes. The region is matched by its generated id (`DndLiveRegion-*`) rather than `role="status"` — the toaster and the loading skeletons are live regions too, and my first attempt matched the toaster's permanently-empty one and timed out.

**Failing 3/3 runs before, passing 3/3 after.**

## Verification

`tsc --noEmit` clean · `pnpm lint` 0 errors · vitest 174/174 · **e2e 37/37** across tags, tasks, boards, auth and settings — the first fully green local run of these suites this session.

Docs page updated with the keyboard behaviour, per CLAUDE.md.

---
_Generated by [Claude Code](https://claude.ai/code/session_011c8hAeLnvvpgeaEqPzcTjS)_