### PR TITLE
feat: add plan comparison table to the pricing page

### DIFF
--- a/e2e/tests/pricing.spec.js
+++ b/e2e/tests/pricing.spec.js
@@ -1,0 +1,47 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+const { BASE_URL } = require("./helpers");
+
+// Public plans & pricing page. The tier cards and the comparison table both
+// render from `pwa/lib/planTiers.ts` (which mirrors App\Billing\PlanCatalog);
+// planTiers.test.ts covers that matrix as data, so what's worth guarding here
+// is that it actually reaches the page — the table markup builds its rows with
+// a flatMap of group-header + feature rows, and the prices in both the cards
+// and the table header have to follow the monthly/annual toggle together.
+test.describe("Plans & pricing", () => {
+  test("lists every plan with a comparison table", async ({ page }) => {
+    await page.goto(`${BASE_URL}/pricing`);
+
+    for (const plan of ["Free", "Pro", "Business", "Enterprise"]) {
+      await expect(
+        page.getByRole("heading", { name: plan, exact: true }),
+      ).toBeVisible();
+    }
+
+    const table = page.locator("table");
+    await expect(table).toBeVisible();
+
+    // One header cell per plan, plus the leading "Feature" column.
+    await expect(table.locator("thead th")).toHaveCount(5);
+
+    // A representative gated row: Free doesn't get automations, Business does.
+    const row = table.locator("tr", { hasText: "Board automations" }).first();
+    await expect(row).toBeVisible();
+    await expect(row.getByText("Not included").first()).toBeAttached();
+    await expect(row.getByText("Included").first()).toBeAttached();
+  });
+
+  test("the annual toggle repriced both the cards and the table", async ({ page }) => {
+    await page.goto(`${BASE_URL}/pricing`);
+
+    // Monthly is the default.
+    await expect(page.getByText("$10", { exact: false }).first()).toBeVisible();
+
+    await page.getByRole("button", { name: /Annual/ }).click();
+
+    // Annual bills at ten months — Pro $10/mo becomes $100/yr. It appears on
+    // the card and again under the plan's table column header.
+    await expect(page.getByText("$100").first()).toBeVisible();
+    await expect(page.locator("thead").getByText("$100 per year")).toBeVisible();
+  });
+});

--- a/pwa/lib/planTiers.test.ts
+++ b/pwa/lib/planTiers.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import {
+  COMPARISON_GROUPS,
+  PLAN_ENTITLEMENTS,
+  PLAN_FEATURES,
+  PLAN_KEYS,
+  PLAN_LIMITS,
+  PLAN_TIERS,
+  formatUsd,
+  priceFor,
+  type PlanTier,
+} from "./planTiers";
+
+const tier = (key: string): PlanTier => {
+  const found = PLAN_TIERS.find((t) => t.key === key);
+  if (!found) throw new Error(`no tier ${key}`);
+  return found;
+};
+
+const allRows = COMPARISON_GROUPS.flatMap((group) => group.rows);
+
+describe("the comparison table", () => {
+  it("covers every feature in the catalog", () => {
+    // The guard that matters: adding a flag to PlanCatalog and mirroring it
+    // into PLAN_ENTITLEMENTS without giving it a row would quietly ship a
+    // pricing page that undersells the plan.
+    const keys = new Set(allRows.map((row) => row.key));
+    for (const feature of PLAN_FEATURES) {
+      expect(keys.has(feature), `no table row for feature "${feature}"`).toBe(true);
+    }
+  });
+
+  it("covers every limit in the catalog", () => {
+    const keys = new Set(allRows.map((row) => row.key));
+    for (const limit of PLAN_LIMITS) {
+      expect(keys.has(limit), `no table row for limit "${limit}"`).toBe(true);
+    }
+  });
+
+  it("gives every row a value for every plan", () => {
+    for (const row of allRows) {
+      for (const plan of PLAN_KEYS) {
+        expect(row.values[plan], `${row.key} has no value for ${plan}`).toBeDefined();
+      }
+    }
+  });
+
+  it("lists each row once, so nothing is advertised twice", () => {
+    const keys = allRows.map((row) => row.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it("renders an unlimited limit as a word and a capped one as a number", () => {
+    const members = allRows.find((row) => row.key === "space_members");
+    expect(members?.values.free).toBe("Up to 5");
+    expect(members?.values.business).toBe("Unlimited");
+  });
+
+  it("renders a zero allowance as not-included rather than as '0'", () => {
+    // AI credits are 0 on Free/Pro. "0 / month" reads as a broken value; the
+    // dash is the honest rendering of an allowance you don't have.
+    const credits = allRows.find((row) => row.key === "ai_credits_per_month");
+    expect(credits?.values.free).toBe(false);
+    expect(credits?.values.business).toBe("2,000 / month");
+  });
+});
+
+describe("PLAN_ENTITLEMENTS", () => {
+  it("has an entry for every plan, feature and limit", () => {
+    for (const plan of PLAN_KEYS) {
+      const entitlements = PLAN_ENTITLEMENTS[plan];
+      expect(Object.keys(entitlements.features).sort()).toEqual(
+        [...PLAN_FEATURES].sort(),
+      );
+      expect(Object.keys(entitlements.limits).sort()).toEqual([...PLAN_LIMITS].sort());
+    }
+  });
+
+  it("never removes a feature as the plan gets more expensive", () => {
+    // Every tier's card promises "Everything in <previous>". This is that
+    // claim, asserted.
+    for (let i = 1; i < PLAN_KEYS.length; i += 1) {
+      const lower = PLAN_ENTITLEMENTS[PLAN_KEYS[i - 1]];
+      const higher = PLAN_ENTITLEMENTS[PLAN_KEYS[i]];
+      for (const feature of PLAN_FEATURES) {
+        if (lower.features[feature]) {
+          expect(
+            higher.features[feature],
+            `${PLAN_KEYS[i]} drops "${feature}" granted by ${PLAN_KEYS[i - 1]}`,
+          ).toBe(true);
+        }
+      }
+    }
+  });
+
+  it("never lowers a limit as the plan gets more expensive", () => {
+    for (let i = 1; i < PLAN_KEYS.length; i += 1) {
+      const lower = PLAN_ENTITLEMENTS[PLAN_KEYS[i - 1]];
+      const higher = PLAN_ENTITLEMENTS[PLAN_KEYS[i]];
+      for (const limit of PLAN_LIMITS) {
+        const below = lower.limits[limit];
+        const above = higher.limits[limit];
+        if (below === null) {
+          // Unlimited below must stay unlimited above.
+          expect(above, `${PLAN_KEYS[i]} caps "${limit}"`).toBeNull();
+        } else if (above !== null) {
+          expect(above, `${PLAN_KEYS[i]} lowers "${limit}"`).toBeGreaterThanOrEqual(below);
+        }
+      }
+    }
+  });
+});
+
+describe("priceFor", () => {
+  it("shows the free plan as $0 forever, with no billing period", () => {
+    expect(priceFor(tier("free"), false)).toEqual({
+      amount: "$0",
+      unit: "",
+      period: "forever",
+    });
+    expect(priceFor(tier("free"), true).period).toBe("forever");
+  });
+
+  it("bills annual at ten months, so 'two months free' is true", () => {
+    expect(priceFor(tier("pro"), false).amount).toBe("$10");
+    expect(priceFor(tier("pro"), true)).toEqual({
+      amount: "$100",
+      unit: "",
+      period: "per year",
+    });
+  });
+
+  it("marks a per-seat plan's price as per seat", () => {
+    expect(priceFor(tier("business"), false)).toEqual({
+      amount: "$15",
+      unit: "/seat",
+      period: "per month",
+    });
+  });
+
+  it("shows a sales-led plan as Custom with no period", () => {
+    expect(priceFor(tier("enterprise"), false)).toEqual({
+      amount: "Custom",
+      unit: "",
+      period: "",
+    });
+  });
+});
+
+describe("formatUsd", () => {
+  it("drops the decimals on a whole-dollar price", () => {
+    expect(formatUsd(1500)).toBe("$15");
+  });
+
+  it("keeps cents when the price isn't a whole dollar", () => {
+    expect(formatUsd(1550)).toBe("$15.50");
+  });
+});

--- a/pwa/lib/planTiers.ts
+++ b/pwa/lib/planTiers.ts
@@ -1,0 +1,413 @@
+/**
+ * The public plan matrix behind `/pricing`.
+ *
+ * This MIRRORS `api/src/Billing/PlanCatalog.php`, which stays the source of
+ * truth for what a plan actually grants. The copy exists because the pricing
+ * page is public and the entitlement API (`GET /spaces/{id}/billing`) is both
+ * authenticated and per-space — a visitor who hasn't signed up has no space to
+ * read entitlements from. Change the two together: the PHP decides what a
+ * customer gets, this decides what we advertise, and they must not disagree.
+ *
+ * Prices mirror `app.plan_price_*_cents` in `api/config/services.yaml` and must
+ * match the configured Stripe Prices (STRIPE_PRICE_{PRO,BUSINESS}_{MONTHLY,YEARLY}).
+ * Annual bills at 10x the monthly rate, i.e. two months free.
+ */
+
+export const PLAN_KEYS = ["free", "pro", "business", "enterprise"] as const;
+export type PlanKey = (typeof PLAN_KEYS)[number];
+
+/** Feature flags, in `PlanCatalog::FEATURES` order. */
+export const PLAN_FEATURES = [
+  "calendar_sync",
+  "time_tracking",
+  "invoicing",
+  "timeline",
+  "automations",
+  "reporting",
+  "portfolios",
+  "goals",
+  "sso",
+  "webhooks",
+  "scim",
+  "audit_export",
+  "private_spaces",
+  "guests",
+  "priority_support",
+  "ai_assist",
+  "data_residency",
+] as const;
+export type PlanFeature = (typeof PLAN_FEATURES)[number];
+
+/** Numeric limits, in `PlanCatalog::LIMITS` order. */
+export const PLAN_LIMITS = [
+  "space_members",
+  "storage_gb",
+  "history_days",
+  "mcp_calls_per_day",
+  "ai_credits_per_month",
+] as const;
+export type PlanLimit = (typeof PLAN_LIMITS)[number];
+
+export interface PlanEntitlements {
+  features: Record<PlanFeature, boolean>;
+  /** null = unlimited (matching `PlanEntitlements::isUnlimited`). */
+  limits: Record<PlanLimit, number | null>;
+}
+
+/**
+ * Build a full feature map from a base of all-false, flipping the named flags
+ * on — the same shape as `PlanCatalog::features()`, so each plan below lists
+ * only what it adds and a missing flag can't silently read as granted.
+ */
+const featureSet = (...granted: PlanFeature[]): Record<PlanFeature, boolean> =>
+  Object.fromEntries(
+    PLAN_FEATURES.map((feature) => [feature, granted.includes(feature)]),
+  ) as Record<PlanFeature, boolean>;
+
+export const PLAN_ENTITLEMENTS: Record<PlanKey, PlanEntitlements> = {
+  free: {
+    features: featureSet("time_tracking"),
+    limits: {
+      space_members: 5,
+      storage_gb: 2,
+      history_days: 30,
+      mcp_calls_per_day: 100,
+      ai_credits_per_month: 0,
+    },
+  },
+  pro: {
+    features: featureSet(
+      "calendar_sync",
+      "time_tracking",
+      "invoicing",
+      "timeline",
+      "guests",
+    ),
+    limits: {
+      space_members: null,
+      storage_gb: 100,
+      history_days: 365,
+      mcp_calls_per_day: 1000,
+      ai_credits_per_month: 0,
+    },
+  },
+  business: {
+    features: featureSet(
+      "calendar_sync",
+      "time_tracking",
+      "invoicing",
+      "timeline",
+      "automations",
+      "reporting",
+      "portfolios",
+      "goals",
+      "sso",
+      "webhooks",
+      "private_spaces",
+      "guests",
+      "priority_support",
+      "ai_assist",
+    ),
+    limits: {
+      space_members: null,
+      storage_gb: null,
+      history_days: null,
+      mcp_calls_per_day: null,
+      ai_credits_per_month: 2000,
+    },
+  },
+  enterprise: {
+    features: featureSet(
+      "calendar_sync",
+      "time_tracking",
+      "invoicing",
+      "timeline",
+      "automations",
+      "reporting",
+      "portfolios",
+      "goals",
+      "sso",
+      "webhooks",
+      "scim",
+      "audit_export",
+      "private_spaces",
+      "guests",
+      "priority_support",
+      "ai_assist",
+      "data_residency",
+    ),
+    limits: {
+      space_members: null,
+      storage_gb: null,
+      history_days: null,
+      mcp_calls_per_day: null,
+      ai_credits_per_month: 10000,
+    },
+  },
+};
+
+/* -------------------------------------------------------------------------- */
+/* Pricing                                                                     */
+/* -------------------------------------------------------------------------- */
+
+/** Annual plans are billed at ten months' rate — the "2 months free" claim. */
+export const ANNUAL_MONTHS_CHARGED = 10;
+
+export interface PlanTier {
+  key: PlanKey;
+  name: string;
+  tagline: string;
+  /** Monthly list price in cents; null = sales-led / custom. */
+  monthlyCents: number | null;
+  /** Charged per member of the account, rather than a flat account price. */
+  perSeat: boolean;
+  highlighted?: boolean;
+  cta: { label: string; href: string };
+  /** Card bullets — the headline story. The table carries the full matrix. */
+  highlights: string[];
+}
+
+export const PLAN_TIERS: PlanTier[] = [
+  {
+    key: "free",
+    name: "Free",
+    tagline: "For individuals and trying things out.",
+    monthlyCents: 0,
+    perSeat: false,
+    cta: { label: "Get started", href: "/signup" },
+    highlights: [
+      "Unlimited personal tasks, boards & pages",
+      "Up to 5 members per shared space",
+      "Time tracking & 100 API calls a day",
+      "2 GB of file storage",
+    ],
+  },
+  {
+    key: "pro",
+    name: "Pro",
+    tagline: "For power users who want more room.",
+    monthlyCents: 1000,
+    perSeat: false,
+    cta: { label: "Start Pro", href: "/signup" },
+    highlights: [
+      "Everything in Free",
+      "Unlimited members in your spaces",
+      "Calendar sync, timeline & invoicing",
+      "100 GB storage and 10x the API limit",
+    ],
+  },
+  {
+    key: "business",
+    name: "Business",
+    tagline: "For teams that collaborate in shared spaces.",
+    monthlyCents: 1500,
+    perSeat: true,
+    highlighted: true,
+    cta: { label: "Start Business", href: "/signup" },
+    highlights: [
+      "Everything in Pro",
+      "Unlimited storage, history & API usage",
+      "Automations, reporting, goals & portfolios",
+      "SSO, private spaces & priority support",
+    ],
+  },
+  {
+    key: "enterprise",
+    name: "Enterprise",
+    tagline: "For organizations with advanced needs.",
+    monthlyCents: null,
+    perSeat: true,
+    cta: { label: "Contact us", href: "/feedback" },
+    highlights: [
+      "Everything in Business",
+      "SCIM provisioning & audit log export",
+      "Data residency & custom terms",
+      "Dedicated onboarding and support",
+    ],
+  },
+];
+
+export interface PriceLabel {
+  /** Formatted amount, or "Custom" for a sales-led plan. */
+  amount: string;
+  /** "/seat" when charged per member, otherwise empty. */
+  unit: string;
+  /** "per month" / "per year" / "forever"; empty for a custom price. */
+  period: string;
+}
+
+export const formatUsd = (cents: number): string => {
+  const dollars = cents / 100;
+  return `$${Number.isInteger(dollars) ? dollars : dollars.toFixed(2)}`;
+};
+
+export const priceFor = (tier: PlanTier, annual: boolean): PriceLabel => {
+  if (tier.monthlyCents === null) return { amount: "Custom", unit: "", period: "" };
+  if (tier.monthlyCents === 0) return { amount: "$0", unit: "", period: "forever" };
+
+  const cents = annual
+    ? tier.monthlyCents * ANNUAL_MONTHS_CHARGED
+    : tier.monthlyCents;
+
+  return {
+    amount: formatUsd(cents),
+    unit: tier.perSeat ? "/seat" : "",
+    period: annual ? "per year" : "per month",
+  };
+};
+
+/* -------------------------------------------------------------------------- */
+/* Comparison table                                                            */
+/* -------------------------------------------------------------------------- */
+
+/** A cell: `true`/`false` renders as an icon, a string renders verbatim. */
+export type ComparisonValue = boolean | string;
+
+export interface ComparisonRow {
+  key: string;
+  label: string;
+  hint?: string;
+  values: Record<PlanKey, ComparisonValue>;
+}
+
+export interface ComparisonGroup {
+  title: string;
+  rows: ComparisonRow[];
+}
+
+const FEATURE_META: Record<PlanFeature, { label: string; hint?: string }> = {
+  calendar_sync: {
+    label: "Calendar sync",
+    hint: "Two-way sync with Google Calendar and Outlook",
+  },
+  time_tracking: { label: "Time tracking", hint: "Timers, timesheets and expenses" },
+  invoicing: { label: "Invoicing & estimates", hint: "Bill clients and take card payments" },
+  timeline: { label: "Timeline (Gantt)", hint: "Dependencies and critical path" },
+  automations: { label: "Board automations", hint: "When/if/then rules on a board" },
+  reporting: { label: "Reporting & dashboards" },
+  portfolios: { label: "Portfolios" },
+  goals: { label: "Goals" },
+  sso: { label: "SSO sign-in", hint: "Google and Microsoft single sign-on" },
+  webhooks: { label: "Webhooks" },
+  scim: { label: "SCIM provisioning" },
+  audit_export: { label: "Audit log export" },
+  private_spaces: { label: "Private spaces" },
+  guests: { label: "Free guest accounts", hint: "Read-only collaborators, never billed" },
+  priority_support: { label: "Priority support" },
+  ai_assist: { label: "AI assist" },
+  data_residency: { label: "Data residency" },
+};
+
+const LIMIT_META: Record<
+  PlanLimit,
+  { label: string; hint?: string; format: (value: number | null) => ComparisonValue }
+> = {
+  space_members: {
+    label: "Members per space",
+    format: (v) => (v === null ? "Unlimited" : `Up to ${v}`),
+  },
+  storage_gb: {
+    label: "File storage",
+    format: (v) => (v === null ? "Unlimited" : `${v} GB`),
+  },
+  history_days: {
+    label: "Activity history",
+    hint: "How far back the audit and activity feeds reach",
+    format: (v) => {
+      if (v === null) return "Unlimited";
+      return v >= 365 ? `${Math.round(v / 365)} year` : `${v} days`;
+    },
+  },
+  mcp_calls_per_day: {
+    label: "API & MCP calls",
+    hint: "Programmatic calls per user, per day. The app itself is never metered.",
+    format: (v) => (v === null ? "Unlimited" : `${v.toLocaleString("en-US")} / day`),
+  },
+  ai_credits_per_month: {
+    label: "AI credits",
+    // 0 is "none", not "unknown" — render it as a plain not-included dash.
+    format: (v) =>
+      v === null ? "Unlimited" : v === 0 ? false : `${v.toLocaleString("en-US")} / month`,
+  },
+};
+
+const featureRow = (feature: PlanFeature): ComparisonRow => ({
+  key: feature,
+  ...FEATURE_META[feature],
+  values: Object.fromEntries(
+    PLAN_KEYS.map((plan) => [plan, PLAN_ENTITLEMENTS[plan].features[feature]]),
+  ) as Record<PlanKey, ComparisonValue>,
+});
+
+const limitRow = (limit: PlanLimit): ComparisonRow => ({
+  key: limit,
+  label: LIMIT_META[limit].label,
+  hint: LIMIT_META[limit].hint,
+  values: Object.fromEntries(
+    PLAN_KEYS.map((plan) => [
+      plan,
+      LIMIT_META[limit].format(PLAN_ENTITLEMENTS[plan].limits[limit]),
+    ]),
+  ) as Record<PlanKey, ComparisonValue>,
+});
+
+/** A capability every plan includes — the baseline product, not a paid gate. */
+const includedRow = (key: string, label: string, hint?: string): ComparisonRow => ({
+  key,
+  label,
+  hint,
+  values: Object.fromEntries(PLAN_KEYS.map((plan) => [plan, true])) as Record<
+    PlanKey,
+    ComparisonValue
+  >,
+});
+
+export const COMPARISON_GROUPS: ComparisonGroup[] = [
+  {
+    title: "The workspace",
+    rows: [
+      includedRow("core_content", "Tasks, boards & pages"),
+      includedRow("views", "List, board, calendar & search views"),
+      includedRow("collaboration", "Comments, @mentions & notifications"),
+      includedRow("custom_fields", "Custom fields & tags"),
+      includedRow("api_access", "REST API & MCP access", "Bring your own AI agent"),
+    ],
+  },
+  {
+    title: "Limits",
+    rows: PLAN_LIMITS.map(limitRow),
+  },
+  {
+    title: "Planning & delivery",
+    rows: [
+      featureRow("timeline"),
+      featureRow("automations"),
+      featureRow("portfolios"),
+      featureRow("goals"),
+      featureRow("reporting"),
+    ],
+  },
+  {
+    title: "Time & billing",
+    rows: [featureRow("time_tracking"), featureRow("invoicing")],
+  },
+  {
+    title: "Integrations",
+    rows: [featureRow("calendar_sync"), featureRow("webhooks"), featureRow("ai_assist")],
+  },
+  {
+    title: "Administration & security",
+    rows: [
+      featureRow("private_spaces"),
+      featureRow("guests"),
+      featureRow("sso"),
+      featureRow("scim"),
+      featureRow("audit_export"),
+      featureRow("data_residency"),
+    ],
+  },
+  {
+    title: "Support",
+    rows: [featureRow("priority_support")],
+  },
+];

--- a/pwa/pages/pricing.tsx
+++ b/pwa/pages/pricing.tsx
@@ -1,107 +1,73 @@
 import { useState } from "react";
 import Head from "next/head";
 import Link from "next/link";
-import { Check } from "lucide-react";
+import { Check, Minus } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { cn } from "@/lib/utils";
 import { pageTitle } from "@/lib/pageTitle";
+import {
+  COMPARISON_GROUPS,
+  PLAN_KEYS,
+  PLAN_TIERS,
+  priceFor,
+  type ComparisonValue,
+  type PlanKey,
+  type PlanTier,
+} from "@/lib/planTiers";
 
 /**
- * Public pricing page.
+ * Public plans & pricing page.
  *
- * Prices: Pro $10/mo (flat), Business $15/mo per seat; annual = ×10 (2 months
- * free). These must match the Stripe Prices
- * (STRIPE_PRICE_{PRO,BUSINESS}_{MONTHLY,YEARLY}) — update both together. Free-tier
- * limits mirror the app.free_* backend defaults (member cap 5, 100 MCP calls/day).
+ * Both the cards and the comparison table read from `@/lib/planTiers`, which
+ * mirrors `App\Billing\PlanCatalog` — so what we advertise here can't drift
+ * from what the server actually grants. Edit the matrix, not this file, to
+ * change a plan's contents.
  */
 
-interface Tier {
-  name: string;
-  tagline: string;
-  /** Monthly price in whole currency units; null = custom / contact us. */
-  monthly: number | null;
-  /** Whether the price is charged per seat (vs a flat account price). */
-  perSeat?: boolean;
-  cta: { label: string; href: string };
-  highlighted?: boolean;
-  features: string[];
-}
+const TIER_BY_KEY = new Map<PlanKey, PlanTier>(
+  PLAN_TIERS.map((tier) => [tier.key, tier]),
+);
 
-const TIERS: Tier[] = [
-  {
-    name: "Free",
-    tagline: "For individuals and trying things out.",
-    monthly: 0,
-    cta: { label: "Get started", href: "/signup" },
-    features: [
-      "Unlimited personal tasks, boards & pages",
-      "Up to 5 members per shared space",
-      "100 MCP (programmatic API) calls per day",
-      "Calendar & file attachments",
-    ],
-  },
-  {
-    name: "Pro",
-    tagline: "For power users who want more room.",
-    monthly: 10,
-    cta: { label: "Start Pro", href: "/signup" },
-    features: [
-      "Everything in Free",
-      "Higher MCP / API limits",
-      "Calendar sync (Google & Microsoft)",
-      "Priority email support",
-    ],
-  },
-  {
-    name: "Business",
-    tagline: "For teams that collaborate in shared spaces.",
-    monthly: 15,
-    perSeat: true,
-    highlighted: true,
-    cta: { label: "Start Business", href: "/signup" },
-    features: [
-      "Everything in Pro",
-      "Unlimited members & unlimited MCP usage",
-      "Custom roles & per-space permissions",
-      "SSO sign-in, automations & AI assist",
-    ],
-  },
-  {
-    name: "Enterprise",
-    tagline: "For organizations with advanced needs.",
-    monthly: null,
-    cta: { label: "Contact us", href: "/feedback" },
-    features: [
-      "Everything in Business",
-      "SCIM provisioning & advanced controls",
-      "Dedicated onboarding & support",
-      "Custom terms & invoicing",
-    ],
-  },
-];
+/**
+ * Render one comparison cell. Booleans become icons carrying an `sr-only`
+ * word, because a bare ✓/✗ glyph tells a screen-reader user nothing about
+ * which plan column it sits in once the row label is read separately.
+ */
+const ValueCell = ({ value }: { value: ComparisonValue }) => {
+  if (typeof value === "string") {
+    return <span className="text-sm text-foreground">{value}</span>;
+  }
+
+  return value ? (
+    <>
+      <Check aria-hidden="true" className="mx-auto h-4 w-4 text-emerald-600" />
+      <span className="sr-only">Included</span>
+    </>
+  ) : (
+    <>
+      <Minus aria-hidden="true" className="mx-auto h-4 w-4 text-muted-foreground/50" />
+      <span className="sr-only">Not included</span>
+    </>
+  );
+};
 
 const Pricing = () => {
   const [annual, setAnnual] = useState(false);
 
-  const priceLabel = (tier: Tier): { amount: string; period: string } => {
-    if (tier.monthly === null) return { amount: "Custom", period: "" };
-    if (tier.monthly === 0) return { amount: "$0", period: "forever" };
-    // Annual billed at 10× the monthly rate → two months free.
-    const amount = annual ? tier.monthly * 10 : tier.monthly;
-    const unit = tier.perSeat ? "/seat" : "";
-    return {
-      amount: `$${amount}${unit}`,
-      period: annual ? "per year" : "per month",
-    };
-  };
-
   return (
     <>
       <Head>
-        <title>{pageTitle("Pricing")}</title>
+        <title>{pageTitle("Plans & pricing")}</title>
         <meta
           name="description"
-          content="Madori pricing — a free plan for individuals, plus Pro, Business, and Enterprise tiers for teams."
+          content="Madori plans and pricing — a free plan for individuals, plus Pro, Business, and Enterprise tiers for teams. Compare features, limits, and costs side by side."
         />
       </Head>
 
@@ -109,7 +75,7 @@ const Pricing = () => {
         <div className="max-w-6xl mx-auto px-4 py-12 md:py-16">
           <header className="text-center mb-10">
             <h1 className="text-3xl md:text-4xl font-bold tracking-tight text-foreground mb-3">
-              Simple, transparent pricing
+              Plans &amp; pricing
             </h1>
             <p className="text-muted-foreground max-w-2xl mx-auto">
               Start free and upgrade when your team grows. Every plan includes
@@ -146,17 +112,24 @@ const Pricing = () => {
                 aria-pressed={annual}
               >
                 Annual
-                <span className="ml-1.5 text-xs text-emerald-600">2 months free</span>
+                <span
+                  className={cn(
+                    "ml-1.5 text-xs",
+                    annual ? "text-primary-foreground/80" : "text-emerald-600",
+                  )}
+                >
+                  2 months free
+                </span>
               </button>
             </div>
           </div>
 
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">
-            {TIERS.map((tier) => {
-              const { amount, period } = priceLabel(tier);
+            {PLAN_TIERS.map((tier) => {
+              const { amount, unit, period } = priceFor(tier, annual);
               return (
                 <div
-                  key={tier.name}
+                  key={tier.key}
                   className={cn(
                     "flex flex-col rounded-xl border bg-card p-6 shadow-sm",
                     tier.highlighted
@@ -170,9 +143,18 @@ const Pricing = () => {
                     </span>
                   ) : null}
                   <h2 className="text-lg font-semibold text-foreground">{tier.name}</h2>
-                  <p className="mt-1 text-sm text-muted-foreground min-h-10">{tier.tagline}</p>
+                  <p className="mt-1 text-sm text-muted-foreground min-h-10">
+                    {tier.tagline}
+                  </p>
                   <div className="mt-4 flex items-baseline gap-1">
-                    <span className="text-3xl font-bold text-foreground">{amount}</span>
+                    <span className="text-3xl font-bold text-foreground">
+                      {amount}
+                      {unit ? (
+                        <span className="text-base font-medium text-muted-foreground">
+                          {unit}
+                        </span>
+                      ) : null}
+                    </span>
                     {period ? (
                       <span className="text-sm text-muted-foreground">{period}</span>
                     ) : null}
@@ -185,9 +167,12 @@ const Pricing = () => {
                     <Link href={tier.cta.href}>{tier.cta.label}</Link>
                   </Button>
                   <ul className="mt-6 space-y-2.5 text-sm">
-                    {tier.features.map((feature) => (
+                    {tier.highlights.map((feature) => (
                       <li key={feature} className="flex items-start gap-2">
-                        <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600" />
+                        <Check
+                          aria-hidden="true"
+                          className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600"
+                        />
                         <span className="text-muted-foreground">{feature}</span>
                       </li>
                     ))}
@@ -197,13 +182,113 @@ const Pricing = () => {
             })}
           </div>
 
+          {/* Full comparison */}
+          <section className="mt-16" aria-labelledby="compare-heading">
+            <h2
+              id="compare-heading"
+              className="text-2xl font-bold tracking-tight text-foreground text-center"
+            >
+              Compare every plan
+            </h2>
+            <p className="mt-2 mb-8 text-center text-sm text-muted-foreground">
+              Everything each plan includes, side by side.
+            </p>
+
+            <div className="rounded-xl border border-border bg-card">
+              <Table
+                scrollRegionLabel="Plan comparison"
+                className="min-w-[46rem] border-separate border-spacing-0"
+              >
+                <TableHeader>
+                  <TableRow className="hover:bg-transparent">
+                    {/* Sticky so the row label stays put while the plan
+                        columns scroll sideways on a narrow screen. */}
+                    <TableHead className="sticky left-0 z-10 bg-card w-[38%] px-4 normal-case tracking-normal text-sm font-semibold text-foreground">
+                      Feature
+                    </TableHead>
+                    {PLAN_KEYS.map((key) => {
+                      const tier = TIER_BY_KEY.get(key);
+                      if (!tier) return null;
+                      const { amount, unit, period } = priceFor(tier, annual);
+                      return (
+                        <TableHead
+                          key={key}
+                          scope="col"
+                          className={cn(
+                            "px-4 py-3 text-center normal-case tracking-normal align-top",
+                            tier.highlighted && "bg-primary/5",
+                          )}
+                        >
+                          <span className="block text-sm font-semibold text-foreground">
+                            {tier.name}
+                          </span>
+                          <span className="mt-0.5 block text-xs font-normal text-muted-foreground">
+                            {amount}
+                            {unit}
+                            {period ? ` ${period}` : ""}
+                          </span>
+                        </TableHead>
+                      );
+                    })}
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {/* flatMap, not a fragment per group: the rows must stay
+                      direct <tbody> children for the Table primitive's
+                      last-child border rules to apply. */}
+                  {COMPARISON_GROUPS.flatMap((group) => [
+                    <TableRow key={`${group.title}-header`} className="hover:bg-transparent">
+                      <th
+                        scope="colgroup"
+                        colSpan={PLAN_KEYS.length + 1}
+                        className="sticky left-0 bg-muted/50 px-4 py-2 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground"
+                      >
+                        {group.title}
+                      </th>
+                    </TableRow>,
+                    ...group.rows.map((row) => (
+                      <TableRow key={`${group.title}-${row.key}`}>
+                        <th
+                          scope="row"
+                          className="sticky left-0 z-10 bg-card px-4 py-2.5 text-left align-middle font-normal"
+                        >
+                          <span className="block text-sm text-foreground">{row.label}</span>
+                          {row.hint ? (
+                            <span className="block text-xs text-muted-foreground">
+                              {row.hint}
+                            </span>
+                          ) : null}
+                        </th>
+                        {PLAN_KEYS.map((key) => (
+                          <td
+                            key={key}
+                            className={cn(
+                              "px-4 py-2.5 text-center align-middle",
+                              TIER_BY_KEY.get(key)?.highlighted && "bg-primary/5",
+                            )}
+                          >
+                            <ValueCell value={row.values[key]} />
+                          </td>
+                        ))}
+                      </TableRow>
+                    )),
+                  ])}
+                </TableBody>
+              </Table>
+            </div>
+          </section>
+
           <p className="mt-10 text-center text-sm text-muted-foreground">
-            Prices in USD. Business is billed per seat. Questions?{" "}
+            Prices in USD, excluding any applicable tax. Business and Enterprise
+            are billed per seat; guests are always free. Questions?{" "}
             <Link href="/faq" className="underline underline-offset-4 hover:text-foreground">
               Read the FAQ
             </Link>{" "}
             or{" "}
-            <Link href="/feedback" className="underline underline-offset-4 hover:text-foreground">
+            <Link
+              href="/feedback"
+              className="underline underline-offset-4 hover:text-foreground"
+            >
               get in touch
             </Link>
             .

--- a/pwa/vitest.config.ts
+++ b/pwa/vitest.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
         "lib/notificationPrefs.ts",
         "lib/notificationTypes.ts",
         "lib/passwordStrength.ts",
+        "lib/planTiers.ts",
         "lib/relativeTime.ts",
         "lib/searchQuery.ts",
         "lib/userDisplay.ts",


### PR DESCRIPTION
## Description

`/pricing` listed four tier cards with hand-written bullets and no way to compare plans side by side. The bullets had also drifted from what the server actually grants — Pro advertised "Priority email support", a feature `PlanCatalog` gives only to Business and above.

This extracts the tier matrix into `pwa/lib/planTiers.ts`, mirroring `App\Billing\PlanCatalog` (features, limits, prices), and drives both the cards and a new full comparison table from it.

**Why a copy of the matrix rather than reading the API:** `/pricing` is public, while the entitlement API (`GET /spaces/{id}/billing`) is authenticated and per-space — a visitor who hasn't signed up has no space to read entitlements from. The new file documents that contract at the top so the PHP and the marketing copy are changed together; the PHP stays the source of truth for what a customer actually gets.

The table renders 27 rows under seven headings (The workspace · Limits · Planning & delivery · Time & billing · Integrations · Administration & security · Support):

- booleans render as icons carrying an `sr-only` word — a bare ✓/– glyph tells a screen-reader user nothing once the row label is read separately;
- the label column is pinned (`sticky left-0`) so the four plan columns scroll on a phone, using the `Table` primitive's existing keyboard-accessible scroll region and shadow cue;
- a zero AI-credit allowance renders as a dash rather than "0 / month", which reads as a broken value;
- the monthly/annual toggle reprices the table's column headers along with the cards.

One behavioural fix falls out of sourcing from the catalog: the Pro card no longer promises priority support.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation

## Component

- [x] PWA (Next.js)
- [x] E2E Tests
- [ ] API (PHP/Symfony)
- [ ] Infrastructure (Docker/Helm)
- [ ] Documentation

## How Has This Been Tested?

- `pnpm test` — 189 passing across 21 files, including 15 new cases in `lib/planTiers.test.ts`.
- `pnpm test:coverage` — passes the gate; `planTiers.ts` is 100% lines/statements/functions, 96% branches.
- `pnpm typecheck` — clean. `pnpm lint` — 0 errors (the 23 warnings are pre-existing, in unrelated files).
- New `e2e/tests/pricing.spec.js` (2 tests) run against the page and pass.
- Rendered and screenshotted at 1280px and 390px, and stepped through the annual toggle: Pro $10/mo → $100/yr and Business $15/seat/mo → $150/seat/yr propagate to both the cards and the table header.

The unit tests pin the properties that matter rather than restating the data: every catalog feature and limit has a table row (so mirroring a new flag without advertising it fails), no plan drops a feature or lowers a limit as it gets more expensive (the "Everything in Pro" claim, asserted), and annual bills at ten months so "2 months free" holds.

## Checklist

- [x] My code follows the project's conventions
- [x] I have added tests that prove my fix or feature works
- [x] New and existing tests pass locally (`pnpm test:coverage`)
- [x] New pure-logic helpers under `pwa/lib` are added to the coverage allowlist in `pwa/vitest.config.ts`
- [x] I have updated documentation if needed — no doc changes; the matrix's mirror contract is documented in the file header

## Note for reviewers

The one thing worth a careful look is the matrix in `pwa/lib/planTiers.ts` against `api/src/Billing/PlanCatalog.php` — I transcribed all 17 features × 4 plans and all 5 limits, and the tests check the matrix's internal consistency but cannot check it against the PHP across the language boundary. The prices ($10 Pro flat, $15/seat Business) match `app.plan_price_*_cents`, but I could not verify them against the live Stripe Prices from here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MULWhP5njMy6SMGTKVnCUQ)_