### PR TITLE
feat(billing): Phase 2 step 1 — personal organizations + space backfill

### DIFF
--- a/api/migrations/Version20260809090000.php
+++ b/api/migrations/Version20260809090000.php
@@ -36,11 +36,21 @@ final class Version20260809090000 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE organization ADD is_personal BOOLEAN DEFAULT FALSE NOT NULL');
-        $this->addSql(
-            'CREATE UNIQUE INDEX uniq_organization_personal_per_user'
-            . ' ON organization (created_by_id) WHERE (is_personal = true)',
-        );
+        // Added nullable → filled → made NOT NULL, rather than with a DEFAULT.
+        // The entity maps a plain `bool` with no column default, and a lingering
+        // server default is exactly the kind of drift doctrine:schema:validate
+        // fails on.
+        $this->addSql('ALTER TABLE organization ADD is_personal BOOLEAN');
+        $this->addSql('UPDATE organization SET is_personal = FALSE WHERE is_personal IS NULL');
+        $this->addSql('ALTER TABLE organization ALTER COLUMN is_personal SET NOT NULL');
+
+        // Matches the formatting of `uniq_space_personal_per_user` so the two
+        // partial indexes normalise identically in pg_indexes.
+        $this->addSql(<<<'SQL'
+            CREATE UNIQUE INDEX uniq_organization_personal_per_user
+            ON organization (created_by_id)
+            WHERE is_personal = TRUE
+        SQL);
 
         // One personal organization per user who doesn't already have one.
         //

--- a/api/migrations/Version20260809090000.php
+++ b/api/migrations/Version20260809090000.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Phase 2, step 1: give every user a personal organization and put every
+ * account-less space inside one.
+ *
+ * **Behaviour-neutral by design.** `space.organization_id` stays nullable and
+ * `PlanGate` still resolves through its existing fallback chain, so nothing
+ * reads differently the moment this runs. The point is to get the backfill
+ * verified in production *before* anything depends on it — the NOT NULL
+ * constraint and the code deletions come in a later step, and those are the
+ * one-way ones.
+ *
+ * Every space must land in the right account: a space attached to the wrong
+ * organization is either invisible to its members or visible to strangers.
+ * The rule is deliberately the narrowest one that can't be wrong — a space with
+ * no organization belongs to whoever created it, which is exactly what
+ * `SpaceCreateProcessor` meant when it left the column null.
+ *
+ * Idempotent: re-running creates no duplicate organizations (guarded by the
+ * partial unique index and a NOT EXISTS) and moves no space twice.
+ */
+final class Version20260809090000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Phase 2 step 1: personal organizations + backfill space.organization_id (behaviour-neutral).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE organization ADD is_personal BOOLEAN DEFAULT FALSE NOT NULL');
+        $this->addSql(
+            'CREATE UNIQUE INDEX uniq_organization_personal_per_user'
+            . ' ON organization (created_by_id) WHERE (is_personal = true)',
+        );
+
+        // One personal organization per user who doesn't already have one.
+        //
+        // The slug has to be unique and stable. `o-<email local part>` is the
+        // readable choice, but two users can share a local part across domains,
+        // so collisions fall back to a suffix from the user id — deterministic,
+        // and it can't collide again on a re-run.
+        $this->addSql(<<<'SQL'
+            INSERT INTO organization (id, name, slug, is_personal, created_by_id, created_at, updated_at)
+            SELECT
+                gen_random_uuid(),
+                COALESCE(NULLIF(TRIM(u.given_name || ' ' || u.family_name), ''), SPLIT_PART(u.email, '@', 1)),
+                'o-' || candidate.slug_base ||
+                    CASE WHEN EXISTS (
+                        SELECT 1 FROM organization o2 WHERE o2.slug = 'o-' || candidate.slug_base
+                    ) THEN '-' || SUBSTRING(REPLACE(u.id::text, '-', '') FROM 1 FOR 8) ELSE '' END,
+                TRUE,
+                u.id,
+                NOW(),
+                NOW()
+            FROM "user" u
+            CROSS JOIN LATERAL (
+                SELECT COALESCE(
+                    NULLIF(TRIM(BOTH '-' FROM REGEXP_REPLACE(LOWER(SPLIT_PART(u.email, '@', 1)), '[^a-z0-9]+', '-', 'g')), ''),
+                    'user'
+                ) AS slug_base
+            ) candidate
+            WHERE NOT EXISTS (
+                SELECT 1 FROM organization o
+                WHERE o.created_by_id = u.id AND o.is_personal = TRUE
+            )
+            SQL);
+
+        // The creator is the owner of their own account, so every "does this org
+        // have an owner?" invariant holds for personal ones too.
+        $this->addSql(<<<'SQL'
+            INSERT INTO organization_membership (id, organization_id, user_id, role, joined_at)
+            SELECT gen_random_uuid(), o.id, o.created_by_id, 'owner', NOW()
+            FROM organization o
+            WHERE o.is_personal = TRUE
+              AND NOT EXISTS (
+                  SELECT 1 FROM organization_membership m
+                  WHERE m.organization_id = o.id AND m.user_id = o.created_by_id
+              )
+            SQL);
+
+        // Every account-less space joins its creator's personal organization.
+        $this->addSql(<<<'SQL'
+            UPDATE space s
+            SET organization_id = o.id
+            FROM organization o
+            WHERE s.organization_id IS NULL
+              AND o.is_personal = TRUE
+              AND o.created_by_id = s.created_by_id
+            SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Detach only the spaces this migration attached — a space that was
+        // already in an organization must keep it.
+        $this->addSql(<<<'SQL'
+            UPDATE space s
+            SET organization_id = NULL
+            FROM organization o
+            WHERE s.organization_id = o.id AND o.is_personal = TRUE
+            SQL);
+        $this->addSql('DELETE FROM organization_membership WHERE organization_id IN'
+            . ' (SELECT id FROM organization WHERE is_personal = TRUE)');
+        $this->addSql('DELETE FROM organization WHERE is_personal = TRUE');
+        $this->addSql('DROP INDEX uniq_organization_personal_per_user');
+        $this->addSql('ALTER TABLE organization DROP is_personal');
+    }
+}

--- a/api/src/Controller/AdminDeletionController.php
+++ b/api/src/Controller/AdminDeletionController.php
@@ -168,9 +168,13 @@ class AdminDeletionController extends AbstractController
         }
         $entity = $this->em->getRepository($class)->find($targetId);
 
-        // A personal space is an artefact of its owner's account, not a thing
-        // with an independent existence — it goes when the account does.
+        // A personal space or personal organization is an artefact of its
+        // owner's account, not a thing with independent existence — both go
+        // when the account does. Delete the account instead.
         if ($entity instanceof Space && $entity->getIsPersonal()) {
+            return null;
+        }
+        if ($entity instanceof Organization && $entity->getIsPersonal()) {
             return null;
         }
 

--- a/api/src/Controller/OrganizationDeletionController.php
+++ b/api/src/Controller/OrganizationDeletionController.php
@@ -61,6 +61,15 @@ class OrganizationDeletionController extends AbstractController
         if ($org->isDeleted()) {
             return $this->json(['error' => 'This organization is already scheduled for deletion.'], 409);
         }
+        // A personal organization is the user's own account — it exists only to
+        // own their spaces and hold their plan, and goes when the account does.
+        // Deleting it on its own would strand their personal space.
+        if ($org->getIsPersonal()) {
+            return $this->json([
+                'error' => 'Your personal organization goes with your account. '
+                    . 'Delete the account from Settings → Danger zone instead.',
+            ], 409);
+        }
 
         $body = $this->body($request);
 

--- a/api/src/Entity/Organization.php
+++ b/api/src/Entity/Organization.php
@@ -53,6 +53,14 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ORM\Table(name: 'organization')]
 #[ORM\UniqueConstraint(name: 'uniq_organization_slug', columns: ['slug'])]
 #[ORM\Index(columns: ['purge_after'], name: 'idx_organization_purge_after')]
+// One personal organization per user, enforced at the DB rather than in code:
+// a duplicate would give someone two personal accounts and two places a plan
+// could live. Mirrors `uniq_space_personal_per_user`.
+#[ORM\UniqueConstraint(
+    name: 'uniq_organization_personal_per_user',
+    columns: ['created_by_id'],
+    options: ['where' => '(is_personal = true)'],
+)]
 class Organization implements SoftDeletable
 {
     /**
@@ -108,6 +116,20 @@ class Organization implements SoftDeletable
     #[Groups(['organization:read'])]
     private string $slug = '';
 
+    /**
+     * A user's own account, provisioned at signup and owning their personal
+     * space (#billing Phase 2). Exactly the role a GitHub personal account
+     * plays: it holds a plan and owns spaces, so nothing in the model has to
+     * special-case "a space with no account behind it".
+     *
+     * Non-deletable and non-leavable — it goes only when its owner's account
+     * does. Server-written: never in `organization:write`, so it can't be set
+     * or cleared through the API.
+     */
+    #[ORM\Column]
+    #[Groups(['organization:read'])]
+    private bool $isPersonal = false;
+
     #[ORM\ManyToOne(targetEntity: User::class)]
     #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
     #[Groups(['organization:read'])]
@@ -154,6 +176,18 @@ class Organization implements SoftDeletable
     public function getSlug(): string
     {
         return $this->slug;
+    }
+
+    public function getIsPersonal(): bool
+    {
+        return $this->isPersonal;
+    }
+
+    public function setIsPersonal(bool $isPersonal): static
+    {
+        $this->isPersonal = $isPersonal;
+
+        return $this;
     }
 
     public function setSlug(string $slug): static

--- a/api/src/Repository/OrganizationRepository.php
+++ b/api/src/Repository/OrganizationRepository.php
@@ -45,6 +45,17 @@ final class OrganizationRepository extends ServiceEntityRepository
      *
      * @return list<Organization>
      */
+    /**
+     * The user's personal organization — their own account. At most one exists;
+     * the partial unique index `uniq_organization_personal_per_user` guarantees
+     * it, and we still take the first hit defensively in case that index is
+     * ever dropped in a migration.
+     */
+    public function findPersonalFor(User $user): ?Organization
+    {
+        return $this->findOneBy(['createdBy' => $user, 'isPersonal' => true]);
+    }
+
     public function findDueForPurge(\DateTimeImmutable $now, int $limit = 50): array
     {
         /** @var list<Organization> $orgs */

--- a/api/src/Repository/OrganizationRepository.php
+++ b/api/src/Repository/OrganizationRepository.php
@@ -39,13 +39,6 @@ final class OrganizationRepository extends ServiceEntityRepository
     }
 
     /**
-     * Soft-deleted organizations whose grace period has lapsed, so the purge
-     * may hard-delete them. Ordered oldest-first so a backlog drains in the
-     * order the deletions were requested.
-     *
-     * @return list<Organization>
-     */
-    /**
      * The user's personal organization — their own account. At most one exists;
      * the partial unique index `uniq_organization_personal_per_user` guarantees
      * it, and we still take the first hit defensively in case that index is
@@ -56,6 +49,13 @@ final class OrganizationRepository extends ServiceEntityRepository
         return $this->findOneBy(['createdBy' => $user, 'isPersonal' => true]);
     }
 
+    /**
+     * Soft-deleted organizations whose grace period has lapsed, so the purge
+     * may hard-delete them. Ordered oldest-first so a backlog drains in the
+     * order the deletions were requested.
+     *
+     * @return list<Organization>
+     */
     public function findDueForPurge(\DateTimeImmutable $now, int $limit = 50): array
     {
         /** @var list<Organization> $orgs */

--- a/api/src/Service/AccountDeletionService.php
+++ b/api/src/Service/AccountDeletionService.php
@@ -7,6 +7,7 @@ namespace App\Service;
 use App\Entity\Comment;
 use App\Entity\Feedback;
 use App\Entity\MediaObject;
+use App\Entity\Organization;
 use App\Entity\Page;
 use App\Entity\Board;
 use App\Entity\Space;
@@ -162,6 +163,7 @@ final class AccountDeletionService
             $this->reassign(MediaObject::class, 'owner', $user, $sentinel);
 
             $this->handleSpaces($user, $userId);
+            $this->handlePersonalOrganization($user);
 
             $managed = $this->em->find(User::class, $userId);
             if (null !== $managed) {
@@ -252,6 +254,24 @@ final class AccountDeletionService
             } else {
                 $this->em->remove($space);
             }
+        }
+    }
+
+    /**
+     * The user's personal organization is their own account — it exists only to
+     * own their spaces and hold their plan, so it goes with them (#billing
+     * Phase 2). Shared organizations they merely belonged to are untouched;
+     * their membership row clears via CASCADE, and the account itself outlives
+     * them.
+     */
+    private function handlePersonalOrganization(User $user): void
+    {
+        $personal = $this->em->getRepository(Organization::class)
+            ->findOneBy(['createdBy' => $user, 'isPersonal' => true]);
+        if (null !== $personal) {
+            // Any space still attached cascades away with it at the DB layer,
+            // which is what should happen — those are this user's own spaces.
+            $this->em->remove($personal);
         }
     }
 

--- a/api/src/Service/PersonalOrganizationProvisioner.php
+++ b/api/src/Service/PersonalOrganizationProvisioner.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\Organization;
+use App\Entity\User;
+use App\Repository\OrganizationRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Provisions a user's personal {@see Organization} — their own account, in the
+ * GitHub sense: it owns their personal space and can hold a plan.
+ *
+ * Phase 2 of the account model exists to delete the "a space might have no
+ * account behind it" branch from `SpaceCreateProcessor`, `SpaceMemberAdder`,
+ * the access extensions, and the three-way fallback in
+ * `SubscriptionRepository::findActiveForSpace()`. That is only possible if
+ * *every* user has an organization, which is what this guarantees.
+ *
+ * Deliberately **does not flush**: the caller provisions the org, the space and
+ * the membership in one transaction, so a half-failed signup can't leave a user
+ * with an account but no space, or a space with no account.
+ */
+final class PersonalOrganizationProvisioner
+{
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly OrganizationRepository $organizations,
+    ) {
+    }
+
+    /**
+     * The user's personal organization, creating it if absent. Idempotent, so
+     * the SSO and password signup paths can both call it without coordinating,
+     * and so a backfilled account isn't given a second one.
+     */
+    public function provision(User $user): Organization
+    {
+        $existing = $this->organizations->findPersonalFor($user);
+        if (null !== $existing) {
+            return $existing;
+        }
+
+        $organization = (new Organization())
+            ->setName($this->nameFor($user))
+            ->setSlug($this->uniqueSlugFor($user))
+            ->setIsPersonal(true)
+            ->setCreatedBy($user);
+        // Owner, so every invariant that asks "does this org have an owner?"
+        // holds for personal accounts too without a special case.
+        $organization->addMember($user, Organization::ROLE_OWNER);
+
+        $this->em->persist($organization);
+
+        return $organization;
+    }
+
+    /**
+     * Their display name, falling back to the local part of their email. Shown
+     * in the org switcher, so it should read as *them* rather than a slug.
+     */
+    private function nameFor(User $user): string
+    {
+        $name = trim($user->getGivenName() . ' ' . $user->getFamilyName());
+        if ('' !== $name) {
+            return $name;
+        }
+        $email = $user->getEmail();
+        $at = strpos($email, '@');
+
+        return false === $at ? $email : substr($email, 0, $at);
+    }
+
+    /**
+     * A stable `o-` slug derived from the email local part, with a numeric
+     * suffix on collision. Two people called `alex@` at different domains would
+     * otherwise fight over the same handle.
+     */
+    private function uniqueSlugFor(User $user): string
+    {
+        $email = $user->getEmail();
+        $at = strpos($email, '@');
+        $local = false === $at ? $email : substr($email, 0, $at);
+
+        $base = trim((string) preg_replace('/[^a-z0-9]+/', '-', strtolower($local)), '-');
+        if ('' === $base) {
+            $base = 'user';
+        }
+        $base = substr($base, 0, 60);
+
+        $slug = 'o-' . $base;
+        $suffix = 1;
+        while (null !== $this->organizations->findOneBy(['slug' => $slug])) {
+            ++$suffix;
+            $slug = 'o-' . $base . '-' . $suffix;
+        }
+
+        return $slug;
+    }
+}

--- a/api/src/Service/PersonalSpaceProvisioner.php
+++ b/api/src/Service/PersonalSpaceProvisioner.php
@@ -10,26 +10,36 @@ use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
 
 /**
- * Provisions a user's non-deletable personal "Private" space (#181): the space
- * row, the owner's admin membership, and the seeded built-in roles, flushed
- * together. Shared by the password signup processor and social sign-up
+ * Provisions a user's non-deletable personal "Private" space (#181): the
+ * personal organization that owns it, the space row, the owner's admin
+ * membership, and the seeded built-in roles — all flushed together. Shared by
+ * the password signup processor and social sign-up
  * ({@see \App\Controller\SsoController}) so both paths create an identical,
  * valid account.
+ *
+ * The organization is created here rather than by a separate caller precisely
+ * so it lands in the same flush: a user with a space but no account behind it
+ * is the state Phase 2 exists to make unrepresentable, and a half-failed signup
+ * is the easiest way to produce one.
  */
 final class PersonalSpaceProvisioner
 {
     public function __construct(
         private readonly EntityManagerInterface $em,
         private readonly SpaceRoleSeeder $roleSeeder,
+        private readonly PersonalOrganizationProvisioner $organizations,
     ) {
     }
 
     public function provision(User $user): void
     {
+        $organization = $this->organizations->provision($user);
+
         $space = (new Space())
             ->setName(Space::PERSONAL_SPACE_NAME)
             ->setIsPersonal(true)
             ->setVisibility(Space::VISIBILITY_PRIVATE)
+            ->setOrganization($organization)
             ->setCreatedBy($user);
 
         $membership = (new SpaceMembership())

--- a/api/src/State/SpaceCreateProcessor.php
+++ b/api/src/State/SpaceCreateProcessor.php
@@ -9,6 +9,7 @@ use App\Entity\Space;
 use App\Entity\SpaceMembership;
 use App\Entity\User;
 use App\Security\AuthenticatedUserResolver;
+use App\Service\PersonalOrganizationProvisioner;
 use App\Service\SpaceMemberAdder;
 use App\Service\SpaceRoleSeeder;
 use Doctrine\ORM\EntityManagerInterface;
@@ -45,6 +46,7 @@ final class SpaceCreateProcessor implements ProcessorInterface
         private EntityManagerInterface $em,
         private SpaceMemberAdder $memberAdder,
         private SpaceRoleSeeder $roleSeeder,
+        private PersonalOrganizationProvisioner $personalOrganizations,
     ) {
     }
 
@@ -59,8 +61,8 @@ final class SpaceCreateProcessor implements ProcessorInterface
         $data->setIsPersonal(false);
 
         // A space can be created under an organization (owner = that org) — the
-        // caller must be a non-guest member of it. Otherwise it's a personal
-        // space owned by the creator (organization stays null). #billing Phase 1
+        // caller must be a non-guest member of it. Otherwise it falls back to
+        // the creator's own personal organization (#billing Phase 2).
         $organization = $data->getOrganization();
         if (null !== $organization) {
             $role = $organization->roleFor($user);
@@ -73,6 +75,13 @@ final class SpaceCreateProcessor implements ProcessorInterface
             if ($organization->isDeleted()) {
                 throw new AccessDeniedHttpException('This organization is scheduled for deletion.');
             }
+        } else {
+            // No organization named: the space belongs to the creator's own
+            // account (#billing Phase 2). Previously this left `organization`
+            // null, which is the branch the whole phase exists to remove — every
+            // space now has an account behind it, so the plan that governs it is
+            // always a single lookup away.
+            $data->setOrganization($this->personalOrganizations->provision($user));
         }
 
         $membership = (new SpaceMembership())

--- a/api/tests/Api/PersonalOrganizationTest.php
+++ b/api/tests/Api/PersonalOrganizationTest.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Deletion\PurgeRunner;
+use App\Entity\Organization;
+use App\Entity\Space;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Phase 2 step 1: every user has a personal organization, and every space they
+ * create belongs to one.
+ *
+ * The invariant these pin is "no space exists without an account behind it".
+ * The column is still nullable at this step — the NOT NULL constraint lands
+ * later — so the tests assert the *behaviour* that makes that constraint safe
+ * to add rather than relying on the database to catch it.
+ */
+class PersonalOrganizationTest extends ApiTestCase
+{
+    private const PASSWORD = 'Password123!@#';
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $em = $kernel->getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+
+        $this->entityManager->createQuery('DELETE FROM App\Entity\OrganizationMembership')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Organization')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\SpaceMembership')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\SpaceRole')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\Space')->execute();
+        $this->entityManager->createQuery('DELETE FROM App\Entity\User')->execute();
+    }
+
+    public function testSignupProvisionsAPersonalOrganizationThatOwnsThePersonalSpace(): void
+    {
+        $client = static::createClient();
+        $client->request('POST', '/users', [
+            'json' => [
+                'email' => 'newbie@example.com',
+                'plainPassword' => self::PASSWORD,
+                'givenName' => 'New',
+                'familyName' => 'Bie',
+            ],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+
+        $em = $this->em();
+        $em->clear();
+        $user = $em->getRepository(User::class)->findOneBy(['email' => 'newbie@example.com']);
+        $this->assertNotNull($user);
+
+        $org = $em->getRepository(Organization::class)
+            ->findOneBy(['createdBy' => $user, 'isPersonal' => true]);
+        $this->assertNotNull($org, 'signup should provision a personal organization');
+        $this->assertTrue($org->isOwner($user), 'the user owns their own account');
+        $this->assertStringStartsWith('o-', $org->getSlug());
+
+        $personalSpace = $em->getRepository(Space::class)
+            ->findOneBy(['createdBy' => $user, 'isPersonal' => true]);
+        $this->assertNotNull($personalSpace);
+        $this->assertSame(
+            (string) $org->getId(),
+            (string) $personalSpace->getOrganization()?->getId(),
+            'the personal space must belong to the personal organization',
+        );
+    }
+
+    public function testSpaceCreatedWithoutAnOrganizationLandsInTheCreatorsOwn(): void
+    {
+        $user = $this->createUser('solo@example.com');
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        $body = $client->request('POST', '/spaces', [
+            'json' => ['name' => 'Side Project'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ])->toArray();
+        $this->assertResponseStatusCodeSame(201);
+
+        // The branch this phase exists to delete: a space with no account
+        // behind it. It should no longer be reachable.
+        $this->assertNotNull($body['organization'] ?? null, 'every space must have an organization');
+
+        $em = $this->em();
+        $em->clear();
+        $reloaded = $em->getRepository(Space::class)->findOneBy(['name' => 'Side Project']);
+        $this->assertNotNull($reloaded);
+        $org = $reloaded->getOrganization();
+        $this->assertNotNull($org);
+        $this->assertTrue($org->getIsPersonal());
+    }
+
+    public function testTheSamePersonalOrganizationIsReusedAcrossSpaces(): void
+    {
+        $user = $this->createUser('solo@example.com');
+        $client = static::createClient();
+        $client->loginUser($user);
+
+        foreach (['One', 'Two'] as $name) {
+            $client->request('POST', '/spaces', [
+                'json' => ['name' => $name],
+                'headers' => ['Content-Type' => 'application/ld+json'],
+            ]);
+            $this->assertResponseStatusCodeSame(201);
+        }
+
+        $em = $this->em();
+        $em->clear();
+        $reloadedUser = $em->getRepository(User::class)->findOneBy(['email' => 'solo@example.com']);
+        $this->assertNotNull($reloadedUser);
+        $personal = $em->getRepository(Organization::class)
+            ->findBy(['createdBy' => $reloadedUser, 'isPersonal' => true]);
+
+        // The partial unique index enforces this at the DB, but a second one
+        // would mean two places a plan could live, so it's worth asserting.
+        $this->assertCount(1, $personal, 'a user has exactly one personal organization');
+    }
+
+    public function testPersonalOrganizationCannotBeDeletedOnItsOwn(): void
+    {
+        $user = $this->createUser('solo@example.com');
+        $client = static::createClient();
+        $client->loginUser($user);
+        // Provision it by creating a space.
+        $client->request('POST', '/spaces', [
+            'json' => ['name' => 'Anything'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $em = $this->em();
+        $reloadedUser = $em->getRepository(User::class)->findOneBy(['email' => 'solo@example.com']);
+        $this->assertNotNull($reloadedUser);
+        $org = $em->getRepository(Organization::class)
+            ->findOneBy(['createdBy' => $reloadedUser, 'isPersonal' => true]);
+        $this->assertNotNull($org);
+
+        $client->request('POST', '/organizations/' . $org->getId() . '/delete', [
+            'json' => [
+                'confirmName' => $org->getName(),
+                'reason' => 'not_using',
+                'currentPassword' => self::PASSWORD,
+            ],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+
+        // It goes with the account, not separately — deleting it alone would
+        // strand the personal space.
+        $this->assertResponseStatusCodeSame(409);
+    }
+
+    public function testAccountDeletionTakesThePersonalOrganization(): void
+    {
+        $user = $this->createUser('leaver@example.com');
+        $client = static::createClient();
+        $client->loginUser($user);
+        $client->request('POST', '/spaces', [
+            'json' => ['name' => 'Goes Away'],
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $client->request('POST', '/me/delete', [
+            'json' => [
+                'confirmEmail' => 'leaver@example.com',
+                'currentPassword' => self::PASSWORD,
+                'reason' => 'not_using',
+            ],
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertResponseStatusCodeSame(202);
+
+        $purge = static::getContainer()->get(PurgeRunner::class);
+        $purge->run(new \DateTimeImmutable('+31 days'));
+
+        $em = $this->em();
+        $em->clear();
+        $this->assertNull($em->getRepository(User::class)->findOneBy(['email' => 'leaver@example.com']));
+        $this->assertCount(
+            0,
+            $em->getRepository(Organization::class)->findBy(['isPersonal' => true]),
+            'a personal organization must not outlive its owner',
+        );
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = static::getContainer()->get('doctrine')->getManager();
+        assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+
+    private function createUser(string $email): User
+    {
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        $user = new User();
+        $user->setEmail($email);
+        $user->setRoles(['ROLE_USER']);
+        $user->setGivenName('Test');
+        $user->setFamilyName('User');
+        $user->setPersonalizedColor('#0369a1');
+        $user->setPassword($hasher->hashPassword($user, self::PASSWORD));
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}


### PR DESCRIPTION
First of the four steps in #818, and deliberately the boring one: **nothing reads differently after this ships.**

## What it does

- `Organization.isPersonal`, with a partial unique index (`uniq_organization_personal_per_user`) so nobody ends up with two personal accounts — which would mean two places a plan could live.
- `PersonalOrganizationProvisioner`, idempotent so the password and SSO signup paths can both call it without coordinating, and so a backfilled account isn't given a second one.
- `PersonalSpaceProvisioner` now provisions the org too, in the **same flush** as the space, membership and seeded roles. A half-failed signup is the easiest way to produce the account-less space this phase exists to make unrepresentable.
- `SpaceCreateProcessor` falls back to the creator's personal org rather than leaving `organization` null.

## Guards

A personal organization can't be deleted on its own (409 — it would strand the personal space), isn't targetable through `POST /admin/deletions`, and is removed by account deletion, with its spaces cascading.

## Why it stops here

`space.organization_id` stays **nullable** and `PlanGate` keeps its existing three-way fallback. The whole point is to get the backfill verified against production data before anything depends on it. A space attached to the wrong organization is either invisible to its members or visible to strangers, and that is not a thing to discover after the NOT NULL constraint has landed.

The backfill rule is the narrowest one that can't be wrong: a space with no organization belongs to whoever created it — exactly what `SpaceCreateProcessor` meant when it left the column null. The migration is idempotent and its `down()` detaches only the spaces it attached.

## Remaining steps (#818)

2. Move `subscription.space_id` and `owner_user_id` onto organizations; flip `PlanGate` to a single lookup.
3. `Space.organization` NOT NULL; drop both subscription columns; delete the fallback code. **One-way.**
4. Backfill `organization_membership` from `space_membership`.

Then the per-org seat cap, which is recorded on #818 and still needs your yes on how existing over-cap free accounts are handled.

## Testing

`App\Tests\Api\PersonalOrganizationTest` — signup provisions the org and it owns the personal space; a space created with no org lands in the creator's; exactly one personal org per user however many spaces they make; it can't be deleted alone; account deletion takes it.

Not run locally (no PHP/Docker here) — CI is the first execution.