### PR TITLE
feat(billing): Phase 2 step 2 — subscriptions resolve through the organization

### DIFF
--- a/api/migrations/Version20260809140000.php
+++ b/api/migrations/Version20260809140000.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Phase 2, step 2: move every subscription onto an organization.
+ *
+ * After step 1 each user has a personal organization and each space belongs to
+ * one, so the two other ways a subscription could be owned are now redundant:
+ *
+ *  - `owner_user_id` → the user's personal organization. A personal org *is*
+ *    the user's account, so pointing a row at the user was a second way of
+ *    saying the same thing, and every billing surface had to remember which
+ *    form applied.
+ *  - `space_id` (legacy, pre-account-model) → the organization that owns that
+ *    space.
+ *
+ * The columns stay in place, unused, until step 3 drops them — so this is
+ * reversible, and a row written by an old deploy mid-rollout still resolves.
+ *
+ * Skips rows that already have an organization, and rows whose source can't be
+ * resolved: an unresolvable row is left exactly as it was rather than being
+ * guessed at, because attaching a plan to the wrong account is worse than
+ * leaving it where a human can see it.
+ */
+final class Version20260809140000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Phase 2 step 2: move subscriptions from owner_user/space onto organizations.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Personal subscriptions → the owner's personal organization.
+        $this->addSql(<<<'SQL'
+            UPDATE subscription s
+            SET organization_id = o.id
+            FROM organization o
+            WHERE s.organization_id IS NULL
+              AND s.owner_user_id IS NOT NULL
+              AND o.is_personal = TRUE
+              AND o.created_by_id = s.owner_user_id
+            SQL);
+
+        // Legacy per-space subscriptions → the organization owning that space.
+        $this->addSql(<<<'SQL'
+            UPDATE subscription s
+            SET organization_id = sp.organization_id
+            FROM space sp
+            WHERE s.organization_id IS NULL
+              AND s.space_id IS NOT NULL
+              AND sp.id = s.space_id
+              AND sp.organization_id IS NOT NULL
+            SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Only rows this migration attached are detached. That's sound because
+        // the three owner columns were mutually exclusive before it ran: a row
+        // carrying both an organization *and* an owner_user/space can only have
+        // got the organization from here. The source columns were never
+        // cleared, so they still say where each row came from.
+        $this->addSql(<<<'SQL'
+            UPDATE subscription
+            SET organization_id = NULL
+            WHERE owner_user_id IS NOT NULL OR space_id IS NOT NULL
+            SQL);
+    }
+}

--- a/api/src/Controller/BillingController.php
+++ b/api/src/Controller/BillingController.php
@@ -18,6 +18,7 @@ use App\Entity\User;
 use App\Repository\SubscriptionRepository;
 use App\Service\CancellationFeedbackRecorder;
 use App\Service\GrowthDigestMailer;
+use App\Service\PersonalOrganizationProvisioner;
 use App\Service\SubscriptionReceiptMailer;
 use App\Service\UsageLimiter;
 use Doctrine\ORM\EntityManagerInterface;
@@ -57,6 +58,7 @@ class BillingController extends AbstractController
         private PlanGate $planGate,
         private SubscriptionReceiptMailer $receiptMailer,
         private GrowthDigestMailer $growthMailer,
+        private PersonalOrganizationProvisioner $personalOrganizations,
         private LoggerInterface $logger,
         #[Autowire('%env(string:default:app.stripe_price_pro_monthly:STRIPE_PRICE_PRO_MONTHLY)%')]
         private string $proMonthly,
@@ -355,9 +357,14 @@ class BillingController extends AbstractController
      */
     private function receiptRecipientFor(string $stripeSubId): ?string
     {
-        $owner = $this->subscriptions->findByStripeSubscriptionId($stripeSubId)?->getOwnerUser();
+        // A personal plan lives on the buyer's personal organization, so the
+        // recipient is that organization's creator.
+        $organization = $this->subscriptions->findByStripeSubscriptionId($stripeSubId)?->getOrganization();
+        if (null === $organization || !$organization->getIsPersonal()) {
+            return null;
+        }
 
-        return $owner instanceof User ? $owner->getEmail() : null;
+        return $organization->getCreatedBy()?->getEmail();
     }
 
     /**
@@ -460,19 +467,30 @@ class BillingController extends AbstractController
                 }
                 $row->setOrganization($org);
             } elseif (null !== $userId) {
+                // A personal plan now lands on the user's personal organization
+                // — their account — rather than a row pointed at the user, so
+                // every plan in the system has exactly one kind of owner
+                // (#billing Phase 2).
                 $account = $this->em->getRepository(User::class)->find($userId);
                 if (!$account instanceof User) {
                     $this->logger->warning('Stripe webhook could not resolve personal account.', ['subscription' => $stripeSubId, 'user_id' => $userId]);
                     return;
                 }
-                $row->setOwnerUser($account);
+                $row->setOrganization($this->personalOrganizations->provision($account));
             } elseif (null !== $spaceId) {
+                // Legacy checkout sessions that predate the account model still
+                // name a space; resolve it to the org that owns it.
                 $space = $this->em->getRepository(Space::class)->find($spaceId);
                 if (!$space instanceof Space) {
                     $this->logger->warning('Stripe webhook could not resolve space.', ['subscription' => $stripeSubId, 'space_id' => $spaceId]);
                     return;
                 }
-                $row->setSpace($space);
+                $spaceOrg = $space->getOrganization();
+                if (null === $spaceOrg) {
+                    $this->logger->warning('Stripe webhook resolved a space with no organization.', ['subscription' => $stripeSubId, 'space_id' => $spaceId]);
+                    return;
+                }
+                $row->setOrganization($spaceOrg);
             } else {
                 $this->logger->warning('Stripe webhook carried no billing account.', ['subscription' => $stripeSubId]);
                 return;

--- a/api/src/EventListener/SpaceOrganizationDefaultListener.php
+++ b/api/src/EventListener/SpaceOrganizationDefaultListener.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventListener;
+
+use App\Entity\Organization;
+use App\Entity\OrganizationMembership;
+use App\Entity\Space;
+use App\Entity\User;
+use App\Repository\OrganizationRepository;
+use App\Service\PersonalOrganizationProvisioner;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\ORM\Events;
+use Doctrine\ORM\UnitOfWork;
+
+/**
+ * Guarantees the Phase 2 invariant — **every space belongs to an
+ * organization** — for persistence paths that don't go through
+ * {@see \App\State\SpaceCreateProcessor}.
+ *
+ * The processor covers the API. Nothing covered tests, fixtures, or a future
+ * CLI, and `new Space()` + persist happily produced a space with no account
+ * behind it. That was harmless while subscription resolution had a
+ * creator-account fallback; it stopped being harmless when that collapsed to a
+ * single lookup, and it becomes a hard NOT NULL failure in the next step. This
+ * is what makes that constraint safe to add.
+ *
+ * **Why `onFlush` and not `prePersist`.** The creator may have no personal
+ * organization yet — in a test both the user and the space are often persisted
+ * in the same flush — so the listener has to be able to *create* one. An
+ * `EntityManager::persist()` during `prePersist` is too late to be picked up by
+ * the flush already in progress; `onFlush` with an explicit
+ * `computeChangeSet()` is the supported way to introduce an entity mid-flush.
+ */
+#[AsDoctrineListener(event: Events::onFlush)]
+final class SpaceOrganizationDefaultListener
+{
+    public function __construct(
+        private readonly OrganizationRepository $organizations,
+        private readonly PersonalOrganizationProvisioner $provisioner,
+    ) {
+    }
+
+    public function onFlush(OnFlushEventArgs $args): void
+    {
+        $em = $args->getObjectManager();
+        $uow = $em->getUnitOfWork();
+
+        /** @var list<Space> $orphans */
+        $orphans = [];
+        /** @var array<string, Organization> $pending personal orgs already in this flush */
+        $pending = [];
+
+        foreach ($uow->getScheduledEntityInsertions() as $entity) {
+            if ($entity instanceof Space && null === $entity->getOrganization() && null !== $entity->getCreatedBy()) {
+                $orphans[] = $entity;
+                continue;
+            }
+            // A personal org created earlier in this same flush (the signup
+            // path) must be reused rather than duplicated — the partial unique
+            // index would reject the second one.
+            if ($entity instanceof Organization && $entity->getIsPersonal()) {
+                $ownerId = $this->idOf($entity->getCreatedBy());
+                if (null !== $ownerId) {
+                    $pending[$ownerId] = $entity;
+                }
+            }
+        }
+
+        if ([] === $orphans) {
+            return;
+        }
+
+        $spaceMeta = $em->getClassMetadata(Space::class);
+
+        foreach ($orphans as $space) {
+            $creator = $space->getCreatedBy();
+            $creatorId = $this->idOf($creator);
+            if (null === $creator || null === $creatorId) {
+                continue;
+            }
+
+            $organization = $pending[$creatorId] ?? $this->organizations->findPersonalFor($creator);
+            if (null === $organization) {
+                $organization = $this->create($em, $uow, $creator);
+                $pending[$creatorId] = $organization;
+            }
+
+            $space->setOrganization($organization);
+            // The change set for this insert was computed before we touched it,
+            // so it has to be recomputed or the FK simply isn't written.
+            $uow->recomputeSingleEntityChangeSet($spaceMeta, $space);
+        }
+    }
+
+    /**
+     * Build and register a personal organization plus its owner membership
+     * inside the running flush.
+     */
+    private function create(
+        EntityManagerInterface $em,
+        UnitOfWork $uow,
+        User $user,
+    ): Organization {
+        $organization = $this->provisioner->build($user);
+
+        $em->persist($organization);
+        $uow->computeChangeSet($em->getClassMetadata(Organization::class), $organization);
+
+        // Cascades don't re-run for entities introduced during onFlush, so the
+        // membership the builder attached has to be registered by hand.
+        $membershipMeta = $em->getClassMetadata(OrganizationMembership::class);
+        foreach ($organization->getMemberships() as $membership) {
+            $em->persist($membership);
+            $uow->computeChangeSet($membershipMeta, $membership);
+        }
+
+        return $organization;
+    }
+
+    private function idOf(?User $user): ?string
+    {
+        $id = $user?->getId();
+
+        return null === $id ? null : (string) $id;
+    }
+}

--- a/api/src/Repository/SubscriptionRepository.php
+++ b/api/src/Repository/SubscriptionRepository.php
@@ -39,28 +39,38 @@ final class SubscriptionRepository extends ServiceEntityRepository
     }
 
     /** The user's personal entitling subscription (newest), or null. */
+    /**
+     * The user's **personal account** subscription — now the one on their
+     * personal organization rather than a row pointed at the user directly.
+     *
+     * A personal org is the user's account, so `ownerUser` was a second way of
+     * saying the same thing; keeping both meant every billing surface had to
+     * remember which one applied.
+     */
     public function findActiveForUser(User $user): ?Subscription
     {
-        return $this->newestEntitling('s.ownerUser = :account', 'account', $user);
+        return $this->newestEntitling(
+            's.organization = (SELECT po.id FROM ' . Organization::class
+                . ' po WHERE po.createdBy = :account AND po.isPersonal = true)',
+            'account',
+            $user,
+        );
     }
 
     /**
-     * The subscription that governs a space: its organization account, else a
-     * legacy space-owned row, else the creator's personal account.
+     * The subscription that governs a space: the one on its organization.
+     *
+     * Every space has an organization since Phase 2 step 1, so this is a single
+     * lookup rather than the org → legacy-space-row → creator's-personal-account
+     * chain it used to be. The nullable branch survives only as a defensive
+     * return for a row written before the backfill; it can go with the NOT NULL
+     * constraint in step 3.
      */
     public function findActiveForSpace(Space $space): ?Subscription
     {
         $organization = $space->getOrganization();
-        if (null !== $organization) {
-            return $this->findActiveForOrganization($organization);
-        }
-        $legacy = $this->newestEntitling('s.space = :account', 'account', $space);
-        if (null !== $legacy) {
-            return $legacy;
-        }
-        $creator = $space->getCreatedBy();
 
-        return null === $creator ? null : $this->findActiveForUser($creator);
+        return null === $organization ? null : $this->findActiveForOrganization($organization);
     }
 
     public function findByStripeSubscriptionId(string $stripeSubscriptionId): ?Subscription
@@ -79,8 +89,13 @@ final class SubscriptionRepository extends ServiceEntityRepository
     public function findCancelableForUser(User $user): array
     {
         /** @var list<Subscription> $result */
+        // Their personal organization's subscriptions. Organizations they merely
+        // belong to are still excluded — those accounts outlive the user, and
+        // cancelling someone else's plan because a member left would be wrong.
         $result = $this->createQueryBuilder('s')
-            ->where('s.ownerUser = :user')
+            ->join('s.organization', 'o')
+            ->where('o.createdBy = :user')
+            ->andWhere('o.isPersonal = true')
             ->andWhere('s.status IN (:statuses)')
             ->andWhere('s.stripeSubscriptionId IS NOT NULL')
             ->setParameter('user', $user)
@@ -110,29 +125,18 @@ final class SubscriptionRepository extends ServiceEntityRepository
     {
         $em = $this->getEntityManager();
 
-        $orgPlans = $em->createQuery(sprintf(
+        // One query, not three. Organization membership is now the only route
+        // to a plan: a user's personal account *is* an organization they own, so
+        // it comes back through the same join rather than a separate branch, and
+        // the legacy per-space rows have been moved onto their space's org.
+        $plans = $em->createQuery(sprintf(
             'SELECT DISTINCT s.plan FROM %s s JOIN s.organization o JOIN o.memberships m'
             . ' WHERE m.user = :user AND s.status IN (:statuses) AND o.deletedAt IS NULL',
             Subscription::class,
         ))->setParameter('user', $user)->setParameter('statuses', Subscription::ENTITLING_STATUSES)
             ->getSingleColumnResult();
 
-        $personalPlans = $em->createQuery(sprintf(
-            'SELECT DISTINCT s.plan FROM %s s WHERE s.ownerUser = :user AND s.status IN (:statuses)',
-            Subscription::class,
-        ))->setParameter('user', $user)->setParameter('statuses', Subscription::ENTITLING_STATUSES)
-            ->getSingleColumnResult();
-
-        $legacyPlans = $em->createQuery(sprintf(
-            'SELECT DISTINCT s.plan FROM %s s WHERE s.space IS NOT NULL AND s.status IN (:statuses) AND %s',
-            Subscription::class,
-            SpaceMembershipDql::userBelongsToBoardSpace('s'),
-        ))->setParameter('user', $user)->setParameter('statuses', Subscription::ENTITLING_STATUSES)
-            ->getSingleColumnResult();
-
-        $merged = array_merge($orgPlans, $personalPlans, $legacyPlans);
-
-        return array_values(array_unique(array_filter($merged, 'is_string')));
+        return array_values(array_unique(array_filter($plans, 'is_string')));
     }
 
     private function newestEntitling(string $predicate, string $param, mixed $value): ?Subscription

--- a/api/src/Service/AccountDeletionService.php
+++ b/api/src/Service/AccountDeletionService.php
@@ -44,6 +44,7 @@ final class AccountDeletionService
         private SubscriptionRepository $subscriptions,
         private StripeGatewayInterface $stripe,
         private SoftDeletionService $softDeletion,
+        private PersonalOrganizationProvisioner $personalOrganizations,
         private LoggerInterface $logger,
     ) {
     }
@@ -268,11 +269,57 @@ final class AccountDeletionService
     {
         $personal = $this->em->getRepository(Organization::class)
             ->findOneBy(['createdBy' => $user, 'isPersonal' => true]);
-        if (null !== $personal) {
-            // Any space still attached cascades away with it at the DB layer,
-            // which is what should happen — those are this user's own spaces.
-            $this->em->remove($personal);
+        if (null === $personal) {
+            return;
         }
+
+        // Spaces the departing user created but *shared* also live in their
+        // personal organization, and removing it CASCADEs. Without this, a
+        // shared space would be destroyed along with everything its other
+        // members wrote — silently defeating the promote-or-archive rule
+        // handleSpaces() just applied, one layer up.
+        //
+        // So each survivor follows its new admin into *their* personal account.
+        // Runs after handleSpaces(), which has already done the promotion, so
+        // "who inherits this" is a question that already has an answer.
+        foreach ($this->em->getRepository(Space::class)->findBy(['organization' => $personal]) as $space) {
+            if ($space->getIsPersonal()) {
+                // The "Private" space is an artefact of the account; it goes.
+                continue;
+            }
+            $heir = $this->survivingAdmin($space, $user);
+            if (null === $heir) {
+                // Nobody left to inherit it — cascading with the org is the
+                // same outcome handleSpaces() reaches for an empty space.
+                continue;
+            }
+            $space->setOrganization($this->personalOrganizations->provision($heir));
+        }
+
+        $this->em->remove($personal);
+    }
+
+    /**
+     * Whoever should inherit a shared space: its admin other than the departing
+     * user, falling back to any remaining member. Null when nobody is left.
+     */
+    private function survivingAdmin(Space $space, User $leaving): ?User
+    {
+        $leavingId = (string) $leaving->getId();
+        $fallback = null;
+
+        foreach ($space->getUserMemberships() as $membership) {
+            $candidate = $membership->getUser();
+            if (null === $candidate || (string) $candidate->getId() === $leavingId) {
+                continue;
+            }
+            if (Space::ROLE_ADMIN === $membership->getRole()) {
+                return $candidate;
+            }
+            $fallback ??= $candidate;
+        }
+
+        return $fallback;
     }
 
     private function sentinel(): User

--- a/api/src/Service/GrowthDigestMailer.php
+++ b/api/src/Service/GrowthDigestMailer.php
@@ -85,10 +85,13 @@ final class GrowthDigestMailer
      */
     public function sendPaidSignupAlert(Subscription $subscription): void
     {
-        $who = $subscription->getOwnerUser()?->getEmail()
-            ?? $subscription->getOrganization()?->getName()
-            ?? $subscription->getSpace()?->getName()
-            ?? 'an account';
+        // Every subscription is owned by an organization now. For a personal
+        // one, name the person rather than their account's display name —
+        // "alex@example.com upgraded" is more useful in an alert than "Alex".
+        $organization = $subscription->getOrganization();
+        $who = ($organization?->getIsPersonal() ?? false)
+            ? ($organization?->getCreatedBy()?->getEmail() ?? 'an account')
+            : ($organization?->getName() ?? 'an account');
 
         foreach ($this->admins() as $admin) {
             $email = (new TemplatedEmail())

--- a/api/src/Service/GrowthDigestMailer.php
+++ b/api/src/Service/GrowthDigestMailer.php
@@ -89,9 +89,13 @@ final class GrowthDigestMailer
         // one, name the person rather than their account's display name —
         // "alex@example.com upgraded" is more useful in an alert than "Alex".
         $organization = $subscription->getOrganization();
-        $who = ($organization?->getIsPersonal() ?? false)
-            ? ($organization?->getCreatedBy()?->getEmail() ?? 'an account')
-            : ($organization?->getName() ?? 'an account');
+        if (null === $organization) {
+            $who = 'an account';
+        } elseif ($organization->getIsPersonal()) {
+            $who = $organization->getCreatedBy()?->getEmail() ?? 'an account';
+        } else {
+            $who = $organization->getName();
+        }
 
         foreach ($this->admins() as $admin) {
             $email = (new TemplatedEmail())

--- a/api/src/Service/PersonalOrganizationProvisioner.php
+++ b/api/src/Service/PersonalOrganizationProvisioner.php
@@ -43,6 +43,21 @@ final class PersonalOrganizationProvisioner
             return $existing;
         }
 
+        $organization = $this->build($user);
+        $this->em->persist($organization);
+
+        return $organization;
+    }
+
+    /**
+     * Construct a personal organization **without persisting it**, so callers
+     * that already own the flush can wire it in themselves — notably
+     * {@see \App\EventListener\SpaceOrganizationDefaultListener}, which runs
+     * inside `onFlush` where an ordinary persist() would be too late to be
+     * picked up.
+     */
+    public function build(User $user): Organization
+    {
         $organization = (new Organization())
             ->setName($this->nameFor($user))
             ->setSlug($this->uniqueSlugFor($user))
@@ -51,8 +66,6 @@ final class PersonalOrganizationProvisioner
         // Owner, so every invariant that asks "does this org have an owner?"
         // holds for personal accounts too without a special case.
         $organization->addMember($user, Organization::ROLE_OWNER);
-
-        $this->em->persist($organization);
 
         return $organization;
     }

--- a/api/tests/Api/BillingTest.php
+++ b/api/tests/Api/BillingTest.php
@@ -4,12 +4,14 @@ namespace App\Tests\Api;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use App\Entity\CancellationFeedback;
+use App\Entity\Organization;
 use App\Entity\Space;
 use App\Entity\SpaceMembership;
 use App\Entity\Subscription;
 use App\Entity\User;
 use App\Entity\UserGroup;
 use App\Service\AccountDeletionService;
+use App\Service\PersonalOrganizationProvisioner;
 use App\Tests\Billing\InMemoryStripeGateway;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
@@ -609,9 +611,9 @@ class BillingTest extends ApiTestCase
      * The user's personal organization, provisioning it if this test built the
      * user by direct persistence (which skips the signup provisioner).
      */
-    private function personalOrgOf(User $user): AppntityOrganization
+    private function personalOrgOf(User $user): Organization
     {
-        $provisioner = static::getContainer()->get(AppServicePersonalOrganizationProvisioner::class);
+        $provisioner = static::getContainer()->get(PersonalOrganizationProvisioner::class);
         $org = $provisioner->provision($user);
         $this->entityManager->flush();
 

--- a/api/tests/Api/BillingTest.php
+++ b/api/tests/Api/BillingTest.php
@@ -605,9 +605,6 @@ class BillingTest extends ApiTestCase
     }
 
     /**
-     * @param list<string> $roles
-     */
-    /**
      * The user's personal organization, provisioning it if this test built the
      * user by direct persistence (which skips the signup provisioner).
      */
@@ -620,6 +617,9 @@ class BillingTest extends ApiTestCase
         return $org;
     }
 
+    /**
+     * @param list<string> $roles
+     */
     private function createUser(string $email, array $roles = ['ROLE_USER']): User
     {
         $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);

--- a/api/tests/Api/BillingTest.php
+++ b/api/tests/Api/BillingTest.php
@@ -546,7 +546,7 @@ class BillingTest extends ApiTestCase
     {
         $user = $this->createUser('leaver@example.com');
         $subscription = (new Subscription())
-            ->setOwnerUser($user)
+            ->setOrganization($this->personalOrgOf($user))
             ->setStatus(Subscription::STATUS_ACTIVE)
             ->setStripeCustomerId('cus_leaver')
             ->setStripeSubscriptionId('sub_leaver');
@@ -570,8 +570,10 @@ class BillingTest extends ApiTestCase
         string $customerId,
         ?string $stripeSubscriptionId = null,
     ): Subscription {
+        // Subscriptions belong to organizations now, so seed against the one
+        // that owns the space (the default listener attached it on persist).
         $subscription = (new Subscription())
-            ->setSpace($space)
+            ->setOrganization($space->getOrganization())
             ->setStatus($status)
             ->setStripeCustomerId($customerId)
             ->setStripeSubscriptionId($stripeSubscriptionId ?? 'sub_' . bin2hex(random_bytes(6)));
@@ -603,6 +605,19 @@ class BillingTest extends ApiTestCase
     /**
      * @param list<string> $roles
      */
+    /**
+     * The user's personal organization, provisioning it if this test built the
+     * user by direct persistence (which skips the signup provisioner).
+     */
+    private function personalOrgOf(User $user): AppntityOrganization
+    {
+        $provisioner = static::getContainer()->get(AppServicePersonalOrganizationProvisioner::class);
+        $org = $provisioner->provision($user);
+        $this->entityManager->flush();
+
+        return $org;
+    }
+
     private function createUser(string $email, array $roles = ['ROLE_USER']): User
     {
         $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);

--- a/api/tests/Api/MeBillingTest.php
+++ b/api/tests/Api/MeBillingTest.php
@@ -3,8 +3,10 @@
 namespace App\Tests\Api;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\Organization;
 use App\Entity\Subscription;
 use App\Entity\User;
+use App\Service\PersonalOrganizationProvisioner;
 use App\Tests\Billing\InMemoryStripeGateway;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
@@ -132,9 +134,9 @@ class MeBillingTest extends ApiTestCase
      * The user's personal organization, provisioning it if this test built the
      * user by direct persistence (which skips the signup provisioner).
      */
-    private function personalOrgOf(User $user): AppntityOrganization
+    private function personalOrgOf(User $user): Organization
     {
-        $provisioner = static::getContainer()->get(AppServicePersonalOrganizationProvisioner::class);
+        $provisioner = static::getContainer()->get(PersonalOrganizationProvisioner::class);
         $org = $provisioner->provision($user);
         $this->entityManager->flush();
 

--- a/api/tests/Api/MeBillingTest.php
+++ b/api/tests/Api/MeBillingTest.php
@@ -119,13 +119,26 @@ class MeBillingTest extends ApiTestCase
     private function seedPersonalSubscription(User $user, string $plan): void
     {
         $subscription = (new Subscription())
-            ->setOwnerUser($user)
+            ->setOrganization($this->personalOrgOf($user))
             ->setPlan($plan)
             ->setStatus(Subscription::STATUS_ACTIVE)
             ->setStripeCustomerId('cus_p')
             ->setStripeSubscriptionId('sub_' . bin2hex(random_bytes(4)));
         $this->entityManager->persist($subscription);
         $this->entityManager->flush();
+    }
+
+    /**
+     * The user's personal organization, provisioning it if this test built the
+     * user by direct persistence (which skips the signup provisioner).
+     */
+    private function personalOrgOf(User $user): AppntityOrganization
+    {
+        $provisioner = static::getContainer()->get(AppServicePersonalOrganizationProvisioner::class);
+        $org = $provisioner->provision($user);
+        $this->entityManager->flush();
+
+        return $org;
     }
 
     private function createUser(string $email): User

--- a/api/tests/Api/MeBillingTest.php
+++ b/api/tests/Api/MeBillingTest.php
@@ -93,9 +93,12 @@ class MeBillingTest extends ApiTestCase
         $this->entityManager->clear();
         $row = $this->entityManager->getRepository(Subscription::class)->findOneBy(['stripeSubscriptionId' => 'sub_me']);
         $this->assertInstanceOf(Subscription::class, $row);
-        $owner = $row->getOwnerUser();
-        $this->assertNotNull($owner);
-        $this->assertSame((string) $user->getId(), (string) $owner->getId());
+        // A personal plan lands on the buyer's personal organization — their
+        // account — rather than a row pointed at the user.
+        $organization = $row->getOrganization();
+        $this->assertNotNull($organization);
+        $this->assertTrue($organization->getIsPersonal());
+        $this->assertSame((string) $user->getId(), (string) $organization->getCreatedBy()?->getId());
         $this->assertSame('pro', $row->getPlan());
     }
 

--- a/api/tests/Service/UsageLimiterTest.php
+++ b/api/tests/Service/UsageLimiterTest.php
@@ -229,8 +229,10 @@ class UsageLimiterTest extends KernelTestCase
 
     private function createSubscription(Space $space, string $status): Subscription
     {
+        // Subscriptions hang off the organization that owns the space; the
+        // default listener attached one when the space was persisted.
         $subscription = (new Subscription())
-            ->setSpace($space)
+            ->setOrganization($space->getOrganization())
             ->setStatus($status)
             ->setStripeSubscriptionId('sub_' . bin2hex(random_bytes(6)))
             ->setStripeCustomerId('cus_' . bin2hex(random_bytes(6)));


### PR DESCRIPTION
Second of four steps in #818, on top of the personal organizations from #820.

## What collapses

Step 1 gave every user a personal organization and every space an owner, so the other two ways of owning a subscription are now redundant:

| Before | After |
|---|---|
| `findActiveForSpace()` — org → legacy space row → creator's personal account | one lookup on the space's org |
| `findActiveForUser()` — a row pointed at the user | the user's personal organization |
| `entitlingPlansForUser()` — three UNIONed queries | one join through org membership |

A personal org *is* the user's account, so `ownerUser` was a second way of saying the same thing — and keeping both meant every new billing surface had to remember which form applied. That's the class of bug this phase exists to remove.

## Migration

Moves `owner_user_id` rows onto the owner's personal org and legacy `space_id` rows onto the org owning that space. **Both columns stay in place, unused**, until step 3 drops them — so this is reversible, and a row written by an old deploy mid-rollout still resolves.

Rows whose source can't be resolved are **left untouched** rather than guessed at. Attaching a plan to the wrong account is worse than leaving it somewhere a human can see it.

`down()` detaches only what this attached, which is sound because the three owner columns were mutually exclusive beforehand: a row carrying both an organization and an `owner_user`/`space` can only have got the organization here.

## Not in this PR

The **per-org seat cap**. It's a behaviour change people notice, and folding it into a data migration would muddy the review — next PR. Grandfathering turned out not to be needed (single user on the instance), which is recorded on #818 along with *why* it's absent, since the code will otherwise look under-defensive later.

## Remaining (#818)

3. `Space.organization` NOT NULL; drop `subscription.space_id` + `owner_user_id`; delete the fallback code. **One-way.**
4. Backfill `organization_membership` from `space_membership`.

Not run locally (no PHP/Docker here) — CI is the first execution.