### PR TITLE
feat(billing): Phase 2 step 3 — space.organization NOT NULL, drop the legacy subscription columns

### DIFF
--- a/api/migrations/Version20260809170000.php
+++ b/api/migrations/Version20260809170000.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\Migrations\Exception\IrreversibleMigration;
+
+/**
+ * Phase 2, step 3: make the account model mandatory. **One-way.**
+ *
+ * Steps 1 and 2 put every space inside an organization and moved every
+ * subscription onto one, leaving `subscription.space_id` and `owner_user_id`
+ * populated but unread. This turns the invariant into a constraint and removes
+ * the columns, which is what stops the old shapes creeping back.
+ *
+ * `up()` **verifies before it constrains**. A space with no organization would
+ * otherwise fail on the ALTER with a Postgres error naming a column rather than
+ * a cause; failing early with a count is the difference between a five-minute
+ * fix and a confusing rollback. Anything unmigrated at this point is a bug in
+ * step 1 or 2, not something to paper over here.
+ *
+ * `down()` is deliberately unimplemented. Re-adding the columns is trivial;
+ * repopulating them is not — the mapping from an organization back to "which
+ * user or space did this originally pay for" is exactly the information being
+ * discarded. Rolling back past this point means restoring from backup, which
+ * the pre-deploy hook takes.
+ */
+final class Version20260809170000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Phase 2 step 3: space.organization_id NOT NULL; drop subscription.space_id + owner_user_id.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->guardAgainstUnmigratedRows();
+
+        $this->addSql('ALTER TABLE space ALTER COLUMN organization_id SET NOT NULL');
+
+        $this->addSql('ALTER TABLE subscription DROP CONSTRAINT IF EXISTS fk_subscription_space');
+        $this->addSql('ALTER TABLE subscription DROP CONSTRAINT IF EXISTS fk_subscription_owner_user');
+        $this->addSql('DROP INDEX IF EXISTS idx_subscription_space');
+        $this->addSql('DROP INDEX IF EXISTS idx_subscription_owner_user');
+        $this->addSql('ALTER TABLE subscription DROP COLUMN space_id');
+        $this->addSql('ALTER TABLE subscription DROP COLUMN owner_user_id');
+    }
+
+    public function down(Schema $schema): void
+    {
+        throw new IrreversibleMigration(
+            'Phase 2 step 3 discards which user or space a subscription originally paid for. '
+            . 'Restore from the pre-deploy backup instead.',
+        );
+    }
+
+    /**
+     * Refuse to run if step 1 or 2 left anything behind. Both counts are zero
+     * on a correctly migrated database.
+     */
+    private function guardAgainstUnmigratedRows(): void
+    {
+        $orphanSpaces = (int) $this->connection->fetchOne(
+            'SELECT count(*) FROM space WHERE organization_id IS NULL',
+        );
+        $this->abortIf(
+            $orphanSpaces > 0,
+            sprintf(
+                '%d space(s) still have no organization. Re-run the Phase 2 step 1 backfill '
+                . '(Version20260809090000) before applying this migration.',
+                $orphanSpaces,
+            ),
+        );
+
+        $orphanSubscriptions = (int) $this->connection->fetchOne(
+            'SELECT count(*) FROM subscription WHERE organization_id IS NULL'
+            . ' AND (space_id IS NOT NULL OR owner_user_id IS NOT NULL)',
+        );
+        $this->abortIf(
+            $orphanSubscriptions > 0,
+            sprintf(
+                '%d subscription(s) still point at a space or user with no organization resolved. '
+                . 'Re-run the Phase 2 step 2 backfill (Version20260809140000) before applying this migration.',
+                $orphanSubscriptions,
+            ),
+        );
+    }
+}

--- a/api/src/Entity/Space.php
+++ b/api/src/Entity/Space.php
@@ -226,8 +226,13 @@ class Space implements SoftDeletable
      * GitHub-style split: a space belongs to a person or an org, never both. The
      * plan a space runs on resolves through this owner (see PlanGate).
      */
+    // NOT NULL as of Phase 2 step 3: every space belongs to an account. The
+    // PHP type stays nullable because the property is unset between `new
+    // Space()` and the point SpaceCreateProcessor or
+    // SpaceOrganizationDefaultListener fills it — the database is what
+    // guarantees no such row is ever written.
     #[ORM\ManyToOne(targetEntity: Organization::class)]
-    #[ORM\JoinColumn(nullable: true, onDelete: 'CASCADE')]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
     #[Groups(['space:read', 'space:write'])]
     private ?Organization $organization = null;
 

--- a/api/src/Entity/Subscription.php
+++ b/api/src/Entity/Subscription.php
@@ -26,9 +26,7 @@ use Symfony\Component\Uid\Uuid;
  */
 #[ORM\Entity(repositoryClass: SubscriptionRepository::class)]
 #[ORM\Table(name: 'subscription')]
-#[ORM\Index(columns: ['space_id'], name: 'idx_subscription_space')]
 #[ORM\Index(columns: ['organization_id'], name: 'idx_subscription_organization')]
-#[ORM\Index(columns: ['owner_user_id'], name: 'idx_subscription_owner_user')]
 #[ORM\Index(columns: ['created_by_id'], name: 'idx_subscription_created_by')]
 #[ORM\UniqueConstraint(name: 'uniq_subscription_stripe_id', columns: ['stripe_subscription_id'])]
 class Subscription
@@ -67,29 +65,22 @@ class Subscription
     private ?Uuid $id = null;
 
     /**
-     * The **account** this subscription pays for (#billing Phase 1b): either an
-     * {@see Organization} (a team account) or a {@see User} (a personal
-     * account) — exactly one is set for new rows. Legacy rows also carry the
-     * originating {@see $space} (now nullable + transitional); resolution goes
-     * account-first, falling back to the space.
+     * The **account** this subscription pays for — always an
+     * {@see Organization} (#billing Phase 2).
+     *
+     * It used to be one of three things: an organization, a user (personal
+     * plan), or a space (pre-account-model). A user's personal organization now
+     * *is* their account, so the other two were different spellings of the same
+     * fact, and every billing surface had to remember which spelling applied.
+     * Both columns are gone.
+     *
+     * Still nullable at the column level only because a subscription outlives
+     * the account it paid for — {@see \App\Service\OrganizationDeletionService::purge()}
+     * detaches it so the billing history survives.
      */
     #[ORM\ManyToOne(targetEntity: Organization::class)]
     #[ORM\JoinColumn(name: 'organization_id', nullable: true, onDelete: 'CASCADE')]
     private ?Organization $organization = null;
-
-    /** The personal account (a User) this subscription pays for, when personal. */
-    #[ORM\ManyToOne(targetEntity: User::class)]
-    #[ORM\JoinColumn(name: 'owner_user_id', nullable: true, onDelete: 'CASCADE')]
-    private ?User $ownerUser = null;
-
-    /**
-     * Legacy: the space this subscription originally paid for (transitional;
-     * superseded by {@see $organization}). Nullable now; a later cleanup drops
-     * it once nothing reads it.
-     */
-    #[ORM\ManyToOne(targetEntity: Space::class)]
-    #[ORM\JoinColumn(name: 'space_id', nullable: true, onDelete: 'CASCADE')]
-    private ?Space $space = null;
 
     #[ORM\Column(length: 32, options: ['default' => self::PLAN_TEAM])]
     private string $plan = self::PLAN_TEAM;
@@ -157,28 +148,6 @@ class Subscription
     public function setOrganization(?Organization $organization): static
     {
         $this->organization = $organization;
-        return $this;
-    }
-
-    public function getOwnerUser(): ?User
-    {
-        return $this->ownerUser;
-    }
-
-    public function setOwnerUser(?User $ownerUser): static
-    {
-        $this->ownerUser = $ownerUser;
-        return $this;
-    }
-
-    public function getSpace(): ?Space
-    {
-        return $this->space;
-    }
-
-    public function setSpace(?Space $space): static
-    {
-        $this->space = $space;
         return $this;
     }
 

--- a/api/tests/Api/GrowthDigestTest.php
+++ b/api/tests/Api/GrowthDigestTest.php
@@ -100,7 +100,6 @@ class GrowthDigestTest extends ApiTestCase
         $this->assertNotNull($admin->getId());
     }
 
-    /** @param list<string> $roles */
     /** The user's personal organization; tests build users by direct persistence. */
     private function personalOrgOf(User $user): Organization
     {
@@ -111,6 +110,7 @@ class GrowthDigestTest extends ApiTestCase
         return $org;
     }
 
+    /** @param list<string> $roles */
     private function makeUser(string $email, array $roles = ['ROLE_USER']): User
     {
         $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);

--- a/api/tests/Api/GrowthDigestTest.php
+++ b/api/tests/Api/GrowthDigestTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace App\Tests\Api;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\Organization;
 use App\Entity\Subscription;
 use App\Entity\User;
 use App\Service\GrowthDigestMailer;
+use App\Service\PersonalOrganizationProvisioner;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 

--- a/api/tests/Api/GrowthDigestTest.php
+++ b/api/tests/Api/GrowthDigestTest.php
@@ -79,7 +79,8 @@ class GrowthDigestTest extends ApiTestCase
         $owner = $this->makeUser('buyer@example.com');
 
         $sub = new Subscription();
-        $sub->setOwnerUser($owner);
+        // A personal plan lives on the buyer's personal organization.
+        $sub->setOrganization($this->personalOrgOf($owner));
         $sub->setPlan('pro');
         $sub->setSeats(1);
         $sub->setBillingInterval('month');
@@ -98,6 +99,16 @@ class GrowthDigestTest extends ApiTestCase
     }
 
     /** @param list<string> $roles */
+    /** The user's personal organization; tests build users by direct persistence. */
+    private function personalOrgOf(User $user): Organization
+    {
+        $provisioner = static::getContainer()->get(PersonalOrganizationProvisioner::class);
+        $org = $provisioner->provision($user);
+        $this->entityManager->flush();
+
+        return $org;
+    }
+
     private function makeUser(string $email, array $roles = ['ROLE_USER']): User
     {
         $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);

--- a/api/tests/Api/GrowthMetricsTest.php
+++ b/api/tests/Api/GrowthMetricsTest.php
@@ -271,7 +271,8 @@ class GrowthMetricsTest extends ApiTestCase
         string $status,
     ): void {
         $sub = new Subscription();
-        $sub->setOwnerUser($owner);
+        // A personal plan lives on the buyer's personal organization.
+        $sub->setOrganization($this->personalOrgOf($owner));
         $sub->setPlan($plan);
         $sub->setBillingInterval($interval);
         $sub->setSeats($seats);
@@ -280,6 +281,16 @@ class GrowthMetricsTest extends ApiTestCase
     }
 
     /** @param list<string> $roles */
+    /** The user's personal organization; tests build users by direct persistence. */
+    private function personalOrgOf(User $user): Organization
+    {
+        $provisioner = static::getContainer()->get(PersonalOrganizationProvisioner::class);
+        $org = $provisioner->provision($user);
+        $this->entityManager->flush();
+
+        return $org;
+    }
+
     private function makeUser(string $email, array $roles = ['ROLE_USER']): User
     {
         $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);

--- a/api/tests/Api/GrowthMetricsTest.php
+++ b/api/tests/Api/GrowthMetricsTest.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace App\Tests\Api;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\Organization;
 use App\Entity\Subscription;
 use App\Entity\Task;
 use App\Entity\User;
 use App\Growth\GrowthMetrics;
+use App\Service\PersonalOrganizationProvisioner;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;

--- a/api/tests/Api/GrowthMetricsTest.php
+++ b/api/tests/Api/GrowthMetricsTest.php
@@ -282,7 +282,6 @@ class GrowthMetricsTest extends ApiTestCase
         $this->entityManager->persist($sub);
     }
 
-    /** @param list<string> $roles */
     /** The user's personal organization; tests build users by direct persistence. */
     private function personalOrgOf(User $user): Organization
     {
@@ -293,6 +292,7 @@ class GrowthMetricsTest extends ApiTestCase
         return $org;
     }
 
+    /** @param list<string> $roles */
     private function makeUser(string $email, array $roles = ['ROLE_USER']): User
     {
         $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);


### PR DESCRIPTION
Step 3 of #818. **This is the one-way step.**

Steps 1 and 2 put every space inside an organization and moved every subscription onto one. This turns that invariant into a database constraint and removes the columns, which is what stops the old shapes creeping back in.

- `space.organization_id` **NOT NULL**
- `subscription` drops **`space_id`** and **`owner_user_id`**

## The migration verifies before it constrains

```
%d space(s) still have no organization. Re-run the Phase 2 step 1 backfill…
```

An unmigrated row aborts with a count and a pointer to the backfill that should have handled it. Without the guard the failure surfaces as a Postgres error naming a column rather than a cause, which is the difference between a five-minute fix and a confusing rollback at deploy time.

## `down()` throws deliberately

Re-adding the columns is trivial. *Repopulating* them is not — the mapping from an organization back to "which user or space did this originally pay for" is precisely the information being discarded. Pretending otherwise would give a rollback that silently produces wrong billing ownership. Rolling back past this point means the pre-deploy backup, which `scripts/deploy.sh` already takes.

## Before merging

Worth running against production first, since the guard aborts rather than corrupts but a failed deploy is still a failed deploy:

```sql
SELECT count(*) FROM space WHERE organization_id IS NULL;
SELECT count(*) FROM subscription WHERE organization_id IS NULL AND (space_id IS NOT NULL OR owner_user_id IS NOT NULL);
```

Both should be zero after #820 and #821.

Not run locally (no PHP/Docker here) — CI is the first execution.