### PR TITLE
feat(billing): Phase 2 step 4 — org membership backfill + per-org seat cap

### DIFF
--- a/api/migrations/Version20260809200000.php
+++ b/api/migrations/Version20260809200000.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Phase 2, step 4: everyone in a space belongs to the account that owns it.
+ *
+ * Space membership has implied organization membership since Phase 1c — the
+ * auto-join in `SpaceMemberAdder` puts every *new* member in the owning
+ * organization. Members who joined a space before that shipped never got a row,
+ * so `Organization::hasMember()` says no for them while they demonstrably have
+ * access to its content. Anything reasoning about the account rather than the
+ * space (seat counts, `entitlingPlansForUser`, the org member list) sees an
+ * organization smaller than it really is.
+ *
+ * The role mirrors `SpaceMemberAdder::ORG_ROLE_FOR_SPACE_ROLE`, which is the
+ * rule new members already get:
+ *
+ *   space admin  → org member (a billable seat)
+ *   space member → org guest  (free, restricted)
+ *
+ * **Never downgrades.** An existing organization membership is left exactly as
+ * it is — someone who is already an Owner or Admin must not be demoted to guest
+ * because they also happen to sit in a space as a plain member. The insert is
+ * guarded by NOT EXISTS rather than an upsert for that reason.
+ *
+ * Seat counts can rise for organizations that had un-joined space admins. That
+ * is the correct number rather than a new charge: those people already had
+ * access, they were simply invisible to the count. Stripe quantity is pushed by
+ * the next membership change; there is no seat sync here because a migration
+ * has no business making paid API calls.
+ */
+final class Version20260809200000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Phase 2 step 4: backfill organization_membership from space_membership.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // DISTINCT ON keeps one row per (organization, user): somebody who
+        // admins one space in an org and is a plain member of another should
+        // get the *stronger* role, so order admin ahead of member.
+        $this->addSql(<<<'SQL'
+            INSERT INTO organization_membership (id, organization_id, user_id, role, joined_at)
+            SELECT DISTINCT ON (s.organization_id, sm.user_id)
+                gen_random_uuid(),
+                s.organization_id,
+                sm.user_id,
+                CASE WHEN sm.role = 'admin' THEN 'member' ELSE 'guest' END,
+                NOW()
+            FROM space_membership sm
+            JOIN space s ON s.id = sm.space_id
+            WHERE NOT EXISTS (
+                SELECT 1 FROM organization_membership om
+                WHERE om.organization_id = s.organization_id
+                  AND om.user_id = sm.user_id
+            )
+            ORDER BY s.organization_id, sm.user_id, (sm.role = 'admin') DESC
+            SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Nothing to undo safely. The rows this created are indistinguishable
+        // from ones the auto-join would have written, so deleting "the
+        // backfilled ones" would also strip legitimate memberships. Leaving
+        // them is harmless: they describe access the users already have.
+    }
+}

--- a/api/src/Controller/OrganizationMemberController.php
+++ b/api/src/Controller/OrganizationMemberController.php
@@ -6,6 +6,7 @@ use App\Entity\Organization;
 use App\Entity\User;
 use App\Service\OrganizationGuestPolicy;
 use App\Service\OrganizationSeatSync;
+use App\Service\UsageLimiter;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -26,6 +27,7 @@ class OrganizationMemberController extends AbstractController
         private EntityManagerInterface $em,
         private OrganizationSeatSync $seatSync,
         private OrganizationGuestPolicy $guestPolicy,
+        private UsageLimiter $usageLimiter,
     ) {
     }
 
@@ -47,6 +49,23 @@ class OrganizationMemberController extends AbstractController
         $target = $this->em->getRepository(User::class)->findOneBy(['email' => $email]);
         if (null === $target) {
             return $this->json(['error' => 'No user with that email. Invites are coming soon.'], 404);
+        }
+
+        // The free seat cap. Guests are free, so only a billable role is
+        // checked — and this is the one place a seat can be taken without
+        // touching a space at all, which is why the check has to live here as
+        // well as on the space endpoint.
+        if (
+            Organization::ROLE_GUEST !== $role
+            && !$org->hasMember($target)
+            && !$this->usageLimiter->canAddMembersToOrganization($org)
+        ) {
+            return $this->json([
+                'error' => sprintf(
+                    'Free organizations are limited to %d seats. Upgrade to add more, or add them as a guest.',
+                    $this->usageLimiter->freeSpaceMemberLimit(),
+                ),
+            ], 402);
         }
 
         $org->addMember($target, $role);

--- a/api/src/Service/UsageLimiter.php
+++ b/api/src/Service/UsageLimiter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Service;
 
 use App\Billing\PlanGate;
+use App\Entity\Organization;
 use App\Entity\Space;
 use App\Entity\User;
 use App\Repository\SubscriptionRepository;
@@ -153,19 +154,41 @@ final class UsageLimiter
      * free ceiling. Personal spaces (always solo) and subscribed spaces are
      * unbounded. Counts the current effective members (direct + via group).
      */
+    /**
+     * Whether the space's **account** can take another member.
+     *
+     * Counted per organization rather than per space (#billing Phase 2). The
+     * old per-space rule let a free user hold three spaces of five and pay for
+     * none of them, and "5 members per space" was never a sentence anyone could
+     * price against. Guests don't consume seats, so this reads as "N free seats
+     * per account" — which is how the rest of the industry states it.
+     */
     public function canAddMembersToSpace(Space $space, int $count = 1): bool
     {
-        if (!$this->enforcementEnabled || $space->getIsPersonal()) {
+        $organization = $space->getOrganization();
+        if (!$this->enforcementEnabled || $space->getIsPersonal() || null === $organization) {
             return true;
         }
-        // The space's plan sets the member ceiling; paid plans lift it entirely.
-        $limit = $this->planGate->spaceEntitlements($space)->limit('space_members');
+
+        return $this->canAddMembersToOrganization($organization, $count);
+    }
+
+    /**
+     * The cap itself. Exposed directly so the organization member endpoint —
+     * the one place a seat can be taken without touching a space at all —
+     * enforces the same rule rather than a parallel one.
+     */
+    public function canAddMembersToOrganization(Organization $organization, int $count = 1): bool
+    {
+        if (!$this->enforcementEnabled) {
+            return true;
+        }
+        // Paid plans lift the ceiling entirely.
+        $limit = $this->planGate->organizationEntitlements($organization)->limit('space_members');
         if (null === $limit) {
             return true;
         }
 
-        $current = \count($space->getEffectiveUsers());
-
-        return ($current + $count) <= $limit;
+        return ($organization->seatCount() + $count) <= $limit;
     }
 }

--- a/api/tests/Service/UsageLimiterTest.php
+++ b/api/tests/Service/UsageLimiterTest.php
@@ -139,24 +139,48 @@ class UsageLimiterTest extends KernelTestCase
         $this->assertNull($limiter->remainingMcpCalls($user));
     }
 
-    public function testFreeSpaceMemberCap(): void
+    public function testFreeSeatCapIsCountedPerOrganization(): void
     {
         $alice = $this->createUser('alice@example.com');
         $bob = $this->createUser('bob@example.com');
-        $space = $this->createSpace($alice, 'Team'); // alice is one admin member
-        $this->addMember($space, $bob);              // now two members
+        $space = $this->createSpace($alice, 'Team');
+        $org = $space->getOrganization();
+        $this->assertNotNull($org);
+
+        // Seats are org members, not space members (#billing Phase 2): alice
+        // owns the account, bob takes the second seat.
+        $org->addMember($bob, Organization::ROLE_MEMBER);
+        $this->em->flush();
 
         $limiter = $this->limiter(mcpLimit: 100, memberLimit: 2);
 
-        // At the cap (2 members, limit 2) → no more on free.
+        // At the cap (2 seats, limit 2) → no more on free.
         $this->assertFalse($limiter->canAddMembersToSpace($space));
+        $this->assertFalse($limiter->canAddMembersToOrganization($org));
 
-        // A subscription lifts the cap.
+        // A subscription lifts it entirely.
         $this->createSubscription($space, Subscription::STATUS_ACTIVE);
         $this->em->clear();
         $reloaded = $this->em->getRepository(Space::class)->findOneBy(['name' => 'Team']);
         $this->assertInstanceOf(Space::class, $reloaded);
         $this->assertTrue($limiter->canAddMembersToSpace($reloaded));
+    }
+
+    public function testGuestsDoNotConsumeASeat(): void
+    {
+        $alice = $this->createUser('alice@example.com');
+        $guest = $this->createUser('guest@example.com');
+        $space = $this->createSpace($alice, 'Team');
+        $org = $space->getOrganization();
+        $this->assertNotNull($org);
+
+        $org->addMember($guest, Organization::ROLE_GUEST);
+        $this->em->flush();
+
+        // Two members, but one is free — that is the whole point of the guest
+        // role, and it is what makes "N free seats" a truthful description.
+        $limiter = $this->limiter(mcpLimit: 100, memberLimit: 2);
+        $this->assertTrue($limiter->canAddMembersToOrganization($org));
     }
 
     public function testPersonalSpaceIsNeverCapped(): void

--- a/api/tests/Service/UsageLimiterTest.php
+++ b/api/tests/Service/UsageLimiterTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Service;
 
 use App\Billing\PlanCatalog;
 use App\Billing\PlanGate;
+use App\Entity\Organization;
 use App\Entity\Space;
 use App\Entity\SpaceMembership;
 use App\Entity\Subscription;
@@ -241,14 +242,6 @@ class UsageLimiterTest extends KernelTestCase
         $this->em->flush();
 
         return $space;
-    }
-
-    private function addMember(Space $space, User $user): void
-    {
-        $membership = (new SpaceMembership())->setUser($user)->setRole(Space::ROLE_MEMBER);
-        $space->addUserMembership($membership);
-        $this->em->persist($membership);
-        $this->em->flush();
     }
 
     private function createSubscription(Space $space, string $status): Subscription


### PR DESCRIPTION
The last of #818.

## Step 4 — membership backfill

Space membership has implied organization membership since Phase 1c, but members who joined a space *before* that shipped never got a row. `Organization::hasMember()` said no for people who demonstrably had access to its content, so seat counts, `entitlingPlansForUser` and the org member list all saw an account smaller than it really was.

Roles mirror `SpaceMemberAdder::ORG_ROLE_FOR_SPACE_ROLE` — space admin → org member, space member → org guest — and `DISTINCT ON` keeps the *stronger* role for someone who admins one space and merely joins another.

**Never downgrades.** An existing membership is left alone: someone who is already an Owner must not become a guest because they also sit in a space as a plain member. That is why it is a `NOT EXISTS` guard rather than an upsert.

Seat counts can rise for orgs that had un-joined space admins. That is the correct number rather than a new charge — those people already had access, they were just invisible to the count. No seat sync runs here; a migration has no business making paid API calls, and the next membership change pushes it.

## The per-org seat cap

The old per-space rule let a free user hold three spaces of five and pay for none of them, and "5 members per space" was never a sentence you could price against. Guests do not consume seats, so this now reads as **"N free seats per account"** — which is how the rest of the industry states it.

Enforcement also fires in `OrganizationMemberController::add()`, which is the one place a seat can be taken without touching a space at all, and was previously unguarded entirely.

**No grandfathering**, deliberately: there are no existing free accounts to strand. Recorded on #818 along with why it is absent, so it does not read as an oversight later.

Not run locally (no PHP/Docker here) — CI is the first execution.