### PR TITLE
build(deps): group @blocknote/* dependabot updates into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,3 +33,10 @@ updates:
     assignees:
       - roboparker
     open-pull-requests-limit: 10
+    groups:
+      # @blocknote/core, /react and /mantine must move in lockstep — the
+      # editor types are cross-package, so bumping one alone leaves two
+      # copies of @blocknote/core in the tree and fails the PWA typecheck.
+      blocknote:
+        patterns:
+          - "@blocknote/*"


### PR DESCRIPTION
## What

Adds a `groups` rule to the `/pwa` npm ecosystem so the three `@blocknote/*` packages are bumped in a single Dependabot PR.

## Why

Dependabot opened #835, #836 and #837 to move `@blocknote/core`, `@blocknote/react` and `@blocknote/mantine` from 0.52.1 → 0.53.0 separately. None of them can merge on their own:

- #836 / #837 fail **Build images** — with only `react`/`mantine` bumped, pnpm keeps *both* `@blocknote/core@0.52.1` and `@0.53.0` in the tree, and `MarkdownEditorInner.tsx` fails to typecheck (`TS2322`, two structurally identical but distinct `BlockNoteEditor` types).
- #835 (core alone) builds but fails **E2E** with 8 editor-interaction timeouts, for the mirror-image reason.

The types are cross-package, so these three only make sense as one change. Grouping makes Dependabot recreate them as a single PR.

## Follow-up

#835, #836 and #837 are closed in favour of the grouped PR.