### PR TITLE
fix(docker): satisfy the rules hadolint 3.4.0 added

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -58,7 +58,7 @@ COPY --link frankenphp/maintenance.html /etc/frankenphp/maintenance.html
 
 ENTRYPOINT ["docker-entrypoint"]
 
-HEALTHCHECK --start-period=60s CMD curl -f http://localhost:2019/metrics || exit 1
+HEALTHCHECK --start-period=60s CMD ["curl", "-f", "http://localhost:2019/metrics"]
 CMD [ "frankenphp", "run", "--config", "/etc/frankenphp/Caddyfile" ]
 
 # Dev FrankenPHP image

--- a/pwa/Dockerfile
+++ b/pwa/Dockerfile
@@ -81,7 +81,9 @@ RUN mkdir .next; \
 COPY --from=builder --link --chown=1001:1001 /srv/app/.next/standalone ./
 COPY --from=builder --link --chown=1001:1001 /srv/app/.next/static ./.next/static
 
-USER nextjs
+# nextjs, by uid — a numeric id is resolvable by the host regardless of the
+# image's /etc/passwd (hadolint DL3066); matches the --chown=1001:1001 above.
+USER 1001:1001
 
 EXPOSE 3000
 


### PR DESCRIPTION
## What

Two small Dockerfile fixes so the hadolint bump in #840 can land.

## Why

`hadolint-action@3.4.0` ships a newer hadolint binary that flags two lines the 3.3.0 binary did not, and the action's default failure threshold is `info`, so both fail the *Docker Lint* job:

- **`api/Dockerfile:61` — DL3025** (warning): `HEALTHCHECK` used shell form. The `|| exit 1` was redundant — Docker treats *any* non-zero probe exit as unhealthy — so the exec form is behaviourally equivalent and drops the `/bin/sh -c` wrapper.
- **`pwa/Dockerfile:84` — DL3066** (info): `USER nextjs` names a user the host can't resolve. `nextjs` is uid/gid 1001, which the two `COPY --chown=1001:1001` lines immediately above already hardcode, so `USER 1001:1001` is the same user.

## Verification

The healthcheck is on the deploy path, so it matters that this is exercised rather than eyeballed: CI's *E2E* job starts the real API container and waits for it to become healthy before loading fixtures, so a broken `HEALTHCHECK` fails *Start services*.