### PR TITLE
build(deps): bump phpstan/phpstan-doctrine to 2.0.28 and drop the array_values() calls it proves are no-ops

### DIFF
--- a/api/composer.lock
+++ b/api/composer.lock
@@ -13677,21 +13677,21 @@
         },
         {
             "name": "phpstan/phpstan-doctrine",
-            "version": "2.0.25",
+            "version": "2.0.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-doctrine.git",
-                "reference": "e20e8bf3223ae6eba9c4b5987c391d922e094b3c"
+                "reference": "b4623954d5ffee6311e4ddbaef65c074ae0f781a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-doctrine/zipball/e20e8bf3223ae6eba9c4b5987c391d922e094b3c",
-                "reference": "e20e8bf3223ae6eba9c4b5987c391d922e094b3c",
+                "url": "https://api.github.com/repos/phpstan/phpstan-doctrine/zipball/b4623954d5ffee6311e4ddbaef65c074ae0f781a",
+                "reference": "b4623954d5ffee6311e4ddbaef65c074ae0f781a",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0",
-                "phpstan/phpstan": "^2.1.34"
+                "phpstan/phpstan": "^2.2.2"
             },
             "conflict": {
                 "doctrine/collections": "<1.0",
@@ -13748,9 +13748,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-doctrine/issues",
-                "source": "https://github.com/phpstan/phpstan-doctrine/tree/2.0.25"
+                "source": "https://github.com/phpstan/phpstan-doctrine/tree/2.0.28"
             },
-            "time": "2026-06-02T20:27:36+00:00"
+            "time": "2026-07-13T08:43:43+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",

--- a/api/src/Controller/SpaceActivityController.php
+++ b/api/src/Controller/SpaceActivityController.php
@@ -62,10 +62,10 @@ class SpaceActivityController extends AbstractController
         $pages = $this->em->getRepository(Page::class)->findBy(['space' => $space]);
 
         /** @var array<class-string, list<string>> $groups */
-        $groups = [Page::class => array_values(array_map(
+        $groups = [Page::class => array_map(
             static fn (Page $p): string => (string) $p->getId(),
             $pages,
-        ))];
+        )];
         foreach ($boards as $board) {
             foreach ($this->scope->groupsForBoard($board) as $class => $ids) {
                 $groups[$class] = array_values(array_unique([

--- a/api/src/Repository/SegmentMembershipRepository.php
+++ b/api/src/Repository/SegmentMembershipRepository.php
@@ -31,6 +31,6 @@ final class SegmentMembershipRepository extends ServiceEntityRepository
      */
     public function findForUser(User $user): array
     {
-        return array_values($this->findBy(['user' => $user]));
+        return $this->findBy(['user' => $user]);
     }
 }

--- a/api/src/Repository/SegmentRepository.php
+++ b/api/src/Repository/SegmentRepository.php
@@ -26,6 +26,6 @@ final class SegmentRepository extends ServiceEntityRepository
      */
     public function findAllEnabled(): array
     {
-        return array_values($this->findBy(['enabled' => true]));
+        return $this->findBy(['enabled' => true]);
     }
 }

--- a/api/src/Service/AgentProvisioner.php
+++ b/api/src/Service/AgentProvisioner.php
@@ -100,7 +100,7 @@ final class AgentProvisioner
      */
     public function tokensFor(User $agent): array
     {
-        return array_values($this->tokens->findBy(['user' => $agent]));
+        return $this->tokens->findBy(['user' => $agent]);
     }
 
     private function buildAgent(string $name): User


### PR DESCRIPTION
## What

Bumps `phpstan/phpstan-doctrine` 2.0.25 → 2.0.28 (superseding #861) **and** removes the four `array_values()` calls that bump proves are no-ops. The two halves have to ship together — see below.

## Why they can't be separated

2.0.28 sharpens Doctrine's `findBy()` return type from `array<int, T>` to `list<T>`, which cuts both ways:

- **With the bump alone** (#861), the existing `array_values()` wrappers become redundant and level 10 fails them under `arrayValues.list` — 4 errors.
- **With the removals alone** (this PR's first commit, CI run [here](https://github.com/roboparker/Aura/pull/864/checks)), `findBy()` is still `array<int, T>`, so the `@return list<...>` docblocks no longer hold — 3 errors under `return.type`.

Only the combination is green, so this PR carries both.

| File | |
|---|---|
| `src/Repository/SegmentRepository.php:29` | `array_values($this->findBy(...))` |
| `src/Repository/SegmentMembershipRepository.php:34` | `array_values($this->findBy(...))` |
| `src/Service/AgentProvisioner.php:103` | `array_values($this->tokens->findBy(...))` |
| `src/Controller/SpaceActivityController.php:65` | `array_values(array_map(..., $pages))` |

`findBy()` has always returned a sequentially-indexed array, so the removals are behaviour-neutral and every `@return list<...>` docblock stays accurate. In `SpaceActivityController` the wrapper sat outside an `array_map` over a `findBy()` result — `array_map` with a single array preserves keys, so mapping a list already yields a list.

The alternative was `treatPhpDocTypesAsCertain: false` in `phpstan.dist.neon`, which PHPStan suggests in its own error output. That would silence the rule repo-wide to keep four redundant calls, so deleting them is the better trade.

## Follow-up

#861 is closed in favour of this PR.